### PR TITLE
Adds deprecated feature to conditionally include deprecated APIs

### DIFF
--- a/crates/gen/src/parser/interface_info.rs
+++ b/crates/gen/src/parser/interface_info.rs
@@ -42,6 +42,7 @@ impl InterfaceInfo {
                     name,
                     vtable_offset: vtable_offset as u32 + 6,
                     overload: *overload,
+                    is_deprecated: method.is_deprecated(),
                 };
 
                 let signature = method.signature(&interface.def.generics);

--- a/crates/gen/src/parser/method_info.rs
+++ b/crates/gen/src/parser/method_info.rs
@@ -2,4 +2,5 @@ pub struct MethodInfo {
     pub name: String,
     pub vtable_offset: u32,
     pub overload: u32,
+    pub is_deprecated: bool,
 }

--- a/crates/gen/src/parser/method_signature.rs
+++ b/crates/gen/src/parser/method_signature.rs
@@ -166,8 +166,15 @@ impl MethodSignature {
             }
         };
 
+        let deprecated = if method.is_deprecated {
+            quote! { #[cfg(feature = "deprecated")] }
+        } else {
+            quote! {}
+        };
+
         match interface.kind {
             InterfaceKind::Default => quote! {
+                #deprecated
                 pub fn #name<#constraints>(&self, #params) -> ::windows::Result<#return_type_tokens> {
                     let this = self;
                     unsafe {
@@ -177,6 +184,7 @@ impl MethodSignature {
             },
             InterfaceKind::NonDefault | InterfaceKind::Overridable => {
                 quote! {
+                    #deprecated
                     pub fn #name<#constraints>(&self, #params) -> ::windows::Result<#return_type_tokens> {
                         let this = &::windows::Interface::cast::<#interface_name>(self).unwrap();
                         unsafe {
@@ -187,6 +195,7 @@ impl MethodSignature {
             }
             InterfaceKind::Static | InterfaceKind::Composable => {
                 quote! {
+                    #deprecated
                     pub fn #name<#constraints>(#params) -> ::windows::Result<#return_type_tokens> {
                         Self::#interface_name(|this| unsafe { #vcall })
                     }

--- a/crates/gen/src/tables/method_def.rs
+++ b/crates/gen/src/tables/method_def.rs
@@ -97,6 +97,14 @@ impl MethodDef {
             .map(Attribute)
     }
 
+    pub fn has_attribute(&self, name: &str) -> bool {
+        self.attributes().any(|attribute| attribute.name() == name)
+    }
+
+    pub fn is_deprecated(&self) -> bool {
+        self.has_attribute("DeprecatedAttribute")
+    }
+
     pub fn impl_map(&self) -> Option<ImplMap> {
         self.0
             .file

--- a/crates/gen/src/types/delegate.rs
+++ b/crates/gen/src/types/delegate.rs
@@ -45,6 +45,7 @@ impl Delegate {
             name: "Invoke".to_string(),
             vtable_offset: 3,
             overload: 0,
+            is_deprecated: false,
         };
 
         let interface = InterfaceInfo {

--- a/tests/deprecated/Cargo.toml
+++ b/tests/deprecated/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "test_deprecated"
+version = "0.7.0"
+authors = ["Microsoft"]
+edition = "2018"
+
+[dependencies]
+windows = { path = "../.." }
+
+[build-dependencies]
+windows = { path = "../.." }
+
+[features]
+default = ["deprecated"]
+deprecated = []

--- a/tests/deprecated/build.rs
+++ b/tests/deprecated/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    windows::build!(Windows::ApplicationModel::Contacts::KnownContactField);
+}

--- a/tests/deprecated/src/lib.rs
+++ b/tests/deprecated/src/lib.rs
@@ -1,0 +1,1 @@
+::windows::include_bindings!();

--- a/tests/deprecated/tests/deprecated.rs
+++ b/tests/deprecated/tests/deprecated.rs
@@ -1,0 +1,8 @@
+use test_deprecated::Windows::ApplicationModel::Contacts::KnownContactField;
+
+#[test]
+fn test() -> windows::Result<()> {
+    assert_eq!(KnownContactField::Email()?, "email");
+
+    Ok(())
+}


### PR DESCRIPTION
Fixes #676

More than just methods can be deprecated, but this is a good start to help measure how well this feature works in practice. The [Win32 metadata project](https://github.com/microsoft/win32metadata/discussions/403) is also considering attributing deprecated APIs. In combination, it should help developers avoid deprecated APIs. 