### PR TITLE
Metadata tweaks

### DIFF
--- a/crates/gen/src/parser/type_reader.rs
+++ b/crates/gen/src/parser/type_reader.rs
@@ -17,7 +17,7 @@ pub struct TypeReader {
     nested: BTreeMap<Row, BTreeMap<String, Row>>,
 }
 
-#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Copy, Clone, Eq, PartialEq, Ord, PartialOrd, Debug)]
 enum TypeRow {
     TypeDef(Row),
     Function(Row),
@@ -114,6 +114,11 @@ impl TypeReader {
 
                 for field in reader.list(def, TableIndex::Field, 4) {
                     let name = reader.str(field, 1);
+
+                    // TODO: https://github.com/microsoft/win32metadata/issues/361
+                    if name == "PEERDIST_RETRIEVAL_OPTIONS_CONTENTINFO_VERSION" {
+                        continue;
+                    }
 
                     types
                         .entry(namespace.to_string())

--- a/crates/gen/src/types/enum.rs
+++ b/crates/gen/src/types/enum.rs
@@ -74,13 +74,7 @@ impl Enum {
             quote! {}
         };
 
-        let underlying_type = match underlying_type {
-            ElementType::I32 => format_ident!("i32"),
-            ElementType::U32 => format_ident!("u32"),
-            ElementType::U16 => format_ident!("u16"),
-            _ => unexpected!(),
-        };
-
+        let underlying_type = underlying_type.gen_name(gen);
         let mut last: Option<ConstantValue> = None;
 
         let fields = self.0.fields().filter_map(|field| {


### PR DESCRIPTION
The latest metadata drop included a bug (for which there is now a workaround) and enums with more underlying types. 