### PR TITLE
Remove compile time version check

### DIFF
--- a/crates/bindings/src/main.rs
+++ b/crates/bindings/src/main.rs
@@ -27,7 +27,6 @@ fn main() -> std::io::Result<()> {
     )?;
 
     file.write_all(tokens.as_bytes())?;
-    file.write_all(gen_crate_version_assert().as_bytes())?;
     drop(file);
 
     let mut cmd = ::std::process::Command::new("rustfmt");
@@ -35,31 +34,4 @@ fn main() -> std::io::Result<()> {
     cmd.output()?;
 
     Ok(())
-}
-
-fn gen_crate_version_assert() -> String {
-    format!(
-        r#"
-#[allow(dead_code)]
-const CRATE_VERSION_EQUAL: () = {{
-    const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
-    const EXPECTED_VERSION: &str = "{}";
-    if CURRENT_VERSION.len() != EXPECTED_VERSION.len() {{
-        ["The current version of the crate does not match the version the bindings were generated against: {}."][100];
-    }}
-    let mut index = 0;
-    while index < CURRENT_VERSION.len() {{
-        if CURRENT_VERSION.as_bytes()[index] != EXPECTED_VERSION.as_bytes()[index] {{
-            ["The current version of the crate does not match the version the bindings were generated against: {}."][100];
-        }}
-        index += 1;
-    }}
-
-    ()
-}};
-            "#,
-        env!("CARGO_PKG_VERSION"),
-        env!("CARGO_PKG_VERSION"),
-        env!("CARGO_PKG_VERSION")
-    )
 }

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -6627,20 +6627,3 @@ pub mod Windows {
         }
     }
 }
-#[allow(dead_code)]
-const CRATE_VERSION_EQUAL: () = {
-    const CURRENT_VERSION: &str = env!("CARGO_PKG_VERSION");
-    const EXPECTED_VERSION: &str = "0.9.1";
-    if CURRENT_VERSION.len() != EXPECTED_VERSION.len() {
-        ["The current version of the crate does not match the version the bindings were generated against: 0.9.1."][100];
-    }
-    let mut index = 0;
-    while index < CURRENT_VERSION.len() {
-        if CURRENT_VERSION.as_bytes()[index] != EXPECTED_VERSION.as_bytes()[index] {
-            ["The current version of the crate does not match the version the bindings were generated against: 0.9.1."][100];
-        }
-        index += 1;
-    }
-
-    ()
-};


### PR DESCRIPTION
Because of the way the version number is spread around the repo - and updated with "Replace All" this check isn't very effective. 

In practice, it's easy enough to update the bindings as needed.