### PR TITLE
Make methods unsafe if any of there parameters are pointers

### DIFF
--- a/crates/gen/src/class.rs
+++ b/crates/gen/src/class.rs
@@ -115,7 +115,7 @@ impl Class {
     pub fn gen(&self) -> TokenStream {
         let name = self.name.gen();
         let type_name = self.type_name(&name);
-        let methods = gen_method(&self.interfaces);
+        let methods = gen_methods(&self.interfaces);
         let call_factory = self.gen_call_factory();
 
         if let Some(default_interface) = self

--- a/crates/gen/src/interface.rs
+++ b/crates/gen/src/interface.rs
@@ -71,7 +71,7 @@ impl Interface {
             .filter(|interface| interface.kind != InterfaceKind::Default)
             .map(|interface| interface.gen_conversions(&name, &constraints));
 
-        let methods = gen_method(&self.interfaces);
+        let methods = gen_methods(&self.interfaces);
 
         let abi_methods = default_interface.methods.iter().map(|method| {
             let signature = method.gen_abi();

--- a/crates/gen/src/required_interface.rs
+++ b/crates/gen/src/required_interface.rs
@@ -170,7 +170,7 @@ pub fn add_dependencies(
     }
 }
 
-pub fn gen_method(interfaces: &Vec<RequiredInterface>) -> TokenStream {
+pub fn gen_methods(interfaces: &Vec<RequiredInterface>) -> TokenStream {
     let mut tokens = TokenStream::new();
 
     for interface in interfaces {


### PR DESCRIPTION
Fixes #485.

This is better but this is still not correct in the general case (since we don't control all WinRT or COM interfaces that will ever pass through the code generator), and I'm not sure it's even correct in the case of Windows APIs. Take the following as an example of a COM interface method that would be marked safe by this tooling but is not safe. I've written it in Rust even though this may obviously be written in another language.

```rust
/// It is up to the caller to *never* pass `TRUE` as the `do_terrible_things` param,
unsafe fn my_method(&self, do_terrible_things: BOOL) -> HRESULT {
   if do_terrible_things.as_bool() {
      /// Literally do anything including dereferencing random memory
  }
}
```

This example is admittedly a bit contrived, but hopefully you get the point that pointer arguments are not the only sign of a whether a COM function is safe. It's unfortunate, but it's probably correct to mark any COM interface that has any parameters (beyond the this pointer) as unsafe.  