### PR TITLE
Update win32 metadata

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -5,7 +5,7 @@ fn main() {
         Windows::Win32::WinRT::{IRestrictedErrorInfo, ILanguageExceptionErrorInfo2},
         Windows::Win32::Debug::{GetLastError, FormatMessageW},
         Windows::Win32::WindowsProgramming::{CloseHandle},
-        Windows::Win32::Com::{CoTaskMemAlloc, CoTaskMemFree, CLSIDFromProgID, CoInitializeEx, CoCreateInstance, COINIT},
+        Windows::Win32::Com::{CoTaskMemAlloc, CoTaskMemFree, CLSIDFromProgID, CoInitializeEx, CoCreateInstance},
         Windows::Win32::SystemServices::{
             CreateEventW, SetEvent, WaitForSingleObject, GetProcessHeap, HeapAlloc, HeapFree, GetProcAddress,
             LoadLibraryA, FreeLibrary,

--- a/crates/gen/default/readme.md
+++ b/crates/gen/default/readme.md
@@ -3,7 +3,7 @@ dependent crate or workspace has an empty or non-existent `.windows/winmd` direc
 
 ## Windows.Win32.winmd
 - Source: https://www.nuget.org/packages/Microsoft.Windows.SDK.Win32Metadata/
-- Version: 10.0.19041.5-preview.101
+- Version: 10.0.19041.5-preview.122
 
 ## Windows.WinRT.winmd
 - Source: https://www.nuget.org/packages/Microsoft.Windows.SDK.Contracts

--- a/crates/gen/src/parser/signature.rs
+++ b/crates/gen/src/parser/signature.rs
@@ -61,6 +61,18 @@ impl Signature {
         self.pointers == 0 && self.kind.is_explicit()
     }
 
+    pub fn is_packed(&self) -> bool {
+        if self.pointers > 0 {
+            return false;
+        }
+
+        match &self.kind {
+            ElementType::Struct(def) => def.is_packed(),
+            ElementType::Array((signature, _)) => signature.is_packed(),
+            _ => false,
+        }
+    }
+
     pub fn gen_win32(&self, gen: &Gen) -> TokenStream {
         let mut tokens = TokenStream::new();
 

--- a/crates/gen/src/parser/type_reader.rs
+++ b/crates/gen/src/parser/type_reader.rs
@@ -118,8 +118,6 @@ impl TypeReader {
             ("Windows.Win32.Direct2D", "D2D_MATRIX_3X2_F"),
             ("Windows.Win32.SystemServices", "LARGE_INTEGER"),
             ("Windows.Win32.SystemServices", "ULARGE_INTEGER"),
-            // TODO: remove once this is fixed: https://github.com/microsoft/win32metadata/issues/30
-            ("Windows.Win32", "CFunctionDiscoveryNotificationWrapper"),
         ];
 
         for (namespace, name) in exclude {
@@ -197,12 +195,7 @@ impl TypeReader {
 
     pub fn resolve_type_ref(&'static self, type_ref: &tables::TypeRef) -> tables::TypeDef {
         if let ResolutionScope::TypeRef(scope) = type_ref.scope() {
-            if let Some(scope) = self.nested.get(&scope.resolve()) {
-                scope[type_ref.name()]
-            } else {
-                // TODO: workaround for https://github.com/microsoft/win32metadata/issues/127
-                self.resolve_type_def("Windows.Win32.WindowsAccessibility", "IUIAutomation6")
-            }
+            self.nested[&scope.resolve()][type_ref.name()]
         } else {
             self.resolve_type_def(type_ref.namespace(), type_ref.name())
         }

--- a/crates/gen/src/types/struct.rs
+++ b/crates/gen/src/types/struct.rs
@@ -63,17 +63,7 @@ impl Struct {
             return true;
         }
 
-        self.0.fields().any(|field| {
-            let signature = field.signature();
-
-            if signature.pointers == 0 {
-                if let ElementType::Struct(def) = signature.kind {
-                    return def.is_packed();
-                }
-            }
-
-            false
-        })
+        self.0.fields().any(|field| field.signature().is_packed())
     }
 
     pub fn is_handle(&self) -> bool {

--- a/src/runtime/com.rs
+++ b/src/runtime/com.rs
@@ -1,30 +1,23 @@
 use crate::*;
 
-use bindings::Windows::Win32::Com::{CoCreateInstance, CoInitializeEx, COINIT};
+use bindings::Windows::Win32::Com::{CoCreateInstance, CoInitializeEx, CLSCTX, COINIT};
 
 /// Initializes COM for use by the calling thread for the multi-threaded apartment (MTA).
 pub fn initialize_mta() -> Result<()> {
-    // https://github.com/microsoft/win32metadata/issues/95
-    unsafe { CoInitializeEx(std::ptr::null_mut(), COINIT::COINIT_MULTITHREADED.0 as u32).ok() }
+    unsafe { CoInitializeEx(std::ptr::null_mut(), COINIT::COINIT_MULTITHREADED).ok() }
 }
 
 /// Initializes COM for use by the calling thread for a single-threaded apartment (STA).
 pub fn initialize_sta() -> Result<()> {
-    unsafe {
-        CoInitializeEx(
-            std::ptr::null_mut(),
-            COINIT::COINIT_APARTMENTTHREADED.0 as u32,
-        )
-        .ok()
-    }
+    unsafe { CoInitializeEx(std::ptr::null_mut(), COINIT::COINIT_APARTMENTTHREADED).ok() }
 }
 
 /// Creates a COM object with the given CLSID.
 pub fn create_instance<T: Interface>(clsid: &Guid) -> Result<T> {
     let mut object = None;
 
-    unsafe { CoCreateInstance(clsid, None, CLSCTX_ALL, &T::IID, object.set_abi()).and_some(object) }
+    unsafe {
+        CoCreateInstance(clsid, None, CLSCTX::CLSCTX_ALL, &T::IID, object.set_abi())
+            .and_some(object)
+    }
 }
-
-// https://github.com/microsoft/win32metadata/issues/203
-const CLSCTX_ALL: u32 = 23;

--- a/tests/win32_arrays/build.rs
+++ b/tests/win32_arrays/build.rs
@@ -3,5 +3,6 @@ fn main() {
         Windows::Win32::Dxgi::DXGI_ADAPTER_DESC1,
         Windows::Win32::WindowsAndMessaging::NCCALCSIZE_PARAMS,
         Windows::Win32::IpHelper::IPV6_ADDRESS_EX,
+        Windows::Win32::Debug::MINIDUMP_MEMORY_LIST,
     );
 }


### PR DESCRIPTION
Removes the need for various workarounds and adds some new APIs.

https://github.com/microsoft/win32metadata/releases/tag/v10.0.19041.5-preview.122

