### PR TITLE
Add weak reference (consumer) support

### DIFF
--- a/src/interfaces/mod.rs
+++ b/src/interfaces/mod.rs
@@ -3,7 +3,11 @@ use super::*;
 mod activation_factory;
 mod object;
 mod unknown;
+mod weak_reference;
+mod weak_reference_source;
 
 pub use activation_factory::*;
 pub use object::*;
 pub use unknown::*;
+pub use weak_reference::*;
+pub use weak_reference_source::*;

--- a/src/interfaces/weak_reference.rs
+++ b/src/interfaces/weak_reference.rs
@@ -1,0 +1,34 @@
+use crate::*;
+
+#[repr(transparent)]
+#[derive(Clone, PartialEq, Eq)]
+pub struct IWeakReference(IUnknown);
+
+impl IWeakReference {
+    pub fn upgrade<I: Interface>(&self) -> Option<I> {
+        unsafe {
+            let mut result = None;
+            let _ = (self.vtable().3)(self.abi(), &I::IID, &mut result as *mut _ as _);
+            result
+        }
+    }
+}
+
+#[repr(C)]
+pub struct IWeakReference_vtable(
+    pub unsafe extern "system" fn(this: RawPtr, iid: &Guid, interface: *mut RawPtr) -> HRESULT,
+    pub unsafe extern "system" fn(this: RawPtr) -> u32,
+    pub unsafe extern "system" fn(this: RawPtr) -> u32,
+    pub unsafe extern "system" fn(this: RawPtr, iid: &Guid, interface: *mut RawPtr) -> HRESULT,
+);
+
+unsafe impl Interface for IWeakReference {
+    type Vtable = IWeakReference_vtable;
+
+    const IID: Guid = Guid::from_values(
+        0x0000_0037,
+        0x0000,
+        0x0000,
+        [0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46],
+    );
+}

--- a/src/interfaces/weak_reference.rs
+++ b/src/interfaces/weak_reference.rs
@@ -1,7 +1,7 @@
 use crate::*;
 
 #[repr(transparent)]
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct IWeakReference(IUnknown);
 
 impl IWeakReference {

--- a/src/interfaces/weak_reference_source.rs
+++ b/src/interfaces/weak_reference_source.rs
@@ -1,0 +1,33 @@
+use super::*;
+
+#[repr(transparent)]
+#[derive(Clone, PartialEq, Eq)]
+pub struct IWeakReferenceSource(IUnknown);
+
+impl IWeakReferenceSource {
+    pub fn downgrade(&self) -> Result<IWeakReference> {
+        unsafe {
+            let mut result = None;
+            (self.vtable().3)(self.abi(), &mut result as *mut _ as _).and_some(result)
+        }
+    }
+}
+
+#[repr(C)]
+pub struct IWeakReferenceSource_vtable(
+    pub unsafe extern "system" fn(this: RawPtr, iid: &Guid, interface: *mut RawPtr) -> HRESULT,
+    pub unsafe extern "system" fn(this: RawPtr) -> u32,
+    pub unsafe extern "system" fn(this: RawPtr) -> u32,
+    pub unsafe extern "system" fn(this: RawPtr, interface: *mut RawPtr) -> HRESULT,
+);
+
+unsafe impl Interface for IWeakReferenceSource {
+    type Vtable = IWeakReferenceSource_vtable;
+
+    const IID: Guid = Guid::from_values(
+        0x0000_0038,
+        0x0000,
+        0x0000,
+        [0xC0, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x46],
+    );
+}

--- a/src/interfaces/weak_reference_source.rs
+++ b/src/interfaces/weak_reference_source.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 #[repr(transparent)]
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone, PartialEq, Eq, Debug)]
 pub struct IWeakReferenceSource(IUnknown);
 
 impl IWeakReferenceSource {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,6 +17,7 @@ mod result;
 mod runtime;
 mod traits;
 
+use interfaces::*;
 use runtime::*;
 
 pub use bindings::Windows::Win32::Com::IAgileObject;
@@ -24,7 +25,7 @@ pub use interfaces::{IActivationFactory, IUnknown, Object};
 pub use result::{Error, Result, HRESULT};
 pub use runtime::{
     create_instance, factory, initialize_mta, initialize_sta, Array, FactoryCache, Guid, HString,
-    Param, RefCount, Waiter,
+    Param, RefCount, Waiter, Weak,
 };
 pub use traits::{Abi, Interface, IntoParam, RuntimeName, RuntimeType};
 

--- a/src/runtime/mod.rs
+++ b/src/runtime/mod.rs
@@ -8,6 +8,7 @@ mod hstring;
 mod param;
 mod ref_count;
 mod waiter;
+mod weak;
 
 pub use array::*;
 pub use com::*;
@@ -19,3 +20,4 @@ pub use hstring::*;
 pub use param::*;
 pub use ref_count::*;
 pub use waiter::*;
+pub use weak::*;

--- a/src/runtime/weak.rs
+++ b/src/runtime/weak.rs
@@ -1,0 +1,22 @@
+use crate::*;
+use std::marker::PhantomData;
+
+/// `Weak` holds a non-owning reference to an object.
+#[derive(Clone, PartialEq, Eq, Default)]
+pub struct Weak<I: Interface>(Option<IWeakReference>, PhantomData<I>);
+
+impl<I: Interface> Weak<I> {
+    /// Creates a new `Weak` object without any backing object.
+    pub fn new() -> Self {
+        Self(None, PhantomData)
+    }
+
+    pub(crate) fn downgrade(source: &IWeakReferenceSource) -> Result<Self> {
+        Ok(Self(Some(source.downgrade()?), PhantomData))
+    }
+
+    /// Attempts to upgradew the weak reference to a strong reference.
+    pub fn upgrade(&self) -> Option<I> {
+        self.0.as_ref().and_then(|inner| inner.upgrade::<I>())
+    }
+}

--- a/src/runtime/weak.rs
+++ b/src/runtime/weak.rs
@@ -2,7 +2,7 @@ use crate::*;
 use std::marker::PhantomData;
 
 /// `Weak` holds a non-owning reference to an object.
-#[derive(Clone, PartialEq, Eq, Default)]
+#[derive(Clone, PartialEq, Eq, Default, Debug)]
 pub struct Weak<I: Interface>(Option<IWeakReference>, PhantomData<I>);
 
 impl<I: Interface> Weak<I> {

--- a/src/runtime/weak.rs
+++ b/src/runtime/weak.rs
@@ -11,12 +11,12 @@ impl<I: Interface> Weak<I> {
         Self(None, PhantomData)
     }
 
-    pub(crate) fn downgrade(source: &IWeakReferenceSource) -> Result<Self> {
-        Ok(Self(Some(source.downgrade()?), PhantomData))
-    }
-
-    /// Attempts to upgradew the weak reference to a strong reference.
+    /// Attempts to upgrade the weak reference to a strong reference.
     pub fn upgrade(&self) -> Option<I> {
         self.0.as_ref().and_then(|inner| inner.upgrade::<I>())
+    }
+
+    pub(crate) fn downgrade(source: &IWeakReferenceSource) -> Result<Self> {
+        Ok(Self(Some(source.downgrade()?), PhantomData))
     }
 }

--- a/src/traits/interface.rs
+++ b/src/traits/interface.rs
@@ -35,4 +35,10 @@ pub unsafe trait Interface: Sized + Abi {
             .and_some(result)
         }
     }
+
+    /// Attempts to create a `Weak` reference to this object.
+    fn downgrade(&self) -> Result<Weak<Self>> {
+        self.cast::<IWeakReferenceSource>()
+            .and_then(|source| Weak::downgrade(&source))
+    }
 }

--- a/tests/weak/Cargo.toml
+++ b/tests/weak/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "test_weak"
+version = "0.8.0"
+authors = ["Microsoft"]
+edition = "2018"
+
+[dependencies]
+windows = { path = "../.." }
+
+[build-dependencies]
+windows = { path = "../.." }

--- a/tests/weak/build.rs
+++ b/tests/weak/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    windows::build!(Windows::Foundation::Uri);
+}

--- a/tests/weak/src/lib.rs
+++ b/tests/weak/src/lib.rs
@@ -1,0 +1,1 @@
+windows::include_bindings!();

--- a/tests/weak/tests/uri.rs
+++ b/tests/weak/tests/uri.rs
@@ -1,0 +1,24 @@
+use test_weak::Windows::Foundation::Uri;
+use windows::{factory, IActivationFactory, Interface, Result};
+
+// The Uri class supports weak references, so it is used to test a successful downgrade and upgrade.
+#[test]
+fn test_success() -> Result<()> {
+    let strong = Uri::CreateUri("http://kennykerr.ca")?;
+    let weak = strong.downgrade()?;
+
+    assert_eq!(weak.upgrade().unwrap(), strong);
+    drop(strong);
+    assert_eq!(weak.upgrade(), None);
+
+    Ok(())
+}
+
+// The Uri class factory does not support weak references, so it is used to test an unsuccessful downgrade.
+#[test]
+fn test_failure() -> Result<()> {
+    let strong = factory::<Uri, IActivationFactory>()?;
+    assert!(strong.downgrade().is_err(), true);
+
+    Ok(())
+}

--- a/tests/weak/tests/uri.rs
+++ b/tests/weak/tests/uri.rs
@@ -1,5 +1,5 @@
 use test_weak::Windows::Foundation::Uri;
-use windows::{factory, IActivationFactory, Interface, Result};
+use windows::{factory, IActivationFactory, Interface, Result, HRESULT};
 
 // The Uri class supports weak references, so it is used to test a successful downgrade and upgrade.
 #[test]
@@ -18,7 +18,12 @@ fn test_success() -> Result<()> {
 #[test]
 fn test_failure() -> Result<()> {
     let strong = factory::<Uri, IActivationFactory>()?;
-    assert!(strong.downgrade().is_err(), true);
+    let result = strong.downgrade();
+
+    assert_eq!(result.is_err(), true);
+
+    // E_NOINTERFACE is returned because IWeakReferenceSource is not implemented.
+    assert_eq!(result.unwrap_err().code(), HRESULT(0x8000_4002));
 
     Ok(())
 }


### PR DESCRIPTION
On the way to #81, first up is support for weak references as this is required for Xaml/WinUI and is just generally what COM and WinRT objects should provide by default. This update adds support for creating a weak reference to an existing implementation. This is the easy part. Next up is implementing weak references as part of the `implement` macro. That's the hard part...