### PR TITLE
Reduce size of published windows crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ description = "Rust for Windows"
 repository = "https://github.com/microsoft/windows-rs"
 documentation = "https://docs.rs/windows"
 readme = "README.md"
+exclude = [".github", ".windows", "docs", "examples"]
 
 [dependencies]
 windows_macros = { path = "crates/macros",  version = "0.4.0" }


### PR DESCRIPTION
This trims it down from 1.8 MB to around 18 KB. Thanks to @rylev for the tip.