### PR TITLE
Introduce a Pod trait for expressing that a type is viewable from bytes

### DIFF
--- a/gen/src/lib.rs
+++ b/gen/src/lib.rs
@@ -15,7 +15,7 @@ use blob::*;
 use codes::*;
 use file::*;
 use flags::*;
-use proc_macro2::{Ident, Literal, TokenStream};
+use proc_macro2::{Ident, TokenStream};
 use quote::{format_ident, quote};
 pub use reader::*;
 use row::*;


### PR DESCRIPTION
This introduces `Pod` which indicates that a type is "**P**lain **O**ld **D**ata". We then constrain the `View` trait to only work with such types.

While this increases the amount of times `unsafe` is used in the codebase, the code now does not contain instances of code that is not marked as `unsafe` but in reality actually is.

For instance, before this code would have been legal but completely memory unsafe:

```rust
struct MyType {
 data: Vec<u8>,
 foo: bool
}

fn code_full_of_ub() {
   let bytes = [0, 1, 5, 10, 1, 0, 0, 1, 5, 10, 1, 0, 0, 1, 5, 10, 1, 0, 0, 1, 5, 10, 1, 0,  0, 1, 5, 10, 1, 0];
   let my_type = bytes.view_as<MyType>();
   // What will happen here? No one knows!
  assert!(my_type.foo);
}
```

Now in order for that to work, the use would have to implement `Pod` for `MyType` at least forcing them to confront whether their type is actually plain old data or not. This also makes reviewing code for safety much easier. Now, we just need to ensure that our `unsafe impls` are correct. 
