### PR TITLE
Trim unused types from cache

### DIFF
--- a/crates/gen/src/parser/generic_type.rs
+++ b/crates/gen/src/parser/generic_type.rs
@@ -40,7 +40,7 @@ impl GenericType {
 
     pub fn definition(&self) -> Vec<ElementType> {
         let mut definition = Vec::new();
-        definition.push(ElementType::from_type_def(self.def, Vec::new()).unwrap());
+        definition.push(ElementType::from_type_def(self.def, Vec::new()));
 
         for generic in &self.generics {
             definition.append(&mut generic.definition());

--- a/crates/gen/src/parser/type_kind.rs
+++ b/crates/gen/src/parser/type_kind.rs
@@ -5,6 +5,4 @@ pub enum TypeKind {
     Enum,
     Struct,
     Delegate,
-    Attribute,
-    Contract,
 }

--- a/crates/gen/src/tables/type_def.rs
+++ b/crates/gen/src/tables/type_def.rs
@@ -128,14 +128,7 @@ impl TypeDef {
             match self.extends().full_name() {
                 ("System", "Enum") => TypeKind::Enum,
                 ("System", "MulticastDelegate") => TypeKind::Delegate,
-                ("System", "Attribute") => TypeKind::Attribute,
-                ("System", "ValueType") => {
-                    if self.has_attribute("Windows.Foundation.Metadata", "ApiContractAttribute") {
-                        TypeKind::Contract
-                    } else {
-                        TypeKind::Struct
-                    }
-                }
+                ("System", "ValueType") => TypeKind::Struct,
                 _ => TypeKind::Class,
             }
         }

--- a/crates/gen/src/types/class.rs
+++ b/crates/gen/src/types/class.rs
@@ -155,7 +155,7 @@ impl Class {
                 | ("Windows.Foundation.Metadata", "ComposableAttribute") => {
                     for (_, arg) in attribute.args() {
                         if let parser::ConstantValue::TypeDef(def) = arg {
-                            return Some(ElementType::from_type_def(def, Vec::new()).unwrap());
+                            return Some(ElementType::from_type_def(def, Vec::new()));
                         }
                     }
                 }

--- a/crates/gen/src/types/com_interface.rs
+++ b/crates/gen/src/types/com_interface.rs
@@ -13,7 +13,7 @@ impl ComInterface {
             .chain(
                 self.0
                     .interfaces()
-                    .map(|i| ElementType::from_type_def(i.def, Vec::new()).unwrap()),
+                    .map(|i| ElementType::from_type_def(i.def, Vec::new())),
             )
             .collect()
     }

--- a/crates/gen/src/types/interface.rs
+++ b/crates/gen/src/types/interface.rs
@@ -64,7 +64,7 @@ impl Interface {
             .chain(
                 self.0
                     .interfaces()
-                    .map(|i| ElementType::from_type_def(i.def, Vec::new()).unwrap()),
+                    .map(|i| ElementType::from_type_def(i.def, Vec::new())),
             )
             .collect()
     }


### PR DESCRIPTION
Attributes and contracts are weird types in WinRT in that they show up in metadata but rarely used by language projections. C++/WinRT has never made them available because they are only used by tools that process metadata (like cppwinrt and windows-rs). 

I finally have a reasonably simple way to strip them out so that they don't pollute the cache and can thus avoid a bunch of workarounds to deal with their presence. 