### PR TITLE
Version 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -11,12 +11,12 @@ readme = "README.md"
 exclude = [".github", ".windows", "docs", "examples"]
 
 [dependencies]
-windows_macros = { path = "crates/macros",  version = "0.5.0" }
-gen = { package = "windows_gen", path = "crates/gen",  version = "0.5.0" }
+windows_macros = { path = "crates/macros",  version = "0.6.0" }
+gen = { package = "windows_gen", path = "crates/gen",  version = "0.6.0" }
 const-sha1 = "0.2"
 
 [build-dependencies]
-windows_macros = { path = "crates/macros",  version = "0.5.0" }
+windows_macros = { path = "crates/macros",  version = "0.6.0" }
 
 [dev-dependencies]
 doc-comment = "0.3"

--- a/crates/gen/Cargo.toml
+++ b/crates/gen/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "windows_gen"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Code generation for the windows crate"
 
 [dependencies]
-windows_gen_macros = { path = "macros",  version = "0.5.0" }
+windows_gen_macros = { path = "macros",  version = "0.6.0" }
 quote = "1.0"
 syn = "1.0"
 proc-macro2 = "1.0"

--- a/crates/gen/macros/Cargo.toml
+++ b/crates/gen/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_gen_macros"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/macros/Cargo.toml
+++ b/crates/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_macros"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -10,7 +10,7 @@ description = "Macros for the windows crate"
 proc-macro = true
 
 [dependencies]
-gen = { package = "windows_gen", path = "../gen", version = "0.5.0" }
+gen = { package = "windows_gen", path = "../gen", version = "0.6.0" }
 syn = "1.0"
 quote = "1.0"
 squote = "0.1.2"

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,3 +1,10 @@
+# 0.6.0
+
+- Add Linux build support (compile only).
+- Add full x64 and x86 build support.
+- Workarounds for Rust documentation issues.
+- Updated metadata providing many fixes and improvements to Win32 APIs.
+
 # 0.5.0
 
 - Support for Win32 arrays. ([#608](https://github.com/microsoft/windows-rs/pull/608))

--- a/examples/clock/Cargo.toml
+++ b/examples/clock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clock"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Kenny Kerr <kenny.kerr@microsoft.com>"]
 edition = "2018"
 

--- a/examples/clock/bindings/Cargo.toml
+++ b/examples/clock/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clock_bindings"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Kenny Kerr <kenny.kerr@microsoft.com>"]
 edition = "2018"
 

--- a/examples/com_uri/Cargo.toml
+++ b/examples/com_uri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "com_uri"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Kenny Kerr <kenny.kerr@microsoft.com>"]
 edition = "2018"
 

--- a/examples/com_uri/bindings/Cargo.toml
+++ b/examples/com_uri/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "com_uri_bindings"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Kenny Kerr <kenny.kerr@microsoft.com>"]
 edition = "2018"
 

--- a/examples/enum_windows/Cargo.toml
+++ b/examples/enum_windows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enum_windows"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Kenny Kerr <kenny.kerr@microsoft.com>"]
 edition = "2018"
 

--- a/examples/enum_windows/bindings/Cargo.toml
+++ b/examples/enum_windows/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enum_windows_bindings"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Kenny Kerr <kenny.kerr@microsoft.com>"]
 edition = "2018"
 

--- a/examples/event/Cargo.toml
+++ b/examples/event/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "event"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Kenny Kerr <kenny.kerr@microsoft.com>"]
 edition = "2018"
 

--- a/examples/event/bindings/Cargo.toml
+++ b/examples/event/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "event_bindings"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Kenny Kerr <kenny.kerr@microsoft.com>"]
 edition = "2018"
 

--- a/examples/message_box/Cargo.toml
+++ b/examples/message_box/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "message_box"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Kenny Kerr <kenny.kerr@microsoft.com>"]
 edition = "2018"
 

--- a/examples/message_box/bindings/Cargo.toml
+++ b/examples/message_box/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "message_box_bindings"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Kenny Kerr <kenny.kerr@microsoft.com>"]
 edition = "2018"
 

--- a/examples/ocr/Cargo.toml
+++ b/examples/ocr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocr"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Kenny Kerr <kenny.kerr@microsoft.com>"]
 edition = "2018"
 

--- a/examples/ocr/bindings/Cargo.toml
+++ b/examples/ocr/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocr_bindings"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Kenny Kerr <kenny.kerr@microsoft.com>"]
 edition = "2018"
 

--- a/examples/overlapped/Cargo.toml
+++ b/examples/overlapped/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "overlapped"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Kenny Kerr <kenny.kerr@microsoft.com>"]
 edition = "2018"
 

--- a/examples/overlapped/bindings/Cargo.toml
+++ b/examples/overlapped/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "overlapped_bindings"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Kenny Kerr <kenny.kerr@microsoft.com>"]
 edition = "2018"
 

--- a/examples/rss/Cargo.toml
+++ b/examples/rss/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rss"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Kenny Kerr <kenny.kerr@microsoft.com>"]
 edition = "2018"
 

--- a/examples/rss/bindings/Cargo.toml
+++ b/examples/rss/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rss_bindings"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Kenny Kerr <kenny.kerr@microsoft.com>"]
 edition = "2018"
 

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/examples/win2d/Cargo.toml
+++ b/examples/win2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "win2d"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Kenny Kerr <kenny.kerr@microsoft.com>"]
 edition = "2018"
 

--- a/examples/win2d/bindings/Cargo.toml
+++ b/examples/win2d/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "win2d_bindings"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Kenny Kerr <kenny.kerr@microsoft.com>"]
 edition = "2018"
 

--- a/examples/xml/Cargo.toml
+++ b/examples/xml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xml"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Kenny Kerr <kenny.kerr@microsoft.com>"]
 edition = "2018"
 

--- a/examples/xml/bindings/Cargo.toml
+++ b/examples/xml/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xml_bindings"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Kenny Kerr <kenny.kerr@microsoft.com>"]
 edition = "2018"
 

--- a/readme.md
+++ b/readme.md
@@ -16,10 +16,10 @@ Start by adding the following to your Cargo.toml file:
 
 ```toml
 [dependencies]
-windows = "0.5.0"
+windows = "0.6.0"
 
 [build-dependencies]
-windows = "0.5.0"
+windows = "0.6.0"
 ```
 
 This will allow Cargo to download, build, and cache Windows support as a package. Next, specify which types you need inside of a `build.rs` build script and the `windows` crate will generate the necessary bindings:

--- a/tests/unions/Cargo.toml
+++ b/tests/unions/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "test_unions"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Microsoft"]
 edition = "2018"
 
 [dependencies]
 windows = { path = "../.." }
-gen = { package = "windows_gen", path = "../../crates/gen",  version = "0.5.0" }
+gen = { package = "windows_gen", path = "../../crates/gen",  version = "0.6.0" }
 
 [build-dependencies]
 windows = { path = "../.." }

--- a/tests/wildcard/Cargo.toml
+++ b/tests/wildcard/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "test_wildcard"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Microsoft"]
 edition = "2018"
 
 [dependencies]
 windows = { path = "../.." }
-gen = { package = "windows_gen", path = "../../crates/gen",  version = "0.5.0" }
+gen = { package = "windows_gen", path = "../../crates/gen",  version = "0.6.0" }
 
 [build-dependencies]
 windows = { path = "../.." }

--- a/tests/win32/Cargo.toml
+++ b/tests/win32/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "test_win32"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Microsoft"]
 edition = "2018"
 
 [dependencies]
 windows = { path = "../.." }
-gen = { package = "windows_gen", path = "../../crates/gen",  version = "0.5.0" }
+gen = { package = "windows_gen", path = "../../crates/gen",  version = "0.6.0" }
 
 [build-dependencies]
 windows = { path = "../.." }

--- a/tests/win32_arrays/Cargo.toml
+++ b/tests/win32_arrays/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "test_win32_arrays"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Microsoft"]
 edition = "2018"
 
 [dependencies]
 windows = { path = "../.." }
-gen = { package = "windows_gen", path = "../../crates/gen",  version = "0.5.0" }
+gen = { package = "windows_gen", path = "../../crates/gen",  version = "0.6.0" }
 
 [build-dependencies]
 windows = { path = "../.." }

--- a/tests/winrt/Cargo.toml
+++ b/tests/winrt/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "test_winrt"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["Microsoft"]
 edition = "2018"
 
 [dependencies]
 windows = { path = "../.." }
-gen = { package = "windows_gen", path = "../../crates/gen",  version = "0.5.0" }
+gen = { package = "windows_gen", path = "../../crates/gen",  version = "0.6.0" }
 
 [dev-dependencies]
 futures = "0.3"


### PR DESCRIPTION
Updated win32 metadata requires a version bump due to breaking changes. From the changelog:

- Add Linux build support (compile only).
- Add full x64 and x86 build support.
- Workarounds for Rust documentation issues.
- Updated metadata providing many fixes and improvements to Win32 APIs.