### PR TITLE
Add unsupported type

### DIFF
--- a/crates/gen/src/type.rs
+++ b/crates/gen/src/type.rs
@@ -46,6 +46,9 @@ pub enum TypeKind {
     Struct(TypeName),
     Delegate(TypeName),
     Generic(&'static str),
+    /// A type that hasn't been supported yet.
+    /// For example, mutlidimensional arrays are not yet supported
+    NotYetSupported,
 }
 
 impl Type {
@@ -95,7 +98,7 @@ impl Type {
 
                 if def.name().0.is_empty() {
                     // TODO: handle nested types
-                    TypeKind::Bool
+                    TypeKind::NotYetSupported
                 } else {
                     TypeKind::from_type_def_or_ref(&def, generics, calling_namespace)
                 }
@@ -107,7 +110,7 @@ impl Type {
                 // rank (dimensions)
                 // bounds count
                 // bound
-                TypeKind::Bool
+                TypeKind::NotYetSupported
             }
             0x15 => TypeKind::from_type_name(TypeName::from_type_spec_blob(
                 blob,
@@ -407,6 +410,7 @@ impl TypeKind {
                 let name = format_ident(name);
                 quote! { #name }
             }
+            Self::NotYetSupported => quote! { ::windows::NOT_YET_SUPPORTED_TYPE },
         }
     }
 
@@ -443,6 +447,7 @@ impl TypeKind {
                 let name = format_ident(name);
                 quote! { #name }
             }
+            Self::NotYetSupported => quote!(::windows::NOT_YET_SUPPORTED_TYPE),
         }
     }
 
@@ -481,6 +486,7 @@ impl TypeKind {
             }
             Self::Enum(name) => name.gen(),
             Self::Struct(name) => name.gen_abi(),
+            Self::NotYetSupported => quote!(::windows::NOT_YET_SUPPORTED_TYPE),
         }
     }
 
@@ -519,6 +525,7 @@ impl TypeKind {
             }
             Self::Enum(name) => name.gen_full(),
             Self::Struct(name) => name.gen_full_abi(),
+            Self::NotYetSupported => quote!(::windows::NOT_YET_SUPPORTED_TYPE),
         }
     }
 

--- a/crates/gen/src/type.rs
+++ b/crates/gen/src/type.rs
@@ -47,7 +47,7 @@ pub enum TypeKind {
     Delegate(TypeName),
     Generic(&'static str),
     /// A type that hasn't been supported yet.
-    /// For example, mutlidimensional arrays are not yet supported
+    /// For example, multidimensional arrays are not yet supported
     NotYetSupported,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -44,3 +44,16 @@ pub use bindings::windows::foundation;
 
 #[doc(hidden)]
 pub use const_sha1::ConstBuffer;
+
+/// A stand-in for a type which is not yet fully supported by the `windows` crate.
+///
+/// There should be tracking issues for each one of these types as they will eventually be supported.
+/// This type is not constructible as it should never be used. It is merely marking that support
+/// needs to be added to the `windows` crate before this functionality becomes available.
+#[allow(non_camel_case_types)]
+#[derive(Clone, Copy, PartialEq, Debug, Default)]
+#[repr(transparent)]
+pub struct NOT_YET_SUPPORTED_TYPE {
+    /// ensures the type cannot be constructed
+    _priv: u8,
+}


### PR DESCRIPTION
As noted in #423, using `BOOL` as a stand-in type for another unsupported type can be very confusing. This exchanges that out for a temporary type explicitly named `NOT_YET_SUPPORTED_TYPE` which is not constructible and can never be used. Hopefully this makes it a bit clearer when a particular API is not yet fully supported. 