### PR TITLE
Mark set_abi as safe

### DIFF
--- a/src/strings/bstring.rs
+++ b/src/strings/bstring.rs
@@ -61,7 +61,7 @@ impl BString {
 unsafe impl Abi for BString {
     type Abi = RawPtr;
 
-    unsafe fn set_abi(&mut self) -> *mut RawPtr {
+    fn set_abi(&mut self) -> *mut RawPtr {
         debug_assert!(self.is_empty());
         &mut self.0 as *mut _ as _
     }

--- a/src/strings/hstring.rs
+++ b/src/strings/hstring.rs
@@ -98,7 +98,7 @@ impl HString {
 unsafe impl Abi for HString {
     type Abi = RawPtr;
 
-    unsafe fn set_abi(&mut self) -> *mut RawPtr {
+    fn set_abi(&mut self) -> *mut RawPtr {
         debug_assert!(self.is_empty());
         &mut self.0 as *mut _ as _
     }


### PR DESCRIPTION
This does not need to be marked as unsafe since making raw pointers is generally considered safe in Rust.

Fixes #487 