### PR TITLE
Error handling and enum flags

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -3,6 +3,6 @@ fn main() {
         windows::foundation::{IReference, IStringable, PropertyValue},
         windows::win32::automation::{BSTR, GetErrorInfo, IErrorInfo, SetErrorInfo},
         windows::win32::winrt::{IRestrictedErrorInfo, ILanguageExceptionErrorInfo2},
-        windows::win32::debug::GetLastError,
+        windows::win32::debug::{GetLastError, FormatMessageW},
     );
 }


### PR DESCRIPTION
This update improves error handling support by adding a message method to the ErrorCode types so you don't have to create a complete Error object just to get a formatted message. 

It also adds bitwise operators for Win32 enums.

And more of the windows crate is dogfooding the generated bindings. 😉 

Fixes #576 #561 #559