### PR TITLE
Update metadata

### DIFF
--- a/crates/gen/default/readme.md
+++ b/crates/gen/default/readme.md
@@ -3,7 +3,7 @@ dependent crate or workspace has an empty or non-existent `.windows/winmd` direc
 
 ## Windows.Win32.winmd
 - Source: https://www.nuget.org/packages/Microsoft.Windows.SDK.Win32Metadata/
-- Version: 10.0.19041.5-preview.138
+- Version: 10.0.19041.5-preview.143
 
 ## Windows.WinRT.winmd
 - Source: https://www.nuget.org/packages/Microsoft.Windows.SDK.Contracts

--- a/crates/gen/src/parser/element_type.rs
+++ b/crates/gen/src/parser/element_type.rs
@@ -124,6 +124,8 @@ impl ElementType {
                         ("Windows.Win32.Com", "IUnknown") => Self::IUnknown,
                         ("Windows.Foundation", "HResult") => Self::HRESULT,
                         ("Windows.Win32.Com", "HRESULT") => Self::HRESULT,
+                        ("Windows.Win32.WinRT", "HSTRING") => Self::String,
+                        ("Windows.Win32.WinRT", "IInspectable") => Self::Object,
                         ("Windows.Win32.SystemServices", "LARGE_INTEGER") => Self::I64,
                         ("Windows.Win32.SystemServices", "ULARGE_INTEGER") => Self::U64,
                         ("Windows.Win32.Direct2D", "D2D_MATRIX_3X2_F") => Self::Matrix3x2,

--- a/crates/gen/src/parser/type_reader.rs
+++ b/crates/gen/src/parser/type_reader.rs
@@ -114,7 +114,11 @@ impl TypeReader {
 
         let exclude = &[
             ("Windows.Foundation", "HResult"),
+            ("Windows.Win32.Com", "HRESULT"),
             ("Windows.Win32.Com", "IUnknown"),
+            ("Windows.Win32.WinRT", "HSTRING"),
+            ("Windows.Win32.WinRT", "IInspectable"),
+            ("Windows.Win32.WinRT", "IActivationFactory"),
             ("Windows.Win32.Direct2D", "D2D_MATRIX_3X2_F"),
             ("Windows.Win32.SystemServices", "LARGE_INTEGER"),
             ("Windows.Win32.SystemServices", "ULARGE_INTEGER"),

--- a/crates/gen/src/types/com_interface.rs
+++ b/crates/gen/src/types/com_interface.rs
@@ -205,14 +205,11 @@ impl ComInterface {
             #[derive(::std::cmp::PartialEq, ::std::cmp::Eq, ::std::clone::Clone, ::std::fmt::Debug)]
             pub struct #name(::windows::IUnknown);
             impl #name {
-
+                #(#methods)*
             }
             unsafe impl ::windows::Interface for #name {
                 type Vtable = #abi_name;
                 const IID: ::windows::Guid = #guid;
-            }
-            impl #name {
-                #(#methods)*
             }
             #conversions
             #send_sync

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1898,16 +1898,6 @@ pub mod Windows {
                 :: std :: fmt :: Debug,
             )]
             pub struct IErrorInfo(::windows::IUnknown);
-            impl IErrorInfo {}
-            unsafe impl ::windows::Interface for IErrorInfo {
-                type Vtable = IErrorInfo_abi;
-                const IID: ::windows::Guid = ::windows::Guid::from_values(
-                    485667104,
-                    21629,
-                    4123,
-                    [142, 101, 8, 0, 43, 43, 209, 25],
-                );
-            }
             impl IErrorInfo {
                 pub unsafe fn GetGUID(&self, pguid: *mut ::windows::Guid) -> ::windows::HRESULT {
                     (::windows::Interface::vtable(self).3)(
@@ -1945,6 +1935,15 @@ pub mod Windows {
                         ::std::mem::transmute(pdwhelpcontext),
                     )
                 }
+            }
+            unsafe impl ::windows::Interface for IErrorInfo {
+                type Vtable = IErrorInfo_abi;
+                const IID: ::windows::Guid = ::windows::Guid::from_values(
+                    485667104,
+                    21629,
+                    4123,
+                    [142, 101, 8, 0, 43, 43, 209, 25],
+                );
             }
             impl ::std::convert::From<IErrorInfo> for ::windows::IUnknown {
                 fn from(value: IErrorInfo) -> Self {
@@ -2255,7 +2254,6 @@ pub mod Windows {
                     [192, 255, 238, 100, 202, 143, 91, 144],
                 );
             }
-            impl IAgileObject {}
             impl ::std::convert::From<IAgileObject> for ::windows::IUnknown {
                 fn from(value: IAgileObject) -> Self {
                     unsafe { ::std::mem::transmute(value) }
@@ -6192,16 +6190,6 @@ pub mod Windows {
                 :: std :: fmt :: Debug,
             )]
             pub struct IRestrictedErrorInfo(::windows::IUnknown);
-            impl IRestrictedErrorInfo {}
-            unsafe impl ::windows::Interface for IRestrictedErrorInfo {
-                type Vtable = IRestrictedErrorInfo_abi;
-                const IID: ::windows::Guid = ::windows::Guid::from_values(
-                    2193256594,
-                    19592,
-                    17021,
-                    [167, 188, 22, 221, 147, 254, 182, 126],
-                );
-            }
             impl IRestrictedErrorInfo {
                 pub unsafe fn GetErrorDetails(
                     &self,
@@ -6227,6 +6215,15 @@ pub mod Windows {
                         ::std::mem::transmute(reference),
                     )
                 }
+            }
+            unsafe impl ::windows::Interface for IRestrictedErrorInfo {
+                type Vtable = IRestrictedErrorInfo_abi;
+                const IID: ::windows::Guid = ::windows::Guid::from_values(
+                    2193256594,
+                    19592,
+                    17021,
+                    [167, 188, 22, 221, 147, 254, 182, 126],
+                );
             }
             impl ::std::convert::From<IRestrictedErrorInfo> for ::windows::IUnknown {
                 fn from(value: IRestrictedErrorInfo) -> Self {
@@ -6282,16 +6279,6 @@ pub mod Windows {
                 :: std :: fmt :: Debug,
             )]
             pub struct ILanguageExceptionErrorInfo(::windows::IUnknown);
-            impl ILanguageExceptionErrorInfo {}
-            unsafe impl ::windows::Interface for ILanguageExceptionErrorInfo {
-                type Vtable = ILanguageExceptionErrorInfo_abi;
-                const IID: ::windows::Guid = ::windows::Guid::from_values(
-                    77782003,
-                    57219,
-                    4460,
-                    [9, 70, 8, 18, 171, 246, 224, 125],
-                );
-            }
             impl ILanguageExceptionErrorInfo {
                 pub unsafe fn GetLanguageException(
                     &self,
@@ -6302,6 +6289,15 @@ pub mod Windows {
                         ::std::mem::transmute(languageexception),
                     )
                 }
+            }
+            unsafe impl ::windows::Interface for ILanguageExceptionErrorInfo {
+                type Vtable = ILanguageExceptionErrorInfo_abi;
+                const IID: ::windows::Guid = ::windows::Guid::from_values(
+                    77782003,
+                    57219,
+                    4460,
+                    [9, 70, 8, 18, 171, 246, 224, 125],
+                );
             }
             impl ::std::convert::From<ILanguageExceptionErrorInfo> for ::windows::IUnknown {
                 fn from(value: ILanguageExceptionErrorInfo) -> Self {
@@ -6348,16 +6344,6 @@ pub mod Windows {
                 :: std :: fmt :: Debug,
             )]
             pub struct ILanguageExceptionErrorInfo2(::windows::IUnknown);
-            impl ILanguageExceptionErrorInfo2 {}
-            unsafe impl ::windows::Interface for ILanguageExceptionErrorInfo2 {
-                type Vtable = ILanguageExceptionErrorInfo2_abi;
-                const IID: ::windows::Guid = ::windows::Guid::from_values(
-                    1464264132,
-                    23447,
-                    16972,
-                    [182, 32, 40, 34, 145, 87, 52, 221],
-                );
-            }
             impl ILanguageExceptionErrorInfo2 {
                 pub unsafe fn GetLanguageException(
                     &self,
@@ -6399,6 +6385,15 @@ pub mod Windows {
                         ::std::mem::transmute(propagatedlanguageexceptionerrorinfohead),
                     )
                 }
+            }
+            unsafe impl ::windows::Interface for ILanguageExceptionErrorInfo2 {
+                type Vtable = ILanguageExceptionErrorInfo2_abi;
+                const IID: ::windows::Guid = ::windows::Guid::from_values(
+                    1464264132,
+                    23447,
+                    16972,
+                    [182, 32, 40, 34, 145, 87, 52, 221],
+                );
             }
             impl ::std::convert::From<ILanguageExceptionErrorInfo2> for ::windows::IUnknown {
                 fn from(value: ILanguageExceptionErrorInfo2) -> Self {

--- a/tests/interop/Cargo.toml
+++ b/tests/interop/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "test_interop"
+version = "0.8.0"
+authors = ["Microsoft"]
+edition = "2018"
+
+[dependencies]
+windows = { path = "../.." }
+
+[build-dependencies]
+windows = { path = "../.." }

--- a/tests/interop/build.rs
+++ b/tests/interop/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    windows::build!(
+        Windows::Win32::WinRT::RoActivateInstance,
+        Windows::Foundation::Collections::StringMap,
+    );
+}

--- a/tests/interop/src/lib.rs
+++ b/tests/interop/src/lib.rs
@@ -1,0 +1,1 @@
+windows::include_bindings!();

--- a/tests/interop/tests/activate_instance.rs
+++ b/tests/interop/tests/activate_instance.rs
@@ -1,0 +1,26 @@
+use test_interop::{
+    Windows::Foundation::Collections::StringMap, Windows::Win32::WinRT::RoActivateInstance,
+};
+
+use windows::{initialize_mta, Interface, Result};
+
+// Calling RoActivateInstance is a useful interop test because it is a function defined by Win32 metadata
+// but refers to three types that are intrinsic to WinRT and thus directly mapped to type in the Windows
+// crate. Calling RoActivateInstance in production code is discouraged. Instead, let the Windows crate
+// activate WinRT types directly as it can do so far more efficiently.
+#[test]
+fn test() -> Result<()> {
+    initialize_mta()?;
+    let mut instance = None;
+
+    let instance = unsafe {
+        RoActivateInstance("Windows.Foundation.Collections.StringMap", &mut instance)
+            .and_some(instance)?
+    };
+
+    let map = instance.cast::<StringMap>()?;
+    map.Insert("hello", "world")?;
+    assert_eq!(map.Lookup("hello")?, "world");
+
+    Ok(())
+}


### PR DESCRIPTION
Updates the Win32 metadata to [preview 143](https://github.com/microsoft/win32metadata/releases/tag/v10.0.19041.5-preview.143). 

This update also deals with some types that are defined in both WinRT and Win32 to ensure they only have a single canonical definition in Rust.