### PR TITLE
Add COM/BSTR example

### DIFF
--- a/examples/com_uri/Cargo.toml
+++ b/examples/com_uri/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "com_uri"
+version = "0.4.0"
+authors = ["Kenny Kerr <kenny.kerr@microsoft.com>"]
+edition = "2018"
+
+[dependencies]
+bindings = { package = "com_uri_bindings", path = "bindings" }
+windows = { path = "../.." }

--- a/examples/com_uri/bindings/Cargo.toml
+++ b/examples/com_uri/bindings/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "com_uri_bindings"
+version = "0.4.0"
+authors = ["Kenny Kerr <kenny.kerr@microsoft.com>"]
+edition = "2018"
+
+[dependencies]
+windows = { path = "../../.." }
+
+[build-dependencies]
+windows = { path = "../../.." }

--- a/examples/com_uri/bindings/build.rs
+++ b/examples/com_uri/bindings/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    windows::build!(windows::win32::com::CreateUri);
+}

--- a/examples/com_uri/bindings/src/lib.rs
+++ b/examples/com_uri/bindings/src/lib.rs
@@ -1,0 +1,1 @@
+::windows::include_bindings!();

--- a/examples/com_uri/src/main.rs
+++ b/examples/com_uri/src/main.rs
@@ -1,0 +1,17 @@
+use bindings::{windows::win32::automation::BSTR, windows::win32::com::CreateUri};
+
+fn main() -> windows::Result<()> {
+    unsafe {
+        let mut uri = None;
+        let uri = CreateUri("http://kennykerr.ca", 0, 0, &mut uri).and_some(uri)?;
+
+        let mut domain = BSTR::default();
+        uri.GetDomain(&mut domain).ok()?;
+
+        let mut port = 0;
+        uri.GetPort(&mut port).ok()?;
+
+        println!("{} ({})", domain, port);
+        Ok(())
+    }
+}


### PR DESCRIPTION
This provides a simple example of using a COM interface and the BSTR string type.