### PR TITLE
Remove workarounds

### DIFF
--- a/crates/gen/src/parser/generic_type.rs
+++ b/crates/gen/src/parser/generic_type.rs
@@ -86,7 +86,6 @@ impl GenericType {
 
     pub fn gen_guid(&self, gen: &Gen) -> TokenStream {
         if self.generics.is_empty() {
-            // TODO: workaround for https://github.com/microsoft/win32metadata/issues/312
             match Guid::from_type_def(&self.def) {
                 Some(guid) => {
                     let guid = guid.gen();

--- a/crates/gen/src/parser/type_reader.rs
+++ b/crates/gen/src/parser/type_reader.rs
@@ -82,11 +82,6 @@ impl TypeReader {
                 for field in def.fields() {
                     let name = field.name();
 
-                    // TODO: https://github.com/microsoft/win32metadata/issues/361
-                    if name == "PEERDIST_RETRIEVAL_OPTIONS_CONTENTINFO_VERSION" {
-                        continue;
-                    }
-
                     types
                         .entry(namespace)
                         .or_default()

--- a/crates/gen/src/types/enum.rs
+++ b/crates/gen/src/types/enum.rs
@@ -96,7 +96,6 @@ impl Enum {
                         pub const #name: Self = Self(#value);
                     })
                 } else {
-                    // TODO: need test for implicit value enums (and create win32metadata bug)
                     last = Some(ConstantValue::I32(0));
 
                     Some(quote! {

--- a/examples/clock/bindings/build.rs
+++ b/examples/clock/bindings/build.rs
@@ -35,6 +35,7 @@ fn main() {
             PostQuitMessage, RegisterClassA, CREATESTRUCTA, HWND, LPARAM, MINMAXINFO, MSG, WNDCLASSA,
             WPARAM, LoadCursorA, IDC_ARROW, SIZE_MINIMIZED, WM_DESTROY, WM_ACTIVATE, WM_DISPLAYCHANGE,
             WM_NCCREATE, WM_PAINT, WM_QUIT, WM_SIZE, WM_USER, GWLP_USERDATA, WNDCLASS_STYLES,
+            CW_USEDEFAULT,
         },
         windows::win32::windows_programming::{
             GetLocalTime, QueryPerformanceCounter, QueryPerformanceFrequency,

--- a/examples/clock/src/main.rs
+++ b/examples/clock/src/main.rs
@@ -413,9 +413,6 @@ impl Window {
             let atom = RegisterClassA(&wc);
             debug_assert!(atom != 0);
 
-            // TODO: https://github.com/microsoft/win32metadata/issues/353
-            const CW_USEDEFAULT: i32 = -2147483648;
-
             let handle = CreateWindowExA(
                 Default::default(),
                 "window",

--- a/examples/overlapped/src/main.rs
+++ b/examples/overlapped/src/main.rs
@@ -14,13 +14,12 @@ fn main() -> windows::Result<()> {
             FILE_SHARE_MODE::FILE_SHARE_READ,
             std::ptr::null_mut(),
             FILE_CREATION_DISPOSITION::OPEN_EXISTING,
-            // TODO: https://github.com/microsoft/win32metadata/issues/317
-            FILE_FLAGS_AND_ATTRIBUTES(0x40000000),
+            FILE_FLAGS_AND_ATTRIBUTES::FILE_FLAG_OVERLAPPED,
             HANDLE(0),
         );
 
+        // TODO: https://github.com/microsoft/win32metadata/issues/316
         if file.0 == -1 {
-            // TODO: https://github.com/microsoft/win32metadata/issues/316
             windows::ErrorCode::from_thread().ok()?;
         }
 

--- a/src/runtime/com.rs
+++ b/src/runtime/com.rs
@@ -4,7 +4,6 @@ use bindings::windows::win32::com::{CoCreateInstance, CoInitializeEx, COINIT};
 
 /// Initializes COM for use by the calling thread for the multi-threaded apartment (MTA).
 pub fn initialize_mta() -> Result<()> {
-    // https://github.com/microsoft/win32metadata/issues/323
     // https://github.com/microsoft/win32metadata/issues/95
     unsafe { CoInitializeEx(std::ptr::null_mut(), COINIT::COINIT_MULTITHREADED.0 as u32).ok() }
 }

--- a/tests/win32/build.rs
+++ b/tests/win32/build.rs
@@ -1,5 +1,6 @@
 fn main() {
     windows::build!(
+        windows::win32::automation::BSTR,
         windows::win32::security::{
             ACCESS_MODE,
         },

--- a/tests/win32/tests/win32.rs
+++ b/tests/win32/tests/win32.rs
@@ -1,4 +1,5 @@
 use test_win32::{
+    windows::win32::automation::BSTR,
     windows::win32::com::CreateUri,
     windows::win32::debug::{MiniDumpWriteDump, MINIDUMP_TYPE},
     windows::win32::direct3d11::D3DDisassemble11Trace,
@@ -289,30 +290,19 @@ fn onecore_imports() -> windows::Result<()> {
     }
 }
 
-// TODO: light up BSTR as windows::BString
+#[test]
+fn interface() -> windows::Result<()> {
+    unsafe {
+        let mut uri = None;
+        let uri =
+            CreateUri("http://kennykerr.ca", Default::default(), 0, &mut uri).and_some(uri)?;
 
-// #[test]
-// fn interface() -> windows::Result<()> {
-//     unsafe {
-//         let s = windows::HString::from("https://kennykerr.ca");
-//         let mut uri = None;
-
-//         // TODO: should unwrap with Result<Uri> like WinRT but need https://github.com/microsoft/win32metadata/issues/24
-//         let hr = CreateUri(s.as_wide().as_ptr() as *mut u16, 1, 0, &mut uri);
-//         windows::ErrorCode(hr as u32).ok()?;
-
-//         assert!(uri.is_some());
-
-//         if let Some(uri) = uri {
-//             let mut domain = windows::BString::new();
-//             let hr = uri.GetDomain(domain.set_abi() as *mut *mut u16);
-//             windows::ErrorCode(hr as u32).ok()?;
-
-//             assert!(domain == "kennykerr.ca");
-//         }
-//     }
-//     Ok(())
-// }
+        let mut domain = BSTR::default();
+        uri.GetDomain(&mut domain).ok()?;
+        assert!(domain == "kennykerr.ca");
+    }
+    Ok(())
+}
 
 #[test]
 fn callback() {


### PR DESCRIPTION
That are no longer needed thanks to [metadata](https://github.com/microsoft/win32metadata) fixes.