### PR TITLE
Rust doc improvements

### DIFF
--- a/crates/gen/src/parser/type_reader.rs
+++ b/crates/gen/src/parser/type_reader.rs
@@ -184,7 +184,7 @@ impl TypeReader {
         self.types.keys()
     }
 
-    /// Get all type definitions ([`TypeDef`]s) for a given namespace
+    /// Get all types for a given namespace
     ///
     /// # Panics
     ///

--- a/crates/gen/src/types/interface.rs
+++ b/crates/gen/src/types/interface.rs
@@ -86,10 +86,18 @@ impl Interface {
             .methods()
             .map(|m| m.signature(&self.0.generics).gen_winrt_abi(gen));
 
+        let is_exclusive = self.0.def.is_exclusive();
+
+        let hidden = if is_exclusive {
+            quote! { #[doc(hidden)] }
+        } else {
+            quote! {}
+        };
+
         // The exclusive interface may be a factory interface and then we still need a type to use
         // with the factory cache. And we don't know at this stage whether the interface is for
         // the class or its factory.
-        let public_type = if self.0.def.is_exclusive() {
+        let public_type = if is_exclusive {
             TokenStream::new()
         } else {
             let type_signature = self
@@ -136,6 +144,7 @@ impl Interface {
         quote! {
             #[repr(transparent)]
             #[derive(::std::cmp::PartialEq, ::std::cmp::Eq, ::std::clone::Clone, ::std::fmt::Debug)]
+            #hidden
             pub struct #name(::windows::Object, #phantoms) where #constraints;
             unsafe impl<#constraints> ::windows::Interface for #name {
                 type Vtable = #abi_name;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,7 +5,7 @@ way for Rust developers to call Windows APIs. The `windows` crate lets you call 
 future using code generated on the fly directly from the metadata describing the API and right into your Rust package
 where you can call them as if they were just another Rust module.
 
-Learn more here: [https://github.com/microsoft/windows-rs](https://github.com/microsoft/windows-rs)
+Learn more here: <https://github.com/microsoft/windows-rs>
 */
 
 #[macro_use]


### PR DESCRIPTION
Removes "internal" types (exclusive interfaces) from the documentation, thereby reducing the amount of documentation that is generated. 