### PR TITLE
Derive PartialEq and Eq on 'enums' to enable pattern matching

### DIFF
--- a/crates/gen/src/enum.rs
+++ b/crates/gen/src/enum.rs
@@ -125,6 +125,7 @@ impl Enum {
 
         quote! {
             #[allow(non_camel_case_types)]
+            #[derive(PartialEq, Eq)]
             #[repr(transparent)]
             pub struct #name(pub #underlying_type);
             impl ::std::convert::From<#underlying_type> for #name {
@@ -147,12 +148,6 @@ impl Enum {
                     write!(f, "{:?}", self.0)
                 }
             }
-            impl ::std::cmp::PartialEq for #name {
-                fn eq(&self, other: &Self) -> bool {
-                    self.0 == other.0
-                }
-            }
-            impl ::std::cmp::Eq for #name {}
             impl ::std::marker::Copy for #name {}
             impl #name {
                 #![allow(non_upper_case_globals)]


### PR DESCRIPTION
This fixes #490.

I tested this against the clock example which is the most intensive example we have and this doesn't seem to impact compile times. From the testing I've done of the impact of derives on compile times, `PartialEq` and `Eq` are nowhere near the level of `PartialOrd` when it comes to hurting compiler performance. 