### PR TITLE
Transform QueryInterface-like functions into generic functions

### DIFF
--- a/crates/gen/src/parser/element_type.rs
+++ b/crates/gen/src/parser/element_type.rs
@@ -38,6 +38,12 @@ pub enum ElementType {
     Callback(types::Callback),
 }
 
+impl Default for ElementType {
+    fn default() -> Self {
+        Self::Void
+    }
+}
+
 impl ElementType {
     pub fn row(&self) -> Row {
         match self {

--- a/crates/gen/src/parser/method_signature.rs
+++ b/crates/gen/src/parser/method_signature.rs
@@ -22,6 +22,15 @@ impl MethodSignature {
             .collect()
     }
 
+    pub fn has_query_interface(&self) -> bool {
+        self.return_type.as_ref().map_or(false, |signature| {
+            signature.kind == ElementType::HRESULT
+                && self.params.len() >= 2
+                && self.params[self.params.len() - 2].signature.kind == ElementType::Guid
+                && self.params[self.params.len() - 1].signature.kind == ElementType::Void
+        })
+    }
+
     pub fn gen_winrt_constraint(&self, gen: &Gen) -> TokenStream {
         let params = self.params.iter().map(|p| p.gen_winrt_produce_type(gen));
 
@@ -216,7 +225,7 @@ impl MethodSignature {
 
     pub fn gen_constraints(&self, params: &[MethodParam]) -> TokenStream {
         if params.iter().any(|param| param.is_convertible()) {
-            quote! { 'a }
+            quote! { 'a, }
         } else {
             quote! {}
         }

--- a/crates/gen/src/parser/signature.rs
+++ b/crates/gen/src/parser/signature.rs
@@ -1,6 +1,6 @@
 use super::*;
 
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord)]
+#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Default)]
 pub struct Signature {
     pub kind: ElementType,
     pub pointers: usize,

--- a/crates/gen/src/types/function.rs
+++ b/crates/gen/src/types/function.rs
@@ -52,13 +52,30 @@ impl Function {
         }
 
         if cfg!(windows) {
-            quote! {
-                pub unsafe fn #name<#constraints>(#params) #return_type {
-                    #[link(name = #link)]
-                    extern "system" {
-                        pub fn #name(#(#abi_params),*) #abi_return_type;
+            if signature.has_query_interface() {
+                let leading_params = &signature.params[..signature.params.len() - 2];
+                let params = signature.gen_win32_params(leading_params, gen);
+                let args = leading_params.iter().map(|p| p.gen_win32_abi_arg());
+
+                quote! {
+                    pub unsafe fn #name<#constraints T: ::windows::Interface>(#params) -> ::windows::Result<T> {
+                        #[link(name = #link)]
+                        extern "system" {
+                            pub fn #name(#(#abi_params),*) #abi_return_type;
+                        }
+                        let mut result__ = ::std::option::Option::None;
+                        #name(#(#args,)* &<T as ::windows::Interface>::IID, ::windows::Abi::set_abi(&mut result__)).and_some(result__)
                     }
-                    #name(#(#args),*)
+                }
+            } else {
+                quote! {
+                    pub unsafe fn #name<#constraints>(#params) #return_type {
+                        #[link(name = #link)]
+                        extern "system" {
+                            pub fn #name(#(#abi_params),*) #abi_return_type;
+                        }
+                        #name(#(#args),*)
+                    }
                 }
             }
         } else {

--- a/examples/clock/src/main.rs
+++ b/examples/clock/src/main.rs
@@ -640,23 +640,15 @@ fn get_dxgi_factory(device: &ID3D11Device) -> Result<IDXGIFactory2> {
     let dxdevice = device.cast::<IDXGIDevice>()?;
     let mut adapter = None;
     unsafe {
-        let adapter = dxdevice.GetAdapter(&mut adapter).and_some(adapter)?;
-        let mut parent = None;
-
-        adapter
-            .GetParent(&IDXGIFactory2::IID, parent.set_abi())
-            .and_some(parent)
+        dxdevice
+            .GetAdapter(&mut adapter)
+            .and_some(adapter)?
+            .GetParent()
     }
 }
 
 fn create_swapchain_bitmap(swapchain: &IDXGISwapChain1, target: &ID2D1DeviceContext) -> Result<()> {
-    let mut surface = None;
-
-    let surface: IDXGISurface = unsafe {
-        swapchain
-            .GetBuffer(0, &IDXGISurface::IID, surface.set_abi())
-            .and_some(surface)?
-    };
+    let surface: IDXGISurface = unsafe { swapchain.GetBuffer(0)? };
 
     let props = D2D1_BITMAP_PROPERTIES1 {
         pixelFormat: D2D1_PIXEL_FORMAT {

--- a/examples/clock/src/main.rs
+++ b/examples/clock/src/main.rs
@@ -60,7 +60,7 @@ impl Angles {
 impl Window {
     fn new() -> Result<Self> {
         let factory = create_factory()?;
-        let dxfactory = create_dxfactory()?;
+        let dxfactory: IDXGIFactory2 = unsafe { CreateDXGIFactory1()? };
         let style = create_style(&factory)?;
         let manager: IUIAnimationManager = create_instance(&UIAnimationManager)?;
         let transition = create_transition()?;
@@ -544,13 +544,6 @@ fn create_factory() -> Result<ID2D1Factory1> {
             result.set_abi(),
         )
         .and_some(result)
-    }
-}
-
-fn create_dxfactory() -> Result<IDXGIFactory2> {
-    unsafe {
-        let mut dxfactory: Option<IDXGIFactory2> = None;
-        CreateDXGIFactory1(&IDXGIFactory2::IID, dxfactory.set_abi()).and_some(dxfactory)
     }
 }
 

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -2211,13 +2211,11 @@ pub mod Windows {
                     self.0.bitand_assign(rhs.0)
                 }
             }
-            pub unsafe fn CoCreateInstance<'a>(
+            pub unsafe fn CoCreateInstance<'a, T: ::windows::Interface>(
                 rclsid: *const ::windows::Guid,
                 punkouter: impl ::windows::IntoParam<'a, ::windows::IUnknown>,
                 dwclscontext: CLSCTX,
-                riid: *const ::windows::Guid,
-                ppv: *mut *mut ::std::ffi::c_void,
-            ) -> ::windows::HRESULT {
+            ) -> ::windows::Result<T> {
                 #[link(name = "OLE32")]
                 extern "system" {
                     pub fn CoCreateInstance(
@@ -2228,13 +2226,15 @@ pub mod Windows {
                         ppv: *mut *mut ::std::ffi::c_void,
                     ) -> ::windows::HRESULT;
                 }
+                let mut result__ = ::std::option::Option::None;
                 CoCreateInstance(
                     ::std::mem::transmute(rclsid),
                     punkouter.into_param().abi(),
                     ::std::mem::transmute(dwclscontext),
-                    ::std::mem::transmute(riid),
-                    ::std::mem::transmute(ppv),
+                    &<T as ::windows::Interface>::IID,
+                    ::windows::Abi::set_abi(&mut result__),
                 )
+                .and_some(result__)
             }
             #[repr(transparent)]
             #[derive(

--- a/src/runtime/com.rs
+++ b/src/runtime/com.rs
@@ -14,10 +14,5 @@ pub fn initialize_sta() -> Result<()> {
 
 /// Creates a COM object with the given CLSID.
 pub fn create_instance<T: Interface>(clsid: &Guid) -> Result<T> {
-    let mut object = None;
-
-    unsafe {
-        CoCreateInstance(clsid, None, CLSCTX::CLSCTX_ALL, &T::IID, object.set_abi())
-            .and_some(object)
-    }
+    unsafe { CoCreateInstance(clsid, None, CLSCTX::CLSCTX_ALL) }
 }

--- a/tests/win32/tests/win32.rs
+++ b/tests/win32/tests/win32.rs
@@ -222,10 +222,7 @@ fn com() -> windows::Result<()> {
 #[test]
 fn com_inheritance() {
     unsafe {
-        let mut factory: Option<IDXGIFactory7> = None;
-        let factory: IDXGIFactory7 = CreateDXGIFactory1(&IDXGIFactory7::IID, factory.set_abi())
-            .and_some(factory)
-            .unwrap();
+        let factory: IDXGIFactory7 = CreateDXGIFactory1().unwrap();
 
         // IDXGIFactory
         assert!(factory.GetWindowAssociation(std::ptr::null_mut()) == DXGI_ERROR_INVALID_CALL);

--- a/tests/win32/tests/win32.rs
+++ b/tests/win32/tests/win32.rs
@@ -27,7 +27,7 @@ use test_win32::{
     Windows::Win32::WindowsProgramming::CloseHandle,
 };
 
-use windows::{Abi, Guid, Interface};
+use windows::{Abi, Guid};
 
 #[test]
 fn signed_enum32() {


### PR DESCRIPTION
A common pattern in COM-related functions and methods is to have a pair of trailing parameters to allow the caller to query for a specific interface. This update now transforms such functions and methods into generic functions, making them safer and and more convenient. Safer because you cannot accidentally use the wrong IID and inadvertently cast to the wrong interface. 

This applies to functions like `CreateDXGIFactory1` and `CoCreateInstance` as well as COM interface methods like `IDXGISwapChain::GetBuffer`.

Fixes #733