### PR TITLE
Win32 array and pointer type generation for struct members

### DIFF
--- a/crates/winmd/src/parsed/blob.rs
+++ b/crates/winmd/src/parsed/blob.rs
@@ -1,7 +1,6 @@
 use crate::*;
 
 use std::convert::TryInto;
-use std::ops::Shl;
 
 pub struct Blob {
     pub reader: &'static TypeReader,

--- a/crates/winmd/src/parsed/blob.rs
+++ b/crates/winmd/src/parsed/blob.rs
@@ -73,7 +73,7 @@ impl Blob {
 
             let combined = (sign | val) >> 3;
 
-            (combined,4)
+            (combined, 4)
         }
     }
 


### PR DESCRIPTION
This solves #423

After encountering this issue myself and seeing the outstanding issue referring to it I decided to hack on the code to see if I could get it implemented. The link in the code to where to start in the referenced issue was very useful and I now have the functionality implemented.

I'd like some input on what to do with the outstanding "TODO" items I've left

```rust
// Recursively parse the type
let kind = Self::read_from_blob(blob, generics, calling_namespace);

// TODO: Don't know how to handle multi dimensional arrays yet
let rank = blob.read_unsigned();
if rank != 1 {
    panic!("Unsupported array rank: {}", rank);
}

// TODO: Don't know how to handle unsized arrays yet
let num_upper_bounds = blob.read_unsigned();
if num_upper_bounds != 1 {
    panic!("Unsupported array upper bound count: {}", num_upper_bounds);
}

let upper_bound = blob.read_unsigned();

// TODO: Don't know how to handle unsized arrays yet
let num_lower_bounds = blob.read_unsigned();
if num_lower_bounds != 1 {
    panic!("Unsupported array lower bound count: {}", num_lower_bounds);
}

// It's not possible for rust to represent a non 0 lower bound in any sane ABI
// compatible manner without generating a boat load of support code
let low_bound = blob.read_signed();
if low_bound != 0 {
    panic!("Unsupported array lower bound: {}", low_bound);
}
 ```

Going over the ECMA 335 spec for the file format, there is potential for a type that can't be sanely expressed by rust to be encoded in the metadata and I was hoping on getting input on how to resolve that.

Currently I'm just panicking on anything that isn't a single dimensional array, panicking when the upper or lower bound is not specified, and panicking when the lower bound is non zero. I wouldn't expect anything from the win32 API surface area to trigger one of those panics.
