### PR TITLE
Fix regression with empty structs

### DIFF
--- a/crates/gen/src/struct.rs
+++ b/crates/gen/src/struct.rs
@@ -57,7 +57,7 @@ impl Struct {
         let guid = TypeGuid::from_type_def(&name.def);
 
         // The C/C++ ABI assumes an empty struct occupies a single byte in memory.
-        if fields.is_empty() && guid != TypeGuid::default() {
+        if fields.is_empty() && guid == TypeGuid::default() {
             let t = Type {
                 kind: TypeKind::U8,
                 pointers: 0,

--- a/crates/tests/build.rs
+++ b/crates/tests/build.rs
@@ -66,5 +66,7 @@ fn main() {
         windows::win32::com::{IUri, CreateUri},
         windows::win32::structured_storage::{CreateStreamOnHGlobal, STREAM_SEEK},
         windows::win32::upnp::UIAnimationTransitionLibrary,
+        windows::win32::ldap::ldapsearch,
+        windows::win32::upnp::UIAnimationManager,
     );
 }

--- a/crates/tests/tests/win32.rs
+++ b/crates/tests/tests/win32.rs
@@ -8,16 +8,19 @@ use tests::{
         CreateDXGIFactory1, IDXGIFactory7, DXGI_ADAPTER_FLAG, DXGI_FORMAT, DXGI_MODE_DESC,
         DXGI_MODE_SCALING, DXGI_MODE_SCANLINE_ORDER, DXGI_RATIONAL,
     },
+    windows::win32::ldap::ldapsearch,
     windows::win32::security::ACCESS_MODE,
     windows::win32::structured_storage::{CreateStreamOnHGlobal, STREAM_SEEK},
     windows::win32::system_services::{
         CreateEventW, SetEvent, WaitForSingleObject, DXGI_ERROR_INVALID_CALL, HANDLE, WM_KEYUP,
     },
+    windows::win32::upnp::UIAnimationManager,
     windows::win32::upnp::UIAnimationTransitionLibrary,
     windows::win32::windows_accessibility::UIA_ScrollPatternNoScroll,
     windows::win32::windows_and_messaging::{CHOOSECOLORW, HWND, PROPENUMPROCA, PROPENUMPROCW},
     windows::win32::windows_programming::CloseHandle,
 };
+use windows::Guid;
 use windows::Interface;
 use windows::BOOL;
 
@@ -329,4 +332,13 @@ extern "system" fn callback_w(param0: HWND, param1: *const u16, param2: HANDLE) 
         assert!(s == "hello w");
         BOOL(789)
     }
+}
+
+#[test]
+fn empty_struct() {
+    let ldap = ldapsearch { reserved: 123 };
+    assert!(ldap.reserved == 123);
+    assert!(std::mem::size_of::<ldapsearch>() == 1);
+
+    assert!(UIAnimationManager == Guid::from("4C1FC63A-695C-47E8-A339-1A194BE3D0B8"));
 }


### PR DESCRIPTION
The C/C++ ABI assumes an empty struct occupies a single byte in memory. This was working until I added [CLSID support](https://github.com/microsoft/windows-rs/pull/448). 

This update fixes the regression and adds tests to ensure we catch this early next time.