### PR TITLE
WinRT enum to Rust support

### DIFF
--- a/crates/winmd/src/types/struct.rs
+++ b/crates/winmd/src/types/struct.rs
@@ -45,7 +45,7 @@ impl Struct {
 
         quote! {
             #[repr(C)]
-            #[derive(Copy, Clone, Default, Debug, PartialEq)]
+            #[derive(Clone, Default, Debug, PartialEq)]
             pub struct #name {
                 #(#fields),*
             }

--- a/src/hstring.rs
+++ b/src/hstring.rs
@@ -94,6 +94,12 @@ impl std::fmt::Display for HString {
     }
 }
 
+impl std::fmt::Debug for HString {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        <Self as std::fmt::Display>::fmt(self, f)
+    }
+}
+
 impl From<&str> for HString {
     fn from(value: &str) -> HString {
         let mut ptr = Header::alloc(value.len() as u32);
@@ -255,5 +261,17 @@ mod tests {
         assert!(HString::from("Hello") != "World");
 
         assert!(HString::from("Hello").to_string() == String::from("Hello"));
+    }
+
+    #[test]
+    fn display_format() {
+        let value = HString::from("Hello world");
+        assert!(format!("{}", value) == "Hello world");
+    }
+
+    #[test]
+    fn debug_format() {
+        let value = HString::from("Hello world");
+        assert!(format!("{:#?}", value) == "Hello world");
     }
 }

--- a/tests/enum.rs
+++ b/tests/enum.rs
@@ -1,0 +1,41 @@
+use winrt::import;
+
+import!(
+    dependencies
+        "os"
+    modules
+        "windows.foundation"
+        "windows.application_model.appointments"
+);
+
+#[test]
+fn signed_enum() {
+    use windows::foundation::AsyncStatus;
+
+    assert!(AsyncStatus::default() == AsyncStatus::Canceled);
+
+    assert!(AsyncStatus::Canceled as i32 == 2);
+    assert!(AsyncStatus::Completed as i32 == 1);
+    assert!(AsyncStatus::Error as i32 == 3);
+    assert!(AsyncStatus::Started as i32 == 0);
+}
+
+#[test]
+fn unsigned_enum() {
+    use windows::application_model::appointments::AppointmentDaysOfWeek;
+
+    assert!(AppointmentDaysOfWeek::default() == AppointmentDaysOfWeek::None);
+
+    assert!(AppointmentDaysOfWeek::None as u32 == 0);
+    assert!(AppointmentDaysOfWeek::Sunday as u32 == 0x1);
+    assert!(AppointmentDaysOfWeek::Monday as u32 == 0x2);
+    assert!(AppointmentDaysOfWeek::Tuesday as u32 == 0x4);
+    assert!(AppointmentDaysOfWeek::Wednesday as u32 == 0x8);
+    assert!(AppointmentDaysOfWeek::Thursday as u32 == 0x10);
+    assert!(AppointmentDaysOfWeek::Friday as u32 == 0x20);
+    assert!(AppointmentDaysOfWeek::Saturday as u32 == 0x40);
+
+    // TODO: Unsigned WinRT enums are meant to be used as bit flags:
+    // let weekend = AppointmentDaysOfWeek::Sunday | AppointmentDaysOfWeek::Saturday;
+    // assert!(weekend as u32 == 0x41);
+}


### PR DESCRIPTION
The WinRT enum test uncovered a few bugs in structs containing strings. Structs should be cloneable but not copyable. Structs also provide debug formatting but that means that strings should do so as well since WinRT strings can be stored in WinRT structs.

Outstanding: Unsigned WinRT enums are meant to be used as bit flags but I'm not sure how to model that as Rust enums don't naturally support this. May need to manually provide the various traits like `BitOr` but this may go against Rust's type safety rules. May need a macro to generate WinRT enums.