### PR TITLE
Use repr(transparent) for handles

### DIFF
--- a/crates/gen/src/types/bool32.rs
+++ b/crates/gen/src/types/bool32.rs
@@ -2,9 +2,6 @@ use super::*;
 
 pub fn gen_bool32() -> TokenStream {
     quote! {
-        #[repr(C)]
-        #[derive(::std::clone::Clone, ::std::marker::Copy, ::std::cmp::PartialEq, ::std::cmp::Eq, ::std::default::Default)]
-        pub struct BOOL(pub i32);
         impl BOOL {
             #[inline]
             pub fn as_bool(self) -> bool {
@@ -26,15 +23,6 @@ pub fn gen_bool32() -> TokenStream {
             pub fn expect(self, msg: &str) {
                 self.ok().expect(msg);
             }
-        }
-        impl ::std::fmt::Debug for BOOL {
-            fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                let msg = if self.as_bool() { "true" } else { "false" };
-                fmt.write_str(msg)
-            }
-        }
-        unsafe impl ::windows::Abi for BOOL {
-            type Abi = Self;
         }
         impl ::std::convert::From<BOOL> for bool {
             fn from(value: BOOL) -> Self {

--- a/crates/gen/src/types/bstr.rs
+++ b/crates/gen/src/types/bstr.rs
@@ -2,8 +2,8 @@ use super::*;
 
 pub fn gen_bstr() -> TokenStream {
     quote! {
-        #[repr(C)]
-        #[derive(::std::clone::Clone, ::std::cmp::Eq)]
+        #[repr(transparent)]
+        #[derive(::std::cmp::Eq)]
         pub struct BSTR(*mut u16);
         impl BSTR {
             pub fn is_empty(&self) -> bool {

--- a/crates/gen/src/types/pstr.rs
+++ b/crates/gen/src/types/pstr.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub fn gen_pstr() -> TokenStream {
     quote! {
-        #[repr(C)]
+        #[repr(transparent)]
         #[derive(::std::clone::Clone, ::std::marker::Copy, ::std::cmp::Eq, ::std::fmt::Debug)]
         pub struct PSTR(pub *mut u8);
         impl PSTR {

--- a/crates/gen/src/types/pwstr.rs
+++ b/crates/gen/src/types/pwstr.rs
@@ -2,7 +2,7 @@ use super::*;
 
 pub fn gen_pwstr() -> TokenStream {
     quote! {
-        #[repr(C)]
+        #[repr(transparent)]
         #[derive(::std::clone::Clone, ::std::marker::Copy, ::std::cmp::Eq, ::std::fmt::Debug)]
         pub struct PWSTR(pub *mut u16);
         impl PWSTR {

--- a/crates/gen/src/types/struct.rs
+++ b/crates/gen/src/types/struct.rs
@@ -126,6 +126,8 @@ impl Struct {
         let repr = if let Some(layout) = layout {
             let packing = Literal::u32_unsuffixed(layout.packing_size());
             quote! { #[repr(C, packed(#packing))] }
+        } else if is_handle {
+            quote! { #[repr(transparent)] }
         } else {
             quote! { #[repr(C)] }
         };
@@ -465,7 +467,6 @@ impl Struct {
 
     fn gen_replacement(&self) -> Option<TokenStream> {
         match self.0.full_name() {
-            ("Windows.Win32.SystemServices", "BOOL") => Some(gen_bool32()),
             ("Windows.Win32.SystemServices", "PWSTR") => Some(gen_pwstr()),
             ("Windows.Win32.SystemServices", "PSTR") => Some(gen_pstr()),
             ("Windows.Win32.Automation", "BSTR") => Some(gen_bstr()),
@@ -481,6 +482,7 @@ impl Struct {
             ("Windows.Foundation.Numerics", "Vector4") => gen_vector4(),
             ("Windows.Foundation.Numerics", "Matrix3x2") => gen_matrix3x2(),
             ("Windows.Foundation.Numerics", "Matrix4x4") => gen_matrix4x4(),
+            ("Windows.Win32.SystemServices", "BOOL") => gen_bool32(),
             ("Windows.Win32.SystemServices", "HANDLE") => gen_handle(),
             _ => TokenStream::new(),
         }

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1771,8 +1771,8 @@ pub mod Windows {
                 }
                 SysFreeString(bstrstring.into_param().abi())
             }
-            #[repr(C)]
-            #[derive(:: std :: clone :: Clone, :: std :: cmp :: Eq)]
+            #[repr(transparent)]
+            #[derive(:: std :: cmp :: Eq)]
             pub struct BSTR(*mut u16);
             impl BSTR {
                 pub fn is_empty(&self) -> bool {
@@ -5600,7 +5600,7 @@ pub mod Windows {
             clippy::all
         )]
         pub mod SystemServices {
-            #[repr(C)]
+            #[repr(transparent)]
             #[derive(
                 :: std :: clone :: Clone,
                 :: std :: marker :: Copy,
@@ -5656,7 +5656,7 @@ pub mod Windows {
                     ) as _))
                 }
             }
-            #[repr(C)]
+            #[repr(transparent)]
             #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
             pub struct HANDLE(pub isize);
             impl HANDLE {}
@@ -5693,15 +5693,37 @@ pub mod Windows {
                     self.0 == -1
                 }
             }
-            #[repr(C)]
-            #[derive(
-                :: std :: clone :: Clone,
-                :: std :: marker :: Copy,
-                :: std :: cmp :: PartialEq,
-                :: std :: cmp :: Eq,
-                :: std :: default :: Default,
-            )]
+            #[repr(transparent)]
+            #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
             pub struct BOOL(pub i32);
+            impl BOOL {}
+            impl BOOL {
+                pub const NULL: Self = Self(0);
+                pub fn is_null(&self) -> bool {
+                    self == &Self::NULL
+                }
+            }
+            impl ::std::default::Default for BOOL {
+                fn default() -> Self {
+                    Self(0)
+                }
+            }
+            impl ::std::fmt::Debug for BOOL {
+                fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                    fmt.debug_struct("BOOL")
+                        .field("Value", &format_args!("{:?}", self.0))
+                        .finish()
+                }
+            }
+            impl ::std::cmp::PartialEq for BOOL {
+                fn eq(&self, other: &Self) -> bool {
+                    self.0 == other.0
+                }
+            }
+            impl ::std::cmp::Eq for BOOL {}
+            unsafe impl ::windows::Abi for BOOL {
+                type Abi = Self;
+            }
             impl BOOL {
                 #[inline]
                 pub fn as_bool(self) -> bool {
@@ -5723,15 +5745,6 @@ pub mod Windows {
                 pub fn expect(self, msg: &str) {
                     self.ok().expect(msg);
                 }
-            }
-            impl ::std::fmt::Debug for BOOL {
-                fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                    let msg = if self.as_bool() { "true" } else { "false" };
-                    fmt.write_str(msg)
-                }
-            }
-            unsafe impl ::windows::Abi for BOOL {
-                type Abi = Self;
             }
             impl ::std::convert::From<BOOL> for bool {
                 fn from(value: BOOL) -> Self {
@@ -5822,7 +5835,7 @@ pub mod Windows {
             unsafe impl ::windows::Abi for SECURITY_ATTRIBUTES {
                 type Abi = Self;
             }
-            #[repr(C)]
+            #[repr(transparent)]
             #[derive(
                 :: std :: clone :: Clone,
                 :: std :: marker :: Copy,
@@ -5971,7 +5984,7 @@ pub mod Windows {
                     ::std::mem::transmute(dwmilliseconds),
                 )
             }
-            #[repr(C)]
+            #[repr(transparent)]
             #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
             pub struct HeapHandle(pub isize);
             impl HeapHandle {}
@@ -6002,7 +6015,7 @@ pub mod Windows {
             unsafe impl ::windows::Abi for HeapHandle {
                 type Abi = Self;
             }
-            #[repr(C)]
+            #[repr(transparent)]
             #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
             pub struct ProcessHeapHandle(pub isize);
             impl ProcessHeapHandle {}


### PR DESCRIPTION
The win32 metadata defines certain handle types as structs with a special attribute indicating these are really just C-style typedefs for improved type safety. These are now marked `repr(transparent)` while regular structs continue to be marked `repr(C)`. I tested both x86 and x64 and it doesn't appear to make a difference but perhaps it will in future. 

Fixes #703