### PR TITLE
Add basic COM helpers

### DIFF
--- a/crates/tests/build.rs
+++ b/crates/tests/build.rs
@@ -71,5 +71,6 @@ fn main() {
         windows::win32::game_mode::HasExpandedResources,
         windows::win32::debug::MiniDumpWriteDump,
         windows::win32::direct3d11::D3DDisassemble11Trace,
+        windows::win32::windows_update_agent::IAutomaticUpdates,
     );
 }

--- a/crates/tests/tests/com.rs
+++ b/crates/tests/tests/com.rs
@@ -10,6 +10,7 @@ fn test_sta() -> Result<()> {
     Ok(())
 }
 
+#[test]
 fn test_mta() -> Result<()> {
     initialize_mta()?;
     let clsid = Guid::from_progid("Microsoft.Update.AutoUpdate")?;

--- a/crates/tests/tests/com.rs
+++ b/crates/tests/tests/com.rs
@@ -1,0 +1,19 @@
+use tests::windows::win32::windows_update_agent::IAutomaticUpdates;
+use windows::{create_instance, initialize_mta, initialize_sta, Guid, Result};
+
+#[test]
+fn test_sta() -> Result<()> {
+    initialize_sta()?;
+    let clsid = Guid::from_progid("Microsoft.Update.AutoUpdate")?;
+    let updates: IAutomaticUpdates = create_instance(&clsid)?;
+    let _ = updates.Pause();
+    Ok(())
+}
+
+fn test_mta() -> Result<()> {
+    initialize_mta()?;
+    let clsid = Guid::from_progid("Microsoft.Update.AutoUpdate")?;
+    let updates: IAutomaticUpdates = create_instance(&clsid)?;
+    let _ = updates.Pause();
+    Ok(())
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,10 @@ use runtime::*;
 
 pub use interfaces::{IActivationFactory, IAgileObject, IUnknown, Object};
 pub use result::{Error, ErrorCode, Result, BOOL, FALSE, TRUE};
-pub use runtime::{factory, Array, FactoryCache, Guid, Param, RefCount, Waiter};
+pub use runtime::{
+    create_instance, factory, initialize_mta, initialize_sta, Array, FactoryCache, Guid, Param,
+    RefCount, Waiter,
+};
 pub use strings::{BString, HString};
 pub use traits::{Abi, Interface, RuntimeName, RuntimeType};
 pub use windows_macros::{build, implement};

--- a/src/runtime/com.rs
+++ b/src/runtime/com.rs
@@ -1,0 +1,44 @@
+use crate::*;
+
+/// Initializes COM for use by the calling thread for the multi-threaded apartment (MTA).
+pub fn initialize_mta() -> Result<()> {
+    unsafe {
+        CoInitializeEx(0, 0).ok() // COINIT_APARTMENTTHREADED
+    }
+}
+
+/// Initializes COM for use by the calling thread for a single-threaded apartment (STA).
+pub fn initialize_sta() -> Result<()> {
+    unsafe {
+        CoInitializeEx(0, 2).ok() // COINIT_MULTITHREADED
+    }
+}
+
+/// Creates a COM object with the given CLSID.
+pub fn create_instance<T: Interface>(clsid: &Guid) -> Result<T> {
+    let mut object = None;
+
+    unsafe {
+        CoCreateInstance(
+            clsid,
+            None,
+            23, // CLSCTX_ALL
+            &T::IID,
+            object.set_abi(),
+        )
+        .and_some(object)
+    }
+}
+
+#[link(name = "ole32")]
+extern "system" {
+    fn CoInitializeEx(reserved: isize, apartment: u32) -> ErrorCode;
+
+    fn CoCreateInstance(
+        clsid: &Guid,
+        outer: Option<IUnknown>,
+        clsctx: u32,
+        iid: &Guid,
+        object: *mut *mut std::ffi::c_void,
+    ) -> ErrorCode;
+}

--- a/src/runtime/com.rs
+++ b/src/runtime/com.rs
@@ -2,33 +2,24 @@ use crate::*;
 
 /// Initializes COM for use by the calling thread for the multi-threaded apartment (MTA).
 pub fn initialize_mta() -> Result<()> {
-    unsafe {
-        CoInitializeEx(0, 0).ok() // COINIT_APARTMENTTHREADED
-    }
+    unsafe { CoInitializeEx(0, COINIT_MULTITHREADED).ok() }
 }
 
 /// Initializes COM for use by the calling thread for a single-threaded apartment (STA).
 pub fn initialize_sta() -> Result<()> {
-    unsafe {
-        CoInitializeEx(0, 2).ok() // COINIT_MULTITHREADED
-    }
+    unsafe { CoInitializeEx(0, COINIT_APARTMENTTHREADED).ok() }
 }
 
 /// Creates a COM object with the given CLSID.
 pub fn create_instance<T: Interface>(clsid: &Guid) -> Result<T> {
     let mut object = None;
 
-    unsafe {
-        CoCreateInstance(
-            clsid,
-            None,
-            23, // CLSCTX_ALL
-            &T::IID,
-            object.set_abi(),
-        )
-        .and_some(object)
-    }
+    unsafe { CoCreateInstance(clsid, None, CLSCTX_ALL, &T::IID, object.set_abi()).and_some(object) }
 }
+
+const COINIT_MULTITHREADED: u32 = 0;
+const COINIT_APARTMENTTHREADED: u32 = 2;
+const CLSCTX_ALL: u32 = 23;
 
 #[link(name = "ole32")]
 extern "system" {

--- a/src/runtime/guid.rs
+++ b/src/runtime/guid.rs
@@ -59,6 +59,18 @@ impl Guid {
             ],
         )
     }
+
+    /// Looks up a CLSID in the registry using the [CLSIDFromProgID](https://docs.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-clsidfromprogid) function.
+    pub fn from_progid(progid: &str) -> crate::Result<Guid> {
+        let progid = HString::from(progid);
+        let mut guid = Guid::zeroed();
+
+        unsafe {
+            CLSIDFromProgID(progid.as_wide().as_ptr() as *mut _, &mut guid).ok()?;
+        }
+
+        Ok(guid)
+    }
 }
 
 unsafe impl Abi for Guid {
@@ -122,4 +134,9 @@ impl From<&str> for Guid {
 
         Guid::from_values(a, b, c, [d, e, f, g, h, i, j, k])
     }
+}
+
+#[link(name = "ole32")]
+extern "system" {
+    fn CLSIDFromProgID(progid: *mut u16, clsid: &mut Guid) -> ErrorCode;
 }

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -1,4 +1,5 @@
 mod array;
+mod com;
 mod delay_load;
 mod factory_cache;
 mod guid;
@@ -10,6 +11,7 @@ mod time_span;
 mod waiter;
 
 pub use array::*;
+pub use com::*;
 pub use delay_load::*;
 pub use factory_cache::*;
 pub use guid::*;


### PR DESCRIPTION
These helpers simplify calling many COM APIs. Fixes #495 and addresses many of the recent questions about using the `windows` crate to call various APIs. 