### PR TITLE
interfaces: Use named struct members for vtable functions

### DIFF
--- a/src/interfaces/activation_factory.rs
+++ b/src/interfaces/activation_factory.rs
@@ -1,4 +1,4 @@
-use crate::*;
+use super::*;
 
 /// WinRT classes have a supporting factory object that implements `IActivationFactory` to create a new
 /// instance of the WinRT class with some default state. `IActivationFactory` represents the
@@ -18,7 +18,7 @@ impl IActivationFactory {
 
             // Even though the factory will generally return the WinRT default interface, this isn't guaranteed
             // so a cast is required to convert the `Object` into `I`, or the class type.
-            (self.vtable().6)(self.abi(), &mut object)
+            (self.vtable().activate_instance)(self.abi(), &mut object)
                 .and_some(object)?
                 .cast()
         }
@@ -26,15 +26,11 @@ impl IActivationFactory {
 }
 
 #[repr(C)]
-pub struct IActivationFactory_vtable(
-    pub unsafe extern "system" fn(this: RawPtr, iid: &Guid, interface: *mut RawPtr) -> HRESULT,
-    pub unsafe extern "system" fn(this: RawPtr) -> u32,
-    pub unsafe extern "system" fn(this: RawPtr) -> u32,
-    pub unsafe extern "system" fn(this: RawPtr, count: *mut u32, values: *mut *mut Guid) -> HRESULT,
-    pub unsafe extern "system" fn(this: RawPtr, value: *mut RawPtr) -> HRESULT,
-    pub unsafe extern "system" fn(this: RawPtr, value: *mut i32) -> HRESULT,
-    pub unsafe extern "system" fn(this: RawPtr, object: &mut Option<Object>) -> HRESULT, // ActivateInstance
-);
+pub struct IActivationFactory_vtable {
+    pubobject_vtable: Object_vtable,
+    pub activate_instance:
+        unsafe extern "system" fn(this: RawPtr, object: &mut Option<Object>) -> HRESULT,
+}
 
 unsafe impl Interface for IActivationFactory {
     type Vtable = IActivationFactory_vtable;

--- a/src/interfaces/object.rs
+++ b/src/interfaces/object.rs
@@ -14,21 +14,21 @@ impl Object {
     pub fn type_name(&self) -> Result<HString> {
         unsafe {
             let mut abi = std::ptr::null_mut();
-            (self.vtable().4)(self.abi(), &mut abi).ok()?;
+            (self.vtable().get_runtime_class_name)(self.abi(), &mut abi).ok()?;
             Ok(std::mem::transmute(abi))
         }
     }
 }
 
 #[repr(C)]
-pub struct Object_vtable(
-    pub unsafe extern "system" fn(this: RawPtr, iid: &Guid, interface: *mut RawPtr) -> HRESULT,
-    pub unsafe extern "system" fn(this: RawPtr) -> u32,
-    pub unsafe extern "system" fn(this: RawPtr) -> u32,
-    pub unsafe extern "system" fn(this: RawPtr, count: *mut u32, values: *mut *mut Guid) -> HRESULT,
-    pub unsafe extern "system" fn(this: RawPtr, value: *mut RawPtr) -> HRESULT,
-    pub unsafe extern "system" fn(this: RawPtr, value: *mut i32) -> HRESULT,
-);
+pub struct Object_vtable {
+    pub iunknown_vtable: IUnknown_vtable,
+    pub get_iids:
+        unsafe extern "system" fn(this: RawPtr, count: *mut u32, values: *mut *mut Guid) -> HRESULT,
+    pub get_runtime_class_name:
+        unsafe extern "system" fn(this: RawPtr, value: *mut RawPtr) -> HRESULT,
+    pub get_trust_level: unsafe extern "system" fn(this: RawPtr, value: *mut i32) -> HRESULT,
+}
 
 unsafe impl Interface for Object {
     type Vtable = Object_vtable;

--- a/src/interfaces/unknown.rs
+++ b/src/interfaces/unknown.rs
@@ -8,11 +8,12 @@ use crate::*;
 pub struct IUnknown(std::ptr::NonNull<std::ffi::c_void>);
 
 #[repr(C)]
-pub struct IUnknown_vtable(
-    pub unsafe extern "system" fn(this: RawPtr, iid: &Guid, interface: *mut RawPtr) -> HRESULT,
-    pub unsafe extern "system" fn(this: RawPtr) -> u32,
-    pub unsafe extern "system" fn(this: RawPtr) -> u32,
-);
+pub struct IUnknown_vtable {
+    pub query_interface:
+        unsafe extern "system" fn(this: RawPtr, iid: &Guid, interface: *mut RawPtr) -> HRESULT,
+    pub add_ref: unsafe extern "system" fn(this: RawPtr) -> u32,
+    pub release: unsafe extern "system" fn(this: RawPtr) -> u32,
+}
 
 unsafe impl Interface for IUnknown {
     type Vtable = IUnknown_vtable;
@@ -28,7 +29,7 @@ unsafe impl Interface for IUnknown {
 impl Clone for IUnknown {
     fn clone(&self) -> Self {
         unsafe {
-            (self.vtable().1)(self.abi()); // AddRef
+            (self.vtable().add_ref)(self.abi());
         }
 
         Self(self.0)
@@ -38,7 +39,7 @@ impl Clone for IUnknown {
 impl Drop for IUnknown {
     fn drop(&mut self) {
         unsafe {
-            (self.vtable().2)(self.abi()); // Release
+            (self.vtable().release)(self.abi());
         }
     }
 }

--- a/src/traits/interface.rs
+++ b/src/traits/interface.rs
@@ -28,7 +28,7 @@ pub unsafe trait Interface: Sized + Abi {
         unsafe {
             let mut result = None;
 
-            (self.assume_vtable::<IUnknown>().0)(
+            (self.assume_vtable::<IUnknown>().query_interface)(
                 std::mem::transmute_copy(self),
                 &T::IID,
                 &mut result as *mut _ as _,


### PR DESCRIPTION
Instead of using seemingly magic numbers in a tuple this is clearer to read.  I am not aware of any ABI differences between tuples and structs under `repr(C)`, [1] states: "Tuple structs are like structs with regards to `repr(C)`, as the only difference from a struct is that the fields aren’t named."

Also reuse "parent" vtables instead of replicating the same function signatures, again improving readability and reusing existing code.

[1]: https://doc.rust-lang.org/nomicon/other-reprs.html#reprc

---

Is there a specific reason it wasn't done like this in the first place?  And is it worth applying the same changes to generated code?
