### PR TITLE
More consistent runtime type

### DIFF
--- a/crates/winmd/src/types/class.rs
+++ b/crates/winmd/src/types/class.rs
@@ -126,12 +126,14 @@ impl Class {
                     const GUID: ::winrt::Guid = ::winrt::Guid::from_values(#guid);
                 }
                 unsafe impl ::winrt::RuntimeType for #name {
-                    type Abi = *const *const <Self as ::winrt::ComInterface>::VTable;
+                    type Abi = <::winrt::ComPtr<Self> as ::winrt::RuntimeType>::Abi;
                     fn abi(&self) -> Self::Abi {
-                        self.ptr.get()
+                        use ::winrt::RuntimeType;
+                        self.ptr.abi()
                     }
                     fn set_abi(&mut self) -> *mut Self::Abi {
-                        self.ptr.set()
+                        use ::winrt::RuntimeType;
+                        self.ptr.set_abi()
                     }
                 }
                 #conversions

--- a/crates/winmd/src/types/delegate.rs
+++ b/crates/winmd/src/types/delegate.rs
@@ -65,10 +65,12 @@ impl Delegate {
             unsafe impl<#constraints> ::winrt::RuntimeType for #name {
                 type Abi = ::winrt::RawPtr;
                 fn abi(&self) -> Self::Abi {
-                    self.ptr.get()
+                    use ::winrt::RuntimeType;
+                    self.ptr.abi() as Self::Abi
                 }
                 fn set_abi(&mut self) -> *mut Self::Abi {
-                    self.ptr.set()
+                    use ::winrt::RuntimeType;
+                    self.ptr.set_abi() as  _
                 }
             }
         }

--- a/crates/winmd/src/types/interface.rs
+++ b/crates/winmd/src/types/interface.rs
@@ -88,12 +88,14 @@ impl Interface {
                 #phantoms
             }
             unsafe impl<#constraints> ::winrt::RuntimeType for #name {
-                type Abi = *const *const <Self as ::winrt::ComInterface>::VTable;
+                type Abi = <::winrt::ComPtr<Self> as ::winrt::RuntimeType>::Abi;
                 fn abi(&self) -> Self::Abi {
-                    self.ptr.get()
+                    use ::winrt::RuntimeType;
+                    self.ptr.abi()
                 }
                 fn set_abi(&mut self) -> *mut Self::Abi {
-                    self.ptr.set()
+                    use ::winrt::RuntimeType;
+                    self.ptr.set_abi()
                 }
             }
             #conversions

--- a/crates/winmd/src/types/method.rs
+++ b/crates/winmd/src/types/method.rs
@@ -211,7 +211,8 @@ impl Method {
 
             quote! {
                 pub fn #method_name<#constraints>(&self, #params) -> ::winrt::Result<#return_type> {
-                    let this = self.ptr.get();
+                    use ::winrt::RuntimeType;
+                    let this = self.ptr.abi();
                     if this.is_null() {
                         panic!("The `this` pointer was null when calling method");
                     }
@@ -225,7 +226,8 @@ impl Method {
         } else {
             quote! {
                 pub fn #method_name<#constraints>(&self, #params) -> ::winrt::Result<()> {
-                    let this = self.ptr.get();
+                    use ::winrt::RuntimeType;
+                    let this = self.ptr.abi();
                     if this.is_null() {
                         panic!("The `this` pointer was null when calling method");
                     }

--- a/src/activation.rs
+++ b/src/activation.rs
@@ -40,7 +40,7 @@ impl IActivationFactory {
 
         let mut object = Object::default();
         unsafe {
-            ((*(*(self.ptr.get()))).activate_instance)(self.ptr.get(), object.set_abi())
+            ((*(*(self.ptr.abi()))).activate_instance)(self.ptr.abi(), object.set_abi())
                 .and_then(|| object.query())
         }
     }

--- a/src/object.rs
+++ b/src/object.rs
@@ -11,7 +11,7 @@ pub struct Object {
 
 impl Object {
     pub fn type_name(&self) -> Result<HString> {
-        let this = self.ptr.get();
+        let this = self.ptr.abi();
         if this.is_null() {
             panic!("The `this` pointer was null when calling method");
         }
@@ -37,11 +37,11 @@ unsafe impl RuntimeType for Object {
     type Abi = *const *const <Self as ComInterface>::VTable;
 
     fn abi(&self) -> Self::Abi {
-        self.ptr.get()
+        self.ptr.abi()
     }
 
     fn set_abi(&mut self) -> *mut Self::Abi {
-        self.ptr.set()
+        self.ptr.set_abi()
     }
 }
 

--- a/src/unknown.rs
+++ b/src/unknown.rs
@@ -7,13 +7,15 @@ pub struct IUnknown {
     ptr: ComPtr<IUnknown>,
 }
 
-impl IUnknown {
-    pub fn get(&self) -> RawPtr {
-        self.ptr.get() as RawPtr
+unsafe impl RuntimeType for IUnknown {
+    type Abi = <ComPtr<IUnknown> as RuntimeType>::Abi;
+
+    fn abi(&self) -> Self::Abi {
+        self.ptr.abi()
     }
 
-    pub fn set(&mut self) -> *mut RawPtr {
-        self.ptr.set() as *mut RawPtr
+    fn set_abi(&mut self) -> *mut Self::Abi {
+        self.ptr.set_abi()
     }
 }
 
@@ -27,11 +29,10 @@ unsafe impl ComInterface for IUnknown {
     );
 }
 
-type IUnknownPtr = *const *const <IUnknown as ComInterface>::VTable;
-
 #[repr(C)]
 pub struct abi_IUnknown {
-    pub(crate) query: extern "system" fn(IUnknownPtr, &Guid, *mut RawPtr) -> ErrorCode,
-    pub(crate) addref: extern "system" fn(IUnknownPtr) -> u32,
-    pub(crate) release: extern "system" fn(IUnknownPtr) -> u32,
+    pub(crate) query:
+        extern "system" fn(<IUnknown as RuntimeType>::Abi, &Guid, *mut RawPtr) -> ErrorCode,
+    pub(crate) addref: extern "system" fn(<IUnknown as RuntimeType>::Abi) -> u32,
+    pub(crate) release: extern "system" fn(<IUnknown as RuntimeType>::Abi) -> u32,
 }

--- a/tests/composition.rs
+++ b/tests/composition.rs
@@ -9,7 +9,7 @@ winrt::import!(
 extern "stdcall" {
     fn CreateDispatcherQueueController(
         options: DispatcherQueueOptions,
-        dispatcherQueueController: *mut winrt::RawPtr,
+        dispatcherQueueController: *mut <winrt::IUnknown as winrt::RuntimeType>::Abi,
     ) -> winrt::ErrorCode;
 }
 
@@ -21,6 +21,7 @@ struct DispatcherQueueOptions {
 }
 
 fn create_dispatcher() -> winrt::IUnknown {
+    use winrt::RuntimeType;
     // We need a DispatcherQueue on our thread to properly create a Compositor. Note that since
     // we aren't pumping messages, the Compositor won't commit. This is fine for the test for now.
 
@@ -32,7 +33,7 @@ fn create_dispatcher() -> winrt::IUnknown {
 
     let mut interop_ptr = winrt::IUnknown::default();
     unsafe {
-        CreateDispatcherQueueController(options, interop_ptr.set())
+        CreateDispatcherQueueController(options, interop_ptr.set_abi())
             .ok()
             .unwrap();
     }


### PR DESCRIPTION
First need to merge #101 

This moves `ComPtr<T>` and `IUnknown` to use `RuntimeType` instead of implementing their own `get` and `set` methods which were logically equivalent to `RuntimeType::abi` and `RuntimeType::set_abi` respectively. It's hard to say this is strictly better, but it is more consistent. 