### PR TITLE
Support for attempted conversions

### DIFF
--- a/src/com_interface.rs
+++ b/src/com_interface.rs
@@ -3,25 +3,3 @@ use crate::*;
 pub unsafe trait ComInterface {
     const GUID: Guid;
 }
-
-pub trait TryInto<T: ComInterface> {
-    fn try_into(self) -> Option<T>;
-}
-
-impl<From: ComInterface + Sized, Into: ComInterface> TryInto<Into> for &From {
-    fn try_into(self) -> Option<Into> {
-        unsafe {
-            let mut into = std::ptr::null_mut();
-            let from: RawPtr = std::mem::transmute_copy(self);
-
-            if !from.is_null() {
-                ((*(*(from as *const *const abi_IUnknown))).query)(from, &Into::GUID, &mut into);
-            }
-
-            match into.is_null() {
-                false => Some(std::mem::transmute_copy(&into)),
-                true => None,
-            }
-        }
-    }
-}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,7 @@ mod ref_count;
 mod runtime;
 mod runtime_name;
 mod runtime_type;
+mod try_into;
 mod unknown;
 mod weak;
 
@@ -29,6 +30,7 @@ pub use ref_count::*;
 pub use runtime::*;
 pub use runtime_name::*;
 pub use runtime_type::*;
+pub use try_into::*;
 pub use unknown::*;
 pub use winrt_macros::*;
 

--- a/src/try_into.rs
+++ b/src/try_into.rs
@@ -1,0 +1,23 @@
+use crate::*;
+
+pub trait TryInto<T: ComInterface> {
+    fn try_into(self) -> Option<T>;
+}
+
+impl<From: ComInterface + Sized, Into: ComInterface> TryInto<Into> for &From {
+    fn try_into(self) -> Option<Into> {
+        unsafe {
+            let mut into = std::ptr::null_mut();
+            let from: RawPtr = std::mem::transmute_copy(self);
+
+            if !from.is_null() {
+                ((*(*(from as *const *const abi_IUnknown))).query)(from, &Into::GUID, &mut into);
+            }
+
+            match into.is_null() {
+                false => Some(std::mem::transmute_copy(&into)),
+                true => None,
+            }
+        }
+    }
+}

--- a/src/unknown.rs
+++ b/src/unknown.rs
@@ -71,7 +71,7 @@ pub fn safe_query<From: ComInterface, Into: ComInterface>(from: &From) -> Into {
 }
 
 #[repr(C)]
-pub struct abi_IUnknown {
+pub(crate) struct abi_IUnknown {
     pub query: extern "system" fn(RawPtr, &Guid, *mut RawPtr) -> ErrorCode,
     addref: extern "system" fn(RawPtr) -> u32,
     release: extern "system" fn(RawPtr) -> u32,


### PR DESCRIPTION
The is analogous to `try_as<T>()` in C++/WinRT.