### PR TITLE
Make IRestrictedErrorInfo Send + Sync

### DIFF
--- a/crates/gen/src/types/com_interface.rs
+++ b/crates/gen/src/types/com_interface.rs
@@ -188,6 +188,18 @@ impl ComInterface {
                 });
         }
 
+        let send_sync = if matches!(
+            self.0.def.full_name(),
+            ("Windows.Win32.WinRT", "IRestrictedErrorInfo")
+        ) {
+            quote! {
+                unsafe impl ::std::marker::Send for #name {}
+                unsafe impl ::std::marker::Sync for #name {}
+            }
+        } else {
+            quote! {}
+        };
+
         quote! {
             #[repr(transparent)]
             #[allow(non_camel_case_types)]
@@ -205,6 +217,7 @@ impl ComInterface {
                 #(#methods)*
             }
             #conversions
+            #send_sync
             #[repr(C)]
             #[doc(hidden)]
             pub struct #abi_name(

--- a/tests/winrt/tests/send_sync.rs
+++ b/tests/winrt/tests/send_sync.rs
@@ -1,7 +1,7 @@
 use std::thread;
 use test_winrt::windows::foundation::*;
 use test_winrt::windows::storage::streams::*;
-use windows::Interface;
+use windows::{ErrorCode, Interface};
 
 // Simple test to validate that types with MarshalingType.Agile are marked Send and Sync
 // (if this compiles it worked)
@@ -79,6 +79,19 @@ fn send_async_no_class() {
         });
 
         wait.join().unwrap();
+    });
+
+    wait.join().unwrap();
+}
+
+#[test]
+fn send_sync_err() {
+    let err = Uri::create_uri("BADURI").unwrap_err();
+    let code = err.code();
+
+    let wait = thread::spawn(move || {
+        assert_eq!(err.message(), "BADURI is not a valid absolute URI.");
+        assert_eq!(code, ErrorCode(0x8007_0057));
     });
 
     wait.join().unwrap();


### PR DESCRIPTION
The implementation is thread-safe. Making it `Send` and `Sync` means that any type that contains it can also be `Send` and `Sync`.

Fixes #600 
