### PR TITLE
Update composition test to run and pass

### DIFF
--- a/tests/composition.rs
+++ b/tests/composition.rs
@@ -31,7 +31,7 @@ fn composition() -> winrt::Result<()> {
     // we aren't pumping messages, the Compositor won't commit. This is fine for the test for now.
     let options = DispatcherQueueOptions {
         size: std::mem::size_of::<DispatcherQueueOptions>() as u32,
-        thread_type: 2, // DQTYPE_THREAD_CURRENT
+        thread_type: 2,    // DQTYPE_THREAD_CURRENT
         apartment_type: 0, // DQTAT_COM_NONE
     };
     let _queue_controller = unsafe {


### PR DESCRIPTION
This change does 3 main things:

1. Remove the "if false" from the test so that it executes at runtime.
2. Create a `DispatcherQueue` for the thread. It's crude, but enough to get the Compositor activating properly.
3. Change the order of the asserts at the end of the test regarding the iterator. It now matches the behavior of a similar test in C++/WinRT. From [MSDN](https://docs.microsoft.com/en-us/uwp/api/Windows.UI.Composition.VisualCollection?view=winrt-18362): "VisualCollections are ordered from bottom to top and iterating or enumerating through a collection is always done from bottom to top."

And finally, there's a caveat to this test. Because the test doesn't pump messages, none of the Visuals or changes will be sent to the system compositor. However that's fine, the test as currently written is enough to test the projection.