### PR TITLE
Workaround for broken docs.rs build

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,4 +31,4 @@ members = [
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"
-targets = ["x86_64-pc-windows-msvc", "i686-pc-windows-msvc"]
+targets = ["x86_64-pc-windows-msvc"]


### PR DESCRIPTION
This will hopefully fix [this issue](https://docs.rs/crate/windows/0.4.0/builds/360477) mentioned [here](https://github.com/microsoft/windows-rs/issues/614).

