### PR TITLE
Workaround for IInspectable interop interfaces

### DIFF
--- a/crates/gen/src/parser/type_reader.rs
+++ b/crates/gen/src/parser/type_reader.rs
@@ -117,7 +117,6 @@ impl TypeReader {
             ("Windows.Win32.Com", "HRESULT"),
             ("Windows.Win32.Com", "IUnknown"),
             ("Windows.Win32.WinRT", "HSTRING"),
-            ("Windows.Win32.WinRT", "IInspectable"),
             ("Windows.Win32.WinRT", "IActivationFactory"),
             ("Windows.Win32.Direct2D", "D2D_MATRIX_3X2_F"),
             ("Windows.Win32.SystemServices", "LARGE_INTEGER"),

--- a/tests/interop/build.rs
+++ b/tests/interop/build.rs
@@ -2,5 +2,6 @@ fn main() {
     windows::build!(
         Windows::Win32::WinRT::RoActivateInstance,
         Windows::Foundation::Collections::StringMap,
+        Windows::Win32::RadialInput::IRadialControllerInterop,
     );
 }


### PR DESCRIPTION
Workaround for #724 where a non-WinRT interface derives from `IInspectable`. This is a workaround rather than a fix because I need to do a better job of assimilating support for `IInspectable`, but this should unblock the specific issue for now. 