### PR TITLE
Rename TypeGuid to ComInterface

### DIFF
--- a/crates/winmd/src/types/class.rs
+++ b/crates/winmd/src/types/class.rs
@@ -131,8 +131,8 @@ impl Class {
         let value = default_interface.guid.to_stream();
 
         quote! {
-            unsafe impl ::winrt::TypeGuid for #name {
-                const TYPE_GUID: ::winrt::Guid = ::winrt::Guid::from_values(#value);
+            unsafe impl ::winrt::ComInterface for #name {
+                const GUID: ::winrt::Guid = ::winrt::Guid::from_values(#value);
             }
         }
     }

--- a/src/object.rs
+++ b/src/object.rs
@@ -19,8 +19,8 @@ impl Object {
     }
 }
 
-unsafe impl TypeGuid for Object {
-    const TYPE_GUID: Guid = Guid::from_values(
+unsafe impl ComInterface for Object {
+    const GUID: Guid = Guid::from_values(
         0xAF86_E2E0,
         0xB12D,
         0x4C6A,

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -3,8 +3,8 @@ use crate::*;
 // WinRT classes and interfaces implement this trait. WinRT classes implement it by returning the Guid
 // of the default interface. Static WinRT classes don't implement this trait. WinRT generic interfaces
 // don't yet return the correct value from type_guid because Rust's const functions are too limited.
-pub unsafe trait TypeGuid {
-    const TYPE_GUID: Guid;
+pub unsafe trait ComInterface {
+    const GUID: Guid;
 }
 
 /// Required for classes and interfaces

--- a/src/unknown.rs
+++ b/src/unknown.rs
@@ -54,7 +54,10 @@ impl Drop for IUnknown {
 // it lacks good const function support to work out the guids in a generic and thus type safe manner. Once
 // const function support arrives, we should be able to remove this function and rely on type_guid to
 // calculate the guid for all types.
-pub unsafe fn unsafe_query<From: TypeGuid, Into: TypeGuid>(from: &From, guid: &Guid) -> Into {
+pub unsafe fn unsafe_query<From: ComInterface, Into: ComInterface>(
+    from: &From,
+    guid: &Guid,
+) -> Into {
     let mut into = std::ptr::null_mut();
     let from: RawPtr = std::mem::transmute_copy(from);
     if !from.is_null() {
@@ -63,8 +66,8 @@ pub unsafe fn unsafe_query<From: TypeGuid, Into: TypeGuid>(from: &From, guid: &G
     std::mem::transmute_copy(&into)
 }
 
-pub fn safe_query<From: TypeGuid, Into: TypeGuid>(from: &From) -> Into {
-    unsafe { unsafe_query(from, &Into::TYPE_GUID) }
+pub fn safe_query<From: ComInterface, Into: ComInterface>(from: &From) -> Into {
+    unsafe { unsafe_query(from, &Into::GUID) }
 }
 
 #[repr(C)]

--- a/src/weak.rs
+++ b/src/weak.rs
@@ -16,8 +16,8 @@ pub(crate) struct IWeakReferenceSource {
     pub weak: extern "system" fn(RawPtr, *mut RawPtr) -> ErrorCode,
 }
 
-unsafe impl TypeGuid for IWeakReferenceSource {
-    const TYPE_GUID: Guid = Guid::from_values(
+unsafe impl ComInterface for IWeakReferenceSource {
+    const GUID: Guid = Guid::from_values(
         0x0000_0038,
         0x0000,
         0x0000,

--- a/tests/uri.rs
+++ b/tests/uri.rs
@@ -15,7 +15,7 @@ fn uri() -> winrt::Result<()> {
     );
 
     assert_eq!(
-        <Uri as winrt::TypeGuid>::TYPE_GUID,
+        <Uri as winrt::ComInterface>::GUID,
         winrt::Guid::from("9E365E57-48B2-4160-956F-C7385120BBFC") // IUriRuntimeClass
     );
 


### PR DESCRIPTION
To capture what it's used for rather than literally what it provides.