### PR TITLE
Update to new namespaces

### DIFF
--- a/crates/bindings/src/main.rs
+++ b/crates/bindings/src/main.rs
@@ -3,17 +3,24 @@ use std::io::prelude::*;
 fn main() -> std::io::Result<()> {
     let tokens = windows_macros::generate!(
         Windows::Foundation::{IReference, IStringable, PropertyValue},
-        Windows::Win32::Automation::{BSTR, GetErrorInfo, IErrorInfo, SetErrorInfo},
-        Windows::Win32::WinRT::{IRestrictedErrorInfo, ILanguageExceptionErrorInfo2, IWeakReference, IWeakReferenceSource},
-        Windows::Win32::Debug::{GetLastError, FormatMessageW},
-        Windows::Win32::WindowsProgramming::CloseHandle,
-        Windows::Win32::Com::{
+        Windows::Win32::System::Com::{
             CoCreateGuid, CoTaskMemAlloc, CoTaskMemFree, CLSIDFromProgID, CoInitializeEx, CoCreateInstance,
             IAgileObject,
         },
-        Windows::Win32::SystemServices::{
-            CreateEventA, SetEvent, WaitForSingleObject, GetProcessHeap, HeapAlloc, HeapFree, GetProcAddress,
-            LoadLibraryA, FreeLibrary, CO_E_NOTINITIALIZED, E_POINTER,
+        Windows::Win32::System::Diagnostics::Debug::{GetLastError, FormatMessageW},
+        Windows::Win32::System::Memory::{
+            GetProcessHeap, HeapAlloc, HeapFree,
+        },
+        Windows::Win32::System::OleAutomation::{BSTR, GetErrorInfo, IErrorInfo, SetErrorInfo},
+        Windows::Win32::System::SystemServices::{
+            GetProcAddress, LoadLibraryA, FreeLibrary, CO_E_NOTINITIALIZED, E_POINTER,
+        },
+        Windows::Win32::System::Threading::{
+            CreateEventA, SetEvent, WaitForSingleObject,
+        },
+        Windows::Win32::System::WindowsProgramming::CloseHandle,
+        Windows::Win32::System::WinRT::{
+            IRestrictedErrorInfo, ILanguageExceptionErrorInfo2, IWeakReference, IWeakReferenceSource,
         },
     );
 

--- a/crates/gen/default/readme.md
+++ b/crates/gen/default/readme.md
@@ -3,7 +3,7 @@ dependent crate or workspace has an empty or non-existent `.windows/winmd` direc
 
 ## Windows.Win32.winmd
 - Source: https://www.nuget.org/packages/Microsoft.Windows.SDK.Win32Metadata/
-- Version: 10.0.19041.5-preview.166
+- Version: 10.0.19041.202-preview
 
 ## Windows.WinRT.winmd
 - Source: https://www.nuget.org/packages/Microsoft.Windows.SDK.Contracts

--- a/crates/gen/src/parser/element_type.rs
+++ b/crates/gen/src/parser/element_type.rs
@@ -126,15 +126,15 @@ impl ElementType {
 
                 match code {
                     TypeDefOrRef::TypeRef(type_ref) => match type_ref.full_name() {
-                        ("System", "Guid") | ("Windows.Win32.Com", "Guid") => Self::Guid,
-                        ("Windows.Win32.Com", "IUnknown") => Self::IUnknown,
+                        ("System", "Guid") | ("Windows.Win32.System.Com", "Guid") => Self::Guid,
+                        ("Windows.Win32.System.Com", "IUnknown") => Self::IUnknown,
                         ("Windows.Foundation", "HResult") => Self::HRESULT,
-                        ("Windows.Win32.Com", "HRESULT") => Self::HRESULT,
-                        ("Windows.Win32.WinRT", "HSTRING") => Self::String,
-                        ("Windows.Win32.WinRT", "IInspectable") => Self::IInspectable,
-                        ("Windows.Win32.SystemServices", "LARGE_INTEGER") => Self::I64,
-                        ("Windows.Win32.SystemServices", "ULARGE_INTEGER") => Self::U64,
-                        ("Windows.Win32.Direct2D", "D2D_MATRIX_3X2_F") => Self::Matrix3x2,
+                        ("Windows.Win32.System.Com", "HRESULT") => Self::HRESULT,
+                        ("Windows.Win32.System.WinRT", "HSTRING") => Self::String,
+                        ("Windows.Win32.System.WinRT", "IInspectable") => Self::IInspectable,
+                        ("Windows.Win32.System.SystemServices", "LARGE_INTEGER") => Self::I64,
+                        ("Windows.Win32.System.SystemServices", "ULARGE_INTEGER") => Self::U64,
+                        ("Windows.Win32.Graphics.Direct2D", "D2D_MATRIX_3X2_F") => Self::Matrix3x2,
                         ("System", "Type") => Self::TypeName,
                         _ => Self::from_type_def(type_ref.resolve(), Vec::new()),
                     },
@@ -521,7 +521,8 @@ mod tests {
 
     #[test]
     fn test_struct() {
-        let t = TypeReader::get().resolve_type("Windows.Win32.Dxgi", "DXGI_FRAME_STATISTICS_MEDIA");
+        let t = TypeReader::get()
+            .resolve_type("Windows.Win32.Graphics.Dxgi", "DXGI_FRAME_STATISTICS_MEDIA");
         let d = t.definition();
         assert_eq!(d.len(), 1);
         assert_eq!(d[0].name(), "DXGI_FRAME_STATISTICS_MEDIA");
@@ -533,8 +534,10 @@ mod tests {
 
     #[test]
     fn test_enum() {
-        let t =
-            TypeReader::get().resolve_type("Windows.Win32.Dxgi", "DXGI_FRAME_PRESENTATION_MODE");
+        let t = TypeReader::get().resolve_type(
+            "Windows.Win32.Graphics.Dxgi",
+            "DXGI_FRAME_PRESENTATION_MODE",
+        );
         let d = t.definition();
         assert_eq!(d.len(), 1);
         assert_eq!(d[0].name(), "DXGI_FRAME_PRESENTATION_MODE");
@@ -545,7 +548,7 @@ mod tests {
 
     #[test]
     fn test_com_interface() {
-        let t = TypeReader::get().resolve_type("Windows.Win32.Direct2D", "ID2D1Resource");
+        let t = TypeReader::get().resolve_type("Windows.Win32.Graphics.Direct2D", "ID2D1Resource");
         let d = t.definition();
         assert_eq!(d.len(), 1);
         assert_eq!(d[0].name(), "ID2D1Resource");
@@ -595,7 +598,8 @@ mod tests {
 
     #[test]
     fn test_win32_function() {
-        let t = TypeReader::get().resolve_type("Windows.Win32.WindowsAndMessaging", "EnumWindows");
+        let t =
+            TypeReader::get().resolve_type("Windows.Win32.UI.WindowsAndMessaging", "EnumWindows");
         assert_eq!(t.definition().len(), 0);
 
         let mut d = t.dependencies();
@@ -610,14 +614,16 @@ mod tests {
 
     #[test]
     fn test_win32_constant() {
-        let t = TypeReader::get().resolve_type("Windows.Win32.Dxgi", "DXGI_USAGE_SHADER_INPUT");
+        let t = TypeReader::get()
+            .resolve_type("Windows.Win32.Graphics.Dxgi", "DXGI_USAGE_SHADER_INPUT");
         assert_eq!(t.definition().len(), 0);
         assert_eq!(t.dependencies().len(), 0);
     }
 
     #[test]
     fn test_win32_callback() {
-        let t = TypeReader::get().resolve_type("Windows.Win32.WindowsAndMessaging", "WNDENUMPROC");
+        let t =
+            TypeReader::get().resolve_type("Windows.Win32.UI.WindowsAndMessaging", "WNDENUMPROC");
         let d = t.definition();
         assert_eq!(d.len(), 1);
         assert_eq!(d[0].name(), "WNDENUMPROC");

--- a/crates/gen/src/parser/type_reader.rs
+++ b/crates/gen/src/parser/type_reader.rs
@@ -114,13 +114,13 @@ impl TypeReader {
 
         let exclude = &[
             ("Windows.Foundation", "HResult"),
-            ("Windows.Win32.Com", "HRESULT"),
-            ("Windows.Win32.Com", "IUnknown"),
-            ("Windows.Win32.WinRT", "HSTRING"),
-            ("Windows.Win32.WinRT", "IActivationFactory"),
-            ("Windows.Win32.Direct2D", "D2D_MATRIX_3X2_F"),
-            ("Windows.Win32.SystemServices", "LARGE_INTEGER"),
-            ("Windows.Win32.SystemServices", "ULARGE_INTEGER"),
+            ("Windows.Win32.System.Com", "HRESULT"),
+            ("Windows.Win32.System.Com", "IUnknown"),
+            ("Windows.Win32.System.WinRT", "HSTRING"),
+            ("Windows.Win32.System.WinRT", "IActivationFactory"),
+            ("Windows.Win32.Graphics.Direct2D", "D2D_MATRIX_3X2_F"),
+            ("Windows.Win32.System.SystemServices", "LARGE_INTEGER"),
+            ("Windows.Win32.System.SystemServices", "ULARGE_INTEGER"),
         ];
 
         for (namespace, name) in exclude {

--- a/crates/gen/src/tables/interface_impl.rs
+++ b/crates/gen/src/tables/interface_impl.rs
@@ -38,7 +38,7 @@ impl InterfaceImpl {
                 generics: Vec::new(),
             },
             TypeDefOrRef::TypeRef(def) => {
-                if def.full_name() == ("Windows.Win32.Com", "IUnknown") {
+                if def.full_name() == ("Windows.Win32.System.Com", "IUnknown") {
                     return None;
                 }
 

--- a/crates/gen/src/type_tree.rs
+++ b/crates/gen/src/type_tree.rs
@@ -154,7 +154,10 @@ mod tests {
         let mut single = BTreeSet::new();
         single.insert("FILE_ACCESS_FLAGS");
 
-        imports.insert("Windows.Win32.FileSystem", ImportLimit::Some(single));
+        imports.insert(
+            "Windows.Win32.Storage.FileSystem",
+            ImportLimit::Some(single),
+        );
 
         let tree = TypeTree::from_imports(reader, &imports);
 
@@ -174,9 +177,15 @@ mod tests {
         assert_eq!(tree.types.len(), 0);
         assert_eq!(tree.namespaces.len(), 1);
 
+        let tree = &tree.namespaces["Storage"];
+
+        assert_eq!(tree.namespace, "Windows.Win32.Storage");
+        assert_eq!(tree.types.len(), 0);
+        assert_eq!(tree.namespaces.len(), 1);
+
         let tree = &tree.namespaces["FileSystem"];
 
-        assert_eq!(tree.namespace, "Windows.Win32.FileSystem");
+        assert_eq!(tree.namespace, "Windows.Win32.Storage.FileSystem");
         assert_eq!(tree.types.len(), 1);
         assert_eq!(tree.namespaces.len(), 0);
 
@@ -184,7 +193,7 @@ mod tests {
         assert_eq!(
             t.gen_name(&Gen::absolute(&TypeTree::from_namespace("")))
                 .as_str(),
-            "Windows :: Win32 :: FileSystem :: FILE_ACCESS_FLAGS"
+            "Windows :: Win32 :: Storage :: FileSystem :: FILE_ACCESS_FLAGS"
         );
     }
 }

--- a/crates/gen/src/types/com_interface.rs
+++ b/crates/gen/src/types/com_interface.rs
@@ -204,7 +204,7 @@ impl ComInterface {
 
         let send_sync = if matches!(
             self.0.def.full_name(),
-            ("Windows.Win32.WinRT", "IRestrictedErrorInfo")
+            ("Windows.Win32.System.WinRT", "IRestrictedErrorInfo")
         ) {
             quote! {
                 unsafe impl ::std::marker::Send for #name {}

--- a/crates/gen/src/types/matrix3x2.rs
+++ b/crates/gen/src/types/matrix3x2.rs
@@ -26,7 +26,7 @@ pub fn gen_matrix3x2() -> TokenStream {
             pub fn rotation(angle: f32, x: f32, y: f32) -> Self {
                 let mut matrix = Self::default();
                 unsafe {
-                    super::super::Win32::Direct2D::D2D1MakeRotateMatrix(angle, super::super::Win32::Direct2D::D2D_POINT_2F{x, y}, &mut matrix);
+                    super::super::Win32::Graphics::Direct2D::D2D1MakeRotateMatrix(angle, super::super::Win32::Graphics::Direct2D::D2D_POINT_2F{x, y}, &mut matrix);
                 }
                 matrix
             }

--- a/crates/gen/src/types/struct.rs
+++ b/crates/gen/src/types/struct.rs
@@ -24,15 +24,21 @@ impl Struct {
         let mut dependencies = vec![];
 
         match self.0.full_name() {
-            ("Windows.Win32.Automation", "BSTR") => {
-                dependencies.push(reader.resolve_type("Windows.Win32.Automation", "SysFreeString"));
-                dependencies
-                    .push(reader.resolve_type("Windows.Win32.Automation", "SysAllocStringLen"));
-                dependencies.push(reader.resolve_type("Windows.Win32.Automation", "SysStringLen"));
+            ("Windows.Win32.System.OleAutomation", "BSTR") => {
+                dependencies.push(
+                    reader.resolve_type("Windows.Win32.System.OleAutomation", "SysFreeString"),
+                );
+                dependencies.push(
+                    reader.resolve_type("Windows.Win32.System.OleAutomation", "SysAllocStringLen"),
+                );
+                dependencies.push(
+                    reader.resolve_type("Windows.Win32.System.OleAutomation", "SysStringLen"),
+                );
             }
             ("Windows.Foundation.Numerics", "Matrix3x2") => {
-                dependencies
-                    .push(reader.resolve_type("Windows.Win32.Direct2D", "D2D1MakeRotateMatrix"));
+                dependencies.push(
+                    reader.resolve_type("Windows.Win32.Graphics.Direct2D", "D2D1MakeRotateMatrix"),
+                );
             }
             _ => {
                 dependencies.extend(self.0.fields().map(|f| f.definition()).flatten());
@@ -52,7 +58,7 @@ impl Struct {
 
     pub fn is_blittable(&self) -> bool {
         // TODO: should be "if self.can_drop().is_some() {" once win32metadata bugs are fixed (423, 422, 421, 389)
-        if self.0.full_name() == ("Windows.Win32.Automation", "BSTR") {
+        if self.0.full_name() == ("Windows.Win32.System.OleAutomation", "BSTR") {
             false
         } else {
             self.0.fields().all(|f| f.is_blittable())
@@ -455,10 +461,10 @@ impl Struct {
 
     fn gen_replacement(&self) -> Option<TokenStream> {
         match self.0.full_name() {
-            ("Windows.Win32.SystemServices", "BOOL") => Some(gen_bool32()),
-            ("Windows.Win32.SystemServices", "PWSTR") => Some(gen_pwstr()),
-            ("Windows.Win32.SystemServices", "PSTR") => Some(gen_pstr()),
-            ("Windows.Win32.Automation", "BSTR") => Some(gen_bstr()),
+            ("Windows.Win32.System.SystemServices", "BOOL") => Some(gen_bool32()),
+            ("Windows.Win32.System.SystemServices", "PWSTR") => Some(gen_pwstr()),
+            ("Windows.Win32.System.SystemServices", "PSTR") => Some(gen_pstr()),
+            ("Windows.Win32.System.OleAutomation", "BSTR") => Some(gen_bstr()),
             _ => None,
         }
     }
@@ -471,7 +477,7 @@ impl Struct {
             ("Windows.Foundation.Numerics", "Vector4") => gen_vector4(),
             ("Windows.Foundation.Numerics", "Matrix3x2") => gen_matrix3x2(),
             ("Windows.Foundation.Numerics", "Matrix4x4") => gen_matrix4x4(),
-            ("Windows.Win32.SystemServices", "HANDLE") => gen_handle(),
+            ("Windows.Win32.System.SystemServices", "HANDLE") => gen_handle(),
             _ => TokenStream::new(),
         }
     }
@@ -505,7 +511,8 @@ mod tests {
 
     #[test]
     fn test_fields() {
-        let t = TypeReader::get_struct("Windows.Win32.Dxgi", "DXGI_FRAME_STATISTICS_MEDIA");
+        let t =
+            TypeReader::get_struct("Windows.Win32.Graphics.Dxgi", "DXGI_FRAME_STATISTICS_MEDIA");
         let f: Vec<tables::Field> = t.0.fields().collect();
         assert_eq!(f.len(), 7);
 
@@ -525,7 +532,7 @@ mod tests {
         assert_eq!(
             f[5].signature().kind,
             ElementType::Enum(TypeReader::get_enum(
-                "Windows.Win32.Dxgi",
+                "Windows.Win32.Graphics.Dxgi",
                 "DXGI_FRAME_PRESENTATION_MODE"
             ))
         );
@@ -537,10 +544,11 @@ mod tests {
         let t = TypeReader::get_struct("Windows.Foundation", "Point");
         assert_eq!(t.dependencies().len(), 0);
 
-        let t = TypeReader::get_struct("Windows.Win32.Dxgi", "DXGI_FRAME_STATISTICS");
+        let t = TypeReader::get_struct("Windows.Win32.Graphics.Dxgi", "DXGI_FRAME_STATISTICS");
         assert_eq!(t.dependencies().len(), 0);
 
-        let t = TypeReader::get_struct("Windows.Win32.Dxgi", "DXGI_FRAME_STATISTICS_MEDIA");
+        let t =
+            TypeReader::get_struct("Windows.Win32.Graphics.Dxgi", "DXGI_FRAME_STATISTICS_MEDIA");
         let deps = t.dependencies();
         assert_eq!(deps.len(), 1);
         assert_eq!(deps[0].name(), "DXGI_FRAME_PRESENTATION_MODE");

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -43,10 +43,10 @@ Doing the search should lead you to find the following:
 
 ![Search Results](./images/ISpellChecker.png)
 
-Remember the module path that `ISpellChecker` is in underneath `bindings`: `Windows::Win32::Intl`. You'll want to use that exactly when specifying the types you need to generate.
+Remember the module path that `ISpellChecker` is in underneath `bindings`: `Windows::Win32::Globalization`. You'll want to use that exactly when specifying the types you need to generate.
 
 > **Note**
-> It's important to note that for COM and WinRT APIs, methods are only available when all the types use in those methods parameters and return types are also generated. When you want to use a certain type's method, make sure you're generating everything you need to use that method. For example, the `ISpellChecker::Suggest` method takes an argument of type `*mut Option<IEnumString>`. If `IEnumString` (which is located in the `Windows::Win32::Com` namespace), is not generated, `ISpellChecker::Suggest` will not be generated as well.
+> It's important to note that for COM and WinRT APIs, methods are only available when all the types use in those methods parameters and return types are also generated. When you want to use a certain type's method, make sure you're generating everything you need to use that method. For example, the `ISpellChecker::Suggest` method takes an argument of type `*mut Option<IEnumString>`. If `IEnumString` (which is located in the `Windows::Win32::System::Com` namespace), is not generated, `ISpellChecker::Suggest` will not be generated as well.
 
 In the build.rs file add the following:
 
@@ -55,9 +55,9 @@ fn main() {
     windows::build!(
         // Note that we're using the `Intl` namespace which is nested inside the `Win32` namespace
         // which itself is inside the `Windows` namespace.
-        Windows::Win32::Intl::{ISpellChecker, SpellCheckerFactory, ISpellCheckerFactory, CORRECTIVE_ACTION, IEnumSpellingError, ISpellingError},
-        Windows::Win32::SystemServices::{BOOL, PWSTR, S_FALSE},
-        Windows::Win32::Com::IEnumString
+        Windows::Win32::Globalization::{ISpellChecker, SpellCheckerFactory, ISpellCheckerFactory, CORRECTIVE_ACTION, IEnumSpellingError, ISpellingError},
+        Windows::Win32::System::SystemServices::{BOOL, PWSTR, S_FALSE},
+        Windows::Win32::System::Com::IEnumString
     )
 }
 ```
@@ -95,8 +95,8 @@ fn main() -> windows::Result<()> {
 Next, we'll initialize the `ISpellCheckerFactory` which is what gives us access to spellcheckers. We'll first make sure the `intl` namespace and two types we'll need `PWSTR` and `BOOL` are in scope at the top of the main.rs file:
 
 ```rust
-use bindings::Windows::Win32::Intl;
-use bindings::Windows::Win32::SystemServices::{BOOL, PWSTR};
+use bindings::Windows::Win32::Globalization;
+use bindings::Windows::Win32::System::SystemServices::{BOOL, PWSTR};
 ```
 
 Then we can do the initialization by calling `windows::create_instance` which calls [CoCreateInstance](https://docs.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-cocreateinstance) under the hood:
@@ -127,7 +127,7 @@ pub unsafe fn IsSupported<'a>(
 ) -> HRESULT
 ```
 
-This looks a little complicated, but it makes using the API straightforward. The method is generic on both a lifetime `'a` and the trait `IntoParam` defined in the `windows` crate. Essentially, `IntoParam` is a slightly specialized version of Rust's `std::convert::Into`. It is implemented on all types that can be converted to a parameter of the type its generic over. In other words, it is any type that can be converted into a parameter of type `PWSTR` that lives for at least the lifetime `'a`. 
+This looks a little complicated, but it makes using the API straightforward. The method is generic on both a lifetime `'a` and the trait `IntoParam` defined in the `windows` crate. Essentially, `IntoParam` is a slightly specialized version of Rust's `std::convert::Into`. It is implemented on all types that can be converted to a parameter of the type its generic over. In other words, it is any type that can be converted into a parameter of type `PWSTR` that lives for at least the lifetime `'a`.
 
 It turns out that `IntoParam<'a, PWSTR>` is implemented for `&'a str` so we can simply pass a string literal. `IntoParam<'a, PWSTR>` is also implemented on `String` and `PWSTR` itself.
 

--- a/examples/buffer/bindings/build.rs
+++ b/examples/buffer/bindings/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     windows::build!(
         Windows::Foundation::*,
-        Windows::Win32::WinRT::IMemoryBufferByteAccess,
+        Windows::Win32::System::WinRT::IMemoryBufferByteAccess,
     );
 }

--- a/examples/buffer/src/main.rs
+++ b/examples/buffer/src/main.rs
@@ -1,4 +1,4 @@
-use bindings::{Windows::Foundation::*, Windows::Win32::WinRT::IMemoryBufferByteAccess};
+use bindings::{Windows::Foundation::*, Windows::Win32::System::WinRT::IMemoryBufferByteAccess};
 use windows::*;
 
 fn as_slice(buffer: &IMemoryBufferReference) -> Result<&mut [u8]> {

--- a/examples/clock/bindings/build.rs
+++ b/examples/clock/bindings/build.rs
@@ -1,7 +1,7 @@
 fn main() {
     windows::build!(
         Windows::Foundation::Numerics::Matrix3x2,
-        Windows::Win32::Direct2D::{
+        Windows::Win32::Graphics::Direct2D::{
             D2D1CreateFactory, ID2D1Bitmap, ID2D1Bitmap1, ID2D1Device, ID2D1DeviceContext, ID2D1Effect,
             ID2D1Factory1, ID2D1Factory7, ID2D1Image, ID2D1SolidColorBrush, ID2D1StrokeStyle,
             D2D1_ALPHA_MODE, D2D1_BITMAP_OPTIONS, D2D1_BITMAP_PROPERTIES, D2D1_BITMAP_PROPERTIES1,
@@ -10,34 +10,34 @@ fn main() {
             D2D1_INTERPOLATION_MODE, D2D1_PIXEL_FORMAT, D2D1_STROKE_STYLE_PROPERTIES, D2D1_UNIT_MODE,
             D2D_POINT_2F, D2D_RECT_F, D2D_SIZE_F, D2D_SIZE_U, CLSID_D2D1Shadow, D2D1_COLOR_F,
         },
-        Windows::Win32::Direct3D11::{
+        Windows::Win32::Graphics::Direct3D11::{
             D3D11CreateDevice, ID3D11Device, D3D11_CREATE_DEVICE_FLAG, D3D11_SDK_VERSION,
             D3D_DRIVER_TYPE,
         },
-        Windows::Win32::Dxgi::{
+        Windows::Win32::Graphics::Dxgi::{
             CreateDXGIFactory1, IDXGIDevice, IDXGIFactory2, IDXGIFactory7, IDXGIOutput, IDXGISurface,
             IDXGISwapChain1, DXGI_FORMAT, DXGI_PRESENT_TEST, DXGI_SAMPLE_DESC,
             DXGI_SWAP_CHAIN_DESC1, DXGI_SWAP_CHAIN_FULLSCREEN_DESC, DXGI_SWAP_EFFECT,
             DXGI_USAGE_RENDER_TARGET_OUTPUT, DXGI_ERROR_UNSUPPORTED,
         },
-        Windows::Win32::Gdi::{BeginPaint, EndPaint, ValidateRect, PAINTSTRUCT},
-        Windows::Win32::SystemServices::{
+        Windows::Win32::Graphics::Gdi::{BeginPaint, EndPaint, ValidateRect, PAINTSTRUCT},
+        Windows::Win32::System::SystemServices::{
             GetModuleHandleA, DXGI_STATUS_OCCLUDED, HINSTANCE, LRESULT,
             PSTR,
         },
-        Windows::Win32::UIAnimation::{
+        Windows::Win32::UI::Animation::{
             IUIAnimationManager, IUIAnimationTransition, IUIAnimationTransitionLibrary,
             IUIAnimationVariable, UIAnimationManager, UIAnimationTransitionLibrary,
             UI_ANIMATION_UPDATE_RESULT,
         },
-        Windows::Win32::WindowsAndMessaging::{
+        Windows::Win32::UI::WindowsAndMessaging::{
             CreateWindowExA, DefWindowProcA, DispatchMessageA, GetMessageA, PeekMessageA,
             PostQuitMessage, RegisterClassA, CREATESTRUCTA, HWND, LPARAM, MINMAXINFO, MSG, WNDCLASSA,
             WPARAM, LoadCursorW, IDC_ARROW, SIZE_MINIMIZED, WM_DESTROY, WM_ACTIVATE, WM_DISPLAYCHANGE,
             WM_NCCREATE, WM_PAINT, WM_QUIT, WM_SIZE, WM_USER, WNDCLASS_STYLES,
             CW_USEDEFAULT, IDC_HAND, SetWindowLongA, SetWindowLongPtrA, GetWindowLongA, GetWindowLongPtrA,
         },
-        Windows::Win32::WindowsProgramming::{
+        Windows::Win32::System::WindowsProgramming::{
             GetLocalTime, QueryPerformanceCounter, QueryPerformanceFrequency,
         },
     );

--- a/examples/clock/src/main.rs
+++ b/examples/clock/src/main.rs
@@ -1,8 +1,9 @@
 use bindings::{
-    Windows::Foundation::Numerics::*, Windows::Win32::Direct2D::*, Windows::Win32::Direct3D11::*,
-    Windows::Win32::Dxgi::*, Windows::Win32::Gdi::*, Windows::Win32::SystemServices::*,
-    Windows::Win32::UIAnimation::*, Windows::Win32::WindowsAndMessaging::*,
-    Windows::Win32::WindowsProgramming::*,
+    Windows::Foundation::Numerics::*, Windows::Win32::Graphics::Direct2D::*,
+    Windows::Win32::Graphics::Direct3D11::*, Windows::Win32::Graphics::Dxgi::*,
+    Windows::Win32::Graphics::Gdi::*, Windows::Win32::System::SystemServices::*,
+    Windows::Win32::System::WindowsProgramming::*, Windows::Win32::UI::Animation::*,
+    Windows::Win32::UI::WindowsAndMessaging::*,
 };
 
 use windows::*;
@@ -393,7 +394,7 @@ impl Window {
 
     fn run(&mut self) -> Result<()> {
         unsafe {
-            let instance = HINSTANCE(GetModuleHandleA(None));
+            let instance = GetModuleHandleA(None);
             debug_assert!(instance.0 != 0);
 
             let wc = WNDCLASSA {
@@ -588,7 +589,7 @@ fn create_device_with_type(drive_type: D3D_DRIVER_TYPE) -> Result<ID3D11Device> 
         D3D11CreateDevice(
             None,
             drive_type,
-            0,
+            HINSTANCE::default(),
             flags,
             std::ptr::null(),
             0,

--- a/examples/com_uri/bindings/build.rs
+++ b/examples/com_uri/bindings/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     windows::build!(
-        Windows::Win32::Automation::BSTR,
-        Windows::Win32::Com::CreateUri,
+        Windows::Win32::System::OleAutomation::BSTR,
+        Windows::Win32::System::Com::CreateUri,
     );
 }

--- a/examples/com_uri/src/main.rs
+++ b/examples/com_uri/src/main.rs
@@ -1,4 +1,6 @@
-use bindings::{Windows::Win32::Automation::BSTR, Windows::Win32::Com::CreateUri};
+use bindings::{
+    Windows::Win32::System::Com::CreateUri, Windows::Win32::System::OleAutomation::BSTR,
+};
 
 fn main() -> windows::Result<()> {
     unsafe {

--- a/examples/enum_windows/bindings/build.rs
+++ b/examples/enum_windows/bindings/build.rs
@@ -1,5 +1,5 @@
 fn main() {
     windows::build!(
-        Windows::Win32::WindowsAndMessaging::{EnumWindows, GetWindowTextW}
+        Windows::Win32::UI::WindowsAndMessaging::{EnumWindows, GetWindowTextW}
     );
 }

--- a/examples/enum_windows/src/main.rs
+++ b/examples/enum_windows/src/main.rs
@@ -1,6 +1,6 @@
 use bindings::{
-    Windows::Win32::SystemServices::{BOOL, PWSTR},
-    Windows::Win32::WindowsAndMessaging::{EnumWindows, GetWindowTextW, HWND, LPARAM},
+    Windows::Win32::System::SystemServices::{BOOL, PWSTR},
+    Windows::Win32::UI::WindowsAndMessaging::{EnumWindows, GetWindowTextW, HWND, LPARAM},
 };
 
 fn main() -> windows::Result<()> {

--- a/examples/event/bindings/build.rs
+++ b/examples/event/bindings/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     windows::build!(
-        Windows::Win32::SystemServices::{CreateEventW, SetEvent, WaitForSingleObject},
-        Windows::Win32::WindowsProgramming::CloseHandle
+        Windows::Win32::System::Threading::{CreateEventW, SetEvent, WaitForSingleObject},
+        Windows::Win32::System::WindowsProgramming::CloseHandle
     );
 }

--- a/examples/event/src/main.rs
+++ b/examples/event/src/main.rs
@@ -1,8 +1,8 @@
 use bindings::{
-    Windows::Win32::SystemServices::{
+    Windows::Win32::System::Threading::{
         CreateEventW, SetEvent, WaitForSingleObject, WAIT_RETURN_CAUSE,
     },
-    Windows::Win32::WindowsProgramming::CloseHandle,
+    Windows::Win32::System::WindowsProgramming::CloseHandle,
 };
 
 fn main() -> windows::Result<()> {

--- a/examples/message_box/bindings/build.rs
+++ b/examples/message_box/bindings/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    windows::build!(Windows::Win32::WindowsAndMessaging::MessageBoxA);
+    windows::build!(Windows::Win32::UI::WindowsAndMessaging::MessageBoxA);
 }

--- a/examples/message_box/src/main.rs
+++ b/examples/message_box/src/main.rs
@@ -1,4 +1,4 @@
-use bindings::Windows::Win32::WindowsAndMessaging::{MessageBoxA, MESSAGEBOX_STYLE};
+use bindings::Windows::Win32::UI::WindowsAndMessaging::{MessageBoxA, MESSAGEBOX_STYLE};
 
 fn main() {
     unsafe {

--- a/examples/overlapped/bindings/build.rs
+++ b/examples/overlapped/bindings/build.rs
@@ -1,10 +1,11 @@
 fn main() {
     windows::build!(
-      Windows::Win32::FileSystem::{CreateFileA, ReadFile},
-      Windows::Win32::SystemServices::{
-          CreateEventA, WaitForSingleObject, GetOverlappedResult,
+      Windows::Win32::Storage::FileSystem::{CreateFileA, ReadFile},
+      Windows::Win32::System::SystemServices::GetOverlappedResult,
+      Windows::Win32::System::Threading::{
+          CreateEventA, WaitForSingleObject,
       },
-      Windows::Win32::Debug::GetLastError,
-      Windows::Win32::WindowsProgramming::CloseHandle,
+      Windows::Win32::System::Diagnostics::Debug::GetLastError,
+      Windows::Win32::System::WindowsProgramming::CloseHandle,
     );
 }

--- a/examples/overlapped/src/main.rs
+++ b/examples/overlapped/src/main.rs
@@ -1,6 +1,7 @@
 use bindings::{
-    Windows::Win32::Debug::*, Windows::Win32::FileSystem::*, Windows::Win32::SystemServices::*,
-    Windows::Win32::WindowsProgramming::*,
+    Windows::Win32::Storage::FileSystem::*, Windows::Win32::System::Diagnostics::Debug::*,
+    Windows::Win32::System::SystemServices::*, Windows::Win32::System::Threading::*,
+    Windows::Win32::System::WindowsProgramming::*,
 };
 
 fn main() -> windows::Result<()> {

--- a/examples/spellchecker/bindings/build.rs
+++ b/examples/spellchecker/bindings/build.rs
@@ -1,7 +1,7 @@
 fn main() {
     windows::build!(
-        Windows::Win32::Intl::{ISpellChecker, SpellCheckerFactory, ISpellCheckerFactory, CORRECTIVE_ACTION, IEnumSpellingError, ISpellingError},
-        Windows::Win32::SystemServices::{BOOL, PWSTR, S_FALSE},
-        Windows::Win32::Com::IEnumString
+        Windows::Win32::Globalization::{ISpellChecker, SpellCheckerFactory, ISpellCheckerFactory, CORRECTIVE_ACTION, IEnumSpellingError, ISpellingError},
+        Windows::Win32::System::SystemServices::{BOOL, PWSTR, S_FALSE},
+        Windows::Win32::System::Com::IEnumString
     )
 }

--- a/examples/spellchecker/src/main.rs
+++ b/examples/spellchecker/src/main.rs
@@ -1,6 +1,6 @@
 use bindings::Windows::Win32;
-use Win32::Intl;
-use Win32::SystemServices::{BOOL, PWSTR, S_FALSE};
+use Win32::Globalization;
+use Win32::System::SystemServices::{BOOL, PWSTR, S_FALSE};
 
 fn main() -> windows::Result<()> {
     let input = std::env::args()
@@ -10,7 +10,8 @@ fn main() -> windows::Result<()> {
     windows::initialize_mta()?;
 
     // Create ISpellCheckerFactory
-    let factory: Intl::ISpellCheckerFactory = windows::create_instance(&Intl::SpellCheckerFactory)?;
+    let factory: Globalization::ISpellCheckerFactory =
+        windows::create_instance(&Globalization::SpellCheckerFactory)?;
 
     // Make sure that the "en-US" locale is supported
     let mut supported: BOOL = false.into();
@@ -56,15 +57,15 @@ fn main() -> windows::Result<()> {
         let substring = &input[start_index as usize..(start_index + length) as usize];
 
         // Get the corrective action
-        let mut action = Intl::CORRECTIVE_ACTION::CORRECTIVE_ACTION_NONE;
+        let mut action = Globalization::CORRECTIVE_ACTION::CORRECTIVE_ACTION_NONE;
         unsafe { error.get_CorrectiveAction(&mut action).ok()? };
         println!("{:?}", action);
 
         match action {
-            Intl::CORRECTIVE_ACTION::CORRECTIVE_ACTION_DELETE => {
+            Globalization::CORRECTIVE_ACTION::CORRECTIVE_ACTION_DELETE => {
                 println!("Delete '{}'", substring);
             }
-            Intl::CORRECTIVE_ACTION::CORRECTIVE_ACTION_REPLACE => {
+            Globalization::CORRECTIVE_ACTION::CORRECTIVE_ACTION_REPLACE => {
                 // Get the replacement as a widestring and convert to a Rust String
                 let mut replacement = PWSTR::NULL;
                 unsafe { error.get_Replacement(&mut replacement).ok()? };
@@ -73,7 +74,7 @@ fn main() -> windows::Result<()> {
                     read_to_string(replacement)
                 });
             }
-            Intl::CORRECTIVE_ACTION::CORRECTIVE_ACTION_GET_SUGGESTIONS => {
+            Globalization::CORRECTIVE_ACTION::CORRECTIVE_ACTION_GET_SUGGESTIONS => {
                 // Get an enumerator for all the suggestions for a substring
                 let mut suggestions = None;
                 unsafe { checker.Suggest(substring, &mut suggestions).ok()? };

--- a/examples/webview2/bindings/build.rs
+++ b/examples/webview2/bindings/build.rs
@@ -2,12 +2,13 @@ fn main() {
     windows::build!(
         Microsoft::Web::WebView2::Core::*,
         Windows::Foundation::*,
-        Windows::Win32::DisplayDevices::{POINT, RECT, SIZE},
-        Windows::Win32::Gdi::UpdateWindow,
-        Windows::Win32::HiDpi::{PROCESS_DPI_AWARENESS, SetProcessDpiAwareness},
-        Windows::Win32::KeyboardAndMouseInput::SetFocus,
-        Windows::Win32::MenusAndResources::HMENU,
-        Windows::Win32::SystemServices::{GetCurrentThreadId, GetModuleHandleA, HINSTANCE, LRESULT, PWSTR},
-        Windows::Win32::WindowsAndMessaging::*
+        Windows::Win32::Graphics::Gdi::UpdateWindow,
+        Windows::Win32::System::SystemServices::{GetModuleHandleA, HINSTANCE, LRESULT, PWSTR},
+        Windows::Win32::System::Threading::GetCurrentThreadId,
+        Windows::Win32::UI::DisplayDevices::{POINT, RECT, SIZE},
+        Windows::Win32::UI::HiDpi::{PROCESS_DPI_AWARENESS, SetProcessDpiAwareness},
+        Windows::Win32::UI::KeyboardAndMouseInput::SetFocus,
+        Windows::Win32::UI::MenusAndResources::HMENU,
+        Windows::Win32::UI::WindowsAndMessaging::*
     )
 }

--- a/examples/webview2/src/main.rs
+++ b/examples/webview2/src/main.rs
@@ -10,14 +10,17 @@ use bindings::{
     Windows::{
         Foundation::*,
         Win32::{
-            DisplayDevices::{RECT, SIZE},
-            Gdi,
-            HiDpi::{self, PROCESS_DPI_AWARENESS},
-            KeyboardAndMouseInput,
-            SystemServices::{self, HINSTANCE, LRESULT, PSTR},
-            WindowsAndMessaging::{
-                self, HWND, LPARAM, MSG, SET_WINDOW_POS_FLAGS, SHOW_WINDOW_CMD,
-                WINDOW_LONG_PTR_INDEX, WINDOW_STYLE, WNDCLASSA, WPARAM,
+            Graphics::Gdi,
+            System::SystemServices::{self, LRESULT, PSTR},
+            System::Threading,
+            UI::{
+                DisplayDevices::{RECT, SIZE},
+                HiDpi::{self, PROCESS_DPI_AWARENESS},
+                KeyboardAndMouseInput,
+                WindowsAndMessaging::{
+                    self, HWND, LPARAM, MSG, SET_WINDOW_POS_FLAGS, SHOW_WINDOW_CMD,
+                    WINDOW_LONG_PTR_INDEX, WINDOW_STYLE, WNDCLASSA, WPARAM,
+                },
             },
         },
     },
@@ -150,7 +153,7 @@ impl FrameWindow {
                     WindowsAndMessaging::CW_USEDEFAULT,
                     None,
                     None,
-                    HINSTANCE(SystemServices::GetModuleHandleA(None)),
+                    SystemServices::GetModuleHandleA(None),
                     0 as *mut _,
                 )
             }
@@ -256,7 +259,7 @@ impl WebView {
 
         let (tx, rx) = mpsc::channel();
         let rx = Arc::new(rx);
-        let thread_id = unsafe { SystemServices::GetCurrentThreadId() };
+        let thread_id = unsafe { Threading::GetCurrentThreadId() };
 
         let webview = WebView {
             controller: Arc::new(WebViewController(controller)),

--- a/readme.md
+++ b/readme.md
@@ -30,10 +30,13 @@ This will allow Cargo to download, build, and cache Windows support as a package
 fn main() {
     windows::build!(
         Windows::Data::Xml::Dom::*,
-        Windows::Win32::WindowsProgramming::CloseHandle,
-        Windows::Win32::WindowsAndMessaging::MessageBoxA,
-        Windows::Win32::SystemServices::{
-            CreateEventW, SetEvent, WaitForSingleObject
+        Windows::Win32::System::WindowsProgramming::CloseHandle,
+        Windows::Win32::UI::WindowsAndMessaging::MessageBoxA,
+        Windows::Win32::Threading::{
+            CreateEventW, SetEvent,
+        }
+        Windows::Win32::System::SystemServices::{
+            WaitForSingleObject
         },
     );
 }
@@ -48,9 +51,10 @@ mod bindings {
 
 use bindings::{
     Windows::Data::Xml::Dom::*,
-    Windows::Win32::SystemServices::{CreateEventW, SetEvent, WaitForSingleObject},
-    Windows::Win32::WindowsAndMessaging::{MessageBoxA, MESSAGEBOX_STYLE},
-    Windows::Win32::WindowsProgramming::CloseHandle,
+    Windows::Win32::System::Threading::{CreateEventW, SetEvent},
+    Windows::Win32::System::SystemServices::{WaitForSingleObject},
+    Windows::Win32::UI::WindowsAndMessaging::{MessageBoxA, MESSAGEBOX_STYLE},
+    Windows::Win32::System::WindowsProgramming::CloseHandle,
 };
 
 fn main() -> windows::Result<()> {

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1746,4883 +1746,5086 @@ pub mod Windows {
             dead_code,
             clippy::all
         )]
-        pub mod Automation {
-            pub unsafe fn SysFreeString<'a>(bstrstring: impl ::windows::IntoParam<'a, BSTR>) {
-                #[link(name = "OLEAUT32")]
-                extern "system" {
-                    pub fn SysFreeString(bstrstring: BSTR_abi);
-                }
-                SysFreeString(bstrstring.into_param().abi())
-            }
-            pub unsafe fn SysAllocStringLen<'a>(
-                strin: impl ::windows::IntoParam<'a, super::SystemServices::PWSTR>,
-                ui: u32,
-            ) -> BSTR {
-                #[link(name = "OLEAUT32")]
-                extern "system" {
-                    pub fn SysAllocStringLen(strin: super::SystemServices::PWSTR, ui: u32) -> BSTR;
-                }
-                SysAllocStringLen(strin.into_param().abi(), ::std::mem::transmute(ui))
-            }
-            pub unsafe fn SysStringLen<'a>(pbstr: impl ::windows::IntoParam<'a, BSTR>) -> u32 {
-                #[link(name = "OLEAUT32")]
-                extern "system" {
-                    pub fn SysStringLen(pbstr: BSTR_abi) -> u32;
-                }
-                SysStringLen(pbstr.into_param().abi())
-            }
-            #[repr(transparent)]
-            #[derive(:: std :: cmp :: Eq)]
-            pub struct BSTR(*mut u16);
-            impl BSTR {
-                pub fn is_empty(&self) -> bool {
-                    self.0.is_null()
-                }
-                fn from_wide(value: &[u16]) -> Self {
-                    if value.len() == 0 {
-                        return Self(::std::ptr::null_mut());
+        pub mod System {
+            #[allow(
+                unused_variables,
+                non_upper_case_globals,
+                non_snake_case,
+                unused_unsafe,
+                non_camel_case_types,
+                dead_code,
+                clippy::all
+            )]
+            pub mod Com {
+                pub unsafe fn CLSIDFromProgID<'a>(
+                    lpszprogid: impl ::windows::IntoParam<'a, super::SystemServices::PWSTR>,
+                    lpclsid: *mut ::windows::Guid,
+                ) -> ::windows::HRESULT {
+                    #[link(name = "OLE32")]
+                    extern "system" {
+                        pub fn CLSIDFromProgID(
+                            lpszprogid: super::SystemServices::PWSTR,
+                            lpclsid: *mut ::windows::Guid,
+                        ) -> ::windows::HRESULT;
                     }
-                    unsafe {
-                        SysAllocStringLen(
-                            super::SystemServices::PWSTR(value.as_ptr() as _),
-                            value.len() as u32,
-                        )
+                    CLSIDFromProgID(
+                        lpszprogid.into_param().abi(),
+                        ::std::mem::transmute(lpclsid),
+                    )
+                }
+                pub unsafe fn CoCreateGuid(pguid: *mut ::windows::Guid) -> ::windows::HRESULT {
+                    #[link(name = "OLE32")]
+                    extern "system" {
+                        pub fn CoCreateGuid(pguid: *mut ::windows::Guid) -> ::windows::HRESULT;
+                    }
+                    CoCreateGuid(::std::mem::transmute(pguid))
+                }
+                #[derive(
+                    :: std :: cmp :: PartialEq,
+                    :: std :: cmp :: Eq,
+                    :: std :: marker :: Copy,
+                    :: std :: clone :: Clone,
+                    :: std :: default :: Default,
+                    :: std :: fmt :: Debug,
+                )]
+                #[repr(transparent)]
+                pub struct CLSCTX(pub u32);
+                impl CLSCTX {
+                    pub const CLSCTX_INPROC_SERVER: Self = Self(1u32);
+                    pub const CLSCTX_INPROC_HANDLER: Self = Self(2u32);
+                    pub const CLSCTX_LOCAL_SERVER: Self = Self(4u32);
+                    pub const CLSCTX_INPROC_SERVER16: Self = Self(8u32);
+                    pub const CLSCTX_REMOTE_SERVER: Self = Self(16u32);
+                    pub const CLSCTX_INPROC_HANDLER16: Self = Self(32u32);
+                    pub const CLSCTX_RESERVED1: Self = Self(64u32);
+                    pub const CLSCTX_RESERVED2: Self = Self(128u32);
+                    pub const CLSCTX_RESERVED3: Self = Self(256u32);
+                    pub const CLSCTX_RESERVED4: Self = Self(512u32);
+                    pub const CLSCTX_NO_CODE_DOWNLOAD: Self = Self(1024u32);
+                    pub const CLSCTX_RESERVED5: Self = Self(2048u32);
+                    pub const CLSCTX_NO_CUSTOM_MARSHAL: Self = Self(4096u32);
+                    pub const CLSCTX_ENABLE_CODE_DOWNLOAD: Self = Self(8192u32);
+                    pub const CLSCTX_NO_FAILURE_LOG: Self = Self(16384u32);
+                    pub const CLSCTX_DISABLE_AAA: Self = Self(32768u32);
+                    pub const CLSCTX_ENABLE_AAA: Self = Self(65536u32);
+                    pub const CLSCTX_FROM_DEFAULT_CONTEXT: Self = Self(131072u32);
+                    pub const CLSCTX_ACTIVATE_X86_SERVER: Self = Self(262144u32);
+                    pub const CLSCTX_ACTIVATE_32_BIT_SERVER: Self = Self(262144u32);
+                    pub const CLSCTX_ACTIVATE_64_BIT_SERVER: Self = Self(524288u32);
+                    pub const CLSCTX_ENABLE_CLOAKING: Self = Self(1048576u32);
+                    pub const CLSCTX_APPCONTAINER: Self = Self(4194304u32);
+                    pub const CLSCTX_ACTIVATE_AAA_AS_IU: Self = Self(8388608u32);
+                    pub const CLSCTX_RESERVED6: Self = Self(16777216u32);
+                    pub const CLSCTX_ACTIVATE_ARM32_SERVER: Self = Self(33554432u32);
+                    pub const CLSCTX_PS_DLL: Self = Self(2147483648u32);
+                    pub const CLSCTX_ALL: Self = Self(23u32);
+                    pub const CLSCTX_SERVER: Self = Self(21u32);
+                }
+                impl ::std::convert::From<u32> for CLSCTX {
+                    fn from(value: u32) -> Self {
+                        Self(value)
                     }
                 }
-                fn as_wide(&self) -> &[u16] {
-                    if self.0.is_null() {
-                        return &[];
-                    }
-                    unsafe {
-                        ::std::slice::from_raw_parts(
-                            self.0 as *const u16,
-                            SysStringLen(self) as usize,
-                        )
+                unsafe impl ::windows::Abi for CLSCTX {
+                    type Abi = Self;
+                }
+                impl ::std::ops::BitOr for CLSCTX {
+                    type Output = Self;
+                    fn bitor(self, rhs: Self) -> Self {
+                        Self(self.0 | rhs.0)
                     }
                 }
-            }
-            impl ::std::clone::Clone for BSTR {
-                fn clone(&self) -> Self {
-                    Self::from_wide(self.as_wide())
-                }
-            }
-            impl ::std::convert::From<&str> for BSTR {
-                fn from(value: &str) -> Self {
-                    let value: ::std::vec::Vec<u16> = value.encode_utf16().collect();
-                    Self::from_wide(&value)
-                }
-            }
-            impl ::std::convert::From<::std::string::String> for BSTR {
-                fn from(value: ::std::string::String) -> Self {
-                    value.as_str().into()
-                }
-            }
-            impl ::std::convert::From<&::std::string::String> for BSTR {
-                fn from(value: &::std::string::String) -> Self {
-                    value.as_str().into()
-                }
-            }
-            impl<'a> ::std::convert::TryFrom<&'a BSTR> for ::std::string::String {
-                type Error = ::std::string::FromUtf16Error;
-                fn try_from(value: &BSTR) -> ::std::result::Result<Self, Self::Error> {
-                    ::std::string::String::from_utf16(value.as_wide())
-                }
-            }
-            impl ::std::convert::TryFrom<BSTR> for ::std::string::String {
-                type Error = ::std::string::FromUtf16Error;
-                fn try_from(value: BSTR) -> ::std::result::Result<Self, Self::Error> {
-                    ::std::string::String::try_from(&value)
-                }
-            }
-            impl ::std::default::Default for BSTR {
-                fn default() -> Self {
-                    Self(::std::ptr::null_mut())
-                }
-            }
-            impl ::std::fmt::Display for BSTR {
-                fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                    use std::fmt::Write;
-                    for c in ::std::char::decode_utf16(self.as_wide().iter().cloned()) {
-                        f.write_char(c.map_err(|_| ::std::fmt::Error)?)?
+                impl ::std::ops::BitAnd for CLSCTX {
+                    type Output = Self;
+                    fn bitand(self, rhs: Self) -> Self {
+                        Self(self.0 & rhs.0)
                     }
-                    Ok(())
                 }
-            }
-            impl ::std::fmt::Debug for BSTR {
-                fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                    ::std::write!(f, "{}", self)
+                impl ::std::ops::BitOrAssign for CLSCTX {
+                    fn bitor_assign(&mut self, rhs: Self) {
+                        self.0.bitor_assign(rhs.0)
+                    }
                 }
-            }
-            impl ::std::cmp::PartialEq for BSTR {
-                fn eq(&self, other: &Self) -> bool {
-                    self.as_wide() == other.as_wide()
+                impl ::std::ops::BitAndAssign for CLSCTX {
+                    fn bitand_assign(&mut self, rhs: Self) {
+                        self.0.bitand_assign(rhs.0)
+                    }
                 }
-            }
-            impl ::std::cmp::PartialEq<::std::string::String> for BSTR {
-                fn eq(&self, other: &::std::string::String) -> bool {
-                    self == other.as_str()
+                pub unsafe fn CoCreateInstance<'a, T: ::windows::Interface>(
+                    rclsid: *const ::windows::Guid,
+                    punkouter: impl ::windows::IntoParam<'a, ::windows::IUnknown>,
+                    dwclscontext: CLSCTX,
+                ) -> ::windows::Result<T> {
+                    #[link(name = "OLE32")]
+                    extern "system" {
+                        pub fn CoCreateInstance(
+                            rclsid: *const ::windows::Guid,
+                            punkouter: ::windows::RawPtr,
+                            dwclscontext: CLSCTX,
+                            riid: *const ::windows::Guid,
+                            ppv: *mut *mut ::std::ffi::c_void,
+                        ) -> ::windows::HRESULT;
+                    }
+                    let mut result__ = ::std::option::Option::None;
+                    CoCreateInstance(
+                        ::std::mem::transmute(rclsid),
+                        punkouter.into_param().abi(),
+                        ::std::mem::transmute(dwclscontext),
+                        &<T as ::windows::Interface>::IID,
+                        ::windows::Abi::set_abi(&mut result__),
+                    )
+                    .and_some(result__)
                 }
-            }
-            impl ::std::cmp::PartialEq<str> for BSTR {
-                fn eq(&self, other: &str) -> bool {
-                    self == other
+                #[derive(
+                    :: std :: cmp :: PartialEq,
+                    :: std :: cmp :: Eq,
+                    :: std :: marker :: Copy,
+                    :: std :: clone :: Clone,
+                    :: std :: default :: Default,
+                    :: std :: fmt :: Debug,
+                )]
+                #[repr(transparent)]
+                pub struct COINIT(pub u32);
+                impl COINIT {
+                    pub const COINIT_APARTMENTTHREADED: Self = Self(2u32);
+                    pub const COINIT_MULTITHREADED: Self = Self(0u32);
+                    pub const COINIT_DISABLE_OLE1DDE: Self = Self(4u32);
+                    pub const COINIT_SPEED_OVER_MEMORY: Self = Self(8u32);
                 }
-            }
-            impl ::std::cmp::PartialEq<&str> for BSTR {
-                fn eq(&self, other: &&str) -> bool {
-                    self.as_wide().iter().copied().eq(other.encode_utf16())
+                impl ::std::convert::From<u32> for COINIT {
+                    fn from(value: u32) -> Self {
+                        Self(value)
+                    }
                 }
-            }
-            impl ::std::cmp::PartialEq<BSTR> for &str {
-                fn eq(&self, other: &BSTR) -> bool {
-                    other == self
+                unsafe impl ::windows::Abi for COINIT {
+                    type Abi = Self;
                 }
+                impl ::std::ops::BitOr for COINIT {
+                    type Output = Self;
+                    fn bitor(self, rhs: Self) -> Self {
+                        Self(self.0 | rhs.0)
+                    }
+                }
+                impl ::std::ops::BitAnd for COINIT {
+                    type Output = Self;
+                    fn bitand(self, rhs: Self) -> Self {
+                        Self(self.0 & rhs.0)
+                    }
+                }
+                impl ::std::ops::BitOrAssign for COINIT {
+                    fn bitor_assign(&mut self, rhs: Self) {
+                        self.0.bitor_assign(rhs.0)
+                    }
+                }
+                impl ::std::ops::BitAndAssign for COINIT {
+                    fn bitand_assign(&mut self, rhs: Self) {
+                        self.0.bitand_assign(rhs.0)
+                    }
+                }
+                pub unsafe fn CoInitializeEx(
+                    pvreserved: *mut ::std::ffi::c_void,
+                    dwcoinit: COINIT,
+                ) -> ::windows::HRESULT {
+                    #[link(name = "OLE32")]
+                    extern "system" {
+                        pub fn CoInitializeEx(
+                            pvreserved: *mut ::std::ffi::c_void,
+                            dwcoinit: COINIT,
+                        ) -> ::windows::HRESULT;
+                    }
+                    CoInitializeEx(
+                        ::std::mem::transmute(pvreserved),
+                        ::std::mem::transmute(dwcoinit),
+                    )
+                }
+                pub unsafe fn CoTaskMemAlloc(cb: usize) -> *mut ::std::ffi::c_void {
+                    #[link(name = "OLE32")]
+                    extern "system" {
+                        pub fn CoTaskMemAlloc(cb: usize) -> *mut ::std::ffi::c_void;
+                    }
+                    CoTaskMemAlloc(::std::mem::transmute(cb))
+                }
+                pub unsafe fn CoTaskMemFree(pv: *mut ::std::ffi::c_void) {
+                    #[link(name = "OLE32")]
+                    extern "system" {
+                        pub fn CoTaskMemFree(pv: *mut ::std::ffi::c_void);
+                    }
+                    CoTaskMemFree(::std::mem::transmute(pv))
+                }
+                #[repr(transparent)]
+                #[derive(
+                    :: std :: cmp :: PartialEq,
+                    :: std :: cmp :: Eq,
+                    :: std :: clone :: Clone,
+                    :: std :: fmt :: Debug,
+                )]
+                pub struct IAgileObject(::windows::IUnknown);
+                impl IAgileObject {}
+                unsafe impl ::windows::Interface for IAgileObject {
+                    type Vtable = IAgileObject_abi;
+                    const IID: ::windows::Guid = ::windows::Guid::from_values(
+                        2498374548,
+                        59852,
+                        18912,
+                        [192, 255, 238, 100, 202, 143, 91, 144],
+                    );
+                }
+                impl ::std::convert::From<IAgileObject> for ::windows::IUnknown {
+                    fn from(value: IAgileObject) -> Self {
+                        unsafe { ::std::mem::transmute(value) }
+                    }
+                }
+                impl ::std::convert::From<&IAgileObject> for ::windows::IUnknown {
+                    fn from(value: &IAgileObject) -> Self {
+                        ::std::convert::From::from(::std::clone::Clone::clone(value))
+                    }
+                }
+                impl<'a> ::windows::IntoParam<'a, ::windows::IUnknown> for IAgileObject {
+                    fn into_param(self) -> ::windows::Param<'a, ::windows::IUnknown> {
+                        ::windows::Param::Owned(::std::convert::Into::<::windows::IUnknown>::into(
+                            self,
+                        ))
+                    }
+                }
+                impl<'a> ::windows::IntoParam<'a, ::windows::IUnknown> for &'a IAgileObject {
+                    fn into_param(self) -> ::windows::Param<'a, ::windows::IUnknown> {
+                        ::windows::Param::Owned(::std::convert::Into::<::windows::IUnknown>::into(
+                            ::std::clone::Clone::clone(self),
+                        ))
+                    }
+                }
+                #[repr(C)]
+                #[doc(hidden)]
+                pub struct IAgileObject_abi(
+                    pub  unsafe extern "system" fn(
+                        this: ::windows::RawPtr,
+                        iid: &::windows::Guid,
+                        interface: *mut ::windows::RawPtr,
+                    ) -> ::windows::HRESULT,
+                    pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
+                    pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
+                );
             }
-            impl ::std::ops::Drop for BSTR {
-                fn drop(&mut self) {
-                    if !self.0.is_null() {
-                        unsafe {
-                            SysFreeString(self as &Self);
+            #[allow(
+                unused_variables,
+                non_upper_case_globals,
+                non_snake_case,
+                unused_unsafe,
+                non_camel_case_types,
+                dead_code,
+                clippy::all
+            )]
+            pub mod Diagnostics {
+                #[allow(
+                    unused_variables,
+                    non_upper_case_globals,
+                    non_snake_case,
+                    unused_unsafe,
+                    non_camel_case_types,
+                    dead_code,
+                    clippy::all
+                )]
+                pub mod Debug {
+                    #[derive(
+                        :: std :: cmp :: PartialEq,
+                        :: std :: cmp :: Eq,
+                        :: std :: marker :: Copy,
+                        :: std :: clone :: Clone,
+                        :: std :: default :: Default,
+                        :: std :: fmt :: Debug,
+                    )]
+                    #[repr(transparent)]
+                    pub struct FORMAT_MESSAGE_OPTIONS(pub u32);
+                    impl FORMAT_MESSAGE_OPTIONS {
+                        pub const FORMAT_MESSAGE_ALLOCATE_BUFFER: Self = Self(256u32);
+                        pub const FORMAT_MESSAGE_ARGUMENT_ARRAY: Self = Self(8192u32);
+                        pub const FORMAT_MESSAGE_FROM_HMODULE: Self = Self(2048u32);
+                        pub const FORMAT_MESSAGE_FROM_STRING: Self = Self(1024u32);
+                        pub const FORMAT_MESSAGE_FROM_SYSTEM: Self = Self(4096u32);
+                        pub const FORMAT_MESSAGE_IGNORE_INSERTS: Self = Self(512u32);
+                    }
+                    impl ::std::convert::From<u32> for FORMAT_MESSAGE_OPTIONS {
+                        fn from(value: u32) -> Self {
+                            Self(value)
                         }
                     }
-                }
-            }
-            unsafe impl ::windows::Abi for BSTR {
-                type Abi = *mut u16;
-                fn set_abi(&mut self) -> *mut *mut u16 {
-                    debug_assert!(self.0.is_null());
-                    &mut self.0 as *mut _ as _
-                }
-            }
-            pub type BSTR_abi = *mut u16;
-            #[repr(transparent)]
-            #[derive(
-                :: std :: cmp :: PartialEq,
-                :: std :: cmp :: Eq,
-                :: std :: clone :: Clone,
-                :: std :: fmt :: Debug,
-            )]
-            pub struct IErrorInfo(::windows::IUnknown);
-            impl IErrorInfo {
-                pub unsafe fn GetGUID(&self, pguid: *mut ::windows::Guid) -> ::windows::HRESULT {
-                    (::windows::Interface::vtable(self).3)(
-                        ::windows::Abi::abi(self),
-                        ::std::mem::transmute(pguid),
-                    )
-                }
-                pub unsafe fn GetSource(&self, pbstrsource: *mut BSTR) -> ::windows::HRESULT {
-                    (::windows::Interface::vtable(self).4)(
-                        ::windows::Abi::abi(self),
-                        ::std::mem::transmute(pbstrsource),
-                    )
-                }
-                pub unsafe fn GetDescription(
-                    &self,
-                    pbstrdescription: *mut BSTR,
-                ) -> ::windows::HRESULT {
-                    (::windows::Interface::vtable(self).5)(
-                        ::windows::Abi::abi(self),
-                        ::std::mem::transmute(pbstrdescription),
-                    )
-                }
-                pub unsafe fn GetHelpFile(&self, pbstrhelpfile: *mut BSTR) -> ::windows::HRESULT {
-                    (::windows::Interface::vtable(self).6)(
-                        ::windows::Abi::abi(self),
-                        ::std::mem::transmute(pbstrhelpfile),
-                    )
-                }
-                pub unsafe fn GetHelpContext(
-                    &self,
-                    pdwhelpcontext: *mut u32,
-                ) -> ::windows::HRESULT {
-                    (::windows::Interface::vtable(self).7)(
-                        ::windows::Abi::abi(self),
-                        ::std::mem::transmute(pdwhelpcontext),
-                    )
-                }
-            }
-            unsafe impl ::windows::Interface for IErrorInfo {
-                type Vtable = IErrorInfo_abi;
-                const IID: ::windows::Guid = ::windows::Guid::from_values(
-                    485667104,
-                    21629,
-                    4123,
-                    [142, 101, 8, 0, 43, 43, 209, 25],
-                );
-            }
-            impl ::std::convert::From<IErrorInfo> for ::windows::IUnknown {
-                fn from(value: IErrorInfo) -> Self {
-                    unsafe { ::std::mem::transmute(value) }
-                }
-            }
-            impl ::std::convert::From<&IErrorInfo> for ::windows::IUnknown {
-                fn from(value: &IErrorInfo) -> Self {
-                    ::std::convert::From::from(::std::clone::Clone::clone(value))
-                }
-            }
-            impl<'a> ::windows::IntoParam<'a, ::windows::IUnknown> for IErrorInfo {
-                fn into_param(self) -> ::windows::Param<'a, ::windows::IUnknown> {
-                    ::windows::Param::Owned(::std::convert::Into::<::windows::IUnknown>::into(self))
-                }
-            }
-            impl<'a> ::windows::IntoParam<'a, ::windows::IUnknown> for &'a IErrorInfo {
-                fn into_param(self) -> ::windows::Param<'a, ::windows::IUnknown> {
-                    ::windows::Param::Owned(::std::convert::Into::<::windows::IUnknown>::into(
-                        ::std::clone::Clone::clone(self),
-                    ))
-                }
-            }
-            #[repr(C)]
-            #[doc(hidden)]
-            pub struct IErrorInfo_abi(
-                pub  unsafe extern "system" fn(
-                    this: ::windows::RawPtr,
-                    iid: &::windows::Guid,
-                    interface: *mut ::windows::RawPtr,
-                ) -> ::windows::HRESULT,
-                pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
-                pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
-                pub  unsafe extern "system" fn(
-                    this: ::windows::RawPtr,
-                    pguid: *mut ::windows::Guid,
-                ) -> ::windows::HRESULT,
-                pub  unsafe extern "system" fn(
-                    this: ::windows::RawPtr,
-                    pbstrsource: *mut BSTR_abi,
-                ) -> ::windows::HRESULT,
-                pub  unsafe extern "system" fn(
-                    this: ::windows::RawPtr,
-                    pbstrdescription: *mut BSTR_abi,
-                ) -> ::windows::HRESULT,
-                pub  unsafe extern "system" fn(
-                    this: ::windows::RawPtr,
-                    pbstrhelpfile: *mut BSTR_abi,
-                ) -> ::windows::HRESULT,
-                pub  unsafe extern "system" fn(
-                    this: ::windows::RawPtr,
-                    pdwhelpcontext: *mut u32,
-                ) -> ::windows::HRESULT,
-            );
-            pub unsafe fn GetErrorInfo(
-                dwreserved: u32,
-                pperrinfo: *mut ::std::option::Option<IErrorInfo>,
-            ) -> ::windows::HRESULT {
-                #[link(name = "OLEAUT32")]
-                extern "system" {
-                    pub fn GetErrorInfo(
-                        dwreserved: u32,
-                        pperrinfo: *mut ::windows::RawPtr,
-                    ) -> ::windows::HRESULT;
-                }
-                GetErrorInfo(
-                    ::std::mem::transmute(dwreserved),
-                    ::std::mem::transmute(pperrinfo),
-                )
-            }
-            pub unsafe fn SetErrorInfo<'a>(
-                dwreserved: u32,
-                perrinfo: impl ::windows::IntoParam<'a, IErrorInfo>,
-            ) -> ::windows::HRESULT {
-                #[link(name = "OLEAUT32")]
-                extern "system" {
-                    pub fn SetErrorInfo(
-                        dwreserved: u32,
-                        perrinfo: ::windows::RawPtr,
-                    ) -> ::windows::HRESULT;
-                }
-                SetErrorInfo(
-                    ::std::mem::transmute(dwreserved),
-                    perrinfo.into_param().abi(),
-                )
-            }
-        }
-        #[allow(
-            unused_variables,
-            non_upper_case_globals,
-            non_snake_case,
-            unused_unsafe,
-            non_camel_case_types,
-            dead_code,
-            clippy::all
-        )]
-        pub mod Com {
-            pub unsafe fn CLSIDFromProgID<'a>(
-                lpszprogid: impl ::windows::IntoParam<'a, super::SystemServices::PWSTR>,
-                lpclsid: *mut ::windows::Guid,
-            ) -> ::windows::HRESULT {
-                #[link(name = "OLE32")]
-                extern "system" {
-                    pub fn CLSIDFromProgID(
-                        lpszprogid: super::SystemServices::PWSTR,
-                        lpclsid: *mut ::windows::Guid,
-                    ) -> ::windows::HRESULT;
-                }
-                CLSIDFromProgID(
-                    lpszprogid.into_param().abi(),
-                    ::std::mem::transmute(lpclsid),
-                )
-            }
-            pub unsafe fn CoCreateGuid(pguid: *mut ::windows::Guid) -> ::windows::HRESULT {
-                #[link(name = "OLE32")]
-                extern "system" {
-                    pub fn CoCreateGuid(pguid: *mut ::windows::Guid) -> ::windows::HRESULT;
-                }
-                CoCreateGuid(::std::mem::transmute(pguid))
-            }
-            #[derive(
-                :: std :: cmp :: PartialEq,
-                :: std :: cmp :: Eq,
-                :: std :: marker :: Copy,
-                :: std :: clone :: Clone,
-                :: std :: default :: Default,
-                :: std :: fmt :: Debug,
-            )]
-            #[repr(transparent)]
-            pub struct CLSCTX(pub u32);
-            impl CLSCTX {
-                pub const CLSCTX_INPROC_SERVER: Self = Self(1u32);
-                pub const CLSCTX_INPROC_HANDLER: Self = Self(2u32);
-                pub const CLSCTX_LOCAL_SERVER: Self = Self(4u32);
-                pub const CLSCTX_INPROC_SERVER16: Self = Self(8u32);
-                pub const CLSCTX_REMOTE_SERVER: Self = Self(16u32);
-                pub const CLSCTX_INPROC_HANDLER16: Self = Self(32u32);
-                pub const CLSCTX_RESERVED1: Self = Self(64u32);
-                pub const CLSCTX_RESERVED2: Self = Self(128u32);
-                pub const CLSCTX_RESERVED3: Self = Self(256u32);
-                pub const CLSCTX_RESERVED4: Self = Self(512u32);
-                pub const CLSCTX_NO_CODE_DOWNLOAD: Self = Self(1024u32);
-                pub const CLSCTX_RESERVED5: Self = Self(2048u32);
-                pub const CLSCTX_NO_CUSTOM_MARSHAL: Self = Self(4096u32);
-                pub const CLSCTX_ENABLE_CODE_DOWNLOAD: Self = Self(8192u32);
-                pub const CLSCTX_NO_FAILURE_LOG: Self = Self(16384u32);
-                pub const CLSCTX_DISABLE_AAA: Self = Self(32768u32);
-                pub const CLSCTX_ENABLE_AAA: Self = Self(65536u32);
-                pub const CLSCTX_FROM_DEFAULT_CONTEXT: Self = Self(131072u32);
-                pub const CLSCTX_ACTIVATE_X86_SERVER: Self = Self(262144u32);
-                pub const CLSCTX_ACTIVATE_32_BIT_SERVER: Self = Self(262144u32);
-                pub const CLSCTX_ACTIVATE_64_BIT_SERVER: Self = Self(524288u32);
-                pub const CLSCTX_ENABLE_CLOAKING: Self = Self(1048576u32);
-                pub const CLSCTX_APPCONTAINER: Self = Self(4194304u32);
-                pub const CLSCTX_ACTIVATE_AAA_AS_IU: Self = Self(8388608u32);
-                pub const CLSCTX_RESERVED6: Self = Self(16777216u32);
-                pub const CLSCTX_ACTIVATE_ARM32_SERVER: Self = Self(33554432u32);
-                pub const CLSCTX_PS_DLL: Self = Self(2147483648u32);
-                pub const CLSCTX_ALL: Self = Self(23u32);
-                pub const CLSCTX_SERVER: Self = Self(21u32);
-            }
-            impl ::std::convert::From<u32> for CLSCTX {
-                fn from(value: u32) -> Self {
-                    Self(value)
-                }
-            }
-            unsafe impl ::windows::Abi for CLSCTX {
-                type Abi = Self;
-            }
-            impl ::std::ops::BitOr for CLSCTX {
-                type Output = Self;
-                fn bitor(self, rhs: Self) -> Self {
-                    Self(self.0 | rhs.0)
-                }
-            }
-            impl ::std::ops::BitAnd for CLSCTX {
-                type Output = Self;
-                fn bitand(self, rhs: Self) -> Self {
-                    Self(self.0 & rhs.0)
-                }
-            }
-            impl ::std::ops::BitOrAssign for CLSCTX {
-                fn bitor_assign(&mut self, rhs: Self) {
-                    self.0.bitor_assign(rhs.0)
-                }
-            }
-            impl ::std::ops::BitAndAssign for CLSCTX {
-                fn bitand_assign(&mut self, rhs: Self) {
-                    self.0.bitand_assign(rhs.0)
-                }
-            }
-            pub unsafe fn CoCreateInstance<'a, T: ::windows::Interface>(
-                rclsid: *const ::windows::Guid,
-                punkouter: impl ::windows::IntoParam<'a, ::windows::IUnknown>,
-                dwclscontext: CLSCTX,
-            ) -> ::windows::Result<T> {
-                #[link(name = "OLE32")]
-                extern "system" {
-                    pub fn CoCreateInstance(
-                        rclsid: *const ::windows::Guid,
-                        punkouter: ::windows::RawPtr,
-                        dwclscontext: CLSCTX,
-                        riid: *const ::windows::Guid,
-                        ppv: *mut *mut ::std::ffi::c_void,
-                    ) -> ::windows::HRESULT;
-                }
-                let mut result__ = ::std::option::Option::None;
-                CoCreateInstance(
-                    ::std::mem::transmute(rclsid),
-                    punkouter.into_param().abi(),
-                    ::std::mem::transmute(dwclscontext),
-                    &<T as ::windows::Interface>::IID,
-                    ::windows::Abi::set_abi(&mut result__),
-                )
-                .and_some(result__)
-            }
-            #[derive(
-                :: std :: cmp :: PartialEq,
-                :: std :: cmp :: Eq,
-                :: std :: marker :: Copy,
-                :: std :: clone :: Clone,
-                :: std :: default :: Default,
-                :: std :: fmt :: Debug,
-            )]
-            #[repr(transparent)]
-            pub struct COINIT(pub u32);
-            impl COINIT {
-                pub const COINIT_APARTMENTTHREADED: Self = Self(2u32);
-                pub const COINIT_MULTITHREADED: Self = Self(0u32);
-                pub const COINIT_DISABLE_OLE1DDE: Self = Self(4u32);
-                pub const COINIT_SPEED_OVER_MEMORY: Self = Self(8u32);
-            }
-            impl ::std::convert::From<u32> for COINIT {
-                fn from(value: u32) -> Self {
-                    Self(value)
-                }
-            }
-            unsafe impl ::windows::Abi for COINIT {
-                type Abi = Self;
-            }
-            impl ::std::ops::BitOr for COINIT {
-                type Output = Self;
-                fn bitor(self, rhs: Self) -> Self {
-                    Self(self.0 | rhs.0)
-                }
-            }
-            impl ::std::ops::BitAnd for COINIT {
-                type Output = Self;
-                fn bitand(self, rhs: Self) -> Self {
-                    Self(self.0 & rhs.0)
-                }
-            }
-            impl ::std::ops::BitOrAssign for COINIT {
-                fn bitor_assign(&mut self, rhs: Self) {
-                    self.0.bitor_assign(rhs.0)
-                }
-            }
-            impl ::std::ops::BitAndAssign for COINIT {
-                fn bitand_assign(&mut self, rhs: Self) {
-                    self.0.bitand_assign(rhs.0)
-                }
-            }
-            pub unsafe fn CoInitializeEx(
-                pvreserved: *mut ::std::ffi::c_void,
-                dwcoinit: COINIT,
-            ) -> ::windows::HRESULT {
-                #[link(name = "OLE32")]
-                extern "system" {
-                    pub fn CoInitializeEx(
-                        pvreserved: *mut ::std::ffi::c_void,
-                        dwcoinit: COINIT,
-                    ) -> ::windows::HRESULT;
-                }
-                CoInitializeEx(
-                    ::std::mem::transmute(pvreserved),
-                    ::std::mem::transmute(dwcoinit),
-                )
-            }
-            pub unsafe fn CoTaskMemAlloc(cb: usize) -> *mut ::std::ffi::c_void {
-                #[link(name = "OLE32")]
-                extern "system" {
-                    pub fn CoTaskMemAlloc(cb: usize) -> *mut ::std::ffi::c_void;
-                }
-                CoTaskMemAlloc(::std::mem::transmute(cb))
-            }
-            pub unsafe fn CoTaskMemFree(pv: *mut ::std::ffi::c_void) {
-                #[link(name = "OLE32")]
-                extern "system" {
-                    pub fn CoTaskMemFree(pv: *mut ::std::ffi::c_void);
-                }
-                CoTaskMemFree(::std::mem::transmute(pv))
-            }
-            #[repr(transparent)]
-            #[derive(
-                :: std :: cmp :: PartialEq,
-                :: std :: cmp :: Eq,
-                :: std :: clone :: Clone,
-                :: std :: fmt :: Debug,
-            )]
-            pub struct IAgileObject(::windows::IUnknown);
-            impl IAgileObject {}
-            unsafe impl ::windows::Interface for IAgileObject {
-                type Vtable = IAgileObject_abi;
-                const IID: ::windows::Guid = ::windows::Guid::from_values(
-                    2498374548,
-                    59852,
-                    18912,
-                    [192, 255, 238, 100, 202, 143, 91, 144],
-                );
-            }
-            impl ::std::convert::From<IAgileObject> for ::windows::IUnknown {
-                fn from(value: IAgileObject) -> Self {
-                    unsafe { ::std::mem::transmute(value) }
-                }
-            }
-            impl ::std::convert::From<&IAgileObject> for ::windows::IUnknown {
-                fn from(value: &IAgileObject) -> Self {
-                    ::std::convert::From::from(::std::clone::Clone::clone(value))
-                }
-            }
-            impl<'a> ::windows::IntoParam<'a, ::windows::IUnknown> for IAgileObject {
-                fn into_param(self) -> ::windows::Param<'a, ::windows::IUnknown> {
-                    ::windows::Param::Owned(::std::convert::Into::<::windows::IUnknown>::into(self))
-                }
-            }
-            impl<'a> ::windows::IntoParam<'a, ::windows::IUnknown> for &'a IAgileObject {
-                fn into_param(self) -> ::windows::Param<'a, ::windows::IUnknown> {
-                    ::windows::Param::Owned(::std::convert::Into::<::windows::IUnknown>::into(
-                        ::std::clone::Clone::clone(self),
-                    ))
-                }
-            }
-            #[repr(C)]
-            #[doc(hidden)]
-            pub struct IAgileObject_abi(
-                pub  unsafe extern "system" fn(
-                    this: ::windows::RawPtr,
-                    iid: &::windows::Guid,
-                    interface: *mut ::windows::RawPtr,
-                ) -> ::windows::HRESULT,
-                pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
-                pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
-            );
-        }
-        #[allow(
-            unused_variables,
-            non_upper_case_globals,
-            non_snake_case,
-            unused_unsafe,
-            non_camel_case_types,
-            dead_code,
-            clippy::all
-        )]
-        pub mod Debug {
-            #[derive(
-                :: std :: cmp :: PartialEq,
-                :: std :: cmp :: Eq,
-                :: std :: marker :: Copy,
-                :: std :: clone :: Clone,
-                :: std :: default :: Default,
-                :: std :: fmt :: Debug,
-            )]
-            #[repr(transparent)]
-            pub struct FORMAT_MESSAGE_OPTIONS(pub u32);
-            impl FORMAT_MESSAGE_OPTIONS {
-                pub const FORMAT_MESSAGE_ALLOCATE_BUFFER: Self = Self(256u32);
-                pub const FORMAT_MESSAGE_ARGUMENT_ARRAY: Self = Self(8192u32);
-                pub const FORMAT_MESSAGE_FROM_HMODULE: Self = Self(2048u32);
-                pub const FORMAT_MESSAGE_FROM_STRING: Self = Self(1024u32);
-                pub const FORMAT_MESSAGE_FROM_SYSTEM: Self = Self(4096u32);
-                pub const FORMAT_MESSAGE_IGNORE_INSERTS: Self = Self(512u32);
-            }
-            impl ::std::convert::From<u32> for FORMAT_MESSAGE_OPTIONS {
-                fn from(value: u32) -> Self {
-                    Self(value)
-                }
-            }
-            unsafe impl ::windows::Abi for FORMAT_MESSAGE_OPTIONS {
-                type Abi = Self;
-            }
-            impl ::std::ops::BitOr for FORMAT_MESSAGE_OPTIONS {
-                type Output = Self;
-                fn bitor(self, rhs: Self) -> Self {
-                    Self(self.0 | rhs.0)
-                }
-            }
-            impl ::std::ops::BitAnd for FORMAT_MESSAGE_OPTIONS {
-                type Output = Self;
-                fn bitand(self, rhs: Self) -> Self {
-                    Self(self.0 & rhs.0)
-                }
-            }
-            impl ::std::ops::BitOrAssign for FORMAT_MESSAGE_OPTIONS {
-                fn bitor_assign(&mut self, rhs: Self) {
-                    self.0.bitor_assign(rhs.0)
-                }
-            }
-            impl ::std::ops::BitAndAssign for FORMAT_MESSAGE_OPTIONS {
-                fn bitand_assign(&mut self, rhs: Self) {
-                    self.0.bitand_assign(rhs.0)
-                }
-            }
-            pub unsafe fn FormatMessageW(
-                dwflags: FORMAT_MESSAGE_OPTIONS,
-                lpsource: *const ::std::ffi::c_void,
-                dwmessageid: u32,
-                dwlanguageid: u32,
-                lpbuffer: super::SystemServices::PWSTR,
-                nsize: u32,
-                arguments: *mut *mut i8,
-            ) -> u32 {
-                #[link(name = "KERNEL32")]
-                extern "system" {
-                    pub fn FormatMessageW(
+                    unsafe impl ::windows::Abi for FORMAT_MESSAGE_OPTIONS {
+                        type Abi = Self;
+                    }
+                    impl ::std::ops::BitOr for FORMAT_MESSAGE_OPTIONS {
+                        type Output = Self;
+                        fn bitor(self, rhs: Self) -> Self {
+                            Self(self.0 | rhs.0)
+                        }
+                    }
+                    impl ::std::ops::BitAnd for FORMAT_MESSAGE_OPTIONS {
+                        type Output = Self;
+                        fn bitand(self, rhs: Self) -> Self {
+                            Self(self.0 & rhs.0)
+                        }
+                    }
+                    impl ::std::ops::BitOrAssign for FORMAT_MESSAGE_OPTIONS {
+                        fn bitor_assign(&mut self, rhs: Self) {
+                            self.0.bitor_assign(rhs.0)
+                        }
+                    }
+                    impl ::std::ops::BitAndAssign for FORMAT_MESSAGE_OPTIONS {
+                        fn bitand_assign(&mut self, rhs: Self) {
+                            self.0.bitand_assign(rhs.0)
+                        }
+                    }
+                    pub unsafe fn FormatMessageW(
                         dwflags: FORMAT_MESSAGE_OPTIONS,
                         lpsource: *const ::std::ffi::c_void,
                         dwmessageid: u32,
                         dwlanguageid: u32,
-                        lpbuffer: super::SystemServices::PWSTR,
+                        lpbuffer: super::super::SystemServices::PWSTR,
                         nsize: u32,
                         arguments: *mut *mut i8,
-                    ) -> u32;
-                }
-                FormatMessageW(
-                    ::std::mem::transmute(dwflags),
-                    ::std::mem::transmute(lpsource),
-                    ::std::mem::transmute(dwmessageid),
-                    ::std::mem::transmute(dwlanguageid),
-                    ::std::mem::transmute(lpbuffer),
-                    ::std::mem::transmute(nsize),
-                    ::std::mem::transmute(arguments),
-                )
-            }
-            #[derive(
-                :: std :: cmp :: PartialEq,
-                :: std :: cmp :: Eq,
-                :: std :: marker :: Copy,
-                :: std :: clone :: Clone,
-                :: std :: default :: Default,
-                :: std :: fmt :: Debug,
-            )]
-            #[repr(transparent)]
-            pub struct WIN32_ERROR(pub u32);
-            impl WIN32_ERROR {
-                pub const NO_ERROR: Self = Self(0u32);
-                pub const ERROR_SUCCESS: Self = Self(0u32);
-                pub const ERROR_INVALID_FUNCTION: Self = Self(1u32);
-                pub const ERROR_FILE_NOT_FOUND: Self = Self(2u32);
-                pub const ERROR_PATH_NOT_FOUND: Self = Self(3u32);
-                pub const ERROR_TOO_MANY_OPEN_FILES: Self = Self(4u32);
-                pub const ERROR_ACCESS_DENIED: Self = Self(5u32);
-                pub const ERROR_INVALID_HANDLE: Self = Self(6u32);
-                pub const ERROR_ARENA_TRASHED: Self = Self(7u32);
-                pub const ERROR_NOT_ENOUGH_MEMORY: Self = Self(8u32);
-                pub const ERROR_INVALID_BLOCK: Self = Self(9u32);
-                pub const ERROR_BAD_ENVIRONMENT: Self = Self(10u32);
-                pub const ERROR_BAD_FORMAT: Self = Self(11u32);
-                pub const ERROR_INVALID_ACCESS: Self = Self(12u32);
-                pub const ERROR_INVALID_DATA: Self = Self(13u32);
-                pub const ERROR_OUTOFMEMORY: Self = Self(14u32);
-                pub const ERROR_INVALID_DRIVE: Self = Self(15u32);
-                pub const ERROR_CURRENT_DIRECTORY: Self = Self(16u32);
-                pub const ERROR_NOT_SAME_DEVICE: Self = Self(17u32);
-                pub const ERROR_NO_MORE_FILES: Self = Self(18u32);
-                pub const ERROR_WRITE_PROTECT: Self = Self(19u32);
-                pub const ERROR_BAD_UNIT: Self = Self(20u32);
-                pub const ERROR_NOT_READY: Self = Self(21u32);
-                pub const ERROR_BAD_COMMAND: Self = Self(22u32);
-                pub const ERROR_CRC: Self = Self(23u32);
-                pub const ERROR_BAD_LENGTH: Self = Self(24u32);
-                pub const ERROR_SEEK: Self = Self(25u32);
-                pub const ERROR_NOT_DOS_DISK: Self = Self(26u32);
-                pub const ERROR_SECTOR_NOT_FOUND: Self = Self(27u32);
-                pub const ERROR_OUT_OF_PAPER: Self = Self(28u32);
-                pub const ERROR_WRITE_FAULT: Self = Self(29u32);
-                pub const ERROR_READ_FAULT: Self = Self(30u32);
-                pub const ERROR_GEN_FAILURE: Self = Self(31u32);
-                pub const ERROR_SHARING_VIOLATION: Self = Self(32u32);
-                pub const ERROR_LOCK_VIOLATION: Self = Self(33u32);
-                pub const ERROR_WRONG_DISK: Self = Self(34u32);
-                pub const ERROR_SHARING_BUFFER_EXCEEDED: Self = Self(36u32);
-                pub const ERROR_HANDLE_EOF: Self = Self(38u32);
-                pub const ERROR_HANDLE_DISK_FULL: Self = Self(39u32);
-                pub const ERROR_NOT_SUPPORTED: Self = Self(50u32);
-                pub const ERROR_REM_NOT_LIST: Self = Self(51u32);
-                pub const ERROR_DUP_NAME: Self = Self(52u32);
-                pub const ERROR_BAD_NETPATH: Self = Self(53u32);
-                pub const ERROR_NETWORK_BUSY: Self = Self(54u32);
-                pub const ERROR_DEV_NOT_EXIST: Self = Self(55u32);
-                pub const ERROR_TOO_MANY_CMDS: Self = Self(56u32);
-                pub const ERROR_ADAP_HDW_ERR: Self = Self(57u32);
-                pub const ERROR_BAD_NET_RESP: Self = Self(58u32);
-                pub const ERROR_UNEXP_NET_ERR: Self = Self(59u32);
-                pub const ERROR_BAD_REM_ADAP: Self = Self(60u32);
-                pub const ERROR_PRINTQ_FULL: Self = Self(61u32);
-                pub const ERROR_NO_SPOOL_SPACE: Self = Self(62u32);
-                pub const ERROR_PRINT_CANCELLED: Self = Self(63u32);
-                pub const ERROR_NETNAME_DELETED: Self = Self(64u32);
-                pub const ERROR_NETWORK_ACCESS_DENIED: Self = Self(65u32);
-                pub const ERROR_BAD_DEV_TYPE: Self = Self(66u32);
-                pub const ERROR_BAD_NET_NAME: Self = Self(67u32);
-                pub const ERROR_TOO_MANY_NAMES: Self = Self(68u32);
-                pub const ERROR_TOO_MANY_SESS: Self = Self(69u32);
-                pub const ERROR_SHARING_PAUSED: Self = Self(70u32);
-                pub const ERROR_REQ_NOT_ACCEP: Self = Self(71u32);
-                pub const ERROR_REDIR_PAUSED: Self = Self(72u32);
-                pub const ERROR_FILE_EXISTS: Self = Self(80u32);
-                pub const ERROR_CANNOT_MAKE: Self = Self(82u32);
-                pub const ERROR_FAIL_I24: Self = Self(83u32);
-                pub const ERROR_OUT_OF_STRUCTURES: Self = Self(84u32);
-                pub const ERROR_ALREADY_ASSIGNED: Self = Self(85u32);
-                pub const ERROR_INVALID_PASSWORD: Self = Self(86u32);
-                pub const ERROR_INVALID_PARAMETER: Self = Self(87u32);
-                pub const ERROR_NET_WRITE_FAULT: Self = Self(88u32);
-                pub const ERROR_NO_PROC_SLOTS: Self = Self(89u32);
-                pub const ERROR_TOO_MANY_SEMAPHORES: Self = Self(100u32);
-                pub const ERROR_EXCL_SEM_ALREADY_OWNED: Self = Self(101u32);
-                pub const ERROR_SEM_IS_SET: Self = Self(102u32);
-                pub const ERROR_TOO_MANY_SEM_REQUESTS: Self = Self(103u32);
-                pub const ERROR_INVALID_AT_INTERRUPT_TIME: Self = Self(104u32);
-                pub const ERROR_SEM_OWNER_DIED: Self = Self(105u32);
-                pub const ERROR_SEM_USER_LIMIT: Self = Self(106u32);
-                pub const ERROR_DISK_CHANGE: Self = Self(107u32);
-                pub const ERROR_DRIVE_LOCKED: Self = Self(108u32);
-                pub const ERROR_BROKEN_PIPE: Self = Self(109u32);
-                pub const ERROR_OPEN_FAILED: Self = Self(110u32);
-                pub const ERROR_BUFFER_OVERFLOW: Self = Self(111u32);
-                pub const ERROR_DISK_FULL: Self = Self(112u32);
-                pub const ERROR_NO_MORE_SEARCH_HANDLES: Self = Self(113u32);
-                pub const ERROR_INVALID_TARGET_HANDLE: Self = Self(114u32);
-                pub const ERROR_INVALID_CATEGORY: Self = Self(117u32);
-                pub const ERROR_INVALID_VERIFY_SWITCH: Self = Self(118u32);
-                pub const ERROR_BAD_DRIVER_LEVEL: Self = Self(119u32);
-                pub const ERROR_CALL_NOT_IMPLEMENTED: Self = Self(120u32);
-                pub const ERROR_SEM_TIMEOUT: Self = Self(121u32);
-                pub const ERROR_INSUFFICIENT_BUFFER: Self = Self(122u32);
-                pub const ERROR_INVALID_NAME: Self = Self(123u32);
-                pub const ERROR_INVALID_LEVEL: Self = Self(124u32);
-                pub const ERROR_NO_VOLUME_LABEL: Self = Self(125u32);
-                pub const ERROR_MOD_NOT_FOUND: Self = Self(126u32);
-                pub const ERROR_PROC_NOT_FOUND: Self = Self(127u32);
-                pub const ERROR_WAIT_NO_CHILDREN: Self = Self(128u32);
-                pub const ERROR_CHILD_NOT_COMPLETE: Self = Self(129u32);
-                pub const ERROR_DIRECT_ACCESS_HANDLE: Self = Self(130u32);
-                pub const ERROR_NEGATIVE_SEEK: Self = Self(131u32);
-                pub const ERROR_SEEK_ON_DEVICE: Self = Self(132u32);
-                pub const ERROR_IS_JOIN_TARGET: Self = Self(133u32);
-                pub const ERROR_IS_JOINED: Self = Self(134u32);
-                pub const ERROR_IS_SUBSTED: Self = Self(135u32);
-                pub const ERROR_NOT_JOINED: Self = Self(136u32);
-                pub const ERROR_NOT_SUBSTED: Self = Self(137u32);
-                pub const ERROR_JOIN_TO_JOIN: Self = Self(138u32);
-                pub const ERROR_SUBST_TO_SUBST: Self = Self(139u32);
-                pub const ERROR_JOIN_TO_SUBST: Self = Self(140u32);
-                pub const ERROR_SUBST_TO_JOIN: Self = Self(141u32);
-                pub const ERROR_BUSY_DRIVE: Self = Self(142u32);
-                pub const ERROR_SAME_DRIVE: Self = Self(143u32);
-                pub const ERROR_DIR_NOT_ROOT: Self = Self(144u32);
-                pub const ERROR_DIR_NOT_EMPTY: Self = Self(145u32);
-                pub const ERROR_IS_SUBST_PATH: Self = Self(146u32);
-                pub const ERROR_IS_JOIN_PATH: Self = Self(147u32);
-                pub const ERROR_PATH_BUSY: Self = Self(148u32);
-                pub const ERROR_IS_SUBST_TARGET: Self = Self(149u32);
-                pub const ERROR_SYSTEM_TRACE: Self = Self(150u32);
-                pub const ERROR_INVALID_EVENT_COUNT: Self = Self(151u32);
-                pub const ERROR_TOO_MANY_MUXWAITERS: Self = Self(152u32);
-                pub const ERROR_INVALID_LIST_FORMAT: Self = Self(153u32);
-                pub const ERROR_LABEL_TOO_LONG: Self = Self(154u32);
-                pub const ERROR_TOO_MANY_TCBS: Self = Self(155u32);
-                pub const ERROR_SIGNAL_REFUSED: Self = Self(156u32);
-                pub const ERROR_DISCARDED: Self = Self(157u32);
-                pub const ERROR_NOT_LOCKED: Self = Self(158u32);
-                pub const ERROR_BAD_THREADID_ADDR: Self = Self(159u32);
-                pub const ERROR_BAD_ARGUMENTS: Self = Self(160u32);
-                pub const ERROR_BAD_PATHNAME: Self = Self(161u32);
-                pub const ERROR_SIGNAL_PENDING: Self = Self(162u32);
-                pub const ERROR_MAX_THRDS_REACHED: Self = Self(164u32);
-                pub const ERROR_LOCK_FAILED: Self = Self(167u32);
-                pub const ERROR_BUSY: Self = Self(170u32);
-                pub const ERROR_DEVICE_SUPPORT_IN_PROGRESS: Self = Self(171u32);
-                pub const ERROR_CANCEL_VIOLATION: Self = Self(173u32);
-                pub const ERROR_ATOMIC_LOCKS_NOT_SUPPORTED: Self = Self(174u32);
-                pub const ERROR_INVALID_SEGMENT_NUMBER: Self = Self(180u32);
-                pub const ERROR_INVALID_ORDINAL: Self = Self(182u32);
-                pub const ERROR_ALREADY_EXISTS: Self = Self(183u32);
-                pub const ERROR_INVALID_FLAG_NUMBER: Self = Self(186u32);
-                pub const ERROR_SEM_NOT_FOUND: Self = Self(187u32);
-                pub const ERROR_INVALID_STARTING_CODESEG: Self = Self(188u32);
-                pub const ERROR_INVALID_STACKSEG: Self = Self(189u32);
-                pub const ERROR_INVALID_MODULETYPE: Self = Self(190u32);
-                pub const ERROR_INVALID_EXE_SIGNATURE: Self = Self(191u32);
-                pub const ERROR_EXE_MARKED_INVALID: Self = Self(192u32);
-                pub const ERROR_BAD_EXE_FORMAT: Self = Self(193u32);
-                pub const ERROR_ITERATED_DATA_EXCEEDS_64k: Self = Self(194u32);
-                pub const ERROR_INVALID_MINALLOCSIZE: Self = Self(195u32);
-                pub const ERROR_DYNLINK_FROM_INVALID_RING: Self = Self(196u32);
-                pub const ERROR_IOPL_NOT_ENABLED: Self = Self(197u32);
-                pub const ERROR_INVALID_SEGDPL: Self = Self(198u32);
-                pub const ERROR_AUTODATASEG_EXCEEDS_64k: Self = Self(199u32);
-                pub const ERROR_RING2SEG_MUST_BE_MOVABLE: Self = Self(200u32);
-                pub const ERROR_RELOC_CHAIN_XEEDS_SEGLIM: Self = Self(201u32);
-                pub const ERROR_INFLOOP_IN_RELOC_CHAIN: Self = Self(202u32);
-                pub const ERROR_ENVVAR_NOT_FOUND: Self = Self(203u32);
-                pub const ERROR_NO_SIGNAL_SENT: Self = Self(205u32);
-                pub const ERROR_FILENAME_EXCED_RANGE: Self = Self(206u32);
-                pub const ERROR_RING2_STACK_IN_USE: Self = Self(207u32);
-                pub const ERROR_META_EXPANSION_TOO_LONG: Self = Self(208u32);
-                pub const ERROR_INVALID_SIGNAL_NUMBER: Self = Self(209u32);
-                pub const ERROR_THREAD_1_INACTIVE: Self = Self(210u32);
-                pub const ERROR_LOCKED: Self = Self(212u32);
-                pub const ERROR_TOO_MANY_MODULES: Self = Self(214u32);
-                pub const ERROR_NESTING_NOT_ALLOWED: Self = Self(215u32);
-                pub const ERROR_EXE_MACHINE_TYPE_MISMATCH: Self = Self(216u32);
-                pub const ERROR_EXE_CANNOT_MODIFY_SIGNED_BINARY: Self = Self(217u32);
-                pub const ERROR_EXE_CANNOT_MODIFY_STRONG_SIGNED_BINARY: Self = Self(218u32);
-                pub const ERROR_FILE_CHECKED_OUT: Self = Self(220u32);
-                pub const ERROR_CHECKOUT_REQUIRED: Self = Self(221u32);
-                pub const ERROR_BAD_FILE_TYPE: Self = Self(222u32);
-                pub const ERROR_FILE_TOO_LARGE: Self = Self(223u32);
-                pub const ERROR_FORMS_AUTH_REQUIRED: Self = Self(224u32);
-                pub const ERROR_VIRUS_INFECTED: Self = Self(225u32);
-                pub const ERROR_VIRUS_DELETED: Self = Self(226u32);
-                pub const ERROR_PIPE_LOCAL: Self = Self(229u32);
-                pub const ERROR_BAD_PIPE: Self = Self(230u32);
-                pub const ERROR_PIPE_BUSY: Self = Self(231u32);
-                pub const ERROR_NO_DATA: Self = Self(232u32);
-                pub const ERROR_PIPE_NOT_CONNECTED: Self = Self(233u32);
-                pub const ERROR_MORE_DATA: Self = Self(234u32);
-                pub const ERROR_NO_WORK_DONE: Self = Self(235u32);
-                pub const ERROR_VC_DISCONNECTED: Self = Self(240u32);
-                pub const ERROR_INVALID_EA_NAME: Self = Self(254u32);
-                pub const ERROR_EA_LIST_INCONSISTENT: Self = Self(255u32);
-                pub const ERROR_NO_MORE_ITEMS: Self = Self(259u32);
-                pub const ERROR_CANNOT_COPY: Self = Self(266u32);
-                pub const ERROR_DIRECTORY: Self = Self(267u32);
-                pub const ERROR_EAS_DIDNT_FIT: Self = Self(275u32);
-                pub const ERROR_EA_FILE_CORRUPT: Self = Self(276u32);
-                pub const ERROR_EA_TABLE_FULL: Self = Self(277u32);
-                pub const ERROR_INVALID_EA_HANDLE: Self = Self(278u32);
-                pub const ERROR_EAS_NOT_SUPPORTED: Self = Self(282u32);
-                pub const ERROR_NOT_OWNER: Self = Self(288u32);
-                pub const ERROR_TOO_MANY_POSTS: Self = Self(298u32);
-                pub const ERROR_PARTIAL_COPY: Self = Self(299u32);
-                pub const ERROR_OPLOCK_NOT_GRANTED: Self = Self(300u32);
-                pub const ERROR_INVALID_OPLOCK_PROTOCOL: Self = Self(301u32);
-                pub const ERROR_DISK_TOO_FRAGMENTED: Self = Self(302u32);
-                pub const ERROR_DELETE_PENDING: Self = Self(303u32);
-                pub const ERROR_INCOMPATIBLE_WITH_GLOBAL_SHORT_NAME_REGISTRY_SETTING: Self =
-                    Self(304u32);
-                pub const ERROR_SHORT_NAMES_NOT_ENABLED_ON_VOLUME: Self = Self(305u32);
-                pub const ERROR_SECURITY_STREAM_IS_INCONSISTENT: Self = Self(306u32);
-                pub const ERROR_INVALID_LOCK_RANGE: Self = Self(307u32);
-                pub const ERROR_IMAGE_SUBSYSTEM_NOT_PRESENT: Self = Self(308u32);
-                pub const ERROR_NOTIFICATION_GUID_ALREADY_DEFINED: Self = Self(309u32);
-                pub const ERROR_INVALID_EXCEPTION_HANDLER: Self = Self(310u32);
-                pub const ERROR_DUPLICATE_PRIVILEGES: Self = Self(311u32);
-                pub const ERROR_NO_RANGES_PROCESSED: Self = Self(312u32);
-                pub const ERROR_NOT_ALLOWED_ON_SYSTEM_FILE: Self = Self(313u32);
-                pub const ERROR_DISK_RESOURCES_EXHAUSTED: Self = Self(314u32);
-                pub const ERROR_INVALID_TOKEN: Self = Self(315u32);
-                pub const ERROR_DEVICE_FEATURE_NOT_SUPPORTED: Self = Self(316u32);
-                pub const ERROR_MR_MID_NOT_FOUND: Self = Self(317u32);
-                pub const ERROR_SCOPE_NOT_FOUND: Self = Self(318u32);
-                pub const ERROR_UNDEFINED_SCOPE: Self = Self(319u32);
-                pub const ERROR_INVALID_CAP: Self = Self(320u32);
-                pub const ERROR_DEVICE_UNREACHABLE: Self = Self(321u32);
-                pub const ERROR_DEVICE_NO_RESOURCES: Self = Self(322u32);
-                pub const ERROR_DATA_CHECKSUM_ERROR: Self = Self(323u32);
-                pub const ERROR_INTERMIXED_KERNEL_EA_OPERATION: Self = Self(324u32);
-                pub const ERROR_FILE_LEVEL_TRIM_NOT_SUPPORTED: Self = Self(326u32);
-                pub const ERROR_OFFSET_ALIGNMENT_VIOLATION: Self = Self(327u32);
-                pub const ERROR_INVALID_FIELD_IN_PARAMETER_LIST: Self = Self(328u32);
-                pub const ERROR_OPERATION_IN_PROGRESS: Self = Self(329u32);
-                pub const ERROR_BAD_DEVICE_PATH: Self = Self(330u32);
-                pub const ERROR_TOO_MANY_DESCRIPTORS: Self = Self(331u32);
-                pub const ERROR_SCRUB_DATA_DISABLED: Self = Self(332u32);
-                pub const ERROR_NOT_REDUNDANT_STORAGE: Self = Self(333u32);
-                pub const ERROR_RESIDENT_FILE_NOT_SUPPORTED: Self = Self(334u32);
-                pub const ERROR_COMPRESSED_FILE_NOT_SUPPORTED: Self = Self(335u32);
-                pub const ERROR_DIRECTORY_NOT_SUPPORTED: Self = Self(336u32);
-                pub const ERROR_NOT_READ_FROM_COPY: Self = Self(337u32);
-                pub const ERROR_FT_WRITE_FAILURE: Self = Self(338u32);
-                pub const ERROR_FT_DI_SCAN_REQUIRED: Self = Self(339u32);
-                pub const ERROR_INVALID_KERNEL_INFO_VERSION: Self = Self(340u32);
-                pub const ERROR_INVALID_PEP_INFO_VERSION: Self = Self(341u32);
-                pub const ERROR_OBJECT_NOT_EXTERNALLY_BACKED: Self = Self(342u32);
-                pub const ERROR_EXTERNAL_BACKING_PROVIDER_UNKNOWN: Self = Self(343u32);
-                pub const ERROR_COMPRESSION_NOT_BENEFICIAL: Self = Self(344u32);
-                pub const ERROR_STORAGE_TOPOLOGY_ID_MISMATCH: Self = Self(345u32);
-                pub const ERROR_BLOCKED_BY_PARENTAL_CONTROLS: Self = Self(346u32);
-                pub const ERROR_BLOCK_TOO_MANY_REFERENCES: Self = Self(347u32);
-                pub const ERROR_MARKED_TO_DISALLOW_WRITES: Self = Self(348u32);
-                pub const ERROR_ENCLAVE_FAILURE: Self = Self(349u32);
-                pub const ERROR_FAIL_NOACTION_REBOOT: Self = Self(350u32);
-                pub const ERROR_FAIL_SHUTDOWN: Self = Self(351u32);
-                pub const ERROR_FAIL_RESTART: Self = Self(352u32);
-                pub const ERROR_MAX_SESSIONS_REACHED: Self = Self(353u32);
-                pub const ERROR_NETWORK_ACCESS_DENIED_EDP: Self = Self(354u32);
-                pub const ERROR_DEVICE_HINT_NAME_BUFFER_TOO_SMALL: Self = Self(355u32);
-                pub const ERROR_EDP_POLICY_DENIES_OPERATION: Self = Self(356u32);
-                pub const ERROR_EDP_DPL_POLICY_CANT_BE_SATISFIED: Self = Self(357u32);
-                pub const ERROR_CLOUD_FILE_SYNC_ROOT_METADATA_CORRUPT: Self = Self(358u32);
-                pub const ERROR_DEVICE_IN_MAINTENANCE: Self = Self(359u32);
-                pub const ERROR_NOT_SUPPORTED_ON_DAX: Self = Self(360u32);
-                pub const ERROR_DAX_MAPPING_EXISTS: Self = Self(361u32);
-                pub const ERROR_CLOUD_FILE_PROVIDER_NOT_RUNNING: Self = Self(362u32);
-                pub const ERROR_CLOUD_FILE_METADATA_CORRUPT: Self = Self(363u32);
-                pub const ERROR_CLOUD_FILE_METADATA_TOO_LARGE: Self = Self(364u32);
-                pub const ERROR_CLOUD_FILE_PROPERTY_BLOB_TOO_LARGE: Self = Self(365u32);
-                pub const ERROR_CLOUD_FILE_PROPERTY_BLOB_CHECKSUM_MISMATCH: Self = Self(366u32);
-                pub const ERROR_CHILD_PROCESS_BLOCKED: Self = Self(367u32);
-                pub const ERROR_STORAGE_LOST_DATA_PERSISTENCE: Self = Self(368u32);
-                pub const ERROR_FILE_SYSTEM_VIRTUALIZATION_UNAVAILABLE: Self = Self(369u32);
-                pub const ERROR_FILE_SYSTEM_VIRTUALIZATION_METADATA_CORRUPT: Self = Self(370u32);
-                pub const ERROR_FILE_SYSTEM_VIRTUALIZATION_BUSY: Self = Self(371u32);
-                pub const ERROR_FILE_SYSTEM_VIRTUALIZATION_PROVIDER_UNKNOWN: Self = Self(372u32);
-                pub const ERROR_GDI_HANDLE_LEAK: Self = Self(373u32);
-                pub const ERROR_CLOUD_FILE_TOO_MANY_PROPERTY_BLOBS: Self = Self(374u32);
-                pub const ERROR_CLOUD_FILE_PROPERTY_VERSION_NOT_SUPPORTED: Self = Self(375u32);
-                pub const ERROR_NOT_A_CLOUD_FILE: Self = Self(376u32);
-                pub const ERROR_CLOUD_FILE_NOT_IN_SYNC: Self = Self(377u32);
-                pub const ERROR_CLOUD_FILE_ALREADY_CONNECTED: Self = Self(378u32);
-                pub const ERROR_CLOUD_FILE_NOT_SUPPORTED: Self = Self(379u32);
-                pub const ERROR_CLOUD_FILE_INVALID_REQUEST: Self = Self(380u32);
-                pub const ERROR_CLOUD_FILE_READ_ONLY_VOLUME: Self = Self(381u32);
-                pub const ERROR_CLOUD_FILE_CONNECTED_PROVIDER_ONLY: Self = Self(382u32);
-                pub const ERROR_CLOUD_FILE_VALIDATION_FAILED: Self = Self(383u32);
-                pub const ERROR_SMB1_NOT_AVAILABLE: Self = Self(384u32);
-                pub const ERROR_FILE_SYSTEM_VIRTUALIZATION_INVALID_OPERATION: Self = Self(385u32);
-                pub const ERROR_CLOUD_FILE_AUTHENTICATION_FAILED: Self = Self(386u32);
-                pub const ERROR_CLOUD_FILE_INSUFFICIENT_RESOURCES: Self = Self(387u32);
-                pub const ERROR_CLOUD_FILE_NETWORK_UNAVAILABLE: Self = Self(388u32);
-                pub const ERROR_CLOUD_FILE_UNSUCCESSFUL: Self = Self(389u32);
-                pub const ERROR_CLOUD_FILE_NOT_UNDER_SYNC_ROOT: Self = Self(390u32);
-                pub const ERROR_CLOUD_FILE_IN_USE: Self = Self(391u32);
-                pub const ERROR_CLOUD_FILE_PINNED: Self = Self(392u32);
-                pub const ERROR_CLOUD_FILE_REQUEST_ABORTED: Self = Self(393u32);
-                pub const ERROR_CLOUD_FILE_PROPERTY_CORRUPT: Self = Self(394u32);
-                pub const ERROR_CLOUD_FILE_ACCESS_DENIED: Self = Self(395u32);
-                pub const ERROR_CLOUD_FILE_INCOMPATIBLE_HARDLINKS: Self = Self(396u32);
-                pub const ERROR_CLOUD_FILE_PROPERTY_LOCK_CONFLICT: Self = Self(397u32);
-                pub const ERROR_CLOUD_FILE_REQUEST_CANCELED: Self = Self(398u32);
-                pub const ERROR_EXTERNAL_SYSKEY_NOT_SUPPORTED: Self = Self(399u32);
-                pub const ERROR_THREAD_MODE_ALREADY_BACKGROUND: Self = Self(400u32);
-                pub const ERROR_THREAD_MODE_NOT_BACKGROUND: Self = Self(401u32);
-                pub const ERROR_PROCESS_MODE_ALREADY_BACKGROUND: Self = Self(402u32);
-                pub const ERROR_PROCESS_MODE_NOT_BACKGROUND: Self = Self(403u32);
-                pub const ERROR_CLOUD_FILE_PROVIDER_TERMINATED: Self = Self(404u32);
-                pub const ERROR_NOT_A_CLOUD_SYNC_ROOT: Self = Self(405u32);
-                pub const ERROR_FILE_PROTECTED_UNDER_DPL: Self = Self(406u32);
-                pub const ERROR_VOLUME_NOT_CLUSTER_ALIGNED: Self = Self(407u32);
-                pub const ERROR_NO_PHYSICALLY_ALIGNED_FREE_SPACE_FOUND: Self = Self(408u32);
-                pub const ERROR_APPX_FILE_NOT_ENCRYPTED: Self = Self(409u32);
-                pub const ERROR_RWRAW_ENCRYPTED_FILE_NOT_ENCRYPTED: Self = Self(410u32);
-                pub const ERROR_RWRAW_ENCRYPTED_INVALID_EDATAINFO_FILEOFFSET: Self = Self(411u32);
-                pub const ERROR_RWRAW_ENCRYPTED_INVALID_EDATAINFO_FILERANGE: Self = Self(412u32);
-                pub const ERROR_RWRAW_ENCRYPTED_INVALID_EDATAINFO_PARAMETER: Self = Self(413u32);
-                pub const ERROR_LINUX_SUBSYSTEM_NOT_PRESENT: Self = Self(414u32);
-                pub const ERROR_FT_READ_FAILURE: Self = Self(415u32);
-                pub const ERROR_STORAGE_RESERVE_ID_INVALID: Self = Self(416u32);
-                pub const ERROR_STORAGE_RESERVE_DOES_NOT_EXIST: Self = Self(417u32);
-                pub const ERROR_STORAGE_RESERVE_ALREADY_EXISTS: Self = Self(418u32);
-                pub const ERROR_STORAGE_RESERVE_NOT_EMPTY: Self = Self(419u32);
-                pub const ERROR_NOT_A_DAX_VOLUME: Self = Self(420u32);
-                pub const ERROR_NOT_DAX_MAPPABLE: Self = Self(421u32);
-                pub const ERROR_TIME_SENSITIVE_THREAD: Self = Self(422u32);
-                pub const ERROR_DPL_NOT_SUPPORTED_FOR_USER: Self = Self(423u32);
-                pub const ERROR_CASE_DIFFERING_NAMES_IN_DIR: Self = Self(424u32);
-                pub const ERROR_FILE_NOT_SUPPORTED: Self = Self(425u32);
-                pub const ERROR_CLOUD_FILE_REQUEST_TIMEOUT: Self = Self(426u32);
-                pub const ERROR_NO_TASK_QUEUE: Self = Self(427u32);
-                pub const ERROR_SRC_SRV_DLL_LOAD_FAILED: Self = Self(428u32);
-                pub const ERROR_NOT_SUPPORTED_WITH_BTT: Self = Self(429u32);
-                pub const ERROR_ENCRYPTION_DISABLED: Self = Self(430u32);
-                pub const ERROR_ENCRYPTING_METADATA_DISALLOWED: Self = Self(431u32);
-                pub const ERROR_CANT_CLEAR_ENCRYPTION_FLAG: Self = Self(432u32);
-                pub const ERROR_NO_SUCH_DEVICE: Self = Self(433u32);
-                pub const ERROR_CLOUD_FILE_DEHYDRATION_DISALLOWED: Self = Self(434u32);
-                pub const ERROR_FILE_SNAP_IN_PROGRESS: Self = Self(435u32);
-                pub const ERROR_FILE_SNAP_USER_SECTION_NOT_SUPPORTED: Self = Self(436u32);
-                pub const ERROR_FILE_SNAP_MODIFY_NOT_SUPPORTED: Self = Self(437u32);
-                pub const ERROR_FILE_SNAP_IO_NOT_COORDINATED: Self = Self(438u32);
-                pub const ERROR_FILE_SNAP_UNEXPECTED_ERROR: Self = Self(439u32);
-                pub const ERROR_FILE_SNAP_INVALID_PARAMETER: Self = Self(440u32);
-                pub const ERROR_UNSATISFIED_DEPENDENCIES: Self = Self(441u32);
-                pub const ERROR_CASE_SENSITIVE_PATH: Self = Self(442u32);
-                pub const ERROR_UNEXPECTED_NTCACHEMANAGER_ERROR: Self = Self(443u32);
-                pub const ERROR_CAPAUTHZ_NOT_DEVUNLOCKED: Self = Self(450u32);
-                pub const ERROR_CAPAUTHZ_CHANGE_TYPE: Self = Self(451u32);
-                pub const ERROR_CAPAUTHZ_NOT_PROVISIONED: Self = Self(452u32);
-                pub const ERROR_CAPAUTHZ_NOT_AUTHORIZED: Self = Self(453u32);
-                pub const ERROR_CAPAUTHZ_NO_POLICY: Self = Self(454u32);
-                pub const ERROR_CAPAUTHZ_DB_CORRUPTED: Self = Self(455u32);
-                pub const ERROR_CAPAUTHZ_SCCD_INVALID_CATALOG: Self = Self(456u32);
-                pub const ERROR_CAPAUTHZ_SCCD_NO_AUTH_ENTITY: Self = Self(457u32);
-                pub const ERROR_CAPAUTHZ_SCCD_PARSE_ERROR: Self = Self(458u32);
-                pub const ERROR_CAPAUTHZ_SCCD_DEV_MODE_REQUIRED: Self = Self(459u32);
-                pub const ERROR_CAPAUTHZ_SCCD_NO_CAPABILITY_MATCH: Self = Self(460u32);
-                pub const ERROR_CIMFS_IMAGE_CORRUPT: Self = Self(470u32);
-                pub const ERROR_PNP_QUERY_REMOVE_DEVICE_TIMEOUT: Self = Self(480u32);
-                pub const ERROR_PNP_QUERY_REMOVE_RELATED_DEVICE_TIMEOUT: Self = Self(481u32);
-                pub const ERROR_PNP_QUERY_REMOVE_UNRELATED_DEVICE_TIMEOUT: Self = Self(482u32);
-                pub const ERROR_DEVICE_HARDWARE_ERROR: Self = Self(483u32);
-                pub const ERROR_INVALID_ADDRESS: Self = Self(487u32);
-                pub const ERROR_VRF_CFG_AND_IO_ENABLED: Self = Self(1183u32);
-                pub const ERROR_PARTITION_TERMINATING: Self = Self(1184u32);
-                pub const ERROR_USER_PROFILE_LOAD: Self = Self(500u32);
-                pub const ERROR_ARITHMETIC_OVERFLOW: Self = Self(534u32);
-                pub const ERROR_PIPE_CONNECTED: Self = Self(535u32);
-                pub const ERROR_PIPE_LISTENING: Self = Self(536u32);
-                pub const ERROR_VERIFIER_STOP: Self = Self(537u32);
-                pub const ERROR_ABIOS_ERROR: Self = Self(538u32);
-                pub const ERROR_WX86_WARNING: Self = Self(539u32);
-                pub const ERROR_WX86_ERROR: Self = Self(540u32);
-                pub const ERROR_TIMER_NOT_CANCELED: Self = Self(541u32);
-                pub const ERROR_UNWIND: Self = Self(542u32);
-                pub const ERROR_BAD_STACK: Self = Self(543u32);
-                pub const ERROR_INVALID_UNWIND_TARGET: Self = Self(544u32);
-                pub const ERROR_INVALID_PORT_ATTRIBUTES: Self = Self(545u32);
-                pub const ERROR_PORT_MESSAGE_TOO_LONG: Self = Self(546u32);
-                pub const ERROR_INVALID_QUOTA_LOWER: Self = Self(547u32);
-                pub const ERROR_DEVICE_ALREADY_ATTACHED: Self = Self(548u32);
-                pub const ERROR_INSTRUCTION_MISALIGNMENT: Self = Self(549u32);
-                pub const ERROR_PROFILING_NOT_STARTED: Self = Self(550u32);
-                pub const ERROR_PROFILING_NOT_STOPPED: Self = Self(551u32);
-                pub const ERROR_COULD_NOT_INTERPRET: Self = Self(552u32);
-                pub const ERROR_PROFILING_AT_LIMIT: Self = Self(553u32);
-                pub const ERROR_CANT_WAIT: Self = Self(554u32);
-                pub const ERROR_CANT_TERMINATE_SELF: Self = Self(555u32);
-                pub const ERROR_UNEXPECTED_MM_CREATE_ERR: Self = Self(556u32);
-                pub const ERROR_UNEXPECTED_MM_MAP_ERROR: Self = Self(557u32);
-                pub const ERROR_UNEXPECTED_MM_EXTEND_ERR: Self = Self(558u32);
-                pub const ERROR_BAD_FUNCTION_TABLE: Self = Self(559u32);
-                pub const ERROR_NO_GUID_TRANSLATION: Self = Self(560u32);
-                pub const ERROR_INVALID_LDT_SIZE: Self = Self(561u32);
-                pub const ERROR_INVALID_LDT_OFFSET: Self = Self(563u32);
-                pub const ERROR_INVALID_LDT_DESCRIPTOR: Self = Self(564u32);
-                pub const ERROR_TOO_MANY_THREADS: Self = Self(565u32);
-                pub const ERROR_THREAD_NOT_IN_PROCESS: Self = Self(566u32);
-                pub const ERROR_PAGEFILE_QUOTA_EXCEEDED: Self = Self(567u32);
-                pub const ERROR_LOGON_SERVER_CONFLICT: Self = Self(568u32);
-                pub const ERROR_SYNCHRONIZATION_REQUIRED: Self = Self(569u32);
-                pub const ERROR_NET_OPEN_FAILED: Self = Self(570u32);
-                pub const ERROR_IO_PRIVILEGE_FAILED: Self = Self(571u32);
-                pub const ERROR_CONTROL_C_EXIT: Self = Self(572u32);
-                pub const ERROR_MISSING_SYSTEMFILE: Self = Self(573u32);
-                pub const ERROR_UNHANDLED_EXCEPTION: Self = Self(574u32);
-                pub const ERROR_APP_INIT_FAILURE: Self = Self(575u32);
-                pub const ERROR_PAGEFILE_CREATE_FAILED: Self = Self(576u32);
-                pub const ERROR_INVALID_IMAGE_HASH: Self = Self(577u32);
-                pub const ERROR_NO_PAGEFILE: Self = Self(578u32);
-                pub const ERROR_ILLEGAL_FLOAT_CONTEXT: Self = Self(579u32);
-                pub const ERROR_NO_EVENT_PAIR: Self = Self(580u32);
-                pub const ERROR_DOMAIN_CTRLR_CONFIG_ERROR: Self = Self(581u32);
-                pub const ERROR_ILLEGAL_CHARACTER: Self = Self(582u32);
-                pub const ERROR_UNDEFINED_CHARACTER: Self = Self(583u32);
-                pub const ERROR_FLOPPY_VOLUME: Self = Self(584u32);
-                pub const ERROR_BIOS_FAILED_TO_CONNECT_INTERRUPT: Self = Self(585u32);
-                pub const ERROR_BACKUP_CONTROLLER: Self = Self(586u32);
-                pub const ERROR_MUTANT_LIMIT_EXCEEDED: Self = Self(587u32);
-                pub const ERROR_FS_DRIVER_REQUIRED: Self = Self(588u32);
-                pub const ERROR_CANNOT_LOAD_REGISTRY_FILE: Self = Self(589u32);
-                pub const ERROR_DEBUG_ATTACH_FAILED: Self = Self(590u32);
-                pub const ERROR_SYSTEM_PROCESS_TERMINATED: Self = Self(591u32);
-                pub const ERROR_DATA_NOT_ACCEPTED: Self = Self(592u32);
-                pub const ERROR_VDM_HARD_ERROR: Self = Self(593u32);
-                pub const ERROR_DRIVER_CANCEL_TIMEOUT: Self = Self(594u32);
-                pub const ERROR_REPLY_MESSAGE_MISMATCH: Self = Self(595u32);
-                pub const ERROR_LOST_WRITEBEHIND_DATA: Self = Self(596u32);
-                pub const ERROR_CLIENT_SERVER_PARAMETERS_INVALID: Self = Self(597u32);
-                pub const ERROR_NOT_TINY_STREAM: Self = Self(598u32);
-                pub const ERROR_STACK_OVERFLOW_READ: Self = Self(599u32);
-                pub const ERROR_CONVERT_TO_LARGE: Self = Self(600u32);
-                pub const ERROR_FOUND_OUT_OF_SCOPE: Self = Self(601u32);
-                pub const ERROR_ALLOCATE_BUCKET: Self = Self(602u32);
-                pub const ERROR_MARSHALL_OVERFLOW: Self = Self(603u32);
-                pub const ERROR_INVALID_VARIANT: Self = Self(604u32);
-                pub const ERROR_BAD_COMPRESSION_BUFFER: Self = Self(605u32);
-                pub const ERROR_AUDIT_FAILED: Self = Self(606u32);
-                pub const ERROR_TIMER_RESOLUTION_NOT_SET: Self = Self(607u32);
-                pub const ERROR_INSUFFICIENT_LOGON_INFO: Self = Self(608u32);
-                pub const ERROR_BAD_DLL_ENTRYPOINT: Self = Self(609u32);
-                pub const ERROR_BAD_SERVICE_ENTRYPOINT: Self = Self(610u32);
-                pub const ERROR_IP_ADDRESS_CONFLICT1: Self = Self(611u32);
-                pub const ERROR_IP_ADDRESS_CONFLICT2: Self = Self(612u32);
-                pub const ERROR_REGISTRY_QUOTA_LIMIT: Self = Self(613u32);
-                pub const ERROR_NO_CALLBACK_ACTIVE: Self = Self(614u32);
-                pub const ERROR_PWD_TOO_SHORT: Self = Self(615u32);
-                pub const ERROR_PWD_TOO_RECENT: Self = Self(616u32);
-                pub const ERROR_PWD_HISTORY_CONFLICT: Self = Self(617u32);
-                pub const ERROR_UNSUPPORTED_COMPRESSION: Self = Self(618u32);
-                pub const ERROR_INVALID_HW_PROFILE: Self = Self(619u32);
-                pub const ERROR_INVALID_PLUGPLAY_DEVICE_PATH: Self = Self(620u32);
-                pub const ERROR_QUOTA_LIST_INCONSISTENT: Self = Self(621u32);
-                pub const ERROR_EVALUATION_EXPIRATION: Self = Self(622u32);
-                pub const ERROR_ILLEGAL_DLL_RELOCATION: Self = Self(623u32);
-                pub const ERROR_DLL_INIT_FAILED_LOGOFF: Self = Self(624u32);
-                pub const ERROR_VALIDATE_CONTINUE: Self = Self(625u32);
-                pub const ERROR_NO_MORE_MATCHES: Self = Self(626u32);
-                pub const ERROR_RANGE_LIST_CONFLICT: Self = Self(627u32);
-                pub const ERROR_SERVER_SID_MISMATCH: Self = Self(628u32);
-                pub const ERROR_CANT_ENABLE_DENY_ONLY: Self = Self(629u32);
-                pub const ERROR_FLOAT_MULTIPLE_FAULTS: Self = Self(630u32);
-                pub const ERROR_FLOAT_MULTIPLE_TRAPS: Self = Self(631u32);
-                pub const ERROR_NOINTERFACE: Self = Self(632u32);
-                pub const ERROR_DRIVER_FAILED_SLEEP: Self = Self(633u32);
-                pub const ERROR_CORRUPT_SYSTEM_FILE: Self = Self(634u32);
-                pub const ERROR_COMMITMENT_MINIMUM: Self = Self(635u32);
-                pub const ERROR_PNP_RESTART_ENUMERATION: Self = Self(636u32);
-                pub const ERROR_SYSTEM_IMAGE_BAD_SIGNATURE: Self = Self(637u32);
-                pub const ERROR_PNP_REBOOT_REQUIRED: Self = Self(638u32);
-                pub const ERROR_INSUFFICIENT_POWER: Self = Self(639u32);
-                pub const ERROR_MULTIPLE_FAULT_VIOLATION: Self = Self(640u32);
-                pub const ERROR_SYSTEM_SHUTDOWN: Self = Self(641u32);
-                pub const ERROR_PORT_NOT_SET: Self = Self(642u32);
-                pub const ERROR_DS_VERSION_CHECK_FAILURE: Self = Self(643u32);
-                pub const ERROR_RANGE_NOT_FOUND: Self = Self(644u32);
-                pub const ERROR_NOT_SAFE_MODE_DRIVER: Self = Self(646u32);
-                pub const ERROR_FAILED_DRIVER_ENTRY: Self = Self(647u32);
-                pub const ERROR_DEVICE_ENUMERATION_ERROR: Self = Self(648u32);
-                pub const ERROR_MOUNT_POINT_NOT_RESOLVED: Self = Self(649u32);
-                pub const ERROR_INVALID_DEVICE_OBJECT_PARAMETER: Self = Self(650u32);
-                pub const ERROR_MCA_OCCURED: Self = Self(651u32);
-                pub const ERROR_DRIVER_DATABASE_ERROR: Self = Self(652u32);
-                pub const ERROR_SYSTEM_HIVE_TOO_LARGE: Self = Self(653u32);
-                pub const ERROR_DRIVER_FAILED_PRIOR_UNLOAD: Self = Self(654u32);
-                pub const ERROR_VOLSNAP_PREPARE_HIBERNATE: Self = Self(655u32);
-                pub const ERROR_HIBERNATION_FAILURE: Self = Self(656u32);
-                pub const ERROR_PWD_TOO_LONG: Self = Self(657u32);
-                pub const ERROR_FILE_SYSTEM_LIMITATION: Self = Self(665u32);
-                pub const ERROR_ASSERTION_FAILURE: Self = Self(668u32);
-                pub const ERROR_ACPI_ERROR: Self = Self(669u32);
-                pub const ERROR_WOW_ASSERTION: Self = Self(670u32);
-                pub const ERROR_PNP_BAD_MPS_TABLE: Self = Self(671u32);
-                pub const ERROR_PNP_TRANSLATION_FAILED: Self = Self(672u32);
-                pub const ERROR_PNP_IRQ_TRANSLATION_FAILED: Self = Self(673u32);
-                pub const ERROR_PNP_INVALID_ID: Self = Self(674u32);
-                pub const ERROR_WAKE_SYSTEM_DEBUGGER: Self = Self(675u32);
-                pub const ERROR_HANDLES_CLOSED: Self = Self(676u32);
-                pub const ERROR_EXTRANEOUS_INFORMATION: Self = Self(677u32);
-                pub const ERROR_RXACT_COMMIT_NECESSARY: Self = Self(678u32);
-                pub const ERROR_MEDIA_CHECK: Self = Self(679u32);
-                pub const ERROR_GUID_SUBSTITUTION_MADE: Self = Self(680u32);
-                pub const ERROR_STOPPED_ON_SYMLINK: Self = Self(681u32);
-                pub const ERROR_LONGJUMP: Self = Self(682u32);
-                pub const ERROR_PLUGPLAY_QUERY_VETOED: Self = Self(683u32);
-                pub const ERROR_UNWIND_CONSOLIDATE: Self = Self(684u32);
-                pub const ERROR_REGISTRY_HIVE_RECOVERED: Self = Self(685u32);
-                pub const ERROR_DLL_MIGHT_BE_INSECURE: Self = Self(686u32);
-                pub const ERROR_DLL_MIGHT_BE_INCOMPATIBLE: Self = Self(687u32);
-                pub const ERROR_DBG_EXCEPTION_NOT_HANDLED: Self = Self(688u32);
-                pub const ERROR_DBG_REPLY_LATER: Self = Self(689u32);
-                pub const ERROR_DBG_UNABLE_TO_PROVIDE_HANDLE: Self = Self(690u32);
-                pub const ERROR_DBG_TERMINATE_THREAD: Self = Self(691u32);
-                pub const ERROR_DBG_TERMINATE_PROCESS: Self = Self(692u32);
-                pub const ERROR_DBG_CONTROL_C: Self = Self(693u32);
-                pub const ERROR_DBG_PRINTEXCEPTION_C: Self = Self(694u32);
-                pub const ERROR_DBG_RIPEXCEPTION: Self = Self(695u32);
-                pub const ERROR_DBG_CONTROL_BREAK: Self = Self(696u32);
-                pub const ERROR_DBG_COMMAND_EXCEPTION: Self = Self(697u32);
-                pub const ERROR_OBJECT_NAME_EXISTS: Self = Self(698u32);
-                pub const ERROR_THREAD_WAS_SUSPENDED: Self = Self(699u32);
-                pub const ERROR_IMAGE_NOT_AT_BASE: Self = Self(700u32);
-                pub const ERROR_RXACT_STATE_CREATED: Self = Self(701u32);
-                pub const ERROR_SEGMENT_NOTIFICATION: Self = Self(702u32);
-                pub const ERROR_BAD_CURRENT_DIRECTORY: Self = Self(703u32);
-                pub const ERROR_FT_READ_RECOVERY_FROM_BACKUP: Self = Self(704u32);
-                pub const ERROR_FT_WRITE_RECOVERY: Self = Self(705u32);
-                pub const ERROR_IMAGE_MACHINE_TYPE_MISMATCH: Self = Self(706u32);
-                pub const ERROR_RECEIVE_PARTIAL: Self = Self(707u32);
-                pub const ERROR_RECEIVE_EXPEDITED: Self = Self(708u32);
-                pub const ERROR_RECEIVE_PARTIAL_EXPEDITED: Self = Self(709u32);
-                pub const ERROR_EVENT_DONE: Self = Self(710u32);
-                pub const ERROR_EVENT_PENDING: Self = Self(711u32);
-                pub const ERROR_CHECKING_FILE_SYSTEM: Self = Self(712u32);
-                pub const ERROR_FATAL_APP_EXIT: Self = Self(713u32);
-                pub const ERROR_PREDEFINED_HANDLE: Self = Self(714u32);
-                pub const ERROR_WAS_UNLOCKED: Self = Self(715u32);
-                pub const ERROR_SERVICE_NOTIFICATION: Self = Self(716u32);
-                pub const ERROR_WAS_LOCKED: Self = Self(717u32);
-                pub const ERROR_LOG_HARD_ERROR: Self = Self(718u32);
-                pub const ERROR_ALREADY_WIN32: Self = Self(719u32);
-                pub const ERROR_IMAGE_MACHINE_TYPE_MISMATCH_EXE: Self = Self(720u32);
-                pub const ERROR_NO_YIELD_PERFORMED: Self = Self(721u32);
-                pub const ERROR_TIMER_RESUME_IGNORED: Self = Self(722u32);
-                pub const ERROR_ARBITRATION_UNHANDLED: Self = Self(723u32);
-                pub const ERROR_CARDBUS_NOT_SUPPORTED: Self = Self(724u32);
-                pub const ERROR_MP_PROCESSOR_MISMATCH: Self = Self(725u32);
-                pub const ERROR_HIBERNATED: Self = Self(726u32);
-                pub const ERROR_RESUME_HIBERNATION: Self = Self(727u32);
-                pub const ERROR_FIRMWARE_UPDATED: Self = Self(728u32);
-                pub const ERROR_DRIVERS_LEAKING_LOCKED_PAGES: Self = Self(729u32);
-                pub const ERROR_WAKE_SYSTEM: Self = Self(730u32);
-                pub const ERROR_WAIT_1: Self = Self(731u32);
-                pub const ERROR_WAIT_2: Self = Self(732u32);
-                pub const ERROR_WAIT_3: Self = Self(733u32);
-                pub const ERROR_WAIT_63: Self = Self(734u32);
-                pub const ERROR_ABANDONED_WAIT_0: Self = Self(735u32);
-                pub const ERROR_ABANDONED_WAIT_63: Self = Self(736u32);
-                pub const ERROR_USER_APC: Self = Self(737u32);
-                pub const ERROR_KERNEL_APC: Self = Self(738u32);
-                pub const ERROR_ALERTED: Self = Self(739u32);
-                pub const ERROR_ELEVATION_REQUIRED: Self = Self(740u32);
-                pub const ERROR_REPARSE: Self = Self(741u32);
-                pub const ERROR_OPLOCK_BREAK_IN_PROGRESS: Self = Self(742u32);
-                pub const ERROR_VOLUME_MOUNTED: Self = Self(743u32);
-                pub const ERROR_RXACT_COMMITTED: Self = Self(744u32);
-                pub const ERROR_NOTIFY_CLEANUP: Self = Self(745u32);
-                pub const ERROR_PRIMARY_TRANSPORT_CONNECT_FAILED: Self = Self(746u32);
-                pub const ERROR_PAGE_FAULT_TRANSITION: Self = Self(747u32);
-                pub const ERROR_PAGE_FAULT_DEMAND_ZERO: Self = Self(748u32);
-                pub const ERROR_PAGE_FAULT_COPY_ON_WRITE: Self = Self(749u32);
-                pub const ERROR_PAGE_FAULT_GUARD_PAGE: Self = Self(750u32);
-                pub const ERROR_PAGE_FAULT_PAGING_FILE: Self = Self(751u32);
-                pub const ERROR_CACHE_PAGE_LOCKED: Self = Self(752u32);
-                pub const ERROR_CRASH_DUMP: Self = Self(753u32);
-                pub const ERROR_BUFFER_ALL_ZEROS: Self = Self(754u32);
-                pub const ERROR_REPARSE_OBJECT: Self = Self(755u32);
-                pub const ERROR_RESOURCE_REQUIREMENTS_CHANGED: Self = Self(756u32);
-                pub const ERROR_TRANSLATION_COMPLETE: Self = Self(757u32);
-                pub const ERROR_NOTHING_TO_TERMINATE: Self = Self(758u32);
-                pub const ERROR_PROCESS_NOT_IN_JOB: Self = Self(759u32);
-                pub const ERROR_PROCESS_IN_JOB: Self = Self(760u32);
-                pub const ERROR_VOLSNAP_HIBERNATE_READY: Self = Self(761u32);
-                pub const ERROR_FSFILTER_OP_COMPLETED_SUCCESSFULLY: Self = Self(762u32);
-                pub const ERROR_INTERRUPT_VECTOR_ALREADY_CONNECTED: Self = Self(763u32);
-                pub const ERROR_INTERRUPT_STILL_CONNECTED: Self = Self(764u32);
-                pub const ERROR_WAIT_FOR_OPLOCK: Self = Self(765u32);
-                pub const ERROR_DBG_EXCEPTION_HANDLED: Self = Self(766u32);
-                pub const ERROR_DBG_CONTINUE: Self = Self(767u32);
-                pub const ERROR_CALLBACK_POP_STACK: Self = Self(768u32);
-                pub const ERROR_COMPRESSION_DISABLED: Self = Self(769u32);
-                pub const ERROR_CANTFETCHBACKWARDS: Self = Self(770u32);
-                pub const ERROR_CANTSCROLLBACKWARDS: Self = Self(771u32);
-                pub const ERROR_ROWSNOTRELEASED: Self = Self(772u32);
-                pub const ERROR_BAD_ACCESSOR_FLAGS: Self = Self(773u32);
-                pub const ERROR_ERRORS_ENCOUNTERED: Self = Self(774u32);
-                pub const ERROR_NOT_CAPABLE: Self = Self(775u32);
-                pub const ERROR_REQUEST_OUT_OF_SEQUENCE: Self = Self(776u32);
-                pub const ERROR_VERSION_PARSE_ERROR: Self = Self(777u32);
-                pub const ERROR_BADSTARTPOSITION: Self = Self(778u32);
-                pub const ERROR_MEMORY_HARDWARE: Self = Self(779u32);
-                pub const ERROR_DISK_REPAIR_DISABLED: Self = Self(780u32);
-                pub const ERROR_INSUFFICIENT_RESOURCE_FOR_SPECIFIED_SHARED_SECTION_SIZE: Self =
-                    Self(781u32);
-                pub const ERROR_SYSTEM_POWERSTATE_TRANSITION: Self = Self(782u32);
-                pub const ERROR_SYSTEM_POWERSTATE_COMPLEX_TRANSITION: Self = Self(783u32);
-                pub const ERROR_MCA_EXCEPTION: Self = Self(784u32);
-                pub const ERROR_ACCESS_AUDIT_BY_POLICY: Self = Self(785u32);
-                pub const ERROR_ACCESS_DISABLED_NO_SAFER_UI_BY_POLICY: Self = Self(786u32);
-                pub const ERROR_ABANDON_HIBERFILE: Self = Self(787u32);
-                pub const ERROR_LOST_WRITEBEHIND_DATA_NETWORK_DISCONNECTED: Self = Self(788u32);
-                pub const ERROR_LOST_WRITEBEHIND_DATA_NETWORK_SERVER_ERROR: Self = Self(789u32);
-                pub const ERROR_LOST_WRITEBEHIND_DATA_LOCAL_DISK_ERROR: Self = Self(790u32);
-                pub const ERROR_BAD_MCFG_TABLE: Self = Self(791u32);
-                pub const ERROR_DISK_REPAIR_REDIRECTED: Self = Self(792u32);
-                pub const ERROR_DISK_REPAIR_UNSUCCESSFUL: Self = Self(793u32);
-                pub const ERROR_CORRUPT_LOG_OVERFULL: Self = Self(794u32);
-                pub const ERROR_CORRUPT_LOG_CORRUPTED: Self = Self(795u32);
-                pub const ERROR_CORRUPT_LOG_UNAVAILABLE: Self = Self(796u32);
-                pub const ERROR_CORRUPT_LOG_DELETED_FULL: Self = Self(797u32);
-                pub const ERROR_CORRUPT_LOG_CLEARED: Self = Self(798u32);
-                pub const ERROR_ORPHAN_NAME_EXHAUSTED: Self = Self(799u32);
-                pub const ERROR_OPLOCK_SWITCHED_TO_NEW_HANDLE: Self = Self(800u32);
-                pub const ERROR_CANNOT_GRANT_REQUESTED_OPLOCK: Self = Self(801u32);
-                pub const ERROR_CANNOT_BREAK_OPLOCK: Self = Self(802u32);
-                pub const ERROR_OPLOCK_HANDLE_CLOSED: Self = Self(803u32);
-                pub const ERROR_NO_ACE_CONDITION: Self = Self(804u32);
-                pub const ERROR_INVALID_ACE_CONDITION: Self = Self(805u32);
-                pub const ERROR_FILE_HANDLE_REVOKED: Self = Self(806u32);
-                pub const ERROR_IMAGE_AT_DIFFERENT_BASE: Self = Self(807u32);
-                pub const ERROR_ENCRYPTED_IO_NOT_POSSIBLE: Self = Self(808u32);
-                pub const ERROR_FILE_METADATA_OPTIMIZATION_IN_PROGRESS: Self = Self(809u32);
-                pub const ERROR_QUOTA_ACTIVITY: Self = Self(810u32);
-                pub const ERROR_HANDLE_REVOKED: Self = Self(811u32);
-                pub const ERROR_CALLBACK_INVOKE_INLINE: Self = Self(812u32);
-                pub const ERROR_CPU_SET_INVALID: Self = Self(813u32);
-                pub const ERROR_ENCLAVE_NOT_TERMINATED: Self = Self(814u32);
-                pub const ERROR_ENCLAVE_VIOLATION: Self = Self(815u32);
-                pub const ERROR_EA_ACCESS_DENIED: Self = Self(994u32);
-                pub const ERROR_OPERATION_ABORTED: Self = Self(995u32);
-                pub const ERROR_IO_INCOMPLETE: Self = Self(996u32);
-                pub const ERROR_IO_PENDING: Self = Self(997u32);
-                pub const ERROR_NOACCESS: Self = Self(998u32);
-                pub const ERROR_SWAPERROR: Self = Self(999u32);
-                pub const ERROR_STACK_OVERFLOW: Self = Self(1001u32);
-                pub const ERROR_INVALID_MESSAGE: Self = Self(1002u32);
-                pub const ERROR_CAN_NOT_COMPLETE: Self = Self(1003u32);
-                pub const ERROR_INVALID_FLAGS: Self = Self(1004u32);
-                pub const ERROR_UNRECOGNIZED_VOLUME: Self = Self(1005u32);
-                pub const ERROR_FILE_INVALID: Self = Self(1006u32);
-                pub const ERROR_FULLSCREEN_MODE: Self = Self(1007u32);
-                pub const ERROR_NO_TOKEN: Self = Self(1008u32);
-                pub const ERROR_BADDB: Self = Self(1009u32);
-                pub const ERROR_BADKEY: Self = Self(1010u32);
-                pub const ERROR_CANTOPEN: Self = Self(1011u32);
-                pub const ERROR_CANTREAD: Self = Self(1012u32);
-                pub const ERROR_CANTWRITE: Self = Self(1013u32);
-                pub const ERROR_REGISTRY_RECOVERED: Self = Self(1014u32);
-                pub const ERROR_REGISTRY_CORRUPT: Self = Self(1015u32);
-                pub const ERROR_REGISTRY_IO_FAILED: Self = Self(1016u32);
-                pub const ERROR_NOT_REGISTRY_FILE: Self = Self(1017u32);
-                pub const ERROR_KEY_DELETED: Self = Self(1018u32);
-                pub const ERROR_NO_LOG_SPACE: Self = Self(1019u32);
-                pub const ERROR_KEY_HAS_CHILDREN: Self = Self(1020u32);
-                pub const ERROR_CHILD_MUST_BE_VOLATILE: Self = Self(1021u32);
-                pub const ERROR_NOTIFY_ENUM_DIR: Self = Self(1022u32);
-                pub const ERROR_DEPENDENT_SERVICES_RUNNING: Self = Self(1051u32);
-                pub const ERROR_INVALID_SERVICE_CONTROL: Self = Self(1052u32);
-                pub const ERROR_SERVICE_REQUEST_TIMEOUT: Self = Self(1053u32);
-                pub const ERROR_SERVICE_NO_THREAD: Self = Self(1054u32);
-                pub const ERROR_SERVICE_DATABASE_LOCKED: Self = Self(1055u32);
-                pub const ERROR_SERVICE_ALREADY_RUNNING: Self = Self(1056u32);
-                pub const ERROR_INVALID_SERVICE_ACCOUNT: Self = Self(1057u32);
-                pub const ERROR_SERVICE_DISABLED: Self = Self(1058u32);
-                pub const ERROR_CIRCULAR_DEPENDENCY: Self = Self(1059u32);
-                pub const ERROR_SERVICE_DOES_NOT_EXIST: Self = Self(1060u32);
-                pub const ERROR_SERVICE_CANNOT_ACCEPT_CTRL: Self = Self(1061u32);
-                pub const ERROR_SERVICE_NOT_ACTIVE: Self = Self(1062u32);
-                pub const ERROR_FAILED_SERVICE_CONTROLLER_CONNECT: Self = Self(1063u32);
-                pub const ERROR_EXCEPTION_IN_SERVICE: Self = Self(1064u32);
-                pub const ERROR_DATABASE_DOES_NOT_EXIST: Self = Self(1065u32);
-                pub const ERROR_SERVICE_SPECIFIC_ERROR: Self = Self(1066u32);
-                pub const ERROR_PROCESS_ABORTED: Self = Self(1067u32);
-                pub const ERROR_SERVICE_DEPENDENCY_FAIL: Self = Self(1068u32);
-                pub const ERROR_SERVICE_LOGON_FAILED: Self = Self(1069u32);
-                pub const ERROR_SERVICE_START_HANG: Self = Self(1070u32);
-                pub const ERROR_INVALID_SERVICE_LOCK: Self = Self(1071u32);
-                pub const ERROR_SERVICE_MARKED_FOR_DELETE: Self = Self(1072u32);
-                pub const ERROR_SERVICE_EXISTS: Self = Self(1073u32);
-                pub const ERROR_ALREADY_RUNNING_LKG: Self = Self(1074u32);
-                pub const ERROR_SERVICE_DEPENDENCY_DELETED: Self = Self(1075u32);
-                pub const ERROR_BOOT_ALREADY_ACCEPTED: Self = Self(1076u32);
-                pub const ERROR_SERVICE_NEVER_STARTED: Self = Self(1077u32);
-                pub const ERROR_DUPLICATE_SERVICE_NAME: Self = Self(1078u32);
-                pub const ERROR_DIFFERENT_SERVICE_ACCOUNT: Self = Self(1079u32);
-                pub const ERROR_CANNOT_DETECT_DRIVER_FAILURE: Self = Self(1080u32);
-                pub const ERROR_CANNOT_DETECT_PROCESS_ABORT: Self = Self(1081u32);
-                pub const ERROR_NO_RECOVERY_PROGRAM: Self = Self(1082u32);
-                pub const ERROR_SERVICE_NOT_IN_EXE: Self = Self(1083u32);
-                pub const ERROR_NOT_SAFEBOOT_SERVICE: Self = Self(1084u32);
-                pub const ERROR_END_OF_MEDIA: Self = Self(1100u32);
-                pub const ERROR_FILEMARK_DETECTED: Self = Self(1101u32);
-                pub const ERROR_BEGINNING_OF_MEDIA: Self = Self(1102u32);
-                pub const ERROR_SETMARK_DETECTED: Self = Self(1103u32);
-                pub const ERROR_NO_DATA_DETECTED: Self = Self(1104u32);
-                pub const ERROR_PARTITION_FAILURE: Self = Self(1105u32);
-                pub const ERROR_INVALID_BLOCK_LENGTH: Self = Self(1106u32);
-                pub const ERROR_DEVICE_NOT_PARTITIONED: Self = Self(1107u32);
-                pub const ERROR_UNABLE_TO_LOCK_MEDIA: Self = Self(1108u32);
-                pub const ERROR_UNABLE_TO_UNLOAD_MEDIA: Self = Self(1109u32);
-                pub const ERROR_MEDIA_CHANGED: Self = Self(1110u32);
-                pub const ERROR_BUS_RESET: Self = Self(1111u32);
-                pub const ERROR_NO_MEDIA_IN_DRIVE: Self = Self(1112u32);
-                pub const ERROR_NO_UNICODE_TRANSLATION: Self = Self(1113u32);
-                pub const ERROR_DLL_INIT_FAILED: Self = Self(1114u32);
-                pub const ERROR_SHUTDOWN_IN_PROGRESS: Self = Self(1115u32);
-                pub const ERROR_NO_SHUTDOWN_IN_PROGRESS: Self = Self(1116u32);
-                pub const ERROR_IO_DEVICE: Self = Self(1117u32);
-                pub const ERROR_SERIAL_NO_DEVICE: Self = Self(1118u32);
-                pub const ERROR_IRQ_BUSY: Self = Self(1119u32);
-                pub const ERROR_MORE_WRITES: Self = Self(1120u32);
-                pub const ERROR_COUNTER_TIMEOUT: Self = Self(1121u32);
-                pub const ERROR_FLOPPY_ID_MARK_NOT_FOUND: Self = Self(1122u32);
-                pub const ERROR_FLOPPY_WRONG_CYLINDER: Self = Self(1123u32);
-                pub const ERROR_FLOPPY_UNKNOWN_ERROR: Self = Self(1124u32);
-                pub const ERROR_FLOPPY_BAD_REGISTERS: Self = Self(1125u32);
-                pub const ERROR_DISK_RECALIBRATE_FAILED: Self = Self(1126u32);
-                pub const ERROR_DISK_OPERATION_FAILED: Self = Self(1127u32);
-                pub const ERROR_DISK_RESET_FAILED: Self = Self(1128u32);
-                pub const ERROR_EOM_OVERFLOW: Self = Self(1129u32);
-                pub const ERROR_NOT_ENOUGH_SERVER_MEMORY: Self = Self(1130u32);
-                pub const ERROR_POSSIBLE_DEADLOCK: Self = Self(1131u32);
-                pub const ERROR_MAPPED_ALIGNMENT: Self = Self(1132u32);
-                pub const ERROR_SET_POWER_STATE_VETOED: Self = Self(1140u32);
-                pub const ERROR_SET_POWER_STATE_FAILED: Self = Self(1141u32);
-                pub const ERROR_TOO_MANY_LINKS: Self = Self(1142u32);
-                pub const ERROR_OLD_WIN_VERSION: Self = Self(1150u32);
-                pub const ERROR_APP_WRONG_OS: Self = Self(1151u32);
-                pub const ERROR_SINGLE_INSTANCE_APP: Self = Self(1152u32);
-                pub const ERROR_RMODE_APP: Self = Self(1153u32);
-                pub const ERROR_INVALID_DLL: Self = Self(1154u32);
-                pub const ERROR_NO_ASSOCIATION: Self = Self(1155u32);
-                pub const ERROR_DDE_FAIL: Self = Self(1156u32);
-                pub const ERROR_DLL_NOT_FOUND: Self = Self(1157u32);
-                pub const ERROR_NO_MORE_USER_HANDLES: Self = Self(1158u32);
-                pub const ERROR_MESSAGE_SYNC_ONLY: Self = Self(1159u32);
-                pub const ERROR_SOURCE_ELEMENT_EMPTY: Self = Self(1160u32);
-                pub const ERROR_DESTINATION_ELEMENT_FULL: Self = Self(1161u32);
-                pub const ERROR_ILLEGAL_ELEMENT_ADDRESS: Self = Self(1162u32);
-                pub const ERROR_MAGAZINE_NOT_PRESENT: Self = Self(1163u32);
-                pub const ERROR_DEVICE_REINITIALIZATION_NEEDED: Self = Self(1164u32);
-                pub const ERROR_DEVICE_REQUIRES_CLEANING: Self = Self(1165u32);
-                pub const ERROR_DEVICE_DOOR_OPEN: Self = Self(1166u32);
-                pub const ERROR_DEVICE_NOT_CONNECTED: Self = Self(1167u32);
-                pub const ERROR_NOT_FOUND: Self = Self(1168u32);
-                pub const ERROR_NO_MATCH: Self = Self(1169u32);
-                pub const ERROR_SET_NOT_FOUND: Self = Self(1170u32);
-                pub const ERROR_POINT_NOT_FOUND: Self = Self(1171u32);
-                pub const ERROR_NO_TRACKING_SERVICE: Self = Self(1172u32);
-                pub const ERROR_NO_VOLUME_ID: Self = Self(1173u32);
-                pub const ERROR_UNABLE_TO_REMOVE_REPLACED: Self = Self(1175u32);
-                pub const ERROR_UNABLE_TO_MOVE_REPLACEMENT: Self = Self(1176u32);
-                pub const ERROR_UNABLE_TO_MOVE_REPLACEMENT_2: Self = Self(1177u32);
-                pub const ERROR_JOURNAL_DELETE_IN_PROGRESS: Self = Self(1178u32);
-                pub const ERROR_JOURNAL_NOT_ACTIVE: Self = Self(1179u32);
-                pub const ERROR_POTENTIAL_FILE_FOUND: Self = Self(1180u32);
-                pub const ERROR_JOURNAL_ENTRY_DELETED: Self = Self(1181u32);
-                pub const ERROR_SHUTDOWN_IS_SCHEDULED: Self = Self(1190u32);
-                pub const ERROR_SHUTDOWN_USERS_LOGGED_ON: Self = Self(1191u32);
-                pub const ERROR_BAD_DEVICE: Self = Self(1200u32);
-                pub const ERROR_CONNECTION_UNAVAIL: Self = Self(1201u32);
-                pub const ERROR_DEVICE_ALREADY_REMEMBERED: Self = Self(1202u32);
-                pub const ERROR_NO_NET_OR_BAD_PATH: Self = Self(1203u32);
-                pub const ERROR_BAD_PROVIDER: Self = Self(1204u32);
-                pub const ERROR_CANNOT_OPEN_PROFILE: Self = Self(1205u32);
-                pub const ERROR_BAD_PROFILE: Self = Self(1206u32);
-                pub const ERROR_NOT_CONTAINER: Self = Self(1207u32);
-                pub const ERROR_EXTENDED_ERROR: Self = Self(1208u32);
-                pub const ERROR_INVALID_GROUPNAME: Self = Self(1209u32);
-                pub const ERROR_INVALID_COMPUTERNAME: Self = Self(1210u32);
-                pub const ERROR_INVALID_EVENTNAME: Self = Self(1211u32);
-                pub const ERROR_INVALID_DOMAINNAME: Self = Self(1212u32);
-                pub const ERROR_INVALID_SERVICENAME: Self = Self(1213u32);
-                pub const ERROR_INVALID_NETNAME: Self = Self(1214u32);
-                pub const ERROR_INVALID_SHARENAME: Self = Self(1215u32);
-                pub const ERROR_INVALID_PASSWORDNAME: Self = Self(1216u32);
-                pub const ERROR_INVALID_MESSAGENAME: Self = Self(1217u32);
-                pub const ERROR_INVALID_MESSAGEDEST: Self = Self(1218u32);
-                pub const ERROR_SESSION_CREDENTIAL_CONFLICT: Self = Self(1219u32);
-                pub const ERROR_REMOTE_SESSION_LIMIT_EXCEEDED: Self = Self(1220u32);
-                pub const ERROR_DUP_DOMAINNAME: Self = Self(1221u32);
-                pub const ERROR_NO_NETWORK: Self = Self(1222u32);
-                pub const ERROR_CANCELLED: Self = Self(1223u32);
-                pub const ERROR_USER_MAPPED_FILE: Self = Self(1224u32);
-                pub const ERROR_CONNECTION_REFUSED: Self = Self(1225u32);
-                pub const ERROR_GRACEFUL_DISCONNECT: Self = Self(1226u32);
-                pub const ERROR_ADDRESS_ALREADY_ASSOCIATED: Self = Self(1227u32);
-                pub const ERROR_ADDRESS_NOT_ASSOCIATED: Self = Self(1228u32);
-                pub const ERROR_CONNECTION_INVALID: Self = Self(1229u32);
-                pub const ERROR_CONNECTION_ACTIVE: Self = Self(1230u32);
-                pub const ERROR_NETWORK_UNREACHABLE: Self = Self(1231u32);
-                pub const ERROR_HOST_UNREACHABLE: Self = Self(1232u32);
-                pub const ERROR_PROTOCOL_UNREACHABLE: Self = Self(1233u32);
-                pub const ERROR_PORT_UNREACHABLE: Self = Self(1234u32);
-                pub const ERROR_REQUEST_ABORTED: Self = Self(1235u32);
-                pub const ERROR_CONNECTION_ABORTED: Self = Self(1236u32);
-                pub const ERROR_RETRY: Self = Self(1237u32);
-                pub const ERROR_CONNECTION_COUNT_LIMIT: Self = Self(1238u32);
-                pub const ERROR_LOGIN_TIME_RESTRICTION: Self = Self(1239u32);
-                pub const ERROR_LOGIN_WKSTA_RESTRICTION: Self = Self(1240u32);
-                pub const ERROR_INCORRECT_ADDRESS: Self = Self(1241u32);
-                pub const ERROR_ALREADY_REGISTERED: Self = Self(1242u32);
-                pub const ERROR_SERVICE_NOT_FOUND: Self = Self(1243u32);
-                pub const ERROR_NOT_AUTHENTICATED: Self = Self(1244u32);
-                pub const ERROR_NOT_LOGGED_ON: Self = Self(1245u32);
-                pub const ERROR_CONTINUE: Self = Self(1246u32);
-                pub const ERROR_ALREADY_INITIALIZED: Self = Self(1247u32);
-                pub const ERROR_NO_MORE_DEVICES: Self = Self(1248u32);
-                pub const ERROR_NO_SUCH_SITE: Self = Self(1249u32);
-                pub const ERROR_DOMAIN_CONTROLLER_EXISTS: Self = Self(1250u32);
-                pub const ERROR_ONLY_IF_CONNECTED: Self = Self(1251u32);
-                pub const ERROR_OVERRIDE_NOCHANGES: Self = Self(1252u32);
-                pub const ERROR_BAD_USER_PROFILE: Self = Self(1253u32);
-                pub const ERROR_NOT_SUPPORTED_ON_SBS: Self = Self(1254u32);
-                pub const ERROR_SERVER_SHUTDOWN_IN_PROGRESS: Self = Self(1255u32);
-                pub const ERROR_HOST_DOWN: Self = Self(1256u32);
-                pub const ERROR_NON_ACCOUNT_SID: Self = Self(1257u32);
-                pub const ERROR_NON_DOMAIN_SID: Self = Self(1258u32);
-                pub const ERROR_APPHELP_BLOCK: Self = Self(1259u32);
-                pub const ERROR_ACCESS_DISABLED_BY_POLICY: Self = Self(1260u32);
-                pub const ERROR_REG_NAT_CONSUMPTION: Self = Self(1261u32);
-                pub const ERROR_CSCSHARE_OFFLINE: Self = Self(1262u32);
-                pub const ERROR_PKINIT_FAILURE: Self = Self(1263u32);
-                pub const ERROR_SMARTCARD_SUBSYSTEM_FAILURE: Self = Self(1264u32);
-                pub const ERROR_DOWNGRADE_DETECTED: Self = Self(1265u32);
-                pub const ERROR_MACHINE_LOCKED: Self = Self(1271u32);
-                pub const ERROR_SMB_GUEST_LOGON_BLOCKED: Self = Self(1272u32);
-                pub const ERROR_CALLBACK_SUPPLIED_INVALID_DATA: Self = Self(1273u32);
-                pub const ERROR_SYNC_FOREGROUND_REFRESH_REQUIRED: Self = Self(1274u32);
-                pub const ERROR_DRIVER_BLOCKED: Self = Self(1275u32);
-                pub const ERROR_INVALID_IMPORT_OF_NON_DLL: Self = Self(1276u32);
-                pub const ERROR_ACCESS_DISABLED_WEBBLADE: Self = Self(1277u32);
-                pub const ERROR_ACCESS_DISABLED_WEBBLADE_TAMPER: Self = Self(1278u32);
-                pub const ERROR_RECOVERY_FAILURE: Self = Self(1279u32);
-                pub const ERROR_ALREADY_FIBER: Self = Self(1280u32);
-                pub const ERROR_ALREADY_THREAD: Self = Self(1281u32);
-                pub const ERROR_STACK_BUFFER_OVERRUN: Self = Self(1282u32);
-                pub const ERROR_PARAMETER_QUOTA_EXCEEDED: Self = Self(1283u32);
-                pub const ERROR_DEBUGGER_INACTIVE: Self = Self(1284u32);
-                pub const ERROR_DELAY_LOAD_FAILED: Self = Self(1285u32);
-                pub const ERROR_VDM_DISALLOWED: Self = Self(1286u32);
-                pub const ERROR_UNIDENTIFIED_ERROR: Self = Self(1287u32);
-                pub const ERROR_INVALID_CRUNTIME_PARAMETER: Self = Self(1288u32);
-                pub const ERROR_BEYOND_VDL: Self = Self(1289u32);
-                pub const ERROR_INCOMPATIBLE_SERVICE_SID_TYPE: Self = Self(1290u32);
-                pub const ERROR_DRIVER_PROCESS_TERMINATED: Self = Self(1291u32);
-                pub const ERROR_IMPLEMENTATION_LIMIT: Self = Self(1292u32);
-                pub const ERROR_PROCESS_IS_PROTECTED: Self = Self(1293u32);
-                pub const ERROR_SERVICE_NOTIFY_CLIENT_LAGGING: Self = Self(1294u32);
-                pub const ERROR_DISK_QUOTA_EXCEEDED: Self = Self(1295u32);
-                pub const ERROR_CONTENT_BLOCKED: Self = Self(1296u32);
-                pub const ERROR_INCOMPATIBLE_SERVICE_PRIVILEGE: Self = Self(1297u32);
-                pub const ERROR_APP_HANG: Self = Self(1298u32);
-                pub const ERROR_INVALID_LABEL: Self = Self(1299u32);
-                pub const ERROR_NOT_ALL_ASSIGNED: Self = Self(1300u32);
-                pub const ERROR_SOME_NOT_MAPPED: Self = Self(1301u32);
-                pub const ERROR_NO_QUOTAS_FOR_ACCOUNT: Self = Self(1302u32);
-                pub const ERROR_LOCAL_USER_SESSION_KEY: Self = Self(1303u32);
-                pub const ERROR_NULL_LM_PASSWORD: Self = Self(1304u32);
-                pub const ERROR_UNKNOWN_REVISION: Self = Self(1305u32);
-                pub const ERROR_REVISION_MISMATCH: Self = Self(1306u32);
-                pub const ERROR_INVALID_OWNER: Self = Self(1307u32);
-                pub const ERROR_INVALID_PRIMARY_GROUP: Self = Self(1308u32);
-                pub const ERROR_NO_IMPERSONATION_TOKEN: Self = Self(1309u32);
-                pub const ERROR_CANT_DISABLE_MANDATORY: Self = Self(1310u32);
-                pub const ERROR_NO_LOGON_SERVERS: Self = Self(1311u32);
-                pub const ERROR_NO_SUCH_LOGON_SESSION: Self = Self(1312u32);
-                pub const ERROR_NO_SUCH_PRIVILEGE: Self = Self(1313u32);
-                pub const ERROR_PRIVILEGE_NOT_HELD: Self = Self(1314u32);
-                pub const ERROR_INVALID_ACCOUNT_NAME: Self = Self(1315u32);
-                pub const ERROR_USER_EXISTS: Self = Self(1316u32);
-                pub const ERROR_NO_SUCH_USER: Self = Self(1317u32);
-                pub const ERROR_GROUP_EXISTS: Self = Self(1318u32);
-                pub const ERROR_NO_SUCH_GROUP: Self = Self(1319u32);
-                pub const ERROR_MEMBER_IN_GROUP: Self = Self(1320u32);
-                pub const ERROR_MEMBER_NOT_IN_GROUP: Self = Self(1321u32);
-                pub const ERROR_LAST_ADMIN: Self = Self(1322u32);
-                pub const ERROR_WRONG_PASSWORD: Self = Self(1323u32);
-                pub const ERROR_ILL_FORMED_PASSWORD: Self = Self(1324u32);
-                pub const ERROR_PASSWORD_RESTRICTION: Self = Self(1325u32);
-                pub const ERROR_LOGON_FAILURE: Self = Self(1326u32);
-                pub const ERROR_ACCOUNT_RESTRICTION: Self = Self(1327u32);
-                pub const ERROR_INVALID_LOGON_HOURS: Self = Self(1328u32);
-                pub const ERROR_INVALID_WORKSTATION: Self = Self(1329u32);
-                pub const ERROR_PASSWORD_EXPIRED: Self = Self(1330u32);
-                pub const ERROR_ACCOUNT_DISABLED: Self = Self(1331u32);
-                pub const ERROR_NONE_MAPPED: Self = Self(1332u32);
-                pub const ERROR_TOO_MANY_LUIDS_REQUESTED: Self = Self(1333u32);
-                pub const ERROR_LUIDS_EXHAUSTED: Self = Self(1334u32);
-                pub const ERROR_INVALID_SUB_AUTHORITY: Self = Self(1335u32);
-                pub const ERROR_INVALID_ACL: Self = Self(1336u32);
-                pub const ERROR_INVALID_SID: Self = Self(1337u32);
-                pub const ERROR_INVALID_SECURITY_DESCR: Self = Self(1338u32);
-                pub const ERROR_BAD_INHERITANCE_ACL: Self = Self(1340u32);
-                pub const ERROR_SERVER_DISABLED: Self = Self(1341u32);
-                pub const ERROR_SERVER_NOT_DISABLED: Self = Self(1342u32);
-                pub const ERROR_INVALID_ID_AUTHORITY: Self = Self(1343u32);
-                pub const ERROR_ALLOTTED_SPACE_EXCEEDED: Self = Self(1344u32);
-                pub const ERROR_INVALID_GROUP_ATTRIBUTES: Self = Self(1345u32);
-                pub const ERROR_BAD_IMPERSONATION_LEVEL: Self = Self(1346u32);
-                pub const ERROR_CANT_OPEN_ANONYMOUS: Self = Self(1347u32);
-                pub const ERROR_BAD_VALIDATION_CLASS: Self = Self(1348u32);
-                pub const ERROR_BAD_TOKEN_TYPE: Self = Self(1349u32);
-                pub const ERROR_NO_SECURITY_ON_OBJECT: Self = Self(1350u32);
-                pub const ERROR_CANT_ACCESS_DOMAIN_INFO: Self = Self(1351u32);
-                pub const ERROR_INVALID_SERVER_STATE: Self = Self(1352u32);
-                pub const ERROR_INVALID_DOMAIN_STATE: Self = Self(1353u32);
-                pub const ERROR_INVALID_DOMAIN_ROLE: Self = Self(1354u32);
-                pub const ERROR_NO_SUCH_DOMAIN: Self = Self(1355u32);
-                pub const ERROR_DOMAIN_EXISTS: Self = Self(1356u32);
-                pub const ERROR_DOMAIN_LIMIT_EXCEEDED: Self = Self(1357u32);
-                pub const ERROR_INTERNAL_DB_CORRUPTION: Self = Self(1358u32);
-                pub const ERROR_INTERNAL_ERROR: Self = Self(1359u32);
-                pub const ERROR_GENERIC_NOT_MAPPED: Self = Self(1360u32);
-                pub const ERROR_BAD_DESCRIPTOR_FORMAT: Self = Self(1361u32);
-                pub const ERROR_NOT_LOGON_PROCESS: Self = Self(1362u32);
-                pub const ERROR_LOGON_SESSION_EXISTS: Self = Self(1363u32);
-                pub const ERROR_NO_SUCH_PACKAGE: Self = Self(1364u32);
-                pub const ERROR_BAD_LOGON_SESSION_STATE: Self = Self(1365u32);
-                pub const ERROR_LOGON_SESSION_COLLISION: Self = Self(1366u32);
-                pub const ERROR_INVALID_LOGON_TYPE: Self = Self(1367u32);
-                pub const ERROR_CANNOT_IMPERSONATE: Self = Self(1368u32);
-                pub const ERROR_RXACT_INVALID_STATE: Self = Self(1369u32);
-                pub const ERROR_RXACT_COMMIT_FAILURE: Self = Self(1370u32);
-                pub const ERROR_SPECIAL_ACCOUNT: Self = Self(1371u32);
-                pub const ERROR_SPECIAL_GROUP: Self = Self(1372u32);
-                pub const ERROR_SPECIAL_USER: Self = Self(1373u32);
-                pub const ERROR_MEMBERS_PRIMARY_GROUP: Self = Self(1374u32);
-                pub const ERROR_TOKEN_ALREADY_IN_USE: Self = Self(1375u32);
-                pub const ERROR_NO_SUCH_ALIAS: Self = Self(1376u32);
-                pub const ERROR_MEMBER_NOT_IN_ALIAS: Self = Self(1377u32);
-                pub const ERROR_MEMBER_IN_ALIAS: Self = Self(1378u32);
-                pub const ERROR_ALIAS_EXISTS: Self = Self(1379u32);
-                pub const ERROR_LOGON_NOT_GRANTED: Self = Self(1380u32);
-                pub const ERROR_TOO_MANY_SECRETS: Self = Self(1381u32);
-                pub const ERROR_SECRET_TOO_LONG: Self = Self(1382u32);
-                pub const ERROR_INTERNAL_DB_ERROR: Self = Self(1383u32);
-                pub const ERROR_TOO_MANY_CONTEXT_IDS: Self = Self(1384u32);
-                pub const ERROR_LOGON_TYPE_NOT_GRANTED: Self = Self(1385u32);
-                pub const ERROR_NT_CROSS_ENCRYPTION_REQUIRED: Self = Self(1386u32);
-                pub const ERROR_NO_SUCH_MEMBER: Self = Self(1387u32);
-                pub const ERROR_INVALID_MEMBER: Self = Self(1388u32);
-                pub const ERROR_TOO_MANY_SIDS: Self = Self(1389u32);
-                pub const ERROR_LM_CROSS_ENCRYPTION_REQUIRED: Self = Self(1390u32);
-                pub const ERROR_NO_INHERITANCE: Self = Self(1391u32);
-                pub const ERROR_FILE_CORRUPT: Self = Self(1392u32);
-                pub const ERROR_DISK_CORRUPT: Self = Self(1393u32);
-                pub const ERROR_NO_USER_SESSION_KEY: Self = Self(1394u32);
-                pub const ERROR_LICENSE_QUOTA_EXCEEDED: Self = Self(1395u32);
-                pub const ERROR_WRONG_TARGET_NAME: Self = Self(1396u32);
-                pub const ERROR_MUTUAL_AUTH_FAILED: Self = Self(1397u32);
-                pub const ERROR_TIME_SKEW: Self = Self(1398u32);
-                pub const ERROR_CURRENT_DOMAIN_NOT_ALLOWED: Self = Self(1399u32);
-                pub const ERROR_INVALID_WINDOW_HANDLE: Self = Self(1400u32);
-                pub const ERROR_INVALID_MENU_HANDLE: Self = Self(1401u32);
-                pub const ERROR_INVALID_CURSOR_HANDLE: Self = Self(1402u32);
-                pub const ERROR_INVALID_ACCEL_HANDLE: Self = Self(1403u32);
-                pub const ERROR_INVALID_HOOK_HANDLE: Self = Self(1404u32);
-                pub const ERROR_INVALID_DWP_HANDLE: Self = Self(1405u32);
-                pub const ERROR_TLW_WITH_WSCHILD: Self = Self(1406u32);
-                pub const ERROR_CANNOT_FIND_WND_CLASS: Self = Self(1407u32);
-                pub const ERROR_WINDOW_OF_OTHER_THREAD: Self = Self(1408u32);
-                pub const ERROR_HOTKEY_ALREADY_REGISTERED: Self = Self(1409u32);
-                pub const ERROR_CLASS_ALREADY_EXISTS: Self = Self(1410u32);
-                pub const ERROR_CLASS_DOES_NOT_EXIST: Self = Self(1411u32);
-                pub const ERROR_CLASS_HAS_WINDOWS: Self = Self(1412u32);
-                pub const ERROR_INVALID_INDEX: Self = Self(1413u32);
-                pub const ERROR_INVALID_ICON_HANDLE: Self = Self(1414u32);
-                pub const ERROR_PRIVATE_DIALOG_INDEX: Self = Self(1415u32);
-                pub const ERROR_LISTBOX_ID_NOT_FOUND: Self = Self(1416u32);
-                pub const ERROR_NO_WILDCARD_CHARACTERS: Self = Self(1417u32);
-                pub const ERROR_CLIPBOARD_NOT_OPEN: Self = Self(1418u32);
-                pub const ERROR_HOTKEY_NOT_REGISTERED: Self = Self(1419u32);
-                pub const ERROR_WINDOW_NOT_DIALOG: Self = Self(1420u32);
-                pub const ERROR_CONTROL_ID_NOT_FOUND: Self = Self(1421u32);
-                pub const ERROR_INVALID_COMBOBOX_MESSAGE: Self = Self(1422u32);
-                pub const ERROR_WINDOW_NOT_COMBOBOX: Self = Self(1423u32);
-                pub const ERROR_INVALID_EDIT_HEIGHT: Self = Self(1424u32);
-                pub const ERROR_DC_NOT_FOUND: Self = Self(1425u32);
-                pub const ERROR_INVALID_HOOK_FILTER: Self = Self(1426u32);
-                pub const ERROR_INVALID_FILTER_PROC: Self = Self(1427u32);
-                pub const ERROR_HOOK_NEEDS_HMOD: Self = Self(1428u32);
-                pub const ERROR_GLOBAL_ONLY_HOOK: Self = Self(1429u32);
-                pub const ERROR_JOURNAL_HOOK_SET: Self = Self(1430u32);
-                pub const ERROR_HOOK_NOT_INSTALLED: Self = Self(1431u32);
-                pub const ERROR_INVALID_LB_MESSAGE: Self = Self(1432u32);
-                pub const ERROR_SETCOUNT_ON_BAD_LB: Self = Self(1433u32);
-                pub const ERROR_LB_WITHOUT_TABSTOPS: Self = Self(1434u32);
-                pub const ERROR_DESTROY_OBJECT_OF_OTHER_THREAD: Self = Self(1435u32);
-                pub const ERROR_CHILD_WINDOW_MENU: Self = Self(1436u32);
-                pub const ERROR_NO_SYSTEM_MENU: Self = Self(1437u32);
-                pub const ERROR_INVALID_MSGBOX_STYLE: Self = Self(1438u32);
-                pub const ERROR_INVALID_SPI_VALUE: Self = Self(1439u32);
-                pub const ERROR_SCREEN_ALREADY_LOCKED: Self = Self(1440u32);
-                pub const ERROR_HWNDS_HAVE_DIFF_PARENT: Self = Self(1441u32);
-                pub const ERROR_NOT_CHILD_WINDOW: Self = Self(1442u32);
-                pub const ERROR_INVALID_GW_COMMAND: Self = Self(1443u32);
-                pub const ERROR_INVALID_THREAD_ID: Self = Self(1444u32);
-                pub const ERROR_NON_MDICHILD_WINDOW: Self = Self(1445u32);
-                pub const ERROR_POPUP_ALREADY_ACTIVE: Self = Self(1446u32);
-                pub const ERROR_NO_SCROLLBARS: Self = Self(1447u32);
-                pub const ERROR_INVALID_SCROLLBAR_RANGE: Self = Self(1448u32);
-                pub const ERROR_INVALID_SHOWWIN_COMMAND: Self = Self(1449u32);
-                pub const ERROR_NO_SYSTEM_RESOURCES: Self = Self(1450u32);
-                pub const ERROR_NONPAGED_SYSTEM_RESOURCES: Self = Self(1451u32);
-                pub const ERROR_PAGED_SYSTEM_RESOURCES: Self = Self(1452u32);
-                pub const ERROR_WORKING_SET_QUOTA: Self = Self(1453u32);
-                pub const ERROR_PAGEFILE_QUOTA: Self = Self(1454u32);
-                pub const ERROR_COMMITMENT_LIMIT: Self = Self(1455u32);
-                pub const ERROR_MENU_ITEM_NOT_FOUND: Self = Self(1456u32);
-                pub const ERROR_INVALID_KEYBOARD_HANDLE: Self = Self(1457u32);
-                pub const ERROR_HOOK_TYPE_NOT_ALLOWED: Self = Self(1458u32);
-                pub const ERROR_REQUIRES_INTERACTIVE_WINDOWSTATION: Self = Self(1459u32);
-                pub const ERROR_TIMEOUT: Self = Self(1460u32);
-                pub const ERROR_INVALID_MONITOR_HANDLE: Self = Self(1461u32);
-                pub const ERROR_INCORRECT_SIZE: Self = Self(1462u32);
-                pub const ERROR_SYMLINK_CLASS_DISABLED: Self = Self(1463u32);
-                pub const ERROR_SYMLINK_NOT_SUPPORTED: Self = Self(1464u32);
-                pub const ERROR_XML_PARSE_ERROR: Self = Self(1465u32);
-                pub const ERROR_XMLDSIG_ERROR: Self = Self(1466u32);
-                pub const ERROR_RESTART_APPLICATION: Self = Self(1467u32);
-                pub const ERROR_WRONG_COMPARTMENT: Self = Self(1468u32);
-                pub const ERROR_AUTHIP_FAILURE: Self = Self(1469u32);
-                pub const ERROR_NO_NVRAM_RESOURCES: Self = Self(1470u32);
-                pub const ERROR_NOT_GUI_PROCESS: Self = Self(1471u32);
-                pub const ERROR_EVENTLOG_FILE_CORRUPT: Self = Self(1500u32);
-                pub const ERROR_EVENTLOG_CANT_START: Self = Self(1501u32);
-                pub const ERROR_LOG_FILE_FULL: Self = Self(1502u32);
-                pub const ERROR_EVENTLOG_FILE_CHANGED: Self = Self(1503u32);
-                pub const ERROR_CONTAINER_ASSIGNED: Self = Self(1504u32);
-                pub const ERROR_JOB_NO_CONTAINER: Self = Self(1505u32);
-                pub const ERROR_INVALID_TASK_NAME: Self = Self(1550u32);
-                pub const ERROR_INVALID_TASK_INDEX: Self = Self(1551u32);
-                pub const ERROR_THREAD_ALREADY_IN_TASK: Self = Self(1552u32);
-                pub const ERROR_INSTALL_SERVICE_FAILURE: Self = Self(1601u32);
-                pub const ERROR_INSTALL_USEREXIT: Self = Self(1602u32);
-                pub const ERROR_INSTALL_FAILURE: Self = Self(1603u32);
-                pub const ERROR_INSTALL_SUSPEND: Self = Self(1604u32);
-                pub const ERROR_UNKNOWN_PRODUCT: Self = Self(1605u32);
-                pub const ERROR_UNKNOWN_FEATURE: Self = Self(1606u32);
-                pub const ERROR_UNKNOWN_COMPONENT: Self = Self(1607u32);
-                pub const ERROR_UNKNOWN_PROPERTY: Self = Self(1608u32);
-                pub const ERROR_INVALID_HANDLE_STATE: Self = Self(1609u32);
-                pub const ERROR_BAD_CONFIGURATION: Self = Self(1610u32);
-                pub const ERROR_INDEX_ABSENT: Self = Self(1611u32);
-                pub const ERROR_INSTALL_SOURCE_ABSENT: Self = Self(1612u32);
-                pub const ERROR_INSTALL_PACKAGE_VERSION: Self = Self(1613u32);
-                pub const ERROR_PRODUCT_UNINSTALLED: Self = Self(1614u32);
-                pub const ERROR_BAD_QUERY_SYNTAX: Self = Self(1615u32);
-                pub const ERROR_INVALID_FIELD: Self = Self(1616u32);
-                pub const ERROR_DEVICE_REMOVED: Self = Self(1617u32);
-                pub const ERROR_INSTALL_ALREADY_RUNNING: Self = Self(1618u32);
-                pub const ERROR_INSTALL_PACKAGE_OPEN_FAILED: Self = Self(1619u32);
-                pub const ERROR_INSTALL_PACKAGE_INVALID: Self = Self(1620u32);
-                pub const ERROR_INSTALL_UI_FAILURE: Self = Self(1621u32);
-                pub const ERROR_INSTALL_LOG_FAILURE: Self = Self(1622u32);
-                pub const ERROR_INSTALL_LANGUAGE_UNSUPPORTED: Self = Self(1623u32);
-                pub const ERROR_INSTALL_TRANSFORM_FAILURE: Self = Self(1624u32);
-                pub const ERROR_INSTALL_PACKAGE_REJECTED: Self = Self(1625u32);
-                pub const ERROR_FUNCTION_NOT_CALLED: Self = Self(1626u32);
-                pub const ERROR_FUNCTION_FAILED: Self = Self(1627u32);
-                pub const ERROR_INVALID_TABLE: Self = Self(1628u32);
-                pub const ERROR_DATATYPE_MISMATCH: Self = Self(1629u32);
-                pub const ERROR_UNSUPPORTED_TYPE: Self = Self(1630u32);
-                pub const ERROR_CREATE_FAILED: Self = Self(1631u32);
-                pub const ERROR_INSTALL_TEMP_UNWRITABLE: Self = Self(1632u32);
-                pub const ERROR_INSTALL_PLATFORM_UNSUPPORTED: Self = Self(1633u32);
-                pub const ERROR_INSTALL_NOTUSED: Self = Self(1634u32);
-                pub const ERROR_PATCH_PACKAGE_OPEN_FAILED: Self = Self(1635u32);
-                pub const ERROR_PATCH_PACKAGE_INVALID: Self = Self(1636u32);
-                pub const ERROR_PATCH_PACKAGE_UNSUPPORTED: Self = Self(1637u32);
-                pub const ERROR_PRODUCT_VERSION: Self = Self(1638u32);
-                pub const ERROR_INVALID_COMMAND_LINE: Self = Self(1639u32);
-                pub const ERROR_INSTALL_REMOTE_DISALLOWED: Self = Self(1640u32);
-                pub const ERROR_SUCCESS_REBOOT_INITIATED: Self = Self(1641u32);
-                pub const ERROR_PATCH_TARGET_NOT_FOUND: Self = Self(1642u32);
-                pub const ERROR_PATCH_PACKAGE_REJECTED: Self = Self(1643u32);
-                pub const ERROR_INSTALL_TRANSFORM_REJECTED: Self = Self(1644u32);
-                pub const ERROR_INSTALL_REMOTE_PROHIBITED: Self = Self(1645u32);
-                pub const ERROR_PATCH_REMOVAL_UNSUPPORTED: Self = Self(1646u32);
-                pub const ERROR_UNKNOWN_PATCH: Self = Self(1647u32);
-                pub const ERROR_PATCH_NO_SEQUENCE: Self = Self(1648u32);
-                pub const ERROR_PATCH_REMOVAL_DISALLOWED: Self = Self(1649u32);
-                pub const ERROR_INVALID_PATCH_XML: Self = Self(1650u32);
-                pub const ERROR_PATCH_MANAGED_ADVERTISED_PRODUCT: Self = Self(1651u32);
-                pub const ERROR_INSTALL_SERVICE_SAFEBOOT: Self = Self(1652u32);
-                pub const ERROR_FAIL_FAST_EXCEPTION: Self = Self(1653u32);
-                pub const ERROR_INSTALL_REJECTED: Self = Self(1654u32);
-                pub const ERROR_DYNAMIC_CODE_BLOCKED: Self = Self(1655u32);
-                pub const ERROR_NOT_SAME_OBJECT: Self = Self(1656u32);
-                pub const ERROR_STRICT_CFG_VIOLATION: Self = Self(1657u32);
-                pub const ERROR_SET_CONTEXT_DENIED: Self = Self(1660u32);
-                pub const ERROR_CROSS_PARTITION_VIOLATION: Self = Self(1661u32);
-                pub const ERROR_RETURN_ADDRESS_HIJACK_ATTEMPT: Self = Self(1662u32);
-                pub const ERROR_INVALID_USER_BUFFER: Self = Self(1784u32);
-                pub const ERROR_UNRECOGNIZED_MEDIA: Self = Self(1785u32);
-                pub const ERROR_NO_TRUST_LSA_SECRET: Self = Self(1786u32);
-                pub const ERROR_NO_TRUST_SAM_ACCOUNT: Self = Self(1787u32);
-                pub const ERROR_TRUSTED_DOMAIN_FAILURE: Self = Self(1788u32);
-                pub const ERROR_TRUSTED_RELATIONSHIP_FAILURE: Self = Self(1789u32);
-                pub const ERROR_TRUST_FAILURE: Self = Self(1790u32);
-                pub const ERROR_NETLOGON_NOT_STARTED: Self = Self(1792u32);
-                pub const ERROR_ACCOUNT_EXPIRED: Self = Self(1793u32);
-                pub const ERROR_REDIRECTOR_HAS_OPEN_HANDLES: Self = Self(1794u32);
-                pub const ERROR_PRINTER_DRIVER_ALREADY_INSTALLED: Self = Self(1795u32);
-                pub const ERROR_UNKNOWN_PORT: Self = Self(1796u32);
-                pub const ERROR_UNKNOWN_PRINTER_DRIVER: Self = Self(1797u32);
-                pub const ERROR_UNKNOWN_PRINTPROCESSOR: Self = Self(1798u32);
-                pub const ERROR_INVALID_SEPARATOR_FILE: Self = Self(1799u32);
-                pub const ERROR_INVALID_PRIORITY: Self = Self(1800u32);
-                pub const ERROR_INVALID_PRINTER_NAME: Self = Self(1801u32);
-                pub const ERROR_PRINTER_ALREADY_EXISTS: Self = Self(1802u32);
-                pub const ERROR_INVALID_PRINTER_COMMAND: Self = Self(1803u32);
-                pub const ERROR_INVALID_DATATYPE: Self = Self(1804u32);
-                pub const ERROR_INVALID_ENVIRONMENT: Self = Self(1805u32);
-                pub const ERROR_NOLOGON_INTERDOMAIN_TRUST_ACCOUNT: Self = Self(1807u32);
-                pub const ERROR_NOLOGON_WORKSTATION_TRUST_ACCOUNT: Self = Self(1808u32);
-                pub const ERROR_NOLOGON_SERVER_TRUST_ACCOUNT: Self = Self(1809u32);
-                pub const ERROR_DOMAIN_TRUST_INCONSISTENT: Self = Self(1810u32);
-                pub const ERROR_SERVER_HAS_OPEN_HANDLES: Self = Self(1811u32);
-                pub const ERROR_RESOURCE_DATA_NOT_FOUND: Self = Self(1812u32);
-                pub const ERROR_RESOURCE_TYPE_NOT_FOUND: Self = Self(1813u32);
-                pub const ERROR_RESOURCE_NAME_NOT_FOUND: Self = Self(1814u32);
-                pub const ERROR_RESOURCE_LANG_NOT_FOUND: Self = Self(1815u32);
-                pub const ERROR_NOT_ENOUGH_QUOTA: Self = Self(1816u32);
-                pub const ERROR_INVALID_TIME: Self = Self(1901u32);
-                pub const ERROR_INVALID_FORM_NAME: Self = Self(1902u32);
-                pub const ERROR_INVALID_FORM_SIZE: Self = Self(1903u32);
-                pub const ERROR_ALREADY_WAITING: Self = Self(1904u32);
-                pub const ERROR_PRINTER_DELETED: Self = Self(1905u32);
-                pub const ERROR_INVALID_PRINTER_STATE: Self = Self(1906u32);
-                pub const ERROR_PASSWORD_MUST_CHANGE: Self = Self(1907u32);
-                pub const ERROR_DOMAIN_CONTROLLER_NOT_FOUND: Self = Self(1908u32);
-                pub const ERROR_ACCOUNT_LOCKED_OUT: Self = Self(1909u32);
-                pub const ERROR_NO_SITENAME: Self = Self(1919u32);
-                pub const ERROR_CANT_ACCESS_FILE: Self = Self(1920u32);
-                pub const ERROR_CANT_RESOLVE_FILENAME: Self = Self(1921u32);
-                pub const ERROR_KM_DRIVER_BLOCKED: Self = Self(1930u32);
-                pub const ERROR_CONTEXT_EXPIRED: Self = Self(1931u32);
-                pub const ERROR_PER_USER_TRUST_QUOTA_EXCEEDED: Self = Self(1932u32);
-                pub const ERROR_ALL_USER_TRUST_QUOTA_EXCEEDED: Self = Self(1933u32);
-                pub const ERROR_USER_DELETE_TRUST_QUOTA_EXCEEDED: Self = Self(1934u32);
-                pub const ERROR_AUTHENTICATION_FIREWALL_FAILED: Self = Self(1935u32);
-                pub const ERROR_REMOTE_PRINT_CONNECTIONS_BLOCKED: Self = Self(1936u32);
-                pub const ERROR_NTLM_BLOCKED: Self = Self(1937u32);
-                pub const ERROR_PASSWORD_CHANGE_REQUIRED: Self = Self(1938u32);
-                pub const ERROR_LOST_MODE_LOGON_RESTRICTION: Self = Self(1939u32);
-                pub const ERROR_INVALID_PIXEL_FORMAT: Self = Self(2000u32);
-                pub const ERROR_BAD_DRIVER: Self = Self(2001u32);
-                pub const ERROR_INVALID_WINDOW_STYLE: Self = Self(2002u32);
-                pub const ERROR_METAFILE_NOT_SUPPORTED: Self = Self(2003u32);
-                pub const ERROR_TRANSFORM_NOT_SUPPORTED: Self = Self(2004u32);
-                pub const ERROR_CLIPPING_NOT_SUPPORTED: Self = Self(2005u32);
-                pub const ERROR_INVALID_CMM: Self = Self(2010u32);
-                pub const ERROR_INVALID_PROFILE: Self = Self(2011u32);
-                pub const ERROR_TAG_NOT_FOUND: Self = Self(2012u32);
-                pub const ERROR_TAG_NOT_PRESENT: Self = Self(2013u32);
-                pub const ERROR_DUPLICATE_TAG: Self = Self(2014u32);
-                pub const ERROR_PROFILE_NOT_ASSOCIATED_WITH_DEVICE: Self = Self(2015u32);
-                pub const ERROR_PROFILE_NOT_FOUND: Self = Self(2016u32);
-                pub const ERROR_INVALID_COLORSPACE: Self = Self(2017u32);
-                pub const ERROR_ICM_NOT_ENABLED: Self = Self(2018u32);
-                pub const ERROR_DELETING_ICM_XFORM: Self = Self(2019u32);
-                pub const ERROR_INVALID_TRANSFORM: Self = Self(2020u32);
-                pub const ERROR_COLORSPACE_MISMATCH: Self = Self(2021u32);
-                pub const ERROR_INVALID_COLORINDEX: Self = Self(2022u32);
-                pub const ERROR_PROFILE_DOES_NOT_MATCH_DEVICE: Self = Self(2023u32);
-                pub const ERROR_CONNECTED_OTHER_PASSWORD: Self = Self(2108u32);
-                pub const ERROR_CONNECTED_OTHER_PASSWORD_DEFAULT: Self = Self(2109u32);
-                pub const ERROR_BAD_USERNAME: Self = Self(2202u32);
-                pub const ERROR_NOT_CONNECTED: Self = Self(2250u32);
-                pub const ERROR_OPEN_FILES: Self = Self(2401u32);
-                pub const ERROR_ACTIVE_CONNECTIONS: Self = Self(2402u32);
-                pub const ERROR_DEVICE_IN_USE: Self = Self(2404u32);
-                pub const ERROR_UNKNOWN_PRINT_MONITOR: Self = Self(3000u32);
-                pub const ERROR_PRINTER_DRIVER_IN_USE: Self = Self(3001u32);
-                pub const ERROR_SPOOL_FILE_NOT_FOUND: Self = Self(3002u32);
-                pub const ERROR_SPL_NO_STARTDOC: Self = Self(3003u32);
-                pub const ERROR_SPL_NO_ADDJOB: Self = Self(3004u32);
-                pub const ERROR_PRINT_PROCESSOR_ALREADY_INSTALLED: Self = Self(3005u32);
-                pub const ERROR_PRINT_MONITOR_ALREADY_INSTALLED: Self = Self(3006u32);
-                pub const ERROR_INVALID_PRINT_MONITOR: Self = Self(3007u32);
-                pub const ERROR_PRINT_MONITOR_IN_USE: Self = Self(3008u32);
-                pub const ERROR_PRINTER_HAS_JOBS_QUEUED: Self = Self(3009u32);
-                pub const ERROR_SUCCESS_REBOOT_REQUIRED: Self = Self(3010u32);
-                pub const ERROR_SUCCESS_RESTART_REQUIRED: Self = Self(3011u32);
-                pub const ERROR_PRINTER_NOT_FOUND: Self = Self(3012u32);
-                pub const ERROR_PRINTER_DRIVER_WARNED: Self = Self(3013u32);
-                pub const ERROR_PRINTER_DRIVER_BLOCKED: Self = Self(3014u32);
-                pub const ERROR_PRINTER_DRIVER_PACKAGE_IN_USE: Self = Self(3015u32);
-                pub const ERROR_CORE_DRIVER_PACKAGE_NOT_FOUND: Self = Self(3016u32);
-                pub const ERROR_FAIL_REBOOT_REQUIRED: Self = Self(3017u32);
-                pub const ERROR_FAIL_REBOOT_INITIATED: Self = Self(3018u32);
-                pub const ERROR_PRINTER_DRIVER_DOWNLOAD_NEEDED: Self = Self(3019u32);
-                pub const ERROR_PRINT_JOB_RESTART_REQUIRED: Self = Self(3020u32);
-                pub const ERROR_INVALID_PRINTER_DRIVER_MANIFEST: Self = Self(3021u32);
-                pub const ERROR_PRINTER_NOT_SHAREABLE: Self = Self(3022u32);
-                pub const ERROR_REQUEST_PAUSED: Self = Self(3050u32);
-                pub const ERROR_APPEXEC_CONDITION_NOT_SATISFIED: Self = Self(3060u32);
-                pub const ERROR_APPEXEC_HANDLE_INVALIDATED: Self = Self(3061u32);
-                pub const ERROR_APPEXEC_INVALID_HOST_GENERATION: Self = Self(3062u32);
-                pub const ERROR_APPEXEC_UNEXPECTED_PROCESS_REGISTRATION: Self = Self(3063u32);
-                pub const ERROR_APPEXEC_INVALID_HOST_STATE: Self = Self(3064u32);
-                pub const ERROR_APPEXEC_NO_DONOR: Self = Self(3065u32);
-                pub const ERROR_APPEXEC_HOST_ID_MISMATCH: Self = Self(3066u32);
-                pub const ERROR_APPEXEC_UNKNOWN_USER: Self = Self(3067u32);
-                pub const ERROR_IO_REISSUE_AS_CACHED: Self = Self(3950u32);
-                pub const ERROR_WINS_INTERNAL: Self = Self(4000u32);
-                pub const ERROR_CAN_NOT_DEL_LOCAL_WINS: Self = Self(4001u32);
-                pub const ERROR_STATIC_INIT: Self = Self(4002u32);
-                pub const ERROR_INC_BACKUP: Self = Self(4003u32);
-                pub const ERROR_FULL_BACKUP: Self = Self(4004u32);
-                pub const ERROR_REC_NON_EXISTENT: Self = Self(4005u32);
-                pub const ERROR_RPL_NOT_ALLOWED: Self = Self(4006u32);
-                pub const ERROR_DHCP_ADDRESS_CONFLICT: Self = Self(4100u32);
-                pub const ERROR_WMI_GUID_NOT_FOUND: Self = Self(4200u32);
-                pub const ERROR_WMI_INSTANCE_NOT_FOUND: Self = Self(4201u32);
-                pub const ERROR_WMI_ITEMID_NOT_FOUND: Self = Self(4202u32);
-                pub const ERROR_WMI_TRY_AGAIN: Self = Self(4203u32);
-                pub const ERROR_WMI_DP_NOT_FOUND: Self = Self(4204u32);
-                pub const ERROR_WMI_UNRESOLVED_INSTANCE_REF: Self = Self(4205u32);
-                pub const ERROR_WMI_ALREADY_ENABLED: Self = Self(4206u32);
-                pub const ERROR_WMI_GUID_DISCONNECTED: Self = Self(4207u32);
-                pub const ERROR_WMI_SERVER_UNAVAILABLE: Self = Self(4208u32);
-                pub const ERROR_WMI_DP_FAILED: Self = Self(4209u32);
-                pub const ERROR_WMI_INVALID_MOF: Self = Self(4210u32);
-                pub const ERROR_WMI_INVALID_REGINFO: Self = Self(4211u32);
-                pub const ERROR_WMI_ALREADY_DISABLED: Self = Self(4212u32);
-                pub const ERROR_WMI_READ_ONLY: Self = Self(4213u32);
-                pub const ERROR_WMI_SET_FAILURE: Self = Self(4214u32);
-                pub const ERROR_NOT_APPCONTAINER: Self = Self(4250u32);
-                pub const ERROR_APPCONTAINER_REQUIRED: Self = Self(4251u32);
-                pub const ERROR_NOT_SUPPORTED_IN_APPCONTAINER: Self = Self(4252u32);
-                pub const ERROR_INVALID_PACKAGE_SID_LENGTH: Self = Self(4253u32);
-                pub const ERROR_INVALID_MEDIA: Self = Self(4300u32);
-                pub const ERROR_INVALID_LIBRARY: Self = Self(4301u32);
-                pub const ERROR_INVALID_MEDIA_POOL: Self = Self(4302u32);
-                pub const ERROR_DRIVE_MEDIA_MISMATCH: Self = Self(4303u32);
-                pub const ERROR_MEDIA_OFFLINE: Self = Self(4304u32);
-                pub const ERROR_LIBRARY_OFFLINE: Self = Self(4305u32);
-                pub const ERROR_EMPTY: Self = Self(4306u32);
-                pub const ERROR_NOT_EMPTY: Self = Self(4307u32);
-                pub const ERROR_MEDIA_UNAVAILABLE: Self = Self(4308u32);
-                pub const ERROR_RESOURCE_DISABLED: Self = Self(4309u32);
-                pub const ERROR_INVALID_CLEANER: Self = Self(4310u32);
-                pub const ERROR_UNABLE_TO_CLEAN: Self = Self(4311u32);
-                pub const ERROR_OBJECT_NOT_FOUND: Self = Self(4312u32);
-                pub const ERROR_DATABASE_FAILURE: Self = Self(4313u32);
-                pub const ERROR_DATABASE_FULL: Self = Self(4314u32);
-                pub const ERROR_MEDIA_INCOMPATIBLE: Self = Self(4315u32);
-                pub const ERROR_RESOURCE_NOT_PRESENT: Self = Self(4316u32);
-                pub const ERROR_INVALID_OPERATION: Self = Self(4317u32);
-                pub const ERROR_MEDIA_NOT_AVAILABLE: Self = Self(4318u32);
-                pub const ERROR_DEVICE_NOT_AVAILABLE: Self = Self(4319u32);
-                pub const ERROR_REQUEST_REFUSED: Self = Self(4320u32);
-                pub const ERROR_INVALID_DRIVE_OBJECT: Self = Self(4321u32);
-                pub const ERROR_LIBRARY_FULL: Self = Self(4322u32);
-                pub const ERROR_MEDIUM_NOT_ACCESSIBLE: Self = Self(4323u32);
-                pub const ERROR_UNABLE_TO_LOAD_MEDIUM: Self = Self(4324u32);
-                pub const ERROR_UNABLE_TO_INVENTORY_DRIVE: Self = Self(4325u32);
-                pub const ERROR_UNABLE_TO_INVENTORY_SLOT: Self = Self(4326u32);
-                pub const ERROR_UNABLE_TO_INVENTORY_TRANSPORT: Self = Self(4327u32);
-                pub const ERROR_TRANSPORT_FULL: Self = Self(4328u32);
-                pub const ERROR_CONTROLLING_IEPORT: Self = Self(4329u32);
-                pub const ERROR_UNABLE_TO_EJECT_MOUNTED_MEDIA: Self = Self(4330u32);
-                pub const ERROR_CLEANER_SLOT_SET: Self = Self(4331u32);
-                pub const ERROR_CLEANER_SLOT_NOT_SET: Self = Self(4332u32);
-                pub const ERROR_CLEANER_CARTRIDGE_SPENT: Self = Self(4333u32);
-                pub const ERROR_UNEXPECTED_OMID: Self = Self(4334u32);
-                pub const ERROR_CANT_DELETE_LAST_ITEM: Self = Self(4335u32);
-                pub const ERROR_MESSAGE_EXCEEDS_MAX_SIZE: Self = Self(4336u32);
-                pub const ERROR_VOLUME_CONTAINS_SYS_FILES: Self = Self(4337u32);
-                pub const ERROR_INDIGENOUS_TYPE: Self = Self(4338u32);
-                pub const ERROR_NO_SUPPORTING_DRIVES: Self = Self(4339u32);
-                pub const ERROR_CLEANER_CARTRIDGE_INSTALLED: Self = Self(4340u32);
-                pub const ERROR_IEPORT_FULL: Self = Self(4341u32);
-                pub const ERROR_FILE_OFFLINE: Self = Self(4350u32);
-                pub const ERROR_REMOTE_STORAGE_NOT_ACTIVE: Self = Self(4351u32);
-                pub const ERROR_REMOTE_STORAGE_MEDIA_ERROR: Self = Self(4352u32);
-                pub const ERROR_NOT_A_REPARSE_POINT: Self = Self(4390u32);
-                pub const ERROR_REPARSE_ATTRIBUTE_CONFLICT: Self = Self(4391u32);
-                pub const ERROR_INVALID_REPARSE_DATA: Self = Self(4392u32);
-                pub const ERROR_REPARSE_TAG_INVALID: Self = Self(4393u32);
-                pub const ERROR_REPARSE_TAG_MISMATCH: Self = Self(4394u32);
-                pub const ERROR_REPARSE_POINT_ENCOUNTERED: Self = Self(4395u32);
-                pub const ERROR_APP_DATA_NOT_FOUND: Self = Self(4400u32);
-                pub const ERROR_APP_DATA_EXPIRED: Self = Self(4401u32);
-                pub const ERROR_APP_DATA_CORRUPT: Self = Self(4402u32);
-                pub const ERROR_APP_DATA_LIMIT_EXCEEDED: Self = Self(4403u32);
-                pub const ERROR_APP_DATA_REBOOT_REQUIRED: Self = Self(4404u32);
-                pub const ERROR_SECUREBOOT_ROLLBACK_DETECTED: Self = Self(4420u32);
-                pub const ERROR_SECUREBOOT_POLICY_VIOLATION: Self = Self(4421u32);
-                pub const ERROR_SECUREBOOT_INVALID_POLICY: Self = Self(4422u32);
-                pub const ERROR_SECUREBOOT_POLICY_PUBLISHER_NOT_FOUND: Self = Self(4423u32);
-                pub const ERROR_SECUREBOOT_POLICY_NOT_SIGNED: Self = Self(4424u32);
-                pub const ERROR_SECUREBOOT_NOT_ENABLED: Self = Self(4425u32);
-                pub const ERROR_SECUREBOOT_FILE_REPLACED: Self = Self(4426u32);
-                pub const ERROR_SECUREBOOT_POLICY_NOT_AUTHORIZED: Self = Self(4427u32);
-                pub const ERROR_SECUREBOOT_POLICY_UNKNOWN: Self = Self(4428u32);
-                pub const ERROR_SECUREBOOT_POLICY_MISSING_ANTIROLLBACKVERSION: Self = Self(4429u32);
-                pub const ERROR_SECUREBOOT_PLATFORM_ID_MISMATCH: Self = Self(4430u32);
-                pub const ERROR_SECUREBOOT_POLICY_ROLLBACK_DETECTED: Self = Self(4431u32);
-                pub const ERROR_SECUREBOOT_POLICY_UPGRADE_MISMATCH: Self = Self(4432u32);
-                pub const ERROR_SECUREBOOT_REQUIRED_POLICY_FILE_MISSING: Self = Self(4433u32);
-                pub const ERROR_SECUREBOOT_NOT_BASE_POLICY: Self = Self(4434u32);
-                pub const ERROR_SECUREBOOT_NOT_SUPPLEMENTAL_POLICY: Self = Self(4435u32);
-                pub const ERROR_OFFLOAD_READ_FLT_NOT_SUPPORTED: Self = Self(4440u32);
-                pub const ERROR_OFFLOAD_WRITE_FLT_NOT_SUPPORTED: Self = Self(4441u32);
-                pub const ERROR_OFFLOAD_READ_FILE_NOT_SUPPORTED: Self = Self(4442u32);
-                pub const ERROR_OFFLOAD_WRITE_FILE_NOT_SUPPORTED: Self = Self(4443u32);
-                pub const ERROR_ALREADY_HAS_STREAM_ID: Self = Self(4444u32);
-                pub const ERROR_SMR_GARBAGE_COLLECTION_REQUIRED: Self = Self(4445u32);
-                pub const ERROR_WOF_WIM_HEADER_CORRUPT: Self = Self(4446u32);
-                pub const ERROR_WOF_WIM_RESOURCE_TABLE_CORRUPT: Self = Self(4447u32);
-                pub const ERROR_WOF_FILE_RESOURCE_TABLE_CORRUPT: Self = Self(4448u32);
-                pub const ERROR_VOLUME_NOT_SIS_ENABLED: Self = Self(4500u32);
-                pub const ERROR_SYSTEM_INTEGRITY_ROLLBACK_DETECTED: Self = Self(4550u32);
-                pub const ERROR_SYSTEM_INTEGRITY_POLICY_VIOLATION: Self = Self(4551u32);
-                pub const ERROR_SYSTEM_INTEGRITY_INVALID_POLICY: Self = Self(4552u32);
-                pub const ERROR_SYSTEM_INTEGRITY_POLICY_NOT_SIGNED: Self = Self(4553u32);
-                pub const ERROR_SYSTEM_INTEGRITY_TOO_MANY_POLICIES: Self = Self(4554u32);
-                pub const ERROR_SYSTEM_INTEGRITY_SUPPLEMENTAL_POLICY_NOT_AUTHORIZED: Self =
-                    Self(4555u32);
-                pub const ERROR_VSM_NOT_INITIALIZED: Self = Self(4560u32);
-                pub const ERROR_VSM_DMA_PROTECTION_NOT_IN_USE: Self = Self(4561u32);
-                pub const ERROR_PLATFORM_MANIFEST_NOT_AUTHORIZED: Self = Self(4570u32);
-                pub const ERROR_PLATFORM_MANIFEST_INVALID: Self = Self(4571u32);
-                pub const ERROR_PLATFORM_MANIFEST_FILE_NOT_AUTHORIZED: Self = Self(4572u32);
-                pub const ERROR_PLATFORM_MANIFEST_CATALOG_NOT_AUTHORIZED: Self = Self(4573u32);
-                pub const ERROR_PLATFORM_MANIFEST_BINARY_ID_NOT_FOUND: Self = Self(4574u32);
-                pub const ERROR_PLATFORM_MANIFEST_NOT_ACTIVE: Self = Self(4575u32);
-                pub const ERROR_PLATFORM_MANIFEST_NOT_SIGNED: Self = Self(4576u32);
-                pub const ERROR_DEPENDENT_RESOURCE_EXISTS: Self = Self(5001u32);
-                pub const ERROR_DEPENDENCY_NOT_FOUND: Self = Self(5002u32);
-                pub const ERROR_DEPENDENCY_ALREADY_EXISTS: Self = Self(5003u32);
-                pub const ERROR_RESOURCE_NOT_ONLINE: Self = Self(5004u32);
-                pub const ERROR_HOST_NODE_NOT_AVAILABLE: Self = Self(5005u32);
-                pub const ERROR_RESOURCE_NOT_AVAILABLE: Self = Self(5006u32);
-                pub const ERROR_RESOURCE_NOT_FOUND: Self = Self(5007u32);
-                pub const ERROR_SHUTDOWN_CLUSTER: Self = Self(5008u32);
-                pub const ERROR_CANT_EVICT_ACTIVE_NODE: Self = Self(5009u32);
-                pub const ERROR_OBJECT_ALREADY_EXISTS: Self = Self(5010u32);
-                pub const ERROR_OBJECT_IN_LIST: Self = Self(5011u32);
-                pub const ERROR_GROUP_NOT_AVAILABLE: Self = Self(5012u32);
-                pub const ERROR_GROUP_NOT_FOUND: Self = Self(5013u32);
-                pub const ERROR_GROUP_NOT_ONLINE: Self = Self(5014u32);
-                pub const ERROR_HOST_NODE_NOT_RESOURCE_OWNER: Self = Self(5015u32);
-                pub const ERROR_HOST_NODE_NOT_GROUP_OWNER: Self = Self(5016u32);
-                pub const ERROR_RESMON_CREATE_FAILED: Self = Self(5017u32);
-                pub const ERROR_RESMON_ONLINE_FAILED: Self = Self(5018u32);
-                pub const ERROR_RESOURCE_ONLINE: Self = Self(5019u32);
-                pub const ERROR_QUORUM_RESOURCE: Self = Self(5020u32);
-                pub const ERROR_NOT_QUORUM_CAPABLE: Self = Self(5021u32);
-                pub const ERROR_CLUSTER_SHUTTING_DOWN: Self = Self(5022u32);
-                pub const ERROR_INVALID_STATE: Self = Self(5023u32);
-                pub const ERROR_RESOURCE_PROPERTIES_STORED: Self = Self(5024u32);
-                pub const ERROR_NOT_QUORUM_CLASS: Self = Self(5025u32);
-                pub const ERROR_CORE_RESOURCE: Self = Self(5026u32);
-                pub const ERROR_QUORUM_RESOURCE_ONLINE_FAILED: Self = Self(5027u32);
-                pub const ERROR_QUORUMLOG_OPEN_FAILED: Self = Self(5028u32);
-                pub const ERROR_CLUSTERLOG_CORRUPT: Self = Self(5029u32);
-                pub const ERROR_CLUSTERLOG_RECORD_EXCEEDS_MAXSIZE: Self = Self(5030u32);
-                pub const ERROR_CLUSTERLOG_EXCEEDS_MAXSIZE: Self = Self(5031u32);
-                pub const ERROR_CLUSTERLOG_CHKPOINT_NOT_FOUND: Self = Self(5032u32);
-                pub const ERROR_CLUSTERLOG_NOT_ENOUGH_SPACE: Self = Self(5033u32);
-                pub const ERROR_QUORUM_OWNER_ALIVE: Self = Self(5034u32);
-                pub const ERROR_NETWORK_NOT_AVAILABLE: Self = Self(5035u32);
-                pub const ERROR_NODE_NOT_AVAILABLE: Self = Self(5036u32);
-                pub const ERROR_ALL_NODES_NOT_AVAILABLE: Self = Self(5037u32);
-                pub const ERROR_RESOURCE_FAILED: Self = Self(5038u32);
-                pub const ERROR_CLUSTER_INVALID_NODE: Self = Self(5039u32);
-                pub const ERROR_CLUSTER_NODE_EXISTS: Self = Self(5040u32);
-                pub const ERROR_CLUSTER_JOIN_IN_PROGRESS: Self = Self(5041u32);
-                pub const ERROR_CLUSTER_NODE_NOT_FOUND: Self = Self(5042u32);
-                pub const ERROR_CLUSTER_LOCAL_NODE_NOT_FOUND: Self = Self(5043u32);
-                pub const ERROR_CLUSTER_NETWORK_EXISTS: Self = Self(5044u32);
-                pub const ERROR_CLUSTER_NETWORK_NOT_FOUND: Self = Self(5045u32);
-                pub const ERROR_CLUSTER_NETINTERFACE_EXISTS: Self = Self(5046u32);
-                pub const ERROR_CLUSTER_NETINTERFACE_NOT_FOUND: Self = Self(5047u32);
-                pub const ERROR_CLUSTER_INVALID_REQUEST: Self = Self(5048u32);
-                pub const ERROR_CLUSTER_INVALID_NETWORK_PROVIDER: Self = Self(5049u32);
-                pub const ERROR_CLUSTER_NODE_DOWN: Self = Self(5050u32);
-                pub const ERROR_CLUSTER_NODE_UNREACHABLE: Self = Self(5051u32);
-                pub const ERROR_CLUSTER_NODE_NOT_MEMBER: Self = Self(5052u32);
-                pub const ERROR_CLUSTER_JOIN_NOT_IN_PROGRESS: Self = Self(5053u32);
-                pub const ERROR_CLUSTER_INVALID_NETWORK: Self = Self(5054u32);
-                pub const ERROR_CLUSTER_NODE_UP: Self = Self(5056u32);
-                pub const ERROR_CLUSTER_IPADDR_IN_USE: Self = Self(5057u32);
-                pub const ERROR_CLUSTER_NODE_NOT_PAUSED: Self = Self(5058u32);
-                pub const ERROR_CLUSTER_NO_SECURITY_CONTEXT: Self = Self(5059u32);
-                pub const ERROR_CLUSTER_NETWORK_NOT_INTERNAL: Self = Self(5060u32);
-                pub const ERROR_CLUSTER_NODE_ALREADY_UP: Self = Self(5061u32);
-                pub const ERROR_CLUSTER_NODE_ALREADY_DOWN: Self = Self(5062u32);
-                pub const ERROR_CLUSTER_NETWORK_ALREADY_ONLINE: Self = Self(5063u32);
-                pub const ERROR_CLUSTER_NETWORK_ALREADY_OFFLINE: Self = Self(5064u32);
-                pub const ERROR_CLUSTER_NODE_ALREADY_MEMBER: Self = Self(5065u32);
-                pub const ERROR_CLUSTER_LAST_INTERNAL_NETWORK: Self = Self(5066u32);
-                pub const ERROR_CLUSTER_NETWORK_HAS_DEPENDENTS: Self = Self(5067u32);
-                pub const ERROR_INVALID_OPERATION_ON_QUORUM: Self = Self(5068u32);
-                pub const ERROR_DEPENDENCY_NOT_ALLOWED: Self = Self(5069u32);
-                pub const ERROR_CLUSTER_NODE_PAUSED: Self = Self(5070u32);
-                pub const ERROR_NODE_CANT_HOST_RESOURCE: Self = Self(5071u32);
-                pub const ERROR_CLUSTER_NODE_NOT_READY: Self = Self(5072u32);
-                pub const ERROR_CLUSTER_NODE_SHUTTING_DOWN: Self = Self(5073u32);
-                pub const ERROR_CLUSTER_JOIN_ABORTED: Self = Self(5074u32);
-                pub const ERROR_CLUSTER_INCOMPATIBLE_VERSIONS: Self = Self(5075u32);
-                pub const ERROR_CLUSTER_MAXNUM_OF_RESOURCES_EXCEEDED: Self = Self(5076u32);
-                pub const ERROR_CLUSTER_SYSTEM_CONFIG_CHANGED: Self = Self(5077u32);
-                pub const ERROR_CLUSTER_RESOURCE_TYPE_NOT_FOUND: Self = Self(5078u32);
-                pub const ERROR_CLUSTER_RESTYPE_NOT_SUPPORTED: Self = Self(5079u32);
-                pub const ERROR_CLUSTER_RESNAME_NOT_FOUND: Self = Self(5080u32);
-                pub const ERROR_CLUSTER_NO_RPC_PACKAGES_REGISTERED: Self = Self(5081u32);
-                pub const ERROR_CLUSTER_OWNER_NOT_IN_PREFLIST: Self = Self(5082u32);
-                pub const ERROR_CLUSTER_DATABASE_SEQMISMATCH: Self = Self(5083u32);
-                pub const ERROR_RESMON_INVALID_STATE: Self = Self(5084u32);
-                pub const ERROR_CLUSTER_GUM_NOT_LOCKER: Self = Self(5085u32);
-                pub const ERROR_QUORUM_DISK_NOT_FOUND: Self = Self(5086u32);
-                pub const ERROR_DATABASE_BACKUP_CORRUPT: Self = Self(5087u32);
-                pub const ERROR_CLUSTER_NODE_ALREADY_HAS_DFS_ROOT: Self = Self(5088u32);
-                pub const ERROR_RESOURCE_PROPERTY_UNCHANGEABLE: Self = Self(5089u32);
-                pub const ERROR_NO_ADMIN_ACCESS_POINT: Self = Self(5090u32);
-                pub const ERROR_CLUSTER_MEMBERSHIP_INVALID_STATE: Self = Self(5890u32);
-                pub const ERROR_CLUSTER_QUORUMLOG_NOT_FOUND: Self = Self(5891u32);
-                pub const ERROR_CLUSTER_MEMBERSHIP_HALT: Self = Self(5892u32);
-                pub const ERROR_CLUSTER_INSTANCE_ID_MISMATCH: Self = Self(5893u32);
-                pub const ERROR_CLUSTER_NETWORK_NOT_FOUND_FOR_IP: Self = Self(5894u32);
-                pub const ERROR_CLUSTER_PROPERTY_DATA_TYPE_MISMATCH: Self = Self(5895u32);
-                pub const ERROR_CLUSTER_EVICT_WITHOUT_CLEANUP: Self = Self(5896u32);
-                pub const ERROR_CLUSTER_PARAMETER_MISMATCH: Self = Self(5897u32);
-                pub const ERROR_NODE_CANNOT_BE_CLUSTERED: Self = Self(5898u32);
-                pub const ERROR_CLUSTER_WRONG_OS_VERSION: Self = Self(5899u32);
-                pub const ERROR_CLUSTER_CANT_CREATE_DUP_CLUSTER_NAME: Self = Self(5900u32);
-                pub const ERROR_CLUSCFG_ALREADY_COMMITTED: Self = Self(5901u32);
-                pub const ERROR_CLUSCFG_ROLLBACK_FAILED: Self = Self(5902u32);
-                pub const ERROR_CLUSCFG_SYSTEM_DISK_DRIVE_LETTER_CONFLICT: Self = Self(5903u32);
-                pub const ERROR_CLUSTER_OLD_VERSION: Self = Self(5904u32);
-                pub const ERROR_CLUSTER_MISMATCHED_COMPUTER_ACCT_NAME: Self = Self(5905u32);
-                pub const ERROR_CLUSTER_NO_NET_ADAPTERS: Self = Self(5906u32);
-                pub const ERROR_CLUSTER_POISONED: Self = Self(5907u32);
-                pub const ERROR_CLUSTER_GROUP_MOVING: Self = Self(5908u32);
-                pub const ERROR_CLUSTER_RESOURCE_TYPE_BUSY: Self = Self(5909u32);
-                pub const ERROR_RESOURCE_CALL_TIMED_OUT: Self = Self(5910u32);
-                pub const ERROR_INVALID_CLUSTER_IPV6_ADDRESS: Self = Self(5911u32);
-                pub const ERROR_CLUSTER_INTERNAL_INVALID_FUNCTION: Self = Self(5912u32);
-                pub const ERROR_CLUSTER_PARAMETER_OUT_OF_BOUNDS: Self = Self(5913u32);
-                pub const ERROR_CLUSTER_PARTIAL_SEND: Self = Self(5914u32);
-                pub const ERROR_CLUSTER_REGISTRY_INVALID_FUNCTION: Self = Self(5915u32);
-                pub const ERROR_CLUSTER_INVALID_STRING_TERMINATION: Self = Self(5916u32);
-                pub const ERROR_CLUSTER_INVALID_STRING_FORMAT: Self = Self(5917u32);
-                pub const ERROR_CLUSTER_DATABASE_TRANSACTION_IN_PROGRESS: Self = Self(5918u32);
-                pub const ERROR_CLUSTER_DATABASE_TRANSACTION_NOT_IN_PROGRESS: Self = Self(5919u32);
-                pub const ERROR_CLUSTER_NULL_DATA: Self = Self(5920u32);
-                pub const ERROR_CLUSTER_PARTIAL_READ: Self = Self(5921u32);
-                pub const ERROR_CLUSTER_PARTIAL_WRITE: Self = Self(5922u32);
-                pub const ERROR_CLUSTER_CANT_DESERIALIZE_DATA: Self = Self(5923u32);
-                pub const ERROR_DEPENDENT_RESOURCE_PROPERTY_CONFLICT: Self = Self(5924u32);
-                pub const ERROR_CLUSTER_NO_QUORUM: Self = Self(5925u32);
-                pub const ERROR_CLUSTER_INVALID_IPV6_NETWORK: Self = Self(5926u32);
-                pub const ERROR_CLUSTER_INVALID_IPV6_TUNNEL_NETWORK: Self = Self(5927u32);
-                pub const ERROR_QUORUM_NOT_ALLOWED_IN_THIS_GROUP: Self = Self(5928u32);
-                pub const ERROR_DEPENDENCY_TREE_TOO_COMPLEX: Self = Self(5929u32);
-                pub const ERROR_EXCEPTION_IN_RESOURCE_CALL: Self = Self(5930u32);
-                pub const ERROR_CLUSTER_RHS_FAILED_INITIALIZATION: Self = Self(5931u32);
-                pub const ERROR_CLUSTER_NOT_INSTALLED: Self = Self(5932u32);
-                pub const ERROR_CLUSTER_RESOURCES_MUST_BE_ONLINE_ON_THE_SAME_NODE: Self =
-                    Self(5933u32);
-                pub const ERROR_CLUSTER_MAX_NODES_IN_CLUSTER: Self = Self(5934u32);
-                pub const ERROR_CLUSTER_TOO_MANY_NODES: Self = Self(5935u32);
-                pub const ERROR_CLUSTER_OBJECT_ALREADY_USED: Self = Self(5936u32);
-                pub const ERROR_NONCORE_GROUPS_FOUND: Self = Self(5937u32);
-                pub const ERROR_FILE_SHARE_RESOURCE_CONFLICT: Self = Self(5938u32);
-                pub const ERROR_CLUSTER_EVICT_INVALID_REQUEST: Self = Self(5939u32);
-                pub const ERROR_CLUSTER_SINGLETON_RESOURCE: Self = Self(5940u32);
-                pub const ERROR_CLUSTER_GROUP_SINGLETON_RESOURCE: Self = Self(5941u32);
-                pub const ERROR_CLUSTER_RESOURCE_PROVIDER_FAILED: Self = Self(5942u32);
-                pub const ERROR_CLUSTER_RESOURCE_CONFIGURATION_ERROR: Self = Self(5943u32);
-                pub const ERROR_CLUSTER_GROUP_BUSY: Self = Self(5944u32);
-                pub const ERROR_CLUSTER_NOT_SHARED_VOLUME: Self = Self(5945u32);
-                pub const ERROR_CLUSTER_INVALID_SECURITY_DESCRIPTOR: Self = Self(5946u32);
-                pub const ERROR_CLUSTER_SHARED_VOLUMES_IN_USE: Self = Self(5947u32);
-                pub const ERROR_CLUSTER_USE_SHARED_VOLUMES_API: Self = Self(5948u32);
-                pub const ERROR_CLUSTER_BACKUP_IN_PROGRESS: Self = Self(5949u32);
-                pub const ERROR_NON_CSV_PATH: Self = Self(5950u32);
-                pub const ERROR_CSV_VOLUME_NOT_LOCAL: Self = Self(5951u32);
-                pub const ERROR_CLUSTER_WATCHDOG_TERMINATING: Self = Self(5952u32);
-                pub const ERROR_CLUSTER_RESOURCE_VETOED_MOVE_INCOMPATIBLE_NODES: Self =
-                    Self(5953u32);
-                pub const ERROR_CLUSTER_INVALID_NODE_WEIGHT: Self = Self(5954u32);
-                pub const ERROR_CLUSTER_RESOURCE_VETOED_CALL: Self = Self(5955u32);
-                pub const ERROR_RESMON_SYSTEM_RESOURCES_LACKING: Self = Self(5956u32);
-                pub const ERROR_CLUSTER_RESOURCE_VETOED_MOVE_NOT_ENOUGH_RESOURCES_ON_DESTINATION:
-                    Self = Self(5957u32);
-                pub const ERROR_CLUSTER_RESOURCE_VETOED_MOVE_NOT_ENOUGH_RESOURCES_ON_SOURCE: Self =
-                    Self(5958u32);
-                pub const ERROR_CLUSTER_GROUP_QUEUED: Self = Self(5959u32);
-                pub const ERROR_CLUSTER_RESOURCE_LOCKED_STATUS: Self = Self(5960u32);
-                pub const ERROR_CLUSTER_SHARED_VOLUME_FAILOVER_NOT_ALLOWED: Self = Self(5961u32);
-                pub const ERROR_CLUSTER_NODE_DRAIN_IN_PROGRESS: Self = Self(5962u32);
-                pub const ERROR_CLUSTER_DISK_NOT_CONNECTED: Self = Self(5963u32);
-                pub const ERROR_DISK_NOT_CSV_CAPABLE: Self = Self(5964u32);
-                pub const ERROR_RESOURCE_NOT_IN_AVAILABLE_STORAGE: Self = Self(5965u32);
-                pub const ERROR_CLUSTER_SHARED_VOLUME_REDIRECTED: Self = Self(5966u32);
-                pub const ERROR_CLUSTER_SHARED_VOLUME_NOT_REDIRECTED: Self = Self(5967u32);
-                pub const ERROR_CLUSTER_CANNOT_RETURN_PROPERTIES: Self = Self(5968u32);
-                pub const ERROR_CLUSTER_RESOURCE_CONTAINS_UNSUPPORTED_DIFF_AREA_FOR_SHARED_VOLUMES : Self = Self ( 5969u32 ) ;
-                pub const ERROR_CLUSTER_RESOURCE_IS_IN_MAINTENANCE_MODE: Self = Self(5970u32);
-                pub const ERROR_CLUSTER_AFFINITY_CONFLICT: Self = Self(5971u32);
-                pub const ERROR_CLUSTER_RESOURCE_IS_REPLICA_VIRTUAL_MACHINE: Self = Self(5972u32);
-                pub const ERROR_CLUSTER_UPGRADE_INCOMPATIBLE_VERSIONS: Self = Self(5973u32);
-                pub const ERROR_CLUSTER_UPGRADE_FIX_QUORUM_NOT_SUPPORTED: Self = Self(5974u32);
-                pub const ERROR_CLUSTER_UPGRADE_RESTART_REQUIRED: Self = Self(5975u32);
-                pub const ERROR_CLUSTER_UPGRADE_IN_PROGRESS: Self = Self(5976u32);
-                pub const ERROR_CLUSTER_UPGRADE_INCOMPLETE: Self = Self(5977u32);
-                pub const ERROR_CLUSTER_NODE_IN_GRACE_PERIOD: Self = Self(5978u32);
-                pub const ERROR_CLUSTER_CSV_IO_PAUSE_TIMEOUT: Self = Self(5979u32);
-                pub const ERROR_NODE_NOT_ACTIVE_CLUSTER_MEMBER: Self = Self(5980u32);
-                pub const ERROR_CLUSTER_RESOURCE_NOT_MONITORED: Self = Self(5981u32);
-                pub const ERROR_CLUSTER_RESOURCE_DOES_NOT_SUPPORT_UNMONITORED: Self = Self(5982u32);
-                pub const ERROR_CLUSTER_RESOURCE_IS_REPLICATED: Self = Self(5983u32);
-                pub const ERROR_CLUSTER_NODE_ISOLATED: Self = Self(5984u32);
-                pub const ERROR_CLUSTER_NODE_QUARANTINED: Self = Self(5985u32);
-                pub const ERROR_CLUSTER_DATABASE_UPDATE_CONDITION_FAILED: Self = Self(5986u32);
-                pub const ERROR_CLUSTER_SPACE_DEGRADED: Self = Self(5987u32);
-                pub const ERROR_CLUSTER_TOKEN_DELEGATION_NOT_SUPPORTED: Self = Self(5988u32);
-                pub const ERROR_CLUSTER_CSV_INVALID_HANDLE: Self = Self(5989u32);
-                pub const ERROR_CLUSTER_CSV_SUPPORTED_ONLY_ON_COORDINATOR: Self = Self(5990u32);
-                pub const ERROR_GROUPSET_NOT_AVAILABLE: Self = Self(5991u32);
-                pub const ERROR_GROUPSET_NOT_FOUND: Self = Self(5992u32);
-                pub const ERROR_GROUPSET_CANT_PROVIDE: Self = Self(5993u32);
-                pub const ERROR_CLUSTER_FAULT_DOMAIN_PARENT_NOT_FOUND: Self = Self(5994u32);
-                pub const ERROR_CLUSTER_FAULT_DOMAIN_INVALID_HIERARCHY: Self = Self(5995u32);
-                pub const ERROR_CLUSTER_FAULT_DOMAIN_FAILED_S2D_VALIDATION: Self = Self(5996u32);
-                pub const ERROR_CLUSTER_FAULT_DOMAIN_S2D_CONNECTIVITY_LOSS: Self = Self(5997u32);
-                pub const ERROR_CLUSTER_INVALID_INFRASTRUCTURE_FILESERVER_NAME: Self =
-                    Self(5998u32);
-                pub const ERROR_CLUSTERSET_MANAGEMENT_CLUSTER_UNREACHABLE: Self = Self(5999u32);
-                pub const ERROR_ENCRYPTION_FAILED: Self = Self(6000u32);
-                pub const ERROR_DECRYPTION_FAILED: Self = Self(6001u32);
-                pub const ERROR_FILE_ENCRYPTED: Self = Self(6002u32);
-                pub const ERROR_NO_RECOVERY_POLICY: Self = Self(6003u32);
-                pub const ERROR_NO_EFS: Self = Self(6004u32);
-                pub const ERROR_WRONG_EFS: Self = Self(6005u32);
-                pub const ERROR_NO_USER_KEYS: Self = Self(6006u32);
-                pub const ERROR_FILE_NOT_ENCRYPTED: Self = Self(6007u32);
-                pub const ERROR_NOT_EXPORT_FORMAT: Self = Self(6008u32);
-                pub const ERROR_FILE_READ_ONLY: Self = Self(6009u32);
-                pub const ERROR_DIR_EFS_DISALLOWED: Self = Self(6010u32);
-                pub const ERROR_EFS_SERVER_NOT_TRUSTED: Self = Self(6011u32);
-                pub const ERROR_BAD_RECOVERY_POLICY: Self = Self(6012u32);
-                pub const ERROR_EFS_ALG_BLOB_TOO_BIG: Self = Self(6013u32);
-                pub const ERROR_VOLUME_NOT_SUPPORT_EFS: Self = Self(6014u32);
-                pub const ERROR_EFS_DISABLED: Self = Self(6015u32);
-                pub const ERROR_EFS_VERSION_NOT_SUPPORT: Self = Self(6016u32);
-                pub const ERROR_CS_ENCRYPTION_INVALID_SERVER_RESPONSE: Self = Self(6017u32);
-                pub const ERROR_CS_ENCRYPTION_UNSUPPORTED_SERVER: Self = Self(6018u32);
-                pub const ERROR_CS_ENCRYPTION_EXISTING_ENCRYPTED_FILE: Self = Self(6019u32);
-                pub const ERROR_CS_ENCRYPTION_NEW_ENCRYPTED_FILE: Self = Self(6020u32);
-                pub const ERROR_CS_ENCRYPTION_FILE_NOT_CSE: Self = Self(6021u32);
-                pub const ERROR_ENCRYPTION_POLICY_DENIES_OPERATION: Self = Self(6022u32);
-                pub const ERROR_WIP_ENCRYPTION_FAILED: Self = Self(6023u32);
-                pub const ERROR_NO_BROWSER_SERVERS_FOUND: Self = Self(6118u32);
-                pub const ERROR_CLUSTER_OBJECT_IS_CLUSTER_SET_VM: Self = Self(6250u32);
-                pub const ERROR_LOG_SECTOR_INVALID: Self = Self(6600u32);
-                pub const ERROR_LOG_SECTOR_PARITY_INVALID: Self = Self(6601u32);
-                pub const ERROR_LOG_SECTOR_REMAPPED: Self = Self(6602u32);
-                pub const ERROR_LOG_BLOCK_INCOMPLETE: Self = Self(6603u32);
-                pub const ERROR_LOG_INVALID_RANGE: Self = Self(6604u32);
-                pub const ERROR_LOG_BLOCKS_EXHAUSTED: Self = Self(6605u32);
-                pub const ERROR_LOG_READ_CONTEXT_INVALID: Self = Self(6606u32);
-                pub const ERROR_LOG_RESTART_INVALID: Self = Self(6607u32);
-                pub const ERROR_LOG_BLOCK_VERSION: Self = Self(6608u32);
-                pub const ERROR_LOG_BLOCK_INVALID: Self = Self(6609u32);
-                pub const ERROR_LOG_READ_MODE_INVALID: Self = Self(6610u32);
-                pub const ERROR_LOG_NO_RESTART: Self = Self(6611u32);
-                pub const ERROR_LOG_METADATA_CORRUPT: Self = Self(6612u32);
-                pub const ERROR_LOG_METADATA_INVALID: Self = Self(6613u32);
-                pub const ERROR_LOG_METADATA_INCONSISTENT: Self = Self(6614u32);
-                pub const ERROR_LOG_RESERVATION_INVALID: Self = Self(6615u32);
-                pub const ERROR_LOG_CANT_DELETE: Self = Self(6616u32);
-                pub const ERROR_LOG_CONTAINER_LIMIT_EXCEEDED: Self = Self(6617u32);
-                pub const ERROR_LOG_START_OF_LOG: Self = Self(6618u32);
-                pub const ERROR_LOG_POLICY_ALREADY_INSTALLED: Self = Self(6619u32);
-                pub const ERROR_LOG_POLICY_NOT_INSTALLED: Self = Self(6620u32);
-                pub const ERROR_LOG_POLICY_INVALID: Self = Self(6621u32);
-                pub const ERROR_LOG_POLICY_CONFLICT: Self = Self(6622u32);
-                pub const ERROR_LOG_PINNED_ARCHIVE_TAIL: Self = Self(6623u32);
-                pub const ERROR_LOG_RECORD_NONEXISTENT: Self = Self(6624u32);
-                pub const ERROR_LOG_RECORDS_RESERVED_INVALID: Self = Self(6625u32);
-                pub const ERROR_LOG_SPACE_RESERVED_INVALID: Self = Self(6626u32);
-                pub const ERROR_LOG_TAIL_INVALID: Self = Self(6627u32);
-                pub const ERROR_LOG_FULL: Self = Self(6628u32);
-                pub const ERROR_COULD_NOT_RESIZE_LOG: Self = Self(6629u32);
-                pub const ERROR_LOG_MULTIPLEXED: Self = Self(6630u32);
-                pub const ERROR_LOG_DEDICATED: Self = Self(6631u32);
-                pub const ERROR_LOG_ARCHIVE_NOT_IN_PROGRESS: Self = Self(6632u32);
-                pub const ERROR_LOG_ARCHIVE_IN_PROGRESS: Self = Self(6633u32);
-                pub const ERROR_LOG_EPHEMERAL: Self = Self(6634u32);
-                pub const ERROR_LOG_NOT_ENOUGH_CONTAINERS: Self = Self(6635u32);
-                pub const ERROR_LOG_CLIENT_ALREADY_REGISTERED: Self = Self(6636u32);
-                pub const ERROR_LOG_CLIENT_NOT_REGISTERED: Self = Self(6637u32);
-                pub const ERROR_LOG_FULL_HANDLER_IN_PROGRESS: Self = Self(6638u32);
-                pub const ERROR_LOG_CONTAINER_READ_FAILED: Self = Self(6639u32);
-                pub const ERROR_LOG_CONTAINER_WRITE_FAILED: Self = Self(6640u32);
-                pub const ERROR_LOG_CONTAINER_OPEN_FAILED: Self = Self(6641u32);
-                pub const ERROR_LOG_CONTAINER_STATE_INVALID: Self = Self(6642u32);
-                pub const ERROR_LOG_STATE_INVALID: Self = Self(6643u32);
-                pub const ERROR_LOG_PINNED: Self = Self(6644u32);
-                pub const ERROR_LOG_METADATA_FLUSH_FAILED: Self = Self(6645u32);
-                pub const ERROR_LOG_INCONSISTENT_SECURITY: Self = Self(6646u32);
-                pub const ERROR_LOG_APPENDED_FLUSH_FAILED: Self = Self(6647u32);
-                pub const ERROR_LOG_PINNED_RESERVATION: Self = Self(6648u32);
-                pub const ERROR_INVALID_TRANSACTION: Self = Self(6700u32);
-                pub const ERROR_TRANSACTION_NOT_ACTIVE: Self = Self(6701u32);
-                pub const ERROR_TRANSACTION_REQUEST_NOT_VALID: Self = Self(6702u32);
-                pub const ERROR_TRANSACTION_NOT_REQUESTED: Self = Self(6703u32);
-                pub const ERROR_TRANSACTION_ALREADY_ABORTED: Self = Self(6704u32);
-                pub const ERROR_TRANSACTION_ALREADY_COMMITTED: Self = Self(6705u32);
-                pub const ERROR_TM_INITIALIZATION_FAILED: Self = Self(6706u32);
-                pub const ERROR_RESOURCEMANAGER_READ_ONLY: Self = Self(6707u32);
-                pub const ERROR_TRANSACTION_NOT_JOINED: Self = Self(6708u32);
-                pub const ERROR_TRANSACTION_SUPERIOR_EXISTS: Self = Self(6709u32);
-                pub const ERROR_CRM_PROTOCOL_ALREADY_EXISTS: Self = Self(6710u32);
-                pub const ERROR_TRANSACTION_PROPAGATION_FAILED: Self = Self(6711u32);
-                pub const ERROR_CRM_PROTOCOL_NOT_FOUND: Self = Self(6712u32);
-                pub const ERROR_TRANSACTION_INVALID_MARSHALL_BUFFER: Self = Self(6713u32);
-                pub const ERROR_CURRENT_TRANSACTION_NOT_VALID: Self = Self(6714u32);
-                pub const ERROR_TRANSACTION_NOT_FOUND: Self = Self(6715u32);
-                pub const ERROR_RESOURCEMANAGER_NOT_FOUND: Self = Self(6716u32);
-                pub const ERROR_ENLISTMENT_NOT_FOUND: Self = Self(6717u32);
-                pub const ERROR_TRANSACTIONMANAGER_NOT_FOUND: Self = Self(6718u32);
-                pub const ERROR_TRANSACTIONMANAGER_NOT_ONLINE: Self = Self(6719u32);
-                pub const ERROR_TRANSACTIONMANAGER_RECOVERY_NAME_COLLISION: Self = Self(6720u32);
-                pub const ERROR_TRANSACTION_NOT_ROOT: Self = Self(6721u32);
-                pub const ERROR_TRANSACTION_OBJECT_EXPIRED: Self = Self(6722u32);
-                pub const ERROR_TRANSACTION_RESPONSE_NOT_ENLISTED: Self = Self(6723u32);
-                pub const ERROR_TRANSACTION_RECORD_TOO_LONG: Self = Self(6724u32);
-                pub const ERROR_IMPLICIT_TRANSACTION_NOT_SUPPORTED: Self = Self(6725u32);
-                pub const ERROR_TRANSACTION_INTEGRITY_VIOLATED: Self = Self(6726u32);
-                pub const ERROR_TRANSACTIONMANAGER_IDENTITY_MISMATCH: Self = Self(6727u32);
-                pub const ERROR_RM_CANNOT_BE_FROZEN_FOR_SNAPSHOT: Self = Self(6728u32);
-                pub const ERROR_TRANSACTION_MUST_WRITETHROUGH: Self = Self(6729u32);
-                pub const ERROR_TRANSACTION_NO_SUPERIOR: Self = Self(6730u32);
-                pub const ERROR_HEURISTIC_DAMAGE_POSSIBLE: Self = Self(6731u32);
-                pub const ERROR_TRANSACTIONAL_CONFLICT: Self = Self(6800u32);
-                pub const ERROR_RM_NOT_ACTIVE: Self = Self(6801u32);
-                pub const ERROR_RM_METADATA_CORRUPT: Self = Self(6802u32);
-                pub const ERROR_DIRECTORY_NOT_RM: Self = Self(6803u32);
-                pub const ERROR_TRANSACTIONS_UNSUPPORTED_REMOTE: Self = Self(6805u32);
-                pub const ERROR_LOG_RESIZE_INVALID_SIZE: Self = Self(6806u32);
-                pub const ERROR_OBJECT_NO_LONGER_EXISTS: Self = Self(6807u32);
-                pub const ERROR_STREAM_MINIVERSION_NOT_FOUND: Self = Self(6808u32);
-                pub const ERROR_STREAM_MINIVERSION_NOT_VALID: Self = Self(6809u32);
-                pub const ERROR_MINIVERSION_INACCESSIBLE_FROM_SPECIFIED_TRANSACTION: Self =
-                    Self(6810u32);
-                pub const ERROR_CANT_OPEN_MINIVERSION_WITH_MODIFY_INTENT: Self = Self(6811u32);
-                pub const ERROR_CANT_CREATE_MORE_STREAM_MINIVERSIONS: Self = Self(6812u32);
-                pub const ERROR_REMOTE_FILE_VERSION_MISMATCH: Self = Self(6814u32);
-                pub const ERROR_HANDLE_NO_LONGER_VALID: Self = Self(6815u32);
-                pub const ERROR_NO_TXF_METADATA: Self = Self(6816u32);
-                pub const ERROR_LOG_CORRUPTION_DETECTED: Self = Self(6817u32);
-                pub const ERROR_CANT_RECOVER_WITH_HANDLE_OPEN: Self = Self(6818u32);
-                pub const ERROR_RM_DISCONNECTED: Self = Self(6819u32);
-                pub const ERROR_ENLISTMENT_NOT_SUPERIOR: Self = Self(6820u32);
-                pub const ERROR_RECOVERY_NOT_NEEDED: Self = Self(6821u32);
-                pub const ERROR_RM_ALREADY_STARTED: Self = Self(6822u32);
-                pub const ERROR_FILE_IDENTITY_NOT_PERSISTENT: Self = Self(6823u32);
-                pub const ERROR_CANT_BREAK_TRANSACTIONAL_DEPENDENCY: Self = Self(6824u32);
-                pub const ERROR_CANT_CROSS_RM_BOUNDARY: Self = Self(6825u32);
-                pub const ERROR_TXF_DIR_NOT_EMPTY: Self = Self(6826u32);
-                pub const ERROR_INDOUBT_TRANSACTIONS_EXIST: Self = Self(6827u32);
-                pub const ERROR_TM_VOLATILE: Self = Self(6828u32);
-                pub const ERROR_ROLLBACK_TIMER_EXPIRED: Self = Self(6829u32);
-                pub const ERROR_TXF_ATTRIBUTE_CORRUPT: Self = Self(6830u32);
-                pub const ERROR_EFS_NOT_ALLOWED_IN_TRANSACTION: Self = Self(6831u32);
-                pub const ERROR_TRANSACTIONAL_OPEN_NOT_ALLOWED: Self = Self(6832u32);
-                pub const ERROR_LOG_GROWTH_FAILED: Self = Self(6833u32);
-                pub const ERROR_TRANSACTED_MAPPING_UNSUPPORTED_REMOTE: Self = Self(6834u32);
-                pub const ERROR_TXF_METADATA_ALREADY_PRESENT: Self = Self(6835u32);
-                pub const ERROR_TRANSACTION_SCOPE_CALLBACKS_NOT_SET: Self = Self(6836u32);
-                pub const ERROR_TRANSACTION_REQUIRED_PROMOTION: Self = Self(6837u32);
-                pub const ERROR_CANNOT_EXECUTE_FILE_IN_TRANSACTION: Self = Self(6838u32);
-                pub const ERROR_TRANSACTIONS_NOT_FROZEN: Self = Self(6839u32);
-                pub const ERROR_TRANSACTION_FREEZE_IN_PROGRESS: Self = Self(6840u32);
-                pub const ERROR_NOT_SNAPSHOT_VOLUME: Self = Self(6841u32);
-                pub const ERROR_NO_SAVEPOINT_WITH_OPEN_FILES: Self = Self(6842u32);
-                pub const ERROR_DATA_LOST_REPAIR: Self = Self(6843u32);
-                pub const ERROR_SPARSE_NOT_ALLOWED_IN_TRANSACTION: Self = Self(6844u32);
-                pub const ERROR_TM_IDENTITY_MISMATCH: Self = Self(6845u32);
-                pub const ERROR_FLOATED_SECTION: Self = Self(6846u32);
-                pub const ERROR_CANNOT_ACCEPT_TRANSACTED_WORK: Self = Self(6847u32);
-                pub const ERROR_CANNOT_ABORT_TRANSACTIONS: Self = Self(6848u32);
-                pub const ERROR_BAD_CLUSTERS: Self = Self(6849u32);
-                pub const ERROR_COMPRESSION_NOT_ALLOWED_IN_TRANSACTION: Self = Self(6850u32);
-                pub const ERROR_VOLUME_DIRTY: Self = Self(6851u32);
-                pub const ERROR_NO_LINK_TRACKING_IN_TRANSACTION: Self = Self(6852u32);
-                pub const ERROR_OPERATION_NOT_SUPPORTED_IN_TRANSACTION: Self = Self(6853u32);
-                pub const ERROR_EXPIRED_HANDLE: Self = Self(6854u32);
-                pub const ERROR_TRANSACTION_NOT_ENLISTED: Self = Self(6855u32);
-                pub const ERROR_CTX_WINSTATION_NAME_INVALID: Self = Self(7001u32);
-                pub const ERROR_CTX_INVALID_PD: Self = Self(7002u32);
-                pub const ERROR_CTX_PD_NOT_FOUND: Self = Self(7003u32);
-                pub const ERROR_CTX_WD_NOT_FOUND: Self = Self(7004u32);
-                pub const ERROR_CTX_CANNOT_MAKE_EVENTLOG_ENTRY: Self = Self(7005u32);
-                pub const ERROR_CTX_SERVICE_NAME_COLLISION: Self = Self(7006u32);
-                pub const ERROR_CTX_CLOSE_PENDING: Self = Self(7007u32);
-                pub const ERROR_CTX_NO_OUTBUF: Self = Self(7008u32);
-                pub const ERROR_CTX_MODEM_INF_NOT_FOUND: Self = Self(7009u32);
-                pub const ERROR_CTX_INVALID_MODEMNAME: Self = Self(7010u32);
-                pub const ERROR_CTX_MODEM_RESPONSE_ERROR: Self = Self(7011u32);
-                pub const ERROR_CTX_MODEM_RESPONSE_TIMEOUT: Self = Self(7012u32);
-                pub const ERROR_CTX_MODEM_RESPONSE_NO_CARRIER: Self = Self(7013u32);
-                pub const ERROR_CTX_MODEM_RESPONSE_NO_DIALTONE: Self = Self(7014u32);
-                pub const ERROR_CTX_MODEM_RESPONSE_BUSY: Self = Self(7015u32);
-                pub const ERROR_CTX_MODEM_RESPONSE_VOICE: Self = Self(7016u32);
-                pub const ERROR_CTX_TD_ERROR: Self = Self(7017u32);
-                pub const ERROR_CTX_WINSTATION_NOT_FOUND: Self = Self(7022u32);
-                pub const ERROR_CTX_WINSTATION_ALREADY_EXISTS: Self = Self(7023u32);
-                pub const ERROR_CTX_WINSTATION_BUSY: Self = Self(7024u32);
-                pub const ERROR_CTX_BAD_VIDEO_MODE: Self = Self(7025u32);
-                pub const ERROR_CTX_GRAPHICS_INVALID: Self = Self(7035u32);
-                pub const ERROR_CTX_LOGON_DISABLED: Self = Self(7037u32);
-                pub const ERROR_CTX_NOT_CONSOLE: Self = Self(7038u32);
-                pub const ERROR_CTX_CLIENT_QUERY_TIMEOUT: Self = Self(7040u32);
-                pub const ERROR_CTX_CONSOLE_DISCONNECT: Self = Self(7041u32);
-                pub const ERROR_CTX_CONSOLE_CONNECT: Self = Self(7042u32);
-                pub const ERROR_CTX_SHADOW_DENIED: Self = Self(7044u32);
-                pub const ERROR_CTX_WINSTATION_ACCESS_DENIED: Self = Self(7045u32);
-                pub const ERROR_CTX_INVALID_WD: Self = Self(7049u32);
-                pub const ERROR_CTX_SHADOW_INVALID: Self = Self(7050u32);
-                pub const ERROR_CTX_SHADOW_DISABLED: Self = Self(7051u32);
-                pub const ERROR_CTX_CLIENT_LICENSE_IN_USE: Self = Self(7052u32);
-                pub const ERROR_CTX_CLIENT_LICENSE_NOT_SET: Self = Self(7053u32);
-                pub const ERROR_CTX_LICENSE_NOT_AVAILABLE: Self = Self(7054u32);
-                pub const ERROR_CTX_LICENSE_CLIENT_INVALID: Self = Self(7055u32);
-                pub const ERROR_CTX_LICENSE_EXPIRED: Self = Self(7056u32);
-                pub const ERROR_CTX_SHADOW_NOT_RUNNING: Self = Self(7057u32);
-                pub const ERROR_CTX_SHADOW_ENDED_BY_MODE_CHANGE: Self = Self(7058u32);
-                pub const ERROR_ACTIVATION_COUNT_EXCEEDED: Self = Self(7059u32);
-                pub const ERROR_CTX_WINSTATIONS_DISABLED: Self = Self(7060u32);
-                pub const ERROR_CTX_ENCRYPTION_LEVEL_REQUIRED: Self = Self(7061u32);
-                pub const ERROR_CTX_SESSION_IN_USE: Self = Self(7062u32);
-                pub const ERROR_CTX_NO_FORCE_LOGOFF: Self = Self(7063u32);
-                pub const ERROR_CTX_ACCOUNT_RESTRICTION: Self = Self(7064u32);
-                pub const ERROR_RDP_PROTOCOL_ERROR: Self = Self(7065u32);
-                pub const ERROR_CTX_CDM_CONNECT: Self = Self(7066u32);
-                pub const ERROR_CTX_CDM_DISCONNECT: Self = Self(7067u32);
-                pub const ERROR_CTX_SECURITY_LAYER_ERROR: Self = Self(7068u32);
-                pub const ERROR_TS_INCOMPATIBLE_SESSIONS: Self = Self(7069u32);
-                pub const ERROR_TS_VIDEO_SUBSYSTEM_ERROR: Self = Self(7070u32);
-                pub const ERROR_DS_NOT_INSTALLED: Self = Self(8200u32);
-                pub const ERROR_DS_MEMBERSHIP_EVALUATED_LOCALLY: Self = Self(8201u32);
-                pub const ERROR_DS_NO_ATTRIBUTE_OR_VALUE: Self = Self(8202u32);
-                pub const ERROR_DS_INVALID_ATTRIBUTE_SYNTAX: Self = Self(8203u32);
-                pub const ERROR_DS_ATTRIBUTE_TYPE_UNDEFINED: Self = Self(8204u32);
-                pub const ERROR_DS_ATTRIBUTE_OR_VALUE_EXISTS: Self = Self(8205u32);
-                pub const ERROR_DS_BUSY: Self = Self(8206u32);
-                pub const ERROR_DS_UNAVAILABLE: Self = Self(8207u32);
-                pub const ERROR_DS_NO_RIDS_ALLOCATED: Self = Self(8208u32);
-                pub const ERROR_DS_NO_MORE_RIDS: Self = Self(8209u32);
-                pub const ERROR_DS_INCORRECT_ROLE_OWNER: Self = Self(8210u32);
-                pub const ERROR_DS_RIDMGR_INIT_ERROR: Self = Self(8211u32);
-                pub const ERROR_DS_OBJ_CLASS_VIOLATION: Self = Self(8212u32);
-                pub const ERROR_DS_CANT_ON_NON_LEAF: Self = Self(8213u32);
-                pub const ERROR_DS_CANT_ON_RDN: Self = Self(8214u32);
-                pub const ERROR_DS_CANT_MOD_OBJ_CLASS: Self = Self(8215u32);
-                pub const ERROR_DS_CROSS_DOM_MOVE_ERROR: Self = Self(8216u32);
-                pub const ERROR_DS_GC_NOT_AVAILABLE: Self = Self(8217u32);
-                pub const ERROR_SHARED_POLICY: Self = Self(8218u32);
-                pub const ERROR_POLICY_OBJECT_NOT_FOUND: Self = Self(8219u32);
-                pub const ERROR_POLICY_ONLY_IN_DS: Self = Self(8220u32);
-                pub const ERROR_PROMOTION_ACTIVE: Self = Self(8221u32);
-                pub const ERROR_NO_PROMOTION_ACTIVE: Self = Self(8222u32);
-                pub const ERROR_DS_OPERATIONS_ERROR: Self = Self(8224u32);
-                pub const ERROR_DS_PROTOCOL_ERROR: Self = Self(8225u32);
-                pub const ERROR_DS_TIMELIMIT_EXCEEDED: Self = Self(8226u32);
-                pub const ERROR_DS_SIZELIMIT_EXCEEDED: Self = Self(8227u32);
-                pub const ERROR_DS_ADMIN_LIMIT_EXCEEDED: Self = Self(8228u32);
-                pub const ERROR_DS_COMPARE_FALSE: Self = Self(8229u32);
-                pub const ERROR_DS_COMPARE_TRUE: Self = Self(8230u32);
-                pub const ERROR_DS_AUTH_METHOD_NOT_SUPPORTED: Self = Self(8231u32);
-                pub const ERROR_DS_STRONG_AUTH_REQUIRED: Self = Self(8232u32);
-                pub const ERROR_DS_INAPPROPRIATE_AUTH: Self = Self(8233u32);
-                pub const ERROR_DS_AUTH_UNKNOWN: Self = Self(8234u32);
-                pub const ERROR_DS_REFERRAL: Self = Self(8235u32);
-                pub const ERROR_DS_UNAVAILABLE_CRIT_EXTENSION: Self = Self(8236u32);
-                pub const ERROR_DS_CONFIDENTIALITY_REQUIRED: Self = Self(8237u32);
-                pub const ERROR_DS_INAPPROPRIATE_MATCHING: Self = Self(8238u32);
-                pub const ERROR_DS_CONSTRAINT_VIOLATION: Self = Self(8239u32);
-                pub const ERROR_DS_NO_SUCH_OBJECT: Self = Self(8240u32);
-                pub const ERROR_DS_ALIAS_PROBLEM: Self = Self(8241u32);
-                pub const ERROR_DS_INVALID_DN_SYNTAX: Self = Self(8242u32);
-                pub const ERROR_DS_IS_LEAF: Self = Self(8243u32);
-                pub const ERROR_DS_ALIAS_DEREF_PROBLEM: Self = Self(8244u32);
-                pub const ERROR_DS_UNWILLING_TO_PERFORM: Self = Self(8245u32);
-                pub const ERROR_DS_LOOP_DETECT: Self = Self(8246u32);
-                pub const ERROR_DS_NAMING_VIOLATION: Self = Self(8247u32);
-                pub const ERROR_DS_OBJECT_RESULTS_TOO_LARGE: Self = Self(8248u32);
-                pub const ERROR_DS_AFFECTS_MULTIPLE_DSAS: Self = Self(8249u32);
-                pub const ERROR_DS_SERVER_DOWN: Self = Self(8250u32);
-                pub const ERROR_DS_LOCAL_ERROR: Self = Self(8251u32);
-                pub const ERROR_DS_ENCODING_ERROR: Self = Self(8252u32);
-                pub const ERROR_DS_DECODING_ERROR: Self = Self(8253u32);
-                pub const ERROR_DS_FILTER_UNKNOWN: Self = Self(8254u32);
-                pub const ERROR_DS_PARAM_ERROR: Self = Self(8255u32);
-                pub const ERROR_DS_NOT_SUPPORTED: Self = Self(8256u32);
-                pub const ERROR_DS_NO_RESULTS_RETURNED: Self = Self(8257u32);
-                pub const ERROR_DS_CONTROL_NOT_FOUND: Self = Self(8258u32);
-                pub const ERROR_DS_CLIENT_LOOP: Self = Self(8259u32);
-                pub const ERROR_DS_REFERRAL_LIMIT_EXCEEDED: Self = Self(8260u32);
-                pub const ERROR_DS_SORT_CONTROL_MISSING: Self = Self(8261u32);
-                pub const ERROR_DS_OFFSET_RANGE_ERROR: Self = Self(8262u32);
-                pub const ERROR_DS_RIDMGR_DISABLED: Self = Self(8263u32);
-                pub const ERROR_DS_ROOT_MUST_BE_NC: Self = Self(8301u32);
-                pub const ERROR_DS_ADD_REPLICA_INHIBITED: Self = Self(8302u32);
-                pub const ERROR_DS_ATT_NOT_DEF_IN_SCHEMA: Self = Self(8303u32);
-                pub const ERROR_DS_MAX_OBJ_SIZE_EXCEEDED: Self = Self(8304u32);
-                pub const ERROR_DS_OBJ_STRING_NAME_EXISTS: Self = Self(8305u32);
-                pub const ERROR_DS_NO_RDN_DEFINED_IN_SCHEMA: Self = Self(8306u32);
-                pub const ERROR_DS_RDN_DOESNT_MATCH_SCHEMA: Self = Self(8307u32);
-                pub const ERROR_DS_NO_REQUESTED_ATTS_FOUND: Self = Self(8308u32);
-                pub const ERROR_DS_USER_BUFFER_TO_SMALL: Self = Self(8309u32);
-                pub const ERROR_DS_ATT_IS_NOT_ON_OBJ: Self = Self(8310u32);
-                pub const ERROR_DS_ILLEGAL_MOD_OPERATION: Self = Self(8311u32);
-                pub const ERROR_DS_OBJ_TOO_LARGE: Self = Self(8312u32);
-                pub const ERROR_DS_BAD_INSTANCE_TYPE: Self = Self(8313u32);
-                pub const ERROR_DS_MASTERDSA_REQUIRED: Self = Self(8314u32);
-                pub const ERROR_DS_OBJECT_CLASS_REQUIRED: Self = Self(8315u32);
-                pub const ERROR_DS_MISSING_REQUIRED_ATT: Self = Self(8316u32);
-                pub const ERROR_DS_ATT_NOT_DEF_FOR_CLASS: Self = Self(8317u32);
-                pub const ERROR_DS_ATT_ALREADY_EXISTS: Self = Self(8318u32);
-                pub const ERROR_DS_CANT_ADD_ATT_VALUES: Self = Self(8320u32);
-                pub const ERROR_DS_SINGLE_VALUE_CONSTRAINT: Self = Self(8321u32);
-                pub const ERROR_DS_RANGE_CONSTRAINT: Self = Self(8322u32);
-                pub const ERROR_DS_ATT_VAL_ALREADY_EXISTS: Self = Self(8323u32);
-                pub const ERROR_DS_CANT_REM_MISSING_ATT: Self = Self(8324u32);
-                pub const ERROR_DS_CANT_REM_MISSING_ATT_VAL: Self = Self(8325u32);
-                pub const ERROR_DS_ROOT_CANT_BE_SUBREF: Self = Self(8326u32);
-                pub const ERROR_DS_NO_CHAINING: Self = Self(8327u32);
-                pub const ERROR_DS_NO_CHAINED_EVAL: Self = Self(8328u32);
-                pub const ERROR_DS_NO_PARENT_OBJECT: Self = Self(8329u32);
-                pub const ERROR_DS_PARENT_IS_AN_ALIAS: Self = Self(8330u32);
-                pub const ERROR_DS_CANT_MIX_MASTER_AND_REPS: Self = Self(8331u32);
-                pub const ERROR_DS_CHILDREN_EXIST: Self = Self(8332u32);
-                pub const ERROR_DS_OBJ_NOT_FOUND: Self = Self(8333u32);
-                pub const ERROR_DS_ALIASED_OBJ_MISSING: Self = Self(8334u32);
-                pub const ERROR_DS_BAD_NAME_SYNTAX: Self = Self(8335u32);
-                pub const ERROR_DS_ALIAS_POINTS_TO_ALIAS: Self = Self(8336u32);
-                pub const ERROR_DS_CANT_DEREF_ALIAS: Self = Self(8337u32);
-                pub const ERROR_DS_OUT_OF_SCOPE: Self = Self(8338u32);
-                pub const ERROR_DS_OBJECT_BEING_REMOVED: Self = Self(8339u32);
-                pub const ERROR_DS_CANT_DELETE_DSA_OBJ: Self = Self(8340u32);
-                pub const ERROR_DS_GENERIC_ERROR: Self = Self(8341u32);
-                pub const ERROR_DS_DSA_MUST_BE_INT_MASTER: Self = Self(8342u32);
-                pub const ERROR_DS_CLASS_NOT_DSA: Self = Self(8343u32);
-                pub const ERROR_DS_INSUFF_ACCESS_RIGHTS: Self = Self(8344u32);
-                pub const ERROR_DS_ILLEGAL_SUPERIOR: Self = Self(8345u32);
-                pub const ERROR_DS_ATTRIBUTE_OWNED_BY_SAM: Self = Self(8346u32);
-                pub const ERROR_DS_NAME_TOO_MANY_PARTS: Self = Self(8347u32);
-                pub const ERROR_DS_NAME_TOO_LONG: Self = Self(8348u32);
-                pub const ERROR_DS_NAME_VALUE_TOO_LONG: Self = Self(8349u32);
-                pub const ERROR_DS_NAME_UNPARSEABLE: Self = Self(8350u32);
-                pub const ERROR_DS_NAME_TYPE_UNKNOWN: Self = Self(8351u32);
-                pub const ERROR_DS_NOT_AN_OBJECT: Self = Self(8352u32);
-                pub const ERROR_DS_SEC_DESC_TOO_SHORT: Self = Self(8353u32);
-                pub const ERROR_DS_SEC_DESC_INVALID: Self = Self(8354u32);
-                pub const ERROR_DS_NO_DELETED_NAME: Self = Self(8355u32);
-                pub const ERROR_DS_SUBREF_MUST_HAVE_PARENT: Self = Self(8356u32);
-                pub const ERROR_DS_NCNAME_MUST_BE_NC: Self = Self(8357u32);
-                pub const ERROR_DS_CANT_ADD_SYSTEM_ONLY: Self = Self(8358u32);
-                pub const ERROR_DS_CLASS_MUST_BE_CONCRETE: Self = Self(8359u32);
-                pub const ERROR_DS_INVALID_DMD: Self = Self(8360u32);
-                pub const ERROR_DS_OBJ_GUID_EXISTS: Self = Self(8361u32);
-                pub const ERROR_DS_NOT_ON_BACKLINK: Self = Self(8362u32);
-                pub const ERROR_DS_NO_CROSSREF_FOR_NC: Self = Self(8363u32);
-                pub const ERROR_DS_SHUTTING_DOWN: Self = Self(8364u32);
-                pub const ERROR_DS_UNKNOWN_OPERATION: Self = Self(8365u32);
-                pub const ERROR_DS_INVALID_ROLE_OWNER: Self = Self(8366u32);
-                pub const ERROR_DS_COULDNT_CONTACT_FSMO: Self = Self(8367u32);
-                pub const ERROR_DS_CROSS_NC_DN_RENAME: Self = Self(8368u32);
-                pub const ERROR_DS_CANT_MOD_SYSTEM_ONLY: Self = Self(8369u32);
-                pub const ERROR_DS_REPLICATOR_ONLY: Self = Self(8370u32);
-                pub const ERROR_DS_OBJ_CLASS_NOT_DEFINED: Self = Self(8371u32);
-                pub const ERROR_DS_OBJ_CLASS_NOT_SUBCLASS: Self = Self(8372u32);
-                pub const ERROR_DS_NAME_REFERENCE_INVALID: Self = Self(8373u32);
-                pub const ERROR_DS_CROSS_REF_EXISTS: Self = Self(8374u32);
-                pub const ERROR_DS_CANT_DEL_MASTER_CROSSREF: Self = Self(8375u32);
-                pub const ERROR_DS_SUBTREE_NOTIFY_NOT_NC_HEAD: Self = Self(8376u32);
-                pub const ERROR_DS_NOTIFY_FILTER_TOO_COMPLEX: Self = Self(8377u32);
-                pub const ERROR_DS_DUP_RDN: Self = Self(8378u32);
-                pub const ERROR_DS_DUP_OID: Self = Self(8379u32);
-                pub const ERROR_DS_DUP_MAPI_ID: Self = Self(8380u32);
-                pub const ERROR_DS_DUP_SCHEMA_ID_GUID: Self = Self(8381u32);
-                pub const ERROR_DS_DUP_LDAP_DISPLAY_NAME: Self = Self(8382u32);
-                pub const ERROR_DS_SEMANTIC_ATT_TEST: Self = Self(8383u32);
-                pub const ERROR_DS_SYNTAX_MISMATCH: Self = Self(8384u32);
-                pub const ERROR_DS_EXISTS_IN_MUST_HAVE: Self = Self(8385u32);
-                pub const ERROR_DS_EXISTS_IN_MAY_HAVE: Self = Self(8386u32);
-                pub const ERROR_DS_NONEXISTENT_MAY_HAVE: Self = Self(8387u32);
-                pub const ERROR_DS_NONEXISTENT_MUST_HAVE: Self = Self(8388u32);
-                pub const ERROR_DS_AUX_CLS_TEST_FAIL: Self = Self(8389u32);
-                pub const ERROR_DS_NONEXISTENT_POSS_SUP: Self = Self(8390u32);
-                pub const ERROR_DS_SUB_CLS_TEST_FAIL: Self = Self(8391u32);
-                pub const ERROR_DS_BAD_RDN_ATT_ID_SYNTAX: Self = Self(8392u32);
-                pub const ERROR_DS_EXISTS_IN_AUX_CLS: Self = Self(8393u32);
-                pub const ERROR_DS_EXISTS_IN_SUB_CLS: Self = Self(8394u32);
-                pub const ERROR_DS_EXISTS_IN_POSS_SUP: Self = Self(8395u32);
-                pub const ERROR_DS_RECALCSCHEMA_FAILED: Self = Self(8396u32);
-                pub const ERROR_DS_TREE_DELETE_NOT_FINISHED: Self = Self(8397u32);
-                pub const ERROR_DS_CANT_DELETE: Self = Self(8398u32);
-                pub const ERROR_DS_ATT_SCHEMA_REQ_ID: Self = Self(8399u32);
-                pub const ERROR_DS_BAD_ATT_SCHEMA_SYNTAX: Self = Self(8400u32);
-                pub const ERROR_DS_CANT_CACHE_ATT: Self = Self(8401u32);
-                pub const ERROR_DS_CANT_CACHE_CLASS: Self = Self(8402u32);
-                pub const ERROR_DS_CANT_REMOVE_ATT_CACHE: Self = Self(8403u32);
-                pub const ERROR_DS_CANT_REMOVE_CLASS_CACHE: Self = Self(8404u32);
-                pub const ERROR_DS_CANT_RETRIEVE_DN: Self = Self(8405u32);
-                pub const ERROR_DS_MISSING_SUPREF: Self = Self(8406u32);
-                pub const ERROR_DS_CANT_RETRIEVE_INSTANCE: Self = Self(8407u32);
-                pub const ERROR_DS_CODE_INCONSISTENCY: Self = Self(8408u32);
-                pub const ERROR_DS_DATABASE_ERROR: Self = Self(8409u32);
-                pub const ERROR_DS_GOVERNSID_MISSING: Self = Self(8410u32);
-                pub const ERROR_DS_MISSING_EXPECTED_ATT: Self = Self(8411u32);
-                pub const ERROR_DS_NCNAME_MISSING_CR_REF: Self = Self(8412u32);
-                pub const ERROR_DS_SECURITY_CHECKING_ERROR: Self = Self(8413u32);
-                pub const ERROR_DS_SCHEMA_NOT_LOADED: Self = Self(8414u32);
-                pub const ERROR_DS_SCHEMA_ALLOC_FAILED: Self = Self(8415u32);
-                pub const ERROR_DS_ATT_SCHEMA_REQ_SYNTAX: Self = Self(8416u32);
-                pub const ERROR_DS_GCVERIFY_ERROR: Self = Self(8417u32);
-                pub const ERROR_DS_DRA_SCHEMA_MISMATCH: Self = Self(8418u32);
-                pub const ERROR_DS_CANT_FIND_DSA_OBJ: Self = Self(8419u32);
-                pub const ERROR_DS_CANT_FIND_EXPECTED_NC: Self = Self(8420u32);
-                pub const ERROR_DS_CANT_FIND_NC_IN_CACHE: Self = Self(8421u32);
-                pub const ERROR_DS_CANT_RETRIEVE_CHILD: Self = Self(8422u32);
-                pub const ERROR_DS_SECURITY_ILLEGAL_MODIFY: Self = Self(8423u32);
-                pub const ERROR_DS_CANT_REPLACE_HIDDEN_REC: Self = Self(8424u32);
-                pub const ERROR_DS_BAD_HIERARCHY_FILE: Self = Self(8425u32);
-                pub const ERROR_DS_BUILD_HIERARCHY_TABLE_FAILED: Self = Self(8426u32);
-                pub const ERROR_DS_CONFIG_PARAM_MISSING: Self = Self(8427u32);
-                pub const ERROR_DS_COUNTING_AB_INDICES_FAILED: Self = Self(8428u32);
-                pub const ERROR_DS_HIERARCHY_TABLE_MALLOC_FAILED: Self = Self(8429u32);
-                pub const ERROR_DS_INTERNAL_FAILURE: Self = Self(8430u32);
-                pub const ERROR_DS_UNKNOWN_ERROR: Self = Self(8431u32);
-                pub const ERROR_DS_ROOT_REQUIRES_CLASS_TOP: Self = Self(8432u32);
-                pub const ERROR_DS_REFUSING_FSMO_ROLES: Self = Self(8433u32);
-                pub const ERROR_DS_MISSING_FSMO_SETTINGS: Self = Self(8434u32);
-                pub const ERROR_DS_UNABLE_TO_SURRENDER_ROLES: Self = Self(8435u32);
-                pub const ERROR_DS_DRA_GENERIC: Self = Self(8436u32);
-                pub const ERROR_DS_DRA_INVALID_PARAMETER: Self = Self(8437u32);
-                pub const ERROR_DS_DRA_BUSY: Self = Self(8438u32);
-                pub const ERROR_DS_DRA_BAD_DN: Self = Self(8439u32);
-                pub const ERROR_DS_DRA_BAD_NC: Self = Self(8440u32);
-                pub const ERROR_DS_DRA_DN_EXISTS: Self = Self(8441u32);
-                pub const ERROR_DS_DRA_INTERNAL_ERROR: Self = Self(8442u32);
-                pub const ERROR_DS_DRA_INCONSISTENT_DIT: Self = Self(8443u32);
-                pub const ERROR_DS_DRA_CONNECTION_FAILED: Self = Self(8444u32);
-                pub const ERROR_DS_DRA_BAD_INSTANCE_TYPE: Self = Self(8445u32);
-                pub const ERROR_DS_DRA_OUT_OF_MEM: Self = Self(8446u32);
-                pub const ERROR_DS_DRA_MAIL_PROBLEM: Self = Self(8447u32);
-                pub const ERROR_DS_DRA_REF_ALREADY_EXISTS: Self = Self(8448u32);
-                pub const ERROR_DS_DRA_REF_NOT_FOUND: Self = Self(8449u32);
-                pub const ERROR_DS_DRA_OBJ_IS_REP_SOURCE: Self = Self(8450u32);
-                pub const ERROR_DS_DRA_DB_ERROR: Self = Self(8451u32);
-                pub const ERROR_DS_DRA_NO_REPLICA: Self = Self(8452u32);
-                pub const ERROR_DS_DRA_ACCESS_DENIED: Self = Self(8453u32);
-                pub const ERROR_DS_DRA_NOT_SUPPORTED: Self = Self(8454u32);
-                pub const ERROR_DS_DRA_RPC_CANCELLED: Self = Self(8455u32);
-                pub const ERROR_DS_DRA_SOURCE_DISABLED: Self = Self(8456u32);
-                pub const ERROR_DS_DRA_SINK_DISABLED: Self = Self(8457u32);
-                pub const ERROR_DS_DRA_NAME_COLLISION: Self = Self(8458u32);
-                pub const ERROR_DS_DRA_SOURCE_REINSTALLED: Self = Self(8459u32);
-                pub const ERROR_DS_DRA_MISSING_PARENT: Self = Self(8460u32);
-                pub const ERROR_DS_DRA_PREEMPTED: Self = Self(8461u32);
-                pub const ERROR_DS_DRA_ABANDON_SYNC: Self = Self(8462u32);
-                pub const ERROR_DS_DRA_SHUTDOWN: Self = Self(8463u32);
-                pub const ERROR_DS_DRA_INCOMPATIBLE_PARTIAL_SET: Self = Self(8464u32);
-                pub const ERROR_DS_DRA_SOURCE_IS_PARTIAL_REPLICA: Self = Self(8465u32);
-                pub const ERROR_DS_DRA_EXTN_CONNECTION_FAILED: Self = Self(8466u32);
-                pub const ERROR_DS_INSTALL_SCHEMA_MISMATCH: Self = Self(8467u32);
-                pub const ERROR_DS_DUP_LINK_ID: Self = Self(8468u32);
-                pub const ERROR_DS_NAME_ERROR_RESOLVING: Self = Self(8469u32);
-                pub const ERROR_DS_NAME_ERROR_NOT_FOUND: Self = Self(8470u32);
-                pub const ERROR_DS_NAME_ERROR_NOT_UNIQUE: Self = Self(8471u32);
-                pub const ERROR_DS_NAME_ERROR_NO_MAPPING: Self = Self(8472u32);
-                pub const ERROR_DS_NAME_ERROR_DOMAIN_ONLY: Self = Self(8473u32);
-                pub const ERROR_DS_NAME_ERROR_NO_SYNTACTICAL_MAPPING: Self = Self(8474u32);
-                pub const ERROR_DS_CONSTRUCTED_ATT_MOD: Self = Self(8475u32);
-                pub const ERROR_DS_WRONG_OM_OBJ_CLASS: Self = Self(8476u32);
-                pub const ERROR_DS_DRA_REPL_PENDING: Self = Self(8477u32);
-                pub const ERROR_DS_DS_REQUIRED: Self = Self(8478u32);
-                pub const ERROR_DS_INVALID_LDAP_DISPLAY_NAME: Self = Self(8479u32);
-                pub const ERROR_DS_NON_BASE_SEARCH: Self = Self(8480u32);
-                pub const ERROR_DS_CANT_RETRIEVE_ATTS: Self = Self(8481u32);
-                pub const ERROR_DS_BACKLINK_WITHOUT_LINK: Self = Self(8482u32);
-                pub const ERROR_DS_EPOCH_MISMATCH: Self = Self(8483u32);
-                pub const ERROR_DS_SRC_NAME_MISMATCH: Self = Self(8484u32);
-                pub const ERROR_DS_SRC_AND_DST_NC_IDENTICAL: Self = Self(8485u32);
-                pub const ERROR_DS_DST_NC_MISMATCH: Self = Self(8486u32);
-                pub const ERROR_DS_NOT_AUTHORITIVE_FOR_DST_NC: Self = Self(8487u32);
-                pub const ERROR_DS_SRC_GUID_MISMATCH: Self = Self(8488u32);
-                pub const ERROR_DS_CANT_MOVE_DELETED_OBJECT: Self = Self(8489u32);
-                pub const ERROR_DS_PDC_OPERATION_IN_PROGRESS: Self = Self(8490u32);
-                pub const ERROR_DS_CROSS_DOMAIN_CLEANUP_REQD: Self = Self(8491u32);
-                pub const ERROR_DS_ILLEGAL_XDOM_MOVE_OPERATION: Self = Self(8492u32);
-                pub const ERROR_DS_CANT_WITH_ACCT_GROUP_MEMBERSHPS: Self = Self(8493u32);
-                pub const ERROR_DS_NC_MUST_HAVE_NC_PARENT: Self = Self(8494u32);
-                pub const ERROR_DS_CR_IMPOSSIBLE_TO_VALIDATE: Self = Self(8495u32);
-                pub const ERROR_DS_DST_DOMAIN_NOT_NATIVE: Self = Self(8496u32);
-                pub const ERROR_DS_MISSING_INFRASTRUCTURE_CONTAINER: Self = Self(8497u32);
-                pub const ERROR_DS_CANT_MOVE_ACCOUNT_GROUP: Self = Self(8498u32);
-                pub const ERROR_DS_CANT_MOVE_RESOURCE_GROUP: Self = Self(8499u32);
-                pub const ERROR_DS_INVALID_SEARCH_FLAG: Self = Self(8500u32);
-                pub const ERROR_DS_NO_TREE_DELETE_ABOVE_NC: Self = Self(8501u32);
-                pub const ERROR_DS_COULDNT_LOCK_TREE_FOR_DELETE: Self = Self(8502u32);
-                pub const ERROR_DS_COULDNT_IDENTIFY_OBJECTS_FOR_TREE_DELETE: Self = Self(8503u32);
-                pub const ERROR_DS_SAM_INIT_FAILURE: Self = Self(8504u32);
-                pub const ERROR_DS_SENSITIVE_GROUP_VIOLATION: Self = Self(8505u32);
-                pub const ERROR_DS_CANT_MOD_PRIMARYGROUPID: Self = Self(8506u32);
-                pub const ERROR_DS_ILLEGAL_BASE_SCHEMA_MOD: Self = Self(8507u32);
-                pub const ERROR_DS_NONSAFE_SCHEMA_CHANGE: Self = Self(8508u32);
-                pub const ERROR_DS_SCHEMA_UPDATE_DISALLOWED: Self = Self(8509u32);
-                pub const ERROR_DS_CANT_CREATE_UNDER_SCHEMA: Self = Self(8510u32);
-                pub const ERROR_DS_INSTALL_NO_SRC_SCH_VERSION: Self = Self(8511u32);
-                pub const ERROR_DS_INSTALL_NO_SCH_VERSION_IN_INIFILE: Self = Self(8512u32);
-                pub const ERROR_DS_INVALID_GROUP_TYPE: Self = Self(8513u32);
-                pub const ERROR_DS_NO_NEST_GLOBALGROUP_IN_MIXEDDOMAIN: Self = Self(8514u32);
-                pub const ERROR_DS_NO_NEST_LOCALGROUP_IN_MIXEDDOMAIN: Self = Self(8515u32);
-                pub const ERROR_DS_GLOBAL_CANT_HAVE_LOCAL_MEMBER: Self = Self(8516u32);
-                pub const ERROR_DS_GLOBAL_CANT_HAVE_UNIVERSAL_MEMBER: Self = Self(8517u32);
-                pub const ERROR_DS_UNIVERSAL_CANT_HAVE_LOCAL_MEMBER: Self = Self(8518u32);
-                pub const ERROR_DS_GLOBAL_CANT_HAVE_CROSSDOMAIN_MEMBER: Self = Self(8519u32);
-                pub const ERROR_DS_LOCAL_CANT_HAVE_CROSSDOMAIN_LOCAL_MEMBER: Self = Self(8520u32);
-                pub const ERROR_DS_HAVE_PRIMARY_MEMBERS: Self = Self(8521u32);
-                pub const ERROR_DS_STRING_SD_CONVERSION_FAILED: Self = Self(8522u32);
-                pub const ERROR_DS_NAMING_MASTER_GC: Self = Self(8523u32);
-                pub const ERROR_DS_DNS_LOOKUP_FAILURE: Self = Self(8524u32);
-                pub const ERROR_DS_COULDNT_UPDATE_SPNS: Self = Self(8525u32);
-                pub const ERROR_DS_CANT_RETRIEVE_SD: Self = Self(8526u32);
-                pub const ERROR_DS_KEY_NOT_UNIQUE: Self = Self(8527u32);
-                pub const ERROR_DS_WRONG_LINKED_ATT_SYNTAX: Self = Self(8528u32);
-                pub const ERROR_DS_SAM_NEED_BOOTKEY_PASSWORD: Self = Self(8529u32);
-                pub const ERROR_DS_SAM_NEED_BOOTKEY_FLOPPY: Self = Self(8530u32);
-                pub const ERROR_DS_CANT_START: Self = Self(8531u32);
-                pub const ERROR_DS_INIT_FAILURE: Self = Self(8532u32);
-                pub const ERROR_DS_NO_PKT_PRIVACY_ON_CONNECTION: Self = Self(8533u32);
-                pub const ERROR_DS_SOURCE_DOMAIN_IN_FOREST: Self = Self(8534u32);
-                pub const ERROR_DS_DESTINATION_DOMAIN_NOT_IN_FOREST: Self = Self(8535u32);
-                pub const ERROR_DS_DESTINATION_AUDITING_NOT_ENABLED: Self = Self(8536u32);
-                pub const ERROR_DS_CANT_FIND_DC_FOR_SRC_DOMAIN: Self = Self(8537u32);
-                pub const ERROR_DS_SRC_OBJ_NOT_GROUP_OR_USER: Self = Self(8538u32);
-                pub const ERROR_DS_SRC_SID_EXISTS_IN_FOREST: Self = Self(8539u32);
-                pub const ERROR_DS_SRC_AND_DST_OBJECT_CLASS_MISMATCH: Self = Self(8540u32);
-                pub const ERROR_SAM_INIT_FAILURE: Self = Self(8541u32);
-                pub const ERROR_DS_DRA_SCHEMA_INFO_SHIP: Self = Self(8542u32);
-                pub const ERROR_DS_DRA_SCHEMA_CONFLICT: Self = Self(8543u32);
-                pub const ERROR_DS_DRA_EARLIER_SCHEMA_CONFLICT: Self = Self(8544u32);
-                pub const ERROR_DS_DRA_OBJ_NC_MISMATCH: Self = Self(8545u32);
-                pub const ERROR_DS_NC_STILL_HAS_DSAS: Self = Self(8546u32);
-                pub const ERROR_DS_GC_REQUIRED: Self = Self(8547u32);
-                pub const ERROR_DS_LOCAL_MEMBER_OF_LOCAL_ONLY: Self = Self(8548u32);
-                pub const ERROR_DS_NO_FPO_IN_UNIVERSAL_GROUPS: Self = Self(8549u32);
-                pub const ERROR_DS_CANT_ADD_TO_GC: Self = Self(8550u32);
-                pub const ERROR_DS_NO_CHECKPOINT_WITH_PDC: Self = Self(8551u32);
-                pub const ERROR_DS_SOURCE_AUDITING_NOT_ENABLED: Self = Self(8552u32);
-                pub const ERROR_DS_CANT_CREATE_IN_NONDOMAIN_NC: Self = Self(8553u32);
-                pub const ERROR_DS_INVALID_NAME_FOR_SPN: Self = Self(8554u32);
-                pub const ERROR_DS_FILTER_USES_CONTRUCTED_ATTRS: Self = Self(8555u32);
-                pub const ERROR_DS_UNICODEPWD_NOT_IN_QUOTES: Self = Self(8556u32);
-                pub const ERROR_DS_MACHINE_ACCOUNT_QUOTA_EXCEEDED: Self = Self(8557u32);
-                pub const ERROR_DS_MUST_BE_RUN_ON_DST_DC: Self = Self(8558u32);
-                pub const ERROR_DS_SRC_DC_MUST_BE_SP4_OR_GREATER: Self = Self(8559u32);
-                pub const ERROR_DS_CANT_TREE_DELETE_CRITICAL_OBJ: Self = Self(8560u32);
-                pub const ERROR_DS_INIT_FAILURE_CONSOLE: Self = Self(8561u32);
-                pub const ERROR_DS_SAM_INIT_FAILURE_CONSOLE: Self = Self(8562u32);
-                pub const ERROR_DS_FOREST_VERSION_TOO_HIGH: Self = Self(8563u32);
-                pub const ERROR_DS_DOMAIN_VERSION_TOO_HIGH: Self = Self(8564u32);
-                pub const ERROR_DS_FOREST_VERSION_TOO_LOW: Self = Self(8565u32);
-                pub const ERROR_DS_DOMAIN_VERSION_TOO_LOW: Self = Self(8566u32);
-                pub const ERROR_DS_INCOMPATIBLE_VERSION: Self = Self(8567u32);
-                pub const ERROR_DS_LOW_DSA_VERSION: Self = Self(8568u32);
-                pub const ERROR_DS_NO_BEHAVIOR_VERSION_IN_MIXEDDOMAIN: Self = Self(8569u32);
-                pub const ERROR_DS_NOT_SUPPORTED_SORT_ORDER: Self = Self(8570u32);
-                pub const ERROR_DS_NAME_NOT_UNIQUE: Self = Self(8571u32);
-                pub const ERROR_DS_MACHINE_ACCOUNT_CREATED_PRENT4: Self = Self(8572u32);
-                pub const ERROR_DS_OUT_OF_VERSION_STORE: Self = Self(8573u32);
-                pub const ERROR_DS_INCOMPATIBLE_CONTROLS_USED: Self = Self(8574u32);
-                pub const ERROR_DS_NO_REF_DOMAIN: Self = Self(8575u32);
-                pub const ERROR_DS_RESERVED_LINK_ID: Self = Self(8576u32);
-                pub const ERROR_DS_LINK_ID_NOT_AVAILABLE: Self = Self(8577u32);
-                pub const ERROR_DS_AG_CANT_HAVE_UNIVERSAL_MEMBER: Self = Self(8578u32);
-                pub const ERROR_DS_MODIFYDN_DISALLOWED_BY_INSTANCE_TYPE: Self = Self(8579u32);
-                pub const ERROR_DS_NO_OBJECT_MOVE_IN_SCHEMA_NC: Self = Self(8580u32);
-                pub const ERROR_DS_MODIFYDN_DISALLOWED_BY_FLAG: Self = Self(8581u32);
-                pub const ERROR_DS_MODIFYDN_WRONG_GRANDPARENT: Self = Self(8582u32);
-                pub const ERROR_DS_NAME_ERROR_TRUST_REFERRAL: Self = Self(8583u32);
-                pub const ERROR_NOT_SUPPORTED_ON_STANDARD_SERVER: Self = Self(8584u32);
-                pub const ERROR_DS_CANT_ACCESS_REMOTE_PART_OF_AD: Self = Self(8585u32);
-                pub const ERROR_DS_CR_IMPOSSIBLE_TO_VALIDATE_V2: Self = Self(8586u32);
-                pub const ERROR_DS_THREAD_LIMIT_EXCEEDED: Self = Self(8587u32);
-                pub const ERROR_DS_NOT_CLOSEST: Self = Self(8588u32);
-                pub const ERROR_DS_CANT_DERIVE_SPN_WITHOUT_SERVER_REF: Self = Self(8589u32);
-                pub const ERROR_DS_SINGLE_USER_MODE_FAILED: Self = Self(8590u32);
-                pub const ERROR_DS_NTDSCRIPT_SYNTAX_ERROR: Self = Self(8591u32);
-                pub const ERROR_DS_NTDSCRIPT_PROCESS_ERROR: Self = Self(8592u32);
-                pub const ERROR_DS_DIFFERENT_REPL_EPOCHS: Self = Self(8593u32);
-                pub const ERROR_DS_DRS_EXTENSIONS_CHANGED: Self = Self(8594u32);
-                pub const ERROR_DS_REPLICA_SET_CHANGE_NOT_ALLOWED_ON_DISABLED_CR: Self =
-                    Self(8595u32);
-                pub const ERROR_DS_NO_MSDS_INTID: Self = Self(8596u32);
-                pub const ERROR_DS_DUP_MSDS_INTID: Self = Self(8597u32);
-                pub const ERROR_DS_EXISTS_IN_RDNATTID: Self = Self(8598u32);
-                pub const ERROR_DS_AUTHORIZATION_FAILED: Self = Self(8599u32);
-                pub const ERROR_DS_INVALID_SCRIPT: Self = Self(8600u32);
-                pub const ERROR_DS_REMOTE_CROSSREF_OP_FAILED: Self = Self(8601u32);
-                pub const ERROR_DS_CROSS_REF_BUSY: Self = Self(8602u32);
-                pub const ERROR_DS_CANT_DERIVE_SPN_FOR_DELETED_DOMAIN: Self = Self(8603u32);
-                pub const ERROR_DS_CANT_DEMOTE_WITH_WRITEABLE_NC: Self = Self(8604u32);
-                pub const ERROR_DS_DUPLICATE_ID_FOUND: Self = Self(8605u32);
-                pub const ERROR_DS_INSUFFICIENT_ATTR_TO_CREATE_OBJECT: Self = Self(8606u32);
-                pub const ERROR_DS_GROUP_CONVERSION_ERROR: Self = Self(8607u32);
-                pub const ERROR_DS_CANT_MOVE_APP_BASIC_GROUP: Self = Self(8608u32);
-                pub const ERROR_DS_CANT_MOVE_APP_QUERY_GROUP: Self = Self(8609u32);
-                pub const ERROR_DS_ROLE_NOT_VERIFIED: Self = Self(8610u32);
-                pub const ERROR_DS_WKO_CONTAINER_CANNOT_BE_SPECIAL: Self = Self(8611u32);
-                pub const ERROR_DS_DOMAIN_RENAME_IN_PROGRESS: Self = Self(8612u32);
-                pub const ERROR_DS_EXISTING_AD_CHILD_NC: Self = Self(8613u32);
-                pub const ERROR_DS_REPL_LIFETIME_EXCEEDED: Self = Self(8614u32);
-                pub const ERROR_DS_DISALLOWED_IN_SYSTEM_CONTAINER: Self = Self(8615u32);
-                pub const ERROR_DS_LDAP_SEND_QUEUE_FULL: Self = Self(8616u32);
-                pub const ERROR_DS_DRA_OUT_SCHEDULE_WINDOW: Self = Self(8617u32);
-                pub const ERROR_DS_POLICY_NOT_KNOWN: Self = Self(8618u32);
-                pub const ERROR_NO_SITE_SETTINGS_OBJECT: Self = Self(8619u32);
-                pub const ERROR_NO_SECRETS: Self = Self(8620u32);
-                pub const ERROR_NO_WRITABLE_DC_FOUND: Self = Self(8621u32);
-                pub const ERROR_DS_NO_SERVER_OBJECT: Self = Self(8622u32);
-                pub const ERROR_DS_NO_NTDSA_OBJECT: Self = Self(8623u32);
-                pub const ERROR_DS_NON_ASQ_SEARCH: Self = Self(8624u32);
-                pub const ERROR_DS_AUDIT_FAILURE: Self = Self(8625u32);
-                pub const ERROR_DS_INVALID_SEARCH_FLAG_SUBTREE: Self = Self(8626u32);
-                pub const ERROR_DS_INVALID_SEARCH_FLAG_TUPLE: Self = Self(8627u32);
-                pub const ERROR_DS_HIERARCHY_TABLE_TOO_DEEP: Self = Self(8628u32);
-                pub const ERROR_DS_DRA_CORRUPT_UTD_VECTOR: Self = Self(8629u32);
-                pub const ERROR_DS_DRA_SECRETS_DENIED: Self = Self(8630u32);
-                pub const ERROR_DS_RESERVED_MAPI_ID: Self = Self(8631u32);
-                pub const ERROR_DS_MAPI_ID_NOT_AVAILABLE: Self = Self(8632u32);
-                pub const ERROR_DS_DRA_MISSING_KRBTGT_SECRET: Self = Self(8633u32);
-                pub const ERROR_DS_DOMAIN_NAME_EXISTS_IN_FOREST: Self = Self(8634u32);
-                pub const ERROR_DS_FLAT_NAME_EXISTS_IN_FOREST: Self = Self(8635u32);
-                pub const ERROR_INVALID_USER_PRINCIPAL_NAME: Self = Self(8636u32);
-                pub const ERROR_DS_OID_MAPPED_GROUP_CANT_HAVE_MEMBERS: Self = Self(8637u32);
-                pub const ERROR_DS_OID_NOT_FOUND: Self = Self(8638u32);
-                pub const ERROR_DS_DRA_RECYCLED_TARGET: Self = Self(8639u32);
-                pub const ERROR_DS_DISALLOWED_NC_REDIRECT: Self = Self(8640u32);
-                pub const ERROR_DS_HIGH_ADLDS_FFL: Self = Self(8641u32);
-                pub const ERROR_DS_HIGH_DSA_VERSION: Self = Self(8642u32);
-                pub const ERROR_DS_LOW_ADLDS_FFL: Self = Self(8643u32);
-                pub const ERROR_DOMAIN_SID_SAME_AS_LOCAL_WORKSTATION: Self = Self(8644u32);
-                pub const ERROR_DS_UNDELETE_SAM_VALIDATION_FAILED: Self = Self(8645u32);
-                pub const ERROR_INCORRECT_ACCOUNT_TYPE: Self = Self(8646u32);
-                pub const ERROR_DS_SPN_VALUE_NOT_UNIQUE_IN_FOREST: Self = Self(8647u32);
-                pub const ERROR_DS_UPN_VALUE_NOT_UNIQUE_IN_FOREST: Self = Self(8648u32);
-                pub const ERROR_DS_MISSING_FOREST_TRUST: Self = Self(8649u32);
-                pub const ERROR_DS_VALUE_KEY_NOT_UNIQUE: Self = Self(8650u32);
-                pub const DNS_ERROR_RESPONSE_CODES_BASE: Self = Self(9000u32);
-                pub const DNS_ERROR_RCODE_NO_ERROR: Self = Self(0u32);
-                pub const DNS_ERROR_MASK: Self = Self(9000u32);
-                pub const DNS_ERROR_RCODE_FORMAT_ERROR: Self = Self(9001u32);
-                pub const DNS_ERROR_RCODE_SERVER_FAILURE: Self = Self(9002u32);
-                pub const DNS_ERROR_RCODE_NAME_ERROR: Self = Self(9003u32);
-                pub const DNS_ERROR_RCODE_NOT_IMPLEMENTED: Self = Self(9004u32);
-                pub const DNS_ERROR_RCODE_REFUSED: Self = Self(9005u32);
-                pub const DNS_ERROR_RCODE_YXDOMAIN: Self = Self(9006u32);
-                pub const DNS_ERROR_RCODE_YXRRSET: Self = Self(9007u32);
-                pub const DNS_ERROR_RCODE_NXRRSET: Self = Self(9008u32);
-                pub const DNS_ERROR_RCODE_NOTAUTH: Self = Self(9009u32);
-                pub const DNS_ERROR_RCODE_NOTZONE: Self = Self(9010u32);
-                pub const DNS_ERROR_RCODE_BADSIG: Self = Self(9016u32);
-                pub const DNS_ERROR_RCODE_BADKEY: Self = Self(9017u32);
-                pub const DNS_ERROR_RCODE_BADTIME: Self = Self(9018u32);
-                pub const DNS_ERROR_RCODE_LAST: Self = Self(9018u32);
-                pub const DNS_ERROR_DNSSEC_BASE: Self = Self(9100u32);
-                pub const DNS_ERROR_KEYMASTER_REQUIRED: Self = Self(9101u32);
-                pub const DNS_ERROR_NOT_ALLOWED_ON_SIGNED_ZONE: Self = Self(9102u32);
-                pub const DNS_ERROR_NSEC3_INCOMPATIBLE_WITH_RSA_SHA1: Self = Self(9103u32);
-                pub const DNS_ERROR_NOT_ENOUGH_SIGNING_KEY_DESCRIPTORS: Self = Self(9104u32);
-                pub const DNS_ERROR_UNSUPPORTED_ALGORITHM: Self = Self(9105u32);
-                pub const DNS_ERROR_INVALID_KEY_SIZE: Self = Self(9106u32);
-                pub const DNS_ERROR_SIGNING_KEY_NOT_ACCESSIBLE: Self = Self(9107u32);
-                pub const DNS_ERROR_KSP_DOES_NOT_SUPPORT_PROTECTION: Self = Self(9108u32);
-                pub const DNS_ERROR_UNEXPECTED_DATA_PROTECTION_ERROR: Self = Self(9109u32);
-                pub const DNS_ERROR_UNEXPECTED_CNG_ERROR: Self = Self(9110u32);
-                pub const DNS_ERROR_UNKNOWN_SIGNING_PARAMETER_VERSION: Self = Self(9111u32);
-                pub const DNS_ERROR_KSP_NOT_ACCESSIBLE: Self = Self(9112u32);
-                pub const DNS_ERROR_TOO_MANY_SKDS: Self = Self(9113u32);
-                pub const DNS_ERROR_INVALID_ROLLOVER_PERIOD: Self = Self(9114u32);
-                pub const DNS_ERROR_INVALID_INITIAL_ROLLOVER_OFFSET: Self = Self(9115u32);
-                pub const DNS_ERROR_ROLLOVER_IN_PROGRESS: Self = Self(9116u32);
-                pub const DNS_ERROR_STANDBY_KEY_NOT_PRESENT: Self = Self(9117u32);
-                pub const DNS_ERROR_NOT_ALLOWED_ON_ZSK: Self = Self(9118u32);
-                pub const DNS_ERROR_NOT_ALLOWED_ON_ACTIVE_SKD: Self = Self(9119u32);
-                pub const DNS_ERROR_ROLLOVER_ALREADY_QUEUED: Self = Self(9120u32);
-                pub const DNS_ERROR_NOT_ALLOWED_ON_UNSIGNED_ZONE: Self = Self(9121u32);
-                pub const DNS_ERROR_BAD_KEYMASTER: Self = Self(9122u32);
-                pub const DNS_ERROR_INVALID_SIGNATURE_VALIDITY_PERIOD: Self = Self(9123u32);
-                pub const DNS_ERROR_INVALID_NSEC3_ITERATION_COUNT: Self = Self(9124u32);
-                pub const DNS_ERROR_DNSSEC_IS_DISABLED: Self = Self(9125u32);
-                pub const DNS_ERROR_INVALID_XML: Self = Self(9126u32);
-                pub const DNS_ERROR_NO_VALID_TRUST_ANCHORS: Self = Self(9127u32);
-                pub const DNS_ERROR_ROLLOVER_NOT_POKEABLE: Self = Self(9128u32);
-                pub const DNS_ERROR_NSEC3_NAME_COLLISION: Self = Self(9129u32);
-                pub const DNS_ERROR_NSEC_INCOMPATIBLE_WITH_NSEC3_RSA_SHA1: Self = Self(9130u32);
-                pub const DNS_ERROR_PACKET_FMT_BASE: Self = Self(9500u32);
-                pub const DNS_ERROR_BAD_PACKET: Self = Self(9502u32);
-                pub const DNS_ERROR_NO_PACKET: Self = Self(9503u32);
-                pub const DNS_ERROR_RCODE: Self = Self(9504u32);
-                pub const DNS_ERROR_UNSECURE_PACKET: Self = Self(9505u32);
-                pub const DNS_ERROR_NO_MEMORY: Self = Self(14u32);
-                pub const DNS_ERROR_INVALID_NAME: Self = Self(123u32);
-                pub const DNS_ERROR_INVALID_DATA: Self = Self(13u32);
-                pub const DNS_ERROR_GENERAL_API_BASE: Self = Self(9550u32);
-                pub const DNS_ERROR_INVALID_TYPE: Self = Self(9551u32);
-                pub const DNS_ERROR_INVALID_IP_ADDRESS: Self = Self(9552u32);
-                pub const DNS_ERROR_INVALID_PROPERTY: Self = Self(9553u32);
-                pub const DNS_ERROR_TRY_AGAIN_LATER: Self = Self(9554u32);
-                pub const DNS_ERROR_NOT_UNIQUE: Self = Self(9555u32);
-                pub const DNS_ERROR_NON_RFC_NAME: Self = Self(9556u32);
-                pub const DNS_ERROR_INVALID_NAME_CHAR: Self = Self(9560u32);
-                pub const DNS_ERROR_NUMERIC_NAME: Self = Self(9561u32);
-                pub const DNS_ERROR_NOT_ALLOWED_ON_ROOT_SERVER: Self = Self(9562u32);
-                pub const DNS_ERROR_NOT_ALLOWED_UNDER_DELEGATION: Self = Self(9563u32);
-                pub const DNS_ERROR_CANNOT_FIND_ROOT_HINTS: Self = Self(9564u32);
-                pub const DNS_ERROR_INCONSISTENT_ROOT_HINTS: Self = Self(9565u32);
-                pub const DNS_ERROR_DWORD_VALUE_TOO_SMALL: Self = Self(9566u32);
-                pub const DNS_ERROR_DWORD_VALUE_TOO_LARGE: Self = Self(9567u32);
-                pub const DNS_ERROR_BACKGROUND_LOADING: Self = Self(9568u32);
-                pub const DNS_ERROR_NOT_ALLOWED_ON_RODC: Self = Self(9569u32);
-                pub const DNS_ERROR_NOT_ALLOWED_UNDER_DNAME: Self = Self(9570u32);
-                pub const DNS_ERROR_DELEGATION_REQUIRED: Self = Self(9571u32);
-                pub const DNS_ERROR_INVALID_POLICY_TABLE: Self = Self(9572u32);
-                pub const DNS_ERROR_ADDRESS_REQUIRED: Self = Self(9573u32);
-                pub const DNS_ERROR_ZONE_BASE: Self = Self(9600u32);
-                pub const DNS_ERROR_ZONE_DOES_NOT_EXIST: Self = Self(9601u32);
-                pub const DNS_ERROR_NO_ZONE_INFO: Self = Self(9602u32);
-                pub const DNS_ERROR_INVALID_ZONE_OPERATION: Self = Self(9603u32);
-                pub const DNS_ERROR_ZONE_CONFIGURATION_ERROR: Self = Self(9604u32);
-                pub const DNS_ERROR_ZONE_HAS_NO_SOA_RECORD: Self = Self(9605u32);
-                pub const DNS_ERROR_ZONE_HAS_NO_NS_RECORDS: Self = Self(9606u32);
-                pub const DNS_ERROR_ZONE_LOCKED: Self = Self(9607u32);
-                pub const DNS_ERROR_ZONE_CREATION_FAILED: Self = Self(9608u32);
-                pub const DNS_ERROR_ZONE_ALREADY_EXISTS: Self = Self(9609u32);
-                pub const DNS_ERROR_AUTOZONE_ALREADY_EXISTS: Self = Self(9610u32);
-                pub const DNS_ERROR_INVALID_ZONE_TYPE: Self = Self(9611u32);
-                pub const DNS_ERROR_SECONDARY_REQUIRES_MASTER_IP: Self = Self(9612u32);
-                pub const DNS_ERROR_ZONE_NOT_SECONDARY: Self = Self(9613u32);
-                pub const DNS_ERROR_NEED_SECONDARY_ADDRESSES: Self = Self(9614u32);
-                pub const DNS_ERROR_WINS_INIT_FAILED: Self = Self(9615u32);
-                pub const DNS_ERROR_NEED_WINS_SERVERS: Self = Self(9616u32);
-                pub const DNS_ERROR_NBSTAT_INIT_FAILED: Self = Self(9617u32);
-                pub const DNS_ERROR_SOA_DELETE_INVALID: Self = Self(9618u32);
-                pub const DNS_ERROR_FORWARDER_ALREADY_EXISTS: Self = Self(9619u32);
-                pub const DNS_ERROR_ZONE_REQUIRES_MASTER_IP: Self = Self(9620u32);
-                pub const DNS_ERROR_ZONE_IS_SHUTDOWN: Self = Self(9621u32);
-                pub const DNS_ERROR_ZONE_LOCKED_FOR_SIGNING: Self = Self(9622u32);
-                pub const DNS_ERROR_DATAFILE_BASE: Self = Self(9650u32);
-                pub const DNS_ERROR_PRIMARY_REQUIRES_DATAFILE: Self = Self(9651u32);
-                pub const DNS_ERROR_INVALID_DATAFILE_NAME: Self = Self(9652u32);
-                pub const DNS_ERROR_DATAFILE_OPEN_FAILURE: Self = Self(9653u32);
-                pub const DNS_ERROR_FILE_WRITEBACK_FAILED: Self = Self(9654u32);
-                pub const DNS_ERROR_DATAFILE_PARSING: Self = Self(9655u32);
-                pub const DNS_ERROR_DATABASE_BASE: Self = Self(9700u32);
-                pub const DNS_ERROR_RECORD_DOES_NOT_EXIST: Self = Self(9701u32);
-                pub const DNS_ERROR_RECORD_FORMAT: Self = Self(9702u32);
-                pub const DNS_ERROR_NODE_CREATION_FAILED: Self = Self(9703u32);
-                pub const DNS_ERROR_UNKNOWN_RECORD_TYPE: Self = Self(9704u32);
-                pub const DNS_ERROR_RECORD_TIMED_OUT: Self = Self(9705u32);
-                pub const DNS_ERROR_NAME_NOT_IN_ZONE: Self = Self(9706u32);
-                pub const DNS_ERROR_CNAME_LOOP: Self = Self(9707u32);
-                pub const DNS_ERROR_NODE_IS_CNAME: Self = Self(9708u32);
-                pub const DNS_ERROR_CNAME_COLLISION: Self = Self(9709u32);
-                pub const DNS_ERROR_RECORD_ONLY_AT_ZONE_ROOT: Self = Self(9710u32);
-                pub const DNS_ERROR_RECORD_ALREADY_EXISTS: Self = Self(9711u32);
-                pub const DNS_ERROR_SECONDARY_DATA: Self = Self(9712u32);
-                pub const DNS_ERROR_NO_CREATE_CACHE_DATA: Self = Self(9713u32);
-                pub const DNS_ERROR_NAME_DOES_NOT_EXIST: Self = Self(9714u32);
-                pub const DNS_ERROR_DS_UNAVAILABLE: Self = Self(9717u32);
-                pub const DNS_ERROR_DS_ZONE_ALREADY_EXISTS: Self = Self(9718u32);
-                pub const DNS_ERROR_NO_BOOTFILE_IF_DS_ZONE: Self = Self(9719u32);
-                pub const DNS_ERROR_NODE_IS_DNAME: Self = Self(9720u32);
-                pub const DNS_ERROR_DNAME_COLLISION: Self = Self(9721u32);
-                pub const DNS_ERROR_ALIAS_LOOP: Self = Self(9722u32);
-                pub const DNS_ERROR_OPERATION_BASE: Self = Self(9750u32);
-                pub const DNS_ERROR_AXFR: Self = Self(9752u32);
-                pub const DNS_ERROR_SECURE_BASE: Self = Self(9800u32);
-                pub const DNS_ERROR_SETUP_BASE: Self = Self(9850u32);
-                pub const DNS_ERROR_NO_TCPIP: Self = Self(9851u32);
-                pub const DNS_ERROR_NO_DNS_SERVERS: Self = Self(9852u32);
-                pub const DNS_ERROR_DP_BASE: Self = Self(9900u32);
-                pub const DNS_ERROR_DP_DOES_NOT_EXIST: Self = Self(9901u32);
-                pub const DNS_ERROR_DP_ALREADY_EXISTS: Self = Self(9902u32);
-                pub const DNS_ERROR_DP_NOT_ENLISTED: Self = Self(9903u32);
-                pub const DNS_ERROR_DP_ALREADY_ENLISTED: Self = Self(9904u32);
-                pub const DNS_ERROR_DP_NOT_AVAILABLE: Self = Self(9905u32);
-                pub const DNS_ERROR_DP_FSMO_ERROR: Self = Self(9906u32);
-                pub const DNS_ERROR_RRL_NOT_ENABLED: Self = Self(9911u32);
-                pub const DNS_ERROR_RRL_INVALID_WINDOW_SIZE: Self = Self(9912u32);
-                pub const DNS_ERROR_RRL_INVALID_IPV4_PREFIX: Self = Self(9913u32);
-                pub const DNS_ERROR_RRL_INVALID_IPV6_PREFIX: Self = Self(9914u32);
-                pub const DNS_ERROR_RRL_INVALID_TC_RATE: Self = Self(9915u32);
-                pub const DNS_ERROR_RRL_INVALID_LEAK_RATE: Self = Self(9916u32);
-                pub const DNS_ERROR_RRL_LEAK_RATE_LESSTHAN_TC_RATE: Self = Self(9917u32);
-                pub const DNS_ERROR_VIRTUALIZATION_INSTANCE_ALREADY_EXISTS: Self = Self(9921u32);
-                pub const DNS_ERROR_VIRTUALIZATION_INSTANCE_DOES_NOT_EXIST: Self = Self(9922u32);
-                pub const DNS_ERROR_VIRTUALIZATION_TREE_LOCKED: Self = Self(9923u32);
-                pub const DNS_ERROR_INVAILD_VIRTUALIZATION_INSTANCE_NAME: Self = Self(9924u32);
-                pub const DNS_ERROR_DEFAULT_VIRTUALIZATION_INSTANCE: Self = Self(9925u32);
-                pub const DNS_ERROR_ZONESCOPE_ALREADY_EXISTS: Self = Self(9951u32);
-                pub const DNS_ERROR_ZONESCOPE_DOES_NOT_EXIST: Self = Self(9952u32);
-                pub const DNS_ERROR_DEFAULT_ZONESCOPE: Self = Self(9953u32);
-                pub const DNS_ERROR_INVALID_ZONESCOPE_NAME: Self = Self(9954u32);
-                pub const DNS_ERROR_NOT_ALLOWED_WITH_ZONESCOPES: Self = Self(9955u32);
-                pub const DNS_ERROR_LOAD_ZONESCOPE_FAILED: Self = Self(9956u32);
-                pub const DNS_ERROR_ZONESCOPE_FILE_WRITEBACK_FAILED: Self = Self(9957u32);
-                pub const DNS_ERROR_INVALID_SCOPE_NAME: Self = Self(9958u32);
-                pub const DNS_ERROR_SCOPE_DOES_NOT_EXIST: Self = Self(9959u32);
-                pub const DNS_ERROR_DEFAULT_SCOPE: Self = Self(9960u32);
-                pub const DNS_ERROR_INVALID_SCOPE_OPERATION: Self = Self(9961u32);
-                pub const DNS_ERROR_SCOPE_LOCKED: Self = Self(9962u32);
-                pub const DNS_ERROR_SCOPE_ALREADY_EXISTS: Self = Self(9963u32);
-                pub const DNS_ERROR_POLICY_ALREADY_EXISTS: Self = Self(9971u32);
-                pub const DNS_ERROR_POLICY_DOES_NOT_EXIST: Self = Self(9972u32);
-                pub const DNS_ERROR_POLICY_INVALID_CRITERIA: Self = Self(9973u32);
-                pub const DNS_ERROR_POLICY_INVALID_SETTINGS: Self = Self(9974u32);
-                pub const DNS_ERROR_CLIENT_SUBNET_IS_ACCESSED: Self = Self(9975u32);
-                pub const DNS_ERROR_CLIENT_SUBNET_DOES_NOT_EXIST: Self = Self(9976u32);
-                pub const DNS_ERROR_CLIENT_SUBNET_ALREADY_EXISTS: Self = Self(9977u32);
-                pub const DNS_ERROR_SUBNET_DOES_NOT_EXIST: Self = Self(9978u32);
-                pub const DNS_ERROR_SUBNET_ALREADY_EXISTS: Self = Self(9979u32);
-                pub const DNS_ERROR_POLICY_LOCKED: Self = Self(9980u32);
-                pub const DNS_ERROR_POLICY_INVALID_WEIGHT: Self = Self(9981u32);
-                pub const DNS_ERROR_POLICY_INVALID_NAME: Self = Self(9982u32);
-                pub const DNS_ERROR_POLICY_MISSING_CRITERIA: Self = Self(9983u32);
-                pub const DNS_ERROR_INVALID_CLIENT_SUBNET_NAME: Self = Self(9984u32);
-                pub const DNS_ERROR_POLICY_PROCESSING_ORDER_INVALID: Self = Self(9985u32);
-                pub const DNS_ERROR_POLICY_SCOPE_MISSING: Self = Self(9986u32);
-                pub const DNS_ERROR_POLICY_SCOPE_NOT_ALLOWED: Self = Self(9987u32);
-                pub const DNS_ERROR_SERVERSCOPE_IS_REFERENCED: Self = Self(9988u32);
-                pub const DNS_ERROR_ZONESCOPE_IS_REFERENCED: Self = Self(9989u32);
-                pub const DNS_ERROR_POLICY_INVALID_CRITERIA_CLIENT_SUBNET: Self = Self(9990u32);
-                pub const DNS_ERROR_POLICY_INVALID_CRITERIA_TRANSPORT_PROTOCOL: Self =
-                    Self(9991u32);
-                pub const DNS_ERROR_POLICY_INVALID_CRITERIA_NETWORK_PROTOCOL: Self = Self(9992u32);
-                pub const DNS_ERROR_POLICY_INVALID_CRITERIA_INTERFACE: Self = Self(9993u32);
-                pub const DNS_ERROR_POLICY_INVALID_CRITERIA_FQDN: Self = Self(9994u32);
-                pub const DNS_ERROR_POLICY_INVALID_CRITERIA_QUERY_TYPE: Self = Self(9995u32);
-                pub const DNS_ERROR_POLICY_INVALID_CRITERIA_TIME_OF_DAY: Self = Self(9996u32);
-                pub const ERROR_IPSEC_QM_POLICY_EXISTS: Self = Self(13000u32);
-                pub const ERROR_IPSEC_QM_POLICY_NOT_FOUND: Self = Self(13001u32);
-                pub const ERROR_IPSEC_QM_POLICY_IN_USE: Self = Self(13002u32);
-                pub const ERROR_IPSEC_MM_POLICY_EXISTS: Self = Self(13003u32);
-                pub const ERROR_IPSEC_MM_POLICY_NOT_FOUND: Self = Self(13004u32);
-                pub const ERROR_IPSEC_MM_POLICY_IN_USE: Self = Self(13005u32);
-                pub const ERROR_IPSEC_MM_FILTER_EXISTS: Self = Self(13006u32);
-                pub const ERROR_IPSEC_MM_FILTER_NOT_FOUND: Self = Self(13007u32);
-                pub const ERROR_IPSEC_TRANSPORT_FILTER_EXISTS: Self = Self(13008u32);
-                pub const ERROR_IPSEC_TRANSPORT_FILTER_NOT_FOUND: Self = Self(13009u32);
-                pub const ERROR_IPSEC_MM_AUTH_EXISTS: Self = Self(13010u32);
-                pub const ERROR_IPSEC_MM_AUTH_NOT_FOUND: Self = Self(13011u32);
-                pub const ERROR_IPSEC_MM_AUTH_IN_USE: Self = Self(13012u32);
-                pub const ERROR_IPSEC_DEFAULT_MM_POLICY_NOT_FOUND: Self = Self(13013u32);
-                pub const ERROR_IPSEC_DEFAULT_MM_AUTH_NOT_FOUND: Self = Self(13014u32);
-                pub const ERROR_IPSEC_DEFAULT_QM_POLICY_NOT_FOUND: Self = Self(13015u32);
-                pub const ERROR_IPSEC_TUNNEL_FILTER_EXISTS: Self = Self(13016u32);
-                pub const ERROR_IPSEC_TUNNEL_FILTER_NOT_FOUND: Self = Self(13017u32);
-                pub const ERROR_IPSEC_MM_FILTER_PENDING_DELETION: Self = Self(13018u32);
-                pub const ERROR_IPSEC_TRANSPORT_FILTER_PENDING_DELETION: Self = Self(13019u32);
-                pub const ERROR_IPSEC_TUNNEL_FILTER_PENDING_DELETION: Self = Self(13020u32);
-                pub const ERROR_IPSEC_MM_POLICY_PENDING_DELETION: Self = Self(13021u32);
-                pub const ERROR_IPSEC_MM_AUTH_PENDING_DELETION: Self = Self(13022u32);
-                pub const ERROR_IPSEC_QM_POLICY_PENDING_DELETION: Self = Self(13023u32);
-                pub const ERROR_IPSEC_IKE_NEG_STATUS_BEGIN: Self = Self(13800u32);
-                pub const ERROR_IPSEC_IKE_AUTH_FAIL: Self = Self(13801u32);
-                pub const ERROR_IPSEC_IKE_ATTRIB_FAIL: Self = Self(13802u32);
-                pub const ERROR_IPSEC_IKE_NEGOTIATION_PENDING: Self = Self(13803u32);
-                pub const ERROR_IPSEC_IKE_GENERAL_PROCESSING_ERROR: Self = Self(13804u32);
-                pub const ERROR_IPSEC_IKE_TIMED_OUT: Self = Self(13805u32);
-                pub const ERROR_IPSEC_IKE_NO_CERT: Self = Self(13806u32);
-                pub const ERROR_IPSEC_IKE_SA_DELETED: Self = Self(13807u32);
-                pub const ERROR_IPSEC_IKE_SA_REAPED: Self = Self(13808u32);
-                pub const ERROR_IPSEC_IKE_MM_ACQUIRE_DROP: Self = Self(13809u32);
-                pub const ERROR_IPSEC_IKE_QM_ACQUIRE_DROP: Self = Self(13810u32);
-                pub const ERROR_IPSEC_IKE_QUEUE_DROP_MM: Self = Self(13811u32);
-                pub const ERROR_IPSEC_IKE_QUEUE_DROP_NO_MM: Self = Self(13812u32);
-                pub const ERROR_IPSEC_IKE_DROP_NO_RESPONSE: Self = Self(13813u32);
-                pub const ERROR_IPSEC_IKE_MM_DELAY_DROP: Self = Self(13814u32);
-                pub const ERROR_IPSEC_IKE_QM_DELAY_DROP: Self = Self(13815u32);
-                pub const ERROR_IPSEC_IKE_ERROR: Self = Self(13816u32);
-                pub const ERROR_IPSEC_IKE_CRL_FAILED: Self = Self(13817u32);
-                pub const ERROR_IPSEC_IKE_INVALID_KEY_USAGE: Self = Self(13818u32);
-                pub const ERROR_IPSEC_IKE_INVALID_CERT_TYPE: Self = Self(13819u32);
-                pub const ERROR_IPSEC_IKE_NO_PRIVATE_KEY: Self = Self(13820u32);
-                pub const ERROR_IPSEC_IKE_SIMULTANEOUS_REKEY: Self = Self(13821u32);
-                pub const ERROR_IPSEC_IKE_DH_FAIL: Self = Self(13822u32);
-                pub const ERROR_IPSEC_IKE_CRITICAL_PAYLOAD_NOT_RECOGNIZED: Self = Self(13823u32);
-                pub const ERROR_IPSEC_IKE_INVALID_HEADER: Self = Self(13824u32);
-                pub const ERROR_IPSEC_IKE_NO_POLICY: Self = Self(13825u32);
-                pub const ERROR_IPSEC_IKE_INVALID_SIGNATURE: Self = Self(13826u32);
-                pub const ERROR_IPSEC_IKE_KERBEROS_ERROR: Self = Self(13827u32);
-                pub const ERROR_IPSEC_IKE_NO_PUBLIC_KEY: Self = Self(13828u32);
-                pub const ERROR_IPSEC_IKE_PROCESS_ERR: Self = Self(13829u32);
-                pub const ERROR_IPSEC_IKE_PROCESS_ERR_SA: Self = Self(13830u32);
-                pub const ERROR_IPSEC_IKE_PROCESS_ERR_PROP: Self = Self(13831u32);
-                pub const ERROR_IPSEC_IKE_PROCESS_ERR_TRANS: Self = Self(13832u32);
-                pub const ERROR_IPSEC_IKE_PROCESS_ERR_KE: Self = Self(13833u32);
-                pub const ERROR_IPSEC_IKE_PROCESS_ERR_ID: Self = Self(13834u32);
-                pub const ERROR_IPSEC_IKE_PROCESS_ERR_CERT: Self = Self(13835u32);
-                pub const ERROR_IPSEC_IKE_PROCESS_ERR_CERT_REQ: Self = Self(13836u32);
-                pub const ERROR_IPSEC_IKE_PROCESS_ERR_HASH: Self = Self(13837u32);
-                pub const ERROR_IPSEC_IKE_PROCESS_ERR_SIG: Self = Self(13838u32);
-                pub const ERROR_IPSEC_IKE_PROCESS_ERR_NONCE: Self = Self(13839u32);
-                pub const ERROR_IPSEC_IKE_PROCESS_ERR_NOTIFY: Self = Self(13840u32);
-                pub const ERROR_IPSEC_IKE_PROCESS_ERR_DELETE: Self = Self(13841u32);
-                pub const ERROR_IPSEC_IKE_PROCESS_ERR_VENDOR: Self = Self(13842u32);
-                pub const ERROR_IPSEC_IKE_INVALID_PAYLOAD: Self = Self(13843u32);
-                pub const ERROR_IPSEC_IKE_LOAD_SOFT_SA: Self = Self(13844u32);
-                pub const ERROR_IPSEC_IKE_SOFT_SA_TORN_DOWN: Self = Self(13845u32);
-                pub const ERROR_IPSEC_IKE_INVALID_COOKIE: Self = Self(13846u32);
-                pub const ERROR_IPSEC_IKE_NO_PEER_CERT: Self = Self(13847u32);
-                pub const ERROR_IPSEC_IKE_PEER_CRL_FAILED: Self = Self(13848u32);
-                pub const ERROR_IPSEC_IKE_POLICY_CHANGE: Self = Self(13849u32);
-                pub const ERROR_IPSEC_IKE_NO_MM_POLICY: Self = Self(13850u32);
-                pub const ERROR_IPSEC_IKE_NOTCBPRIV: Self = Self(13851u32);
-                pub const ERROR_IPSEC_IKE_SECLOADFAIL: Self = Self(13852u32);
-                pub const ERROR_IPSEC_IKE_FAILSSPINIT: Self = Self(13853u32);
-                pub const ERROR_IPSEC_IKE_FAILQUERYSSP: Self = Self(13854u32);
-                pub const ERROR_IPSEC_IKE_SRVACQFAIL: Self = Self(13855u32);
-                pub const ERROR_IPSEC_IKE_SRVQUERYCRED: Self = Self(13856u32);
-                pub const ERROR_IPSEC_IKE_GETSPIFAIL: Self = Self(13857u32);
-                pub const ERROR_IPSEC_IKE_INVALID_FILTER: Self = Self(13858u32);
-                pub const ERROR_IPSEC_IKE_OUT_OF_MEMORY: Self = Self(13859u32);
-                pub const ERROR_IPSEC_IKE_ADD_UPDATE_KEY_FAILED: Self = Self(13860u32);
-                pub const ERROR_IPSEC_IKE_INVALID_POLICY: Self = Self(13861u32);
-                pub const ERROR_IPSEC_IKE_UNKNOWN_DOI: Self = Self(13862u32);
-                pub const ERROR_IPSEC_IKE_INVALID_SITUATION: Self = Self(13863u32);
-                pub const ERROR_IPSEC_IKE_DH_FAILURE: Self = Self(13864u32);
-                pub const ERROR_IPSEC_IKE_INVALID_GROUP: Self = Self(13865u32);
-                pub const ERROR_IPSEC_IKE_ENCRYPT: Self = Self(13866u32);
-                pub const ERROR_IPSEC_IKE_DECRYPT: Self = Self(13867u32);
-                pub const ERROR_IPSEC_IKE_POLICY_MATCH: Self = Self(13868u32);
-                pub const ERROR_IPSEC_IKE_UNSUPPORTED_ID: Self = Self(13869u32);
-                pub const ERROR_IPSEC_IKE_INVALID_HASH: Self = Self(13870u32);
-                pub const ERROR_IPSEC_IKE_INVALID_HASH_ALG: Self = Self(13871u32);
-                pub const ERROR_IPSEC_IKE_INVALID_HASH_SIZE: Self = Self(13872u32);
-                pub const ERROR_IPSEC_IKE_INVALID_ENCRYPT_ALG: Self = Self(13873u32);
-                pub const ERROR_IPSEC_IKE_INVALID_AUTH_ALG: Self = Self(13874u32);
-                pub const ERROR_IPSEC_IKE_INVALID_SIG: Self = Self(13875u32);
-                pub const ERROR_IPSEC_IKE_LOAD_FAILED: Self = Self(13876u32);
-                pub const ERROR_IPSEC_IKE_RPC_DELETE: Self = Self(13877u32);
-                pub const ERROR_IPSEC_IKE_BENIGN_REINIT: Self = Self(13878u32);
-                pub const ERROR_IPSEC_IKE_INVALID_RESPONDER_LIFETIME_NOTIFY: Self = Self(13879u32);
-                pub const ERROR_IPSEC_IKE_INVALID_MAJOR_VERSION: Self = Self(13880u32);
-                pub const ERROR_IPSEC_IKE_INVALID_CERT_KEYLEN: Self = Self(13881u32);
-                pub const ERROR_IPSEC_IKE_MM_LIMIT: Self = Self(13882u32);
-                pub const ERROR_IPSEC_IKE_NEGOTIATION_DISABLED: Self = Self(13883u32);
-                pub const ERROR_IPSEC_IKE_QM_LIMIT: Self = Self(13884u32);
-                pub const ERROR_IPSEC_IKE_MM_EXPIRED: Self = Self(13885u32);
-                pub const ERROR_IPSEC_IKE_PEER_MM_ASSUMED_INVALID: Self = Self(13886u32);
-                pub const ERROR_IPSEC_IKE_CERT_CHAIN_POLICY_MISMATCH: Self = Self(13887u32);
-                pub const ERROR_IPSEC_IKE_UNEXPECTED_MESSAGE_ID: Self = Self(13888u32);
-                pub const ERROR_IPSEC_IKE_INVALID_AUTH_PAYLOAD: Self = Self(13889u32);
-                pub const ERROR_IPSEC_IKE_DOS_COOKIE_SENT: Self = Self(13890u32);
-                pub const ERROR_IPSEC_IKE_SHUTTING_DOWN: Self = Self(13891u32);
-                pub const ERROR_IPSEC_IKE_CGA_AUTH_FAILED: Self = Self(13892u32);
-                pub const ERROR_IPSEC_IKE_PROCESS_ERR_NATOA: Self = Self(13893u32);
-                pub const ERROR_IPSEC_IKE_INVALID_MM_FOR_QM: Self = Self(13894u32);
-                pub const ERROR_IPSEC_IKE_QM_EXPIRED: Self = Self(13895u32);
-                pub const ERROR_IPSEC_IKE_TOO_MANY_FILTERS: Self = Self(13896u32);
-                pub const ERROR_IPSEC_IKE_NEG_STATUS_END: Self = Self(13897u32);
-                pub const ERROR_IPSEC_IKE_KILL_DUMMY_NAP_TUNNEL: Self = Self(13898u32);
-                pub const ERROR_IPSEC_IKE_INNER_IP_ASSIGNMENT_FAILURE: Self = Self(13899u32);
-                pub const ERROR_IPSEC_IKE_REQUIRE_CP_PAYLOAD_MISSING: Self = Self(13900u32);
-                pub const ERROR_IPSEC_KEY_MODULE_IMPERSONATION_NEGOTIATION_PENDING: Self =
-                    Self(13901u32);
-                pub const ERROR_IPSEC_IKE_COEXISTENCE_SUPPRESS: Self = Self(13902u32);
-                pub const ERROR_IPSEC_IKE_RATELIMIT_DROP: Self = Self(13903u32);
-                pub const ERROR_IPSEC_IKE_PEER_DOESNT_SUPPORT_MOBIKE: Self = Self(13904u32);
-                pub const ERROR_IPSEC_IKE_AUTHORIZATION_FAILURE: Self = Self(13905u32);
-                pub const ERROR_IPSEC_IKE_STRONG_CRED_AUTHORIZATION_FAILURE: Self = Self(13906u32);
-                pub const ERROR_IPSEC_IKE_AUTHORIZATION_FAILURE_WITH_OPTIONAL_RETRY: Self =
-                    Self(13907u32);
-                pub const ERROR_IPSEC_IKE_STRONG_CRED_AUTHORIZATION_AND_CERTMAP_FAILURE: Self =
-                    Self(13908u32);
-                pub const ERROR_IPSEC_IKE_NEG_STATUS_EXTENDED_END: Self = Self(13909u32);
-                pub const ERROR_IPSEC_BAD_SPI: Self = Self(13910u32);
-                pub const ERROR_IPSEC_SA_LIFETIME_EXPIRED: Self = Self(13911u32);
-                pub const ERROR_IPSEC_WRONG_SA: Self = Self(13912u32);
-                pub const ERROR_IPSEC_REPLAY_CHECK_FAILED: Self = Self(13913u32);
-                pub const ERROR_IPSEC_INVALID_PACKET: Self = Self(13914u32);
-                pub const ERROR_IPSEC_INTEGRITY_CHECK_FAILED: Self = Self(13915u32);
-                pub const ERROR_IPSEC_CLEAR_TEXT_DROP: Self = Self(13916u32);
-                pub const ERROR_IPSEC_AUTH_FIREWALL_DROP: Self = Self(13917u32);
-                pub const ERROR_IPSEC_THROTTLE_DROP: Self = Self(13918u32);
-                pub const ERROR_IPSEC_DOSP_BLOCK: Self = Self(13925u32);
-                pub const ERROR_IPSEC_DOSP_RECEIVED_MULTICAST: Self = Self(13926u32);
-                pub const ERROR_IPSEC_DOSP_INVALID_PACKET: Self = Self(13927u32);
-                pub const ERROR_IPSEC_DOSP_STATE_LOOKUP_FAILED: Self = Self(13928u32);
-                pub const ERROR_IPSEC_DOSP_MAX_ENTRIES: Self = Self(13929u32);
-                pub const ERROR_IPSEC_DOSP_KEYMOD_NOT_ALLOWED: Self = Self(13930u32);
-                pub const ERROR_IPSEC_DOSP_NOT_INSTALLED: Self = Self(13931u32);
-                pub const ERROR_IPSEC_DOSP_MAX_PER_IP_RATELIMIT_QUEUES: Self = Self(13932u32);
-                pub const ERROR_SXS_SECTION_NOT_FOUND: Self = Self(14000u32);
-                pub const ERROR_SXS_CANT_GEN_ACTCTX: Self = Self(14001u32);
-                pub const ERROR_SXS_INVALID_ACTCTXDATA_FORMAT: Self = Self(14002u32);
-                pub const ERROR_SXS_ASSEMBLY_NOT_FOUND: Self = Self(14003u32);
-                pub const ERROR_SXS_MANIFEST_FORMAT_ERROR: Self = Self(14004u32);
-                pub const ERROR_SXS_MANIFEST_PARSE_ERROR: Self = Self(14005u32);
-                pub const ERROR_SXS_ACTIVATION_CONTEXT_DISABLED: Self = Self(14006u32);
-                pub const ERROR_SXS_KEY_NOT_FOUND: Self = Self(14007u32);
-                pub const ERROR_SXS_VERSION_CONFLICT: Self = Self(14008u32);
-                pub const ERROR_SXS_WRONG_SECTION_TYPE: Self = Self(14009u32);
-                pub const ERROR_SXS_THREAD_QUERIES_DISABLED: Self = Self(14010u32);
-                pub const ERROR_SXS_PROCESS_DEFAULT_ALREADY_SET: Self = Self(14011u32);
-                pub const ERROR_SXS_UNKNOWN_ENCODING_GROUP: Self = Self(14012u32);
-                pub const ERROR_SXS_UNKNOWN_ENCODING: Self = Self(14013u32);
-                pub const ERROR_SXS_INVALID_XML_NAMESPACE_URI: Self = Self(14014u32);
-                pub const ERROR_SXS_ROOT_MANIFEST_DEPENDENCY_NOT_INSTALLED: Self = Self(14015u32);
-                pub const ERROR_SXS_LEAF_MANIFEST_DEPENDENCY_NOT_INSTALLED: Self = Self(14016u32);
-                pub const ERROR_SXS_INVALID_ASSEMBLY_IDENTITY_ATTRIBUTE: Self = Self(14017u32);
-                pub const ERROR_SXS_MANIFEST_MISSING_REQUIRED_DEFAULT_NAMESPACE: Self =
-                    Self(14018u32);
-                pub const ERROR_SXS_MANIFEST_INVALID_REQUIRED_DEFAULT_NAMESPACE: Self =
-                    Self(14019u32);
-                pub const ERROR_SXS_PRIVATE_MANIFEST_CROSS_PATH_WITH_REPARSE_POINT: Self =
-                    Self(14020u32);
-                pub const ERROR_SXS_DUPLICATE_DLL_NAME: Self = Self(14021u32);
-                pub const ERROR_SXS_DUPLICATE_WINDOWCLASS_NAME: Self = Self(14022u32);
-                pub const ERROR_SXS_DUPLICATE_CLSID: Self = Self(14023u32);
-                pub const ERROR_SXS_DUPLICATE_IID: Self = Self(14024u32);
-                pub const ERROR_SXS_DUPLICATE_TLBID: Self = Self(14025u32);
-                pub const ERROR_SXS_DUPLICATE_PROGID: Self = Self(14026u32);
-                pub const ERROR_SXS_DUPLICATE_ASSEMBLY_NAME: Self = Self(14027u32);
-                pub const ERROR_SXS_FILE_HASH_MISMATCH: Self = Self(14028u32);
-                pub const ERROR_SXS_POLICY_PARSE_ERROR: Self = Self(14029u32);
-                pub const ERROR_SXS_XML_E_MISSINGQUOTE: Self = Self(14030u32);
-                pub const ERROR_SXS_XML_E_COMMENTSYNTAX: Self = Self(14031u32);
-                pub const ERROR_SXS_XML_E_BADSTARTNAMECHAR: Self = Self(14032u32);
-                pub const ERROR_SXS_XML_E_BADNAMECHAR: Self = Self(14033u32);
-                pub const ERROR_SXS_XML_E_BADCHARINSTRING: Self = Self(14034u32);
-                pub const ERROR_SXS_XML_E_XMLDECLSYNTAX: Self = Self(14035u32);
-                pub const ERROR_SXS_XML_E_BADCHARDATA: Self = Self(14036u32);
-                pub const ERROR_SXS_XML_E_MISSINGWHITESPACE: Self = Self(14037u32);
-                pub const ERROR_SXS_XML_E_EXPECTINGTAGEND: Self = Self(14038u32);
-                pub const ERROR_SXS_XML_E_MISSINGSEMICOLON: Self = Self(14039u32);
-                pub const ERROR_SXS_XML_E_UNBALANCEDPAREN: Self = Self(14040u32);
-                pub const ERROR_SXS_XML_E_INTERNALERROR: Self = Self(14041u32);
-                pub const ERROR_SXS_XML_E_UNEXPECTED_WHITESPACE: Self = Self(14042u32);
-                pub const ERROR_SXS_XML_E_INCOMPLETE_ENCODING: Self = Self(14043u32);
-                pub const ERROR_SXS_XML_E_MISSING_PAREN: Self = Self(14044u32);
-                pub const ERROR_SXS_XML_E_EXPECTINGCLOSEQUOTE: Self = Self(14045u32);
-                pub const ERROR_SXS_XML_E_MULTIPLE_COLONS: Self = Self(14046u32);
-                pub const ERROR_SXS_XML_E_INVALID_DECIMAL: Self = Self(14047u32);
-                pub const ERROR_SXS_XML_E_INVALID_HEXIDECIMAL: Self = Self(14048u32);
-                pub const ERROR_SXS_XML_E_INVALID_UNICODE: Self = Self(14049u32);
-                pub const ERROR_SXS_XML_E_WHITESPACEORQUESTIONMARK: Self = Self(14050u32);
-                pub const ERROR_SXS_XML_E_UNEXPECTEDENDTAG: Self = Self(14051u32);
-                pub const ERROR_SXS_XML_E_UNCLOSEDTAG: Self = Self(14052u32);
-                pub const ERROR_SXS_XML_E_DUPLICATEATTRIBUTE: Self = Self(14053u32);
-                pub const ERROR_SXS_XML_E_MULTIPLEROOTS: Self = Self(14054u32);
-                pub const ERROR_SXS_XML_E_INVALIDATROOTLEVEL: Self = Self(14055u32);
-                pub const ERROR_SXS_XML_E_BADXMLDECL: Self = Self(14056u32);
-                pub const ERROR_SXS_XML_E_MISSINGROOT: Self = Self(14057u32);
-                pub const ERROR_SXS_XML_E_UNEXPECTEDEOF: Self = Self(14058u32);
-                pub const ERROR_SXS_XML_E_BADPEREFINSUBSET: Self = Self(14059u32);
-                pub const ERROR_SXS_XML_E_UNCLOSEDSTARTTAG: Self = Self(14060u32);
-                pub const ERROR_SXS_XML_E_UNCLOSEDENDTAG: Self = Self(14061u32);
-                pub const ERROR_SXS_XML_E_UNCLOSEDSTRING: Self = Self(14062u32);
-                pub const ERROR_SXS_XML_E_UNCLOSEDCOMMENT: Self = Self(14063u32);
-                pub const ERROR_SXS_XML_E_UNCLOSEDDECL: Self = Self(14064u32);
-                pub const ERROR_SXS_XML_E_UNCLOSEDCDATA: Self = Self(14065u32);
-                pub const ERROR_SXS_XML_E_RESERVEDNAMESPACE: Self = Self(14066u32);
-                pub const ERROR_SXS_XML_E_INVALIDENCODING: Self = Self(14067u32);
-                pub const ERROR_SXS_XML_E_INVALIDSWITCH: Self = Self(14068u32);
-                pub const ERROR_SXS_XML_E_BADXMLCASE: Self = Self(14069u32);
-                pub const ERROR_SXS_XML_E_INVALID_STANDALONE: Self = Self(14070u32);
-                pub const ERROR_SXS_XML_E_UNEXPECTED_STANDALONE: Self = Self(14071u32);
-                pub const ERROR_SXS_XML_E_INVALID_VERSION: Self = Self(14072u32);
-                pub const ERROR_SXS_XML_E_MISSINGEQUALS: Self = Self(14073u32);
-                pub const ERROR_SXS_PROTECTION_RECOVERY_FAILED: Self = Self(14074u32);
-                pub const ERROR_SXS_PROTECTION_PUBLIC_KEY_TOO_SHORT: Self = Self(14075u32);
-                pub const ERROR_SXS_PROTECTION_CATALOG_NOT_VALID: Self = Self(14076u32);
-                pub const ERROR_SXS_UNTRANSLATABLE_HRESULT: Self = Self(14077u32);
-                pub const ERROR_SXS_PROTECTION_CATALOG_FILE_MISSING: Self = Self(14078u32);
-                pub const ERROR_SXS_MISSING_ASSEMBLY_IDENTITY_ATTRIBUTE: Self = Self(14079u32);
-                pub const ERROR_SXS_INVALID_ASSEMBLY_IDENTITY_ATTRIBUTE_NAME: Self = Self(14080u32);
-                pub const ERROR_SXS_ASSEMBLY_MISSING: Self = Self(14081u32);
-                pub const ERROR_SXS_CORRUPT_ACTIVATION_STACK: Self = Self(14082u32);
-                pub const ERROR_SXS_CORRUPTION: Self = Self(14083u32);
-                pub const ERROR_SXS_EARLY_DEACTIVATION: Self = Self(14084u32);
-                pub const ERROR_SXS_INVALID_DEACTIVATION: Self = Self(14085u32);
-                pub const ERROR_SXS_MULTIPLE_DEACTIVATION: Self = Self(14086u32);
-                pub const ERROR_SXS_PROCESS_TERMINATION_REQUESTED: Self = Self(14087u32);
-                pub const ERROR_SXS_RELEASE_ACTIVATION_CONTEXT: Self = Self(14088u32);
-                pub const ERROR_SXS_SYSTEM_DEFAULT_ACTIVATION_CONTEXT_EMPTY: Self = Self(14089u32);
-                pub const ERROR_SXS_INVALID_IDENTITY_ATTRIBUTE_VALUE: Self = Self(14090u32);
-                pub const ERROR_SXS_INVALID_IDENTITY_ATTRIBUTE_NAME: Self = Self(14091u32);
-                pub const ERROR_SXS_IDENTITY_DUPLICATE_ATTRIBUTE: Self = Self(14092u32);
-                pub const ERROR_SXS_IDENTITY_PARSE_ERROR: Self = Self(14093u32);
-                pub const ERROR_MALFORMED_SUBSTITUTION_STRING: Self = Self(14094u32);
-                pub const ERROR_SXS_INCORRECT_PUBLIC_KEY_TOKEN: Self = Self(14095u32);
-                pub const ERROR_UNMAPPED_SUBSTITUTION_STRING: Self = Self(14096u32);
-                pub const ERROR_SXS_ASSEMBLY_NOT_LOCKED: Self = Self(14097u32);
-                pub const ERROR_SXS_COMPONENT_STORE_CORRUPT: Self = Self(14098u32);
-                pub const ERROR_ADVANCED_INSTALLER_FAILED: Self = Self(14099u32);
-                pub const ERROR_XML_ENCODING_MISMATCH: Self = Self(14100u32);
-                pub const ERROR_SXS_MANIFEST_IDENTITY_SAME_BUT_CONTENTS_DIFFERENT: Self =
-                    Self(14101u32);
-                pub const ERROR_SXS_IDENTITIES_DIFFERENT: Self = Self(14102u32);
-                pub const ERROR_SXS_ASSEMBLY_IS_NOT_A_DEPLOYMENT: Self = Self(14103u32);
-                pub const ERROR_SXS_FILE_NOT_PART_OF_ASSEMBLY: Self = Self(14104u32);
-                pub const ERROR_SXS_MANIFEST_TOO_BIG: Self = Self(14105u32);
-                pub const ERROR_SXS_SETTING_NOT_REGISTERED: Self = Self(14106u32);
-                pub const ERROR_SXS_TRANSACTION_CLOSURE_INCOMPLETE: Self = Self(14107u32);
-                pub const ERROR_SMI_PRIMITIVE_INSTALLER_FAILED: Self = Self(14108u32);
-                pub const ERROR_GENERIC_COMMAND_FAILED: Self = Self(14109u32);
-                pub const ERROR_SXS_FILE_HASH_MISSING: Self = Self(14110u32);
-                pub const ERROR_SXS_DUPLICATE_ACTIVATABLE_CLASS: Self = Self(14111u32);
-                pub const ERROR_EVT_INVALID_CHANNEL_PATH: Self = Self(15000u32);
-                pub const ERROR_EVT_INVALID_QUERY: Self = Self(15001u32);
-                pub const ERROR_EVT_PUBLISHER_METADATA_NOT_FOUND: Self = Self(15002u32);
-                pub const ERROR_EVT_EVENT_TEMPLATE_NOT_FOUND: Self = Self(15003u32);
-                pub const ERROR_EVT_INVALID_PUBLISHER_NAME: Self = Self(15004u32);
-                pub const ERROR_EVT_INVALID_EVENT_DATA: Self = Self(15005u32);
-                pub const ERROR_EVT_CHANNEL_NOT_FOUND: Self = Self(15007u32);
-                pub const ERROR_EVT_MALFORMED_XML_TEXT: Self = Self(15008u32);
-                pub const ERROR_EVT_SUBSCRIPTION_TO_DIRECT_CHANNEL: Self = Self(15009u32);
-                pub const ERROR_EVT_CONFIGURATION_ERROR: Self = Self(15010u32);
-                pub const ERROR_EVT_QUERY_RESULT_STALE: Self = Self(15011u32);
-                pub const ERROR_EVT_QUERY_RESULT_INVALID_POSITION: Self = Self(15012u32);
-                pub const ERROR_EVT_NON_VALIDATING_MSXML: Self = Self(15013u32);
-                pub const ERROR_EVT_FILTER_ALREADYSCOPED: Self = Self(15014u32);
-                pub const ERROR_EVT_FILTER_NOTELTSET: Self = Self(15015u32);
-                pub const ERROR_EVT_FILTER_INVARG: Self = Self(15016u32);
-                pub const ERROR_EVT_FILTER_INVTEST: Self = Self(15017u32);
-                pub const ERROR_EVT_FILTER_INVTYPE: Self = Self(15018u32);
-                pub const ERROR_EVT_FILTER_PARSEERR: Self = Self(15019u32);
-                pub const ERROR_EVT_FILTER_UNSUPPORTEDOP: Self = Self(15020u32);
-                pub const ERROR_EVT_FILTER_UNEXPECTEDTOKEN: Self = Self(15021u32);
-                pub const ERROR_EVT_INVALID_OPERATION_OVER_ENABLED_DIRECT_CHANNEL: Self =
-                    Self(15022u32);
-                pub const ERROR_EVT_INVALID_CHANNEL_PROPERTY_VALUE: Self = Self(15023u32);
-                pub const ERROR_EVT_INVALID_PUBLISHER_PROPERTY_VALUE: Self = Self(15024u32);
-                pub const ERROR_EVT_CHANNEL_CANNOT_ACTIVATE: Self = Self(15025u32);
-                pub const ERROR_EVT_FILTER_TOO_COMPLEX: Self = Self(15026u32);
-                pub const ERROR_EVT_MESSAGE_NOT_FOUND: Self = Self(15027u32);
-                pub const ERROR_EVT_MESSAGE_ID_NOT_FOUND: Self = Self(15028u32);
-                pub const ERROR_EVT_UNRESOLVED_VALUE_INSERT: Self = Self(15029u32);
-                pub const ERROR_EVT_UNRESOLVED_PARAMETER_INSERT: Self = Self(15030u32);
-                pub const ERROR_EVT_MAX_INSERTS_REACHED: Self = Self(15031u32);
-                pub const ERROR_EVT_EVENT_DEFINITION_NOT_FOUND: Self = Self(15032u32);
-                pub const ERROR_EVT_MESSAGE_LOCALE_NOT_FOUND: Self = Self(15033u32);
-                pub const ERROR_EVT_VERSION_TOO_OLD: Self = Self(15034u32);
-                pub const ERROR_EVT_VERSION_TOO_NEW: Self = Self(15035u32);
-                pub const ERROR_EVT_CANNOT_OPEN_CHANNEL_OF_QUERY: Self = Self(15036u32);
-                pub const ERROR_EVT_PUBLISHER_DISABLED: Self = Self(15037u32);
-                pub const ERROR_EVT_FILTER_OUT_OF_RANGE: Self = Self(15038u32);
-                pub const ERROR_EC_SUBSCRIPTION_CANNOT_ACTIVATE: Self = Self(15080u32);
-                pub const ERROR_EC_LOG_DISABLED: Self = Self(15081u32);
-                pub const ERROR_EC_CIRCULAR_FORWARDING: Self = Self(15082u32);
-                pub const ERROR_EC_CREDSTORE_FULL: Self = Self(15083u32);
-                pub const ERROR_EC_CRED_NOT_FOUND: Self = Self(15084u32);
-                pub const ERROR_EC_NO_ACTIVE_CHANNEL: Self = Self(15085u32);
-                pub const ERROR_MUI_FILE_NOT_FOUND: Self = Self(15100u32);
-                pub const ERROR_MUI_INVALID_FILE: Self = Self(15101u32);
-                pub const ERROR_MUI_INVALID_RC_CONFIG: Self = Self(15102u32);
-                pub const ERROR_MUI_INVALID_LOCALE_NAME: Self = Self(15103u32);
-                pub const ERROR_MUI_INVALID_ULTIMATEFALLBACK_NAME: Self = Self(15104u32);
-                pub const ERROR_MUI_FILE_NOT_LOADED: Self = Self(15105u32);
-                pub const ERROR_RESOURCE_ENUM_USER_STOP: Self = Self(15106u32);
-                pub const ERROR_MUI_INTLSETTINGS_UILANG_NOT_INSTALLED: Self = Self(15107u32);
-                pub const ERROR_MUI_INTLSETTINGS_INVALID_LOCALE_NAME: Self = Self(15108u32);
-                pub const ERROR_MRM_RUNTIME_NO_DEFAULT_OR_NEUTRAL_RESOURCE: Self = Self(15110u32);
-                pub const ERROR_MRM_INVALID_PRICONFIG: Self = Self(15111u32);
-                pub const ERROR_MRM_INVALID_FILE_TYPE: Self = Self(15112u32);
-                pub const ERROR_MRM_UNKNOWN_QUALIFIER: Self = Self(15113u32);
-                pub const ERROR_MRM_INVALID_QUALIFIER_VALUE: Self = Self(15114u32);
-                pub const ERROR_MRM_NO_CANDIDATE: Self = Self(15115u32);
-                pub const ERROR_MRM_NO_MATCH_OR_DEFAULT_CANDIDATE: Self = Self(15116u32);
-                pub const ERROR_MRM_RESOURCE_TYPE_MISMATCH: Self = Self(15117u32);
-                pub const ERROR_MRM_DUPLICATE_MAP_NAME: Self = Self(15118u32);
-                pub const ERROR_MRM_DUPLICATE_ENTRY: Self = Self(15119u32);
-                pub const ERROR_MRM_INVALID_RESOURCE_IDENTIFIER: Self = Self(15120u32);
-                pub const ERROR_MRM_FILEPATH_TOO_LONG: Self = Self(15121u32);
-                pub const ERROR_MRM_UNSUPPORTED_DIRECTORY_TYPE: Self = Self(15122u32);
-                pub const ERROR_MRM_INVALID_PRI_FILE: Self = Self(15126u32);
-                pub const ERROR_MRM_NAMED_RESOURCE_NOT_FOUND: Self = Self(15127u32);
-                pub const ERROR_MRM_MAP_NOT_FOUND: Self = Self(15135u32);
-                pub const ERROR_MRM_UNSUPPORTED_PROFILE_TYPE: Self = Self(15136u32);
-                pub const ERROR_MRM_INVALID_QUALIFIER_OPERATOR: Self = Self(15137u32);
-                pub const ERROR_MRM_INDETERMINATE_QUALIFIER_VALUE: Self = Self(15138u32);
-                pub const ERROR_MRM_AUTOMERGE_ENABLED: Self = Self(15139u32);
-                pub const ERROR_MRM_TOO_MANY_RESOURCES: Self = Self(15140u32);
-                pub const ERROR_MRM_UNSUPPORTED_FILE_TYPE_FOR_MERGE: Self = Self(15141u32);
-                pub const ERROR_MRM_UNSUPPORTED_FILE_TYPE_FOR_LOAD_UNLOAD_PRI_FILE: Self =
-                    Self(15142u32);
-                pub const ERROR_MRM_NO_CURRENT_VIEW_ON_THREAD: Self = Self(15143u32);
-                pub const ERROR_DIFFERENT_PROFILE_RESOURCE_MANAGER_EXIST: Self = Self(15144u32);
-                pub const ERROR_OPERATION_NOT_ALLOWED_FROM_SYSTEM_COMPONENT: Self = Self(15145u32);
-                pub const ERROR_MRM_DIRECT_REF_TO_NON_DEFAULT_RESOURCE: Self = Self(15146u32);
-                pub const ERROR_MRM_GENERATION_COUNT_MISMATCH: Self = Self(15147u32);
-                pub const ERROR_PRI_MERGE_VERSION_MISMATCH: Self = Self(15148u32);
-                pub const ERROR_PRI_MERGE_MISSING_SCHEMA: Self = Self(15149u32);
-                pub const ERROR_PRI_MERGE_LOAD_FILE_FAILED: Self = Self(15150u32);
-                pub const ERROR_PRI_MERGE_ADD_FILE_FAILED: Self = Self(15151u32);
-                pub const ERROR_PRI_MERGE_WRITE_FILE_FAILED: Self = Self(15152u32);
-                pub const ERROR_PRI_MERGE_MULTIPLE_PACKAGE_FAMILIES_NOT_ALLOWED: Self =
-                    Self(15153u32);
-                pub const ERROR_PRI_MERGE_MULTIPLE_MAIN_PACKAGES_NOT_ALLOWED: Self = Self(15154u32);
-                pub const ERROR_PRI_MERGE_BUNDLE_PACKAGES_NOT_ALLOWED: Self = Self(15155u32);
-                pub const ERROR_PRI_MERGE_MAIN_PACKAGE_REQUIRED: Self = Self(15156u32);
-                pub const ERROR_PRI_MERGE_RESOURCE_PACKAGE_REQUIRED: Self = Self(15157u32);
-                pub const ERROR_PRI_MERGE_INVALID_FILE_NAME: Self = Self(15158u32);
-                pub const ERROR_MRM_PACKAGE_NOT_FOUND: Self = Self(15159u32);
-                pub const ERROR_MRM_MISSING_DEFAULT_LANGUAGE: Self = Self(15160u32);
-                pub const ERROR_MCA_INVALID_CAPABILITIES_STRING: Self = Self(15200u32);
-                pub const ERROR_MCA_INVALID_VCP_VERSION: Self = Self(15201u32);
-                pub const ERROR_MCA_MONITOR_VIOLATES_MCCS_SPECIFICATION: Self = Self(15202u32);
-                pub const ERROR_MCA_MCCS_VERSION_MISMATCH: Self = Self(15203u32);
-                pub const ERROR_MCA_UNSUPPORTED_MCCS_VERSION: Self = Self(15204u32);
-                pub const ERROR_MCA_INTERNAL_ERROR: Self = Self(15205u32);
-                pub const ERROR_MCA_INVALID_TECHNOLOGY_TYPE_RETURNED: Self = Self(15206u32);
-                pub const ERROR_MCA_UNSUPPORTED_COLOR_TEMPERATURE: Self = Self(15207u32);
-                pub const ERROR_AMBIGUOUS_SYSTEM_DEVICE: Self = Self(15250u32);
-                pub const ERROR_SYSTEM_DEVICE_NOT_FOUND: Self = Self(15299u32);
-                pub const ERROR_HASH_NOT_SUPPORTED: Self = Self(15300u32);
-                pub const ERROR_HASH_NOT_PRESENT: Self = Self(15301u32);
-                pub const ERROR_SECONDARY_IC_PROVIDER_NOT_REGISTERED: Self = Self(15321u32);
-                pub const ERROR_GPIO_CLIENT_INFORMATION_INVALID: Self = Self(15322u32);
-                pub const ERROR_GPIO_VERSION_NOT_SUPPORTED: Self = Self(15323u32);
-                pub const ERROR_GPIO_INVALID_REGISTRATION_PACKET: Self = Self(15324u32);
-                pub const ERROR_GPIO_OPERATION_DENIED: Self = Self(15325u32);
-                pub const ERROR_GPIO_INCOMPATIBLE_CONNECT_MODE: Self = Self(15326u32);
-                pub const ERROR_GPIO_INTERRUPT_ALREADY_UNMASKED: Self = Self(15327u32);
-                pub const ERROR_CANNOT_SWITCH_RUNLEVEL: Self = Self(15400u32);
-                pub const ERROR_INVALID_RUNLEVEL_SETTING: Self = Self(15401u32);
-                pub const ERROR_RUNLEVEL_SWITCH_TIMEOUT: Self = Self(15402u32);
-                pub const ERROR_RUNLEVEL_SWITCH_AGENT_TIMEOUT: Self = Self(15403u32);
-                pub const ERROR_RUNLEVEL_SWITCH_IN_PROGRESS: Self = Self(15404u32);
-                pub const ERROR_SERVICES_FAILED_AUTOSTART: Self = Self(15405u32);
-                pub const ERROR_COM_TASK_STOP_PENDING: Self = Self(15501u32);
-                pub const ERROR_INSTALL_OPEN_PACKAGE_FAILED: Self = Self(15600u32);
-                pub const ERROR_INSTALL_PACKAGE_NOT_FOUND: Self = Self(15601u32);
-                pub const ERROR_INSTALL_INVALID_PACKAGE: Self = Self(15602u32);
-                pub const ERROR_INSTALL_RESOLVE_DEPENDENCY_FAILED: Self = Self(15603u32);
-                pub const ERROR_INSTALL_OUT_OF_DISK_SPACE: Self = Self(15604u32);
-                pub const ERROR_INSTALL_NETWORK_FAILURE: Self = Self(15605u32);
-                pub const ERROR_INSTALL_REGISTRATION_FAILURE: Self = Self(15606u32);
-                pub const ERROR_INSTALL_DEREGISTRATION_FAILURE: Self = Self(15607u32);
-                pub const ERROR_INSTALL_CANCEL: Self = Self(15608u32);
-                pub const ERROR_INSTALL_FAILED: Self = Self(15609u32);
-                pub const ERROR_REMOVE_FAILED: Self = Self(15610u32);
-                pub const ERROR_PACKAGE_ALREADY_EXISTS: Self = Self(15611u32);
-                pub const ERROR_NEEDS_REMEDIATION: Self = Self(15612u32);
-                pub const ERROR_INSTALL_PREREQUISITE_FAILED: Self = Self(15613u32);
-                pub const ERROR_PACKAGE_REPOSITORY_CORRUPTED: Self = Self(15614u32);
-                pub const ERROR_INSTALL_POLICY_FAILURE: Self = Self(15615u32);
-                pub const ERROR_PACKAGE_UPDATING: Self = Self(15616u32);
-                pub const ERROR_DEPLOYMENT_BLOCKED_BY_POLICY: Self = Self(15617u32);
-                pub const ERROR_PACKAGES_IN_USE: Self = Self(15618u32);
-                pub const ERROR_RECOVERY_FILE_CORRUPT: Self = Self(15619u32);
-                pub const ERROR_INVALID_STAGED_SIGNATURE: Self = Self(15620u32);
-                pub const ERROR_DELETING_EXISTING_APPLICATIONDATA_STORE_FAILED: Self =
-                    Self(15621u32);
-                pub const ERROR_INSTALL_PACKAGE_DOWNGRADE: Self = Self(15622u32);
-                pub const ERROR_SYSTEM_NEEDS_REMEDIATION: Self = Self(15623u32);
-                pub const ERROR_APPX_INTEGRITY_FAILURE_CLR_NGEN: Self = Self(15624u32);
-                pub const ERROR_RESILIENCY_FILE_CORRUPT: Self = Self(15625u32);
-                pub const ERROR_INSTALL_FIREWALL_SERVICE_NOT_RUNNING: Self = Self(15626u32);
-                pub const ERROR_PACKAGE_MOVE_FAILED: Self = Self(15627u32);
-                pub const ERROR_INSTALL_VOLUME_NOT_EMPTY: Self = Self(15628u32);
-                pub const ERROR_INSTALL_VOLUME_OFFLINE: Self = Self(15629u32);
-                pub const ERROR_INSTALL_VOLUME_CORRUPT: Self = Self(15630u32);
-                pub const ERROR_NEEDS_REGISTRATION: Self = Self(15631u32);
-                pub const ERROR_INSTALL_WRONG_PROCESSOR_ARCHITECTURE: Self = Self(15632u32);
-                pub const ERROR_DEV_SIDELOAD_LIMIT_EXCEEDED: Self = Self(15633u32);
-                pub const ERROR_INSTALL_OPTIONAL_PACKAGE_REQUIRES_MAIN_PACKAGE: Self =
-                    Self(15634u32);
-                pub const ERROR_PACKAGE_NOT_SUPPORTED_ON_FILESYSTEM: Self = Self(15635u32);
-                pub const ERROR_PACKAGE_MOVE_BLOCKED_BY_STREAMING: Self = Self(15636u32);
-                pub const ERROR_INSTALL_OPTIONAL_PACKAGE_APPLICATIONID_NOT_UNIQUE: Self =
-                    Self(15637u32);
-                pub const ERROR_PACKAGE_STAGING_ONHOLD: Self = Self(15638u32);
-                pub const ERROR_INSTALL_INVALID_RELATED_SET_UPDATE: Self = Self(15639u32);
-                pub const ERROR_INSTALL_OPTIONAL_PACKAGE_REQUIRES_MAIN_PACKAGE_FULLTRUST_CAPABILITY : Self = Self ( 15640u32 ) ;
-                pub const ERROR_DEPLOYMENT_BLOCKED_BY_USER_LOG_OFF: Self = Self(15641u32);
-                pub const ERROR_PROVISION_OPTIONAL_PACKAGE_REQUIRES_MAIN_PACKAGE_PROVISIONED: Self =
-                    Self(15642u32);
-                pub const ERROR_PACKAGES_REPUTATION_CHECK_FAILED: Self = Self(15643u32);
-                pub const ERROR_PACKAGES_REPUTATION_CHECK_TIMEDOUT: Self = Self(15644u32);
-                pub const ERROR_DEPLOYMENT_OPTION_NOT_SUPPORTED: Self = Self(15645u32);
-                pub const ERROR_APPINSTALLER_ACTIVATION_BLOCKED: Self = Self(15646u32);
-                pub const ERROR_REGISTRATION_FROM_REMOTE_DRIVE_NOT_SUPPORTED: Self = Self(15647u32);
-                pub const ERROR_APPX_RAW_DATA_WRITE_FAILED: Self = Self(15648u32);
-                pub const ERROR_DEPLOYMENT_BLOCKED_BY_VOLUME_POLICY_PACKAGE: Self = Self(15649u32);
-                pub const ERROR_DEPLOYMENT_BLOCKED_BY_VOLUME_POLICY_MACHINE: Self = Self(15650u32);
-                pub const ERROR_DEPLOYMENT_BLOCKED_BY_PROFILE_POLICY: Self = Self(15651u32);
-                pub const ERROR_DEPLOYMENT_FAILED_CONFLICTING_MUTABLE_PACKAGE_DIRECTORY: Self =
-                    Self(15652u32);
-                pub const ERROR_SINGLETON_RESOURCE_INSTALLED_IN_ACTIVE_USER: Self = Self(15653u32);
-                pub const ERROR_DIFFERENT_VERSION_OF_PACKAGED_SERVICE_INSTALLED: Self =
-                    Self(15654u32);
-                pub const ERROR_SERVICE_EXISTS_AS_NON_PACKAGED_SERVICE: Self = Self(15655u32);
-                pub const ERROR_PACKAGED_SERVICE_REQUIRES_ADMIN_PRIVILEGES: Self = Self(15656u32);
-                pub const ERROR_REDIRECTION_TO_DEFAULT_ACCOUNT_NOT_ALLOWED: Self = Self(15657u32);
-                pub const ERROR_PACKAGE_LACKS_CAPABILITY_TO_DEPLOY_ON_HOST: Self = Self(15658u32);
-                pub const ERROR_UNSIGNED_PACKAGE_INVALID_CONTENT: Self = Self(15659u32);
-                pub const ERROR_UNSIGNED_PACKAGE_INVALID_PUBLISHER_NAMESPACE: Self = Self(15660u32);
-                pub const ERROR_SIGNED_PACKAGE_INVALID_PUBLISHER_NAMESPACE: Self = Self(15661u32);
-                pub const ERROR_PACKAGE_EXTERNAL_LOCATION_NOT_ALLOWED: Self = Self(15662u32);
-                pub const ERROR_INSTALL_FULLTRUST_HOSTRUNTIME_REQUIRES_MAIN_PACKAGE_FULLTRUST_CAPABILITY : Self = Self ( 15663u32 ) ;
-                pub const ERROR_STATE_LOAD_STORE_FAILED: Self = Self(15800u32);
-                pub const ERROR_STATE_GET_VERSION_FAILED: Self = Self(15801u32);
-                pub const ERROR_STATE_SET_VERSION_FAILED: Self = Self(15802u32);
-                pub const ERROR_STATE_STRUCTURED_RESET_FAILED: Self = Self(15803u32);
-                pub const ERROR_STATE_OPEN_CONTAINER_FAILED: Self = Self(15804u32);
-                pub const ERROR_STATE_CREATE_CONTAINER_FAILED: Self = Self(15805u32);
-                pub const ERROR_STATE_DELETE_CONTAINER_FAILED: Self = Self(15806u32);
-                pub const ERROR_STATE_READ_SETTING_FAILED: Self = Self(15807u32);
-                pub const ERROR_STATE_WRITE_SETTING_FAILED: Self = Self(15808u32);
-                pub const ERROR_STATE_DELETE_SETTING_FAILED: Self = Self(15809u32);
-                pub const ERROR_STATE_QUERY_SETTING_FAILED: Self = Self(15810u32);
-                pub const ERROR_STATE_READ_COMPOSITE_SETTING_FAILED: Self = Self(15811u32);
-                pub const ERROR_STATE_WRITE_COMPOSITE_SETTING_FAILED: Self = Self(15812u32);
-                pub const ERROR_STATE_ENUMERATE_CONTAINER_FAILED: Self = Self(15813u32);
-                pub const ERROR_STATE_ENUMERATE_SETTINGS_FAILED: Self = Self(15814u32);
-                pub const ERROR_STATE_COMPOSITE_SETTING_VALUE_SIZE_LIMIT_EXCEEDED: Self =
-                    Self(15815u32);
-                pub const ERROR_STATE_SETTING_VALUE_SIZE_LIMIT_EXCEEDED: Self = Self(15816u32);
-                pub const ERROR_STATE_SETTING_NAME_SIZE_LIMIT_EXCEEDED: Self = Self(15817u32);
-                pub const ERROR_STATE_CONTAINER_NAME_SIZE_LIMIT_EXCEEDED: Self = Self(15818u32);
-                pub const ERROR_API_UNAVAILABLE: Self = Self(15841u32);
-                pub const ERROR_NDIS_INTERFACE_CLOSING: Self = Self(2150891522u32);
-                pub const ERROR_NDIS_BAD_VERSION: Self = Self(2150891524u32);
-                pub const ERROR_NDIS_BAD_CHARACTERISTICS: Self = Self(2150891525u32);
-                pub const ERROR_NDIS_ADAPTER_NOT_FOUND: Self = Self(2150891526u32);
-                pub const ERROR_NDIS_OPEN_FAILED: Self = Self(2150891527u32);
-                pub const ERROR_NDIS_DEVICE_FAILED: Self = Self(2150891528u32);
-                pub const ERROR_NDIS_MULTICAST_FULL: Self = Self(2150891529u32);
-                pub const ERROR_NDIS_MULTICAST_EXISTS: Self = Self(2150891530u32);
-                pub const ERROR_NDIS_MULTICAST_NOT_FOUND: Self = Self(2150891531u32);
-                pub const ERROR_NDIS_REQUEST_ABORTED: Self = Self(2150891532u32);
-                pub const ERROR_NDIS_RESET_IN_PROGRESS: Self = Self(2150891533u32);
-                pub const ERROR_NDIS_NOT_SUPPORTED: Self = Self(2150891707u32);
-                pub const ERROR_NDIS_INVALID_PACKET: Self = Self(2150891535u32);
-                pub const ERROR_NDIS_ADAPTER_NOT_READY: Self = Self(2150891537u32);
-                pub const ERROR_NDIS_INVALID_LENGTH: Self = Self(2150891540u32);
-                pub const ERROR_NDIS_INVALID_DATA: Self = Self(2150891541u32);
-                pub const ERROR_NDIS_BUFFER_TOO_SHORT: Self = Self(2150891542u32);
-                pub const ERROR_NDIS_INVALID_OID: Self = Self(2150891543u32);
-                pub const ERROR_NDIS_ADAPTER_REMOVED: Self = Self(2150891544u32);
-                pub const ERROR_NDIS_UNSUPPORTED_MEDIA: Self = Self(2150891545u32);
-                pub const ERROR_NDIS_GROUP_ADDRESS_IN_USE: Self = Self(2150891546u32);
-                pub const ERROR_NDIS_FILE_NOT_FOUND: Self = Self(2150891547u32);
-                pub const ERROR_NDIS_ERROR_READING_FILE: Self = Self(2150891548u32);
-                pub const ERROR_NDIS_ALREADY_MAPPED: Self = Self(2150891549u32);
-                pub const ERROR_NDIS_RESOURCE_CONFLICT: Self = Self(2150891550u32);
-                pub const ERROR_NDIS_MEDIA_DISCONNECTED: Self = Self(2150891551u32);
-                pub const ERROR_NDIS_INVALID_ADDRESS: Self = Self(2150891554u32);
-                pub const ERROR_NDIS_INVALID_DEVICE_REQUEST: Self = Self(2150891536u32);
-                pub const ERROR_NDIS_PAUSED: Self = Self(2150891562u32);
-                pub const ERROR_NDIS_INTERFACE_NOT_FOUND: Self = Self(2150891563u32);
-                pub const ERROR_NDIS_UNSUPPORTED_REVISION: Self = Self(2150891564u32);
-                pub const ERROR_NDIS_INVALID_PORT: Self = Self(2150891565u32);
-                pub const ERROR_NDIS_INVALID_PORT_STATE: Self = Self(2150891566u32);
-                pub const ERROR_NDIS_LOW_POWER_STATE: Self = Self(2150891567u32);
-                pub const ERROR_NDIS_REINIT_REQUIRED: Self = Self(2150891568u32);
-                pub const ERROR_NDIS_NO_QUEUES: Self = Self(2150891569u32);
-                pub const ERROR_NDIS_DOT11_AUTO_CONFIG_ENABLED: Self = Self(2150899712u32);
-                pub const ERROR_NDIS_DOT11_MEDIA_IN_USE: Self = Self(2150899713u32);
-                pub const ERROR_NDIS_DOT11_POWER_STATE_INVALID: Self = Self(2150899714u32);
-                pub const ERROR_NDIS_PM_WOL_PATTERN_LIST_FULL: Self = Self(2150899715u32);
-                pub const ERROR_NDIS_PM_PROTOCOL_OFFLOAD_LIST_FULL: Self = Self(2150899716u32);
-                pub const ERROR_NDIS_DOT11_AP_CHANNEL_CURRENTLY_NOT_AVAILABLE: Self =
-                    Self(2150899717u32);
-                pub const ERROR_NDIS_DOT11_AP_BAND_CURRENTLY_NOT_AVAILABLE: Self =
-                    Self(2150899718u32);
-                pub const ERROR_NDIS_DOT11_AP_CHANNEL_NOT_ALLOWED: Self = Self(2150899719u32);
-                pub const ERROR_NDIS_DOT11_AP_BAND_NOT_ALLOWED: Self = Self(2150899720u32);
-                pub const ERROR_NDIS_INDICATION_REQUIRED: Self = Self(3407873u32);
-                pub const ERROR_NDIS_OFFLOAD_POLICY: Self = Self(3224637455u32);
-                pub const ERROR_NDIS_OFFLOAD_CONNECTION_REJECTED: Self = Self(3224637458u32);
-                pub const ERROR_NDIS_OFFLOAD_PATH_REJECTED: Self = Self(3224637459u32);
-                pub const ERROR_HV_INVALID_HYPERCALL_CODE: Self = Self(3224698882u32);
-                pub const ERROR_HV_INVALID_HYPERCALL_INPUT: Self = Self(3224698883u32);
-                pub const ERROR_HV_INVALID_ALIGNMENT: Self = Self(3224698884u32);
-                pub const ERROR_HV_INVALID_PARAMETER: Self = Self(3224698885u32);
-                pub const ERROR_HV_ACCESS_DENIED: Self = Self(3224698886u32);
-                pub const ERROR_HV_INVALID_PARTITION_STATE: Self = Self(3224698887u32);
-                pub const ERROR_HV_OPERATION_DENIED: Self = Self(3224698888u32);
-                pub const ERROR_HV_UNKNOWN_PROPERTY: Self = Self(3224698889u32);
-                pub const ERROR_HV_PROPERTY_VALUE_OUT_OF_RANGE: Self = Self(3224698890u32);
-                pub const ERROR_HV_INSUFFICIENT_MEMORY: Self = Self(3224698891u32);
-                pub const ERROR_HV_PARTITION_TOO_DEEP: Self = Self(3224698892u32);
-                pub const ERROR_HV_INVALID_PARTITION_ID: Self = Self(3224698893u32);
-                pub const ERROR_HV_INVALID_VP_INDEX: Self = Self(3224698894u32);
-                pub const ERROR_HV_INVALID_PORT_ID: Self = Self(3224698897u32);
-                pub const ERROR_HV_INVALID_CONNECTION_ID: Self = Self(3224698898u32);
-                pub const ERROR_HV_INSUFFICIENT_BUFFERS: Self = Self(3224698899u32);
-                pub const ERROR_HV_NOT_ACKNOWLEDGED: Self = Self(3224698900u32);
-                pub const ERROR_HV_INVALID_VP_STATE: Self = Self(3224698901u32);
-                pub const ERROR_HV_ACKNOWLEDGED: Self = Self(3224698902u32);
-                pub const ERROR_HV_INVALID_SAVE_RESTORE_STATE: Self = Self(3224698903u32);
-                pub const ERROR_HV_INVALID_SYNIC_STATE: Self = Self(3224698904u32);
-                pub const ERROR_HV_OBJECT_IN_USE: Self = Self(3224698905u32);
-                pub const ERROR_HV_INVALID_PROXIMITY_DOMAIN_INFO: Self = Self(3224698906u32);
-                pub const ERROR_HV_NO_DATA: Self = Self(3224698907u32);
-                pub const ERROR_HV_INACTIVE: Self = Self(3224698908u32);
-                pub const ERROR_HV_NO_RESOURCES: Self = Self(3224698909u32);
-                pub const ERROR_HV_FEATURE_UNAVAILABLE: Self = Self(3224698910u32);
-                pub const ERROR_HV_INSUFFICIENT_BUFFER: Self = Self(3224698931u32);
-                pub const ERROR_HV_INSUFFICIENT_DEVICE_DOMAINS: Self = Self(3224698936u32);
-                pub const ERROR_HV_CPUID_FEATURE_VALIDATION: Self = Self(3224698940u32);
-                pub const ERROR_HV_CPUID_XSAVE_FEATURE_VALIDATION: Self = Self(3224698941u32);
-                pub const ERROR_HV_PROCESSOR_STARTUP_TIMEOUT: Self = Self(3224698942u32);
-                pub const ERROR_HV_SMX_ENABLED: Self = Self(3224698943u32);
-                pub const ERROR_HV_INVALID_LP_INDEX: Self = Self(3224698945u32);
-                pub const ERROR_HV_INVALID_REGISTER_VALUE: Self = Self(3224698960u32);
-                pub const ERROR_HV_INVALID_VTL_STATE: Self = Self(3224698961u32);
-                pub const ERROR_HV_NX_NOT_DETECTED: Self = Self(3224698965u32);
-                pub const ERROR_HV_INVALID_DEVICE_ID: Self = Self(3224698967u32);
-                pub const ERROR_HV_INVALID_DEVICE_STATE: Self = Self(3224698968u32);
-                pub const ERROR_HV_PENDING_PAGE_REQUESTS: Self = Self(3473497u32);
-                pub const ERROR_HV_PAGE_REQUEST_INVALID: Self = Self(3224698976u32);
-                pub const ERROR_HV_INVALID_CPU_GROUP_ID: Self = Self(3224698991u32);
-                pub const ERROR_HV_INVALID_CPU_GROUP_STATE: Self = Self(3224698992u32);
-                pub const ERROR_HV_OPERATION_FAILED: Self = Self(3224698993u32);
-                pub const ERROR_HV_NOT_ALLOWED_WITH_NESTED_VIRT_ACTIVE: Self = Self(3224698994u32);
-                pub const ERROR_HV_INSUFFICIENT_ROOT_MEMORY: Self = Self(3224698995u32);
-                pub const ERROR_HV_EVENT_BUFFER_ALREADY_FREED: Self = Self(3224698996u32);
-                pub const ERROR_HV_INSUFFICIENT_CONTIGUOUS_MEMORY: Self = Self(3224698997u32);
-                pub const ERROR_HV_NOT_PRESENT: Self = Self(3224702976u32);
-                pub const ERROR_VID_DUPLICATE_HANDLER: Self = Self(3224829953u32);
-                pub const ERROR_VID_TOO_MANY_HANDLERS: Self = Self(3224829954u32);
-                pub const ERROR_VID_QUEUE_FULL: Self = Self(3224829955u32);
-                pub const ERROR_VID_HANDLER_NOT_PRESENT: Self = Self(3224829956u32);
-                pub const ERROR_VID_INVALID_OBJECT_NAME: Self = Self(3224829957u32);
-                pub const ERROR_VID_PARTITION_NAME_TOO_LONG: Self = Self(3224829958u32);
-                pub const ERROR_VID_MESSAGE_QUEUE_NAME_TOO_LONG: Self = Self(3224829959u32);
-                pub const ERROR_VID_PARTITION_ALREADY_EXISTS: Self = Self(3224829960u32);
-                pub const ERROR_VID_PARTITION_DOES_NOT_EXIST: Self = Self(3224829961u32);
-                pub const ERROR_VID_PARTITION_NAME_NOT_FOUND: Self = Self(3224829962u32);
-                pub const ERROR_VID_MESSAGE_QUEUE_ALREADY_EXISTS: Self = Self(3224829963u32);
-                pub const ERROR_VID_EXCEEDED_MBP_ENTRY_MAP_LIMIT: Self = Self(3224829964u32);
-                pub const ERROR_VID_MB_STILL_REFERENCED: Self = Self(3224829965u32);
-                pub const ERROR_VID_CHILD_GPA_PAGE_SET_CORRUPTED: Self = Self(3224829966u32);
-                pub const ERROR_VID_INVALID_NUMA_SETTINGS: Self = Self(3224829967u32);
-                pub const ERROR_VID_INVALID_NUMA_NODE_INDEX: Self = Self(3224829968u32);
-                pub const ERROR_VID_NOTIFICATION_QUEUE_ALREADY_ASSOCIATED: Self =
-                    Self(3224829969u32);
-                pub const ERROR_VID_INVALID_MEMORY_BLOCK_HANDLE: Self = Self(3224829970u32);
-                pub const ERROR_VID_PAGE_RANGE_OVERFLOW: Self = Self(3224829971u32);
-                pub const ERROR_VID_INVALID_MESSAGE_QUEUE_HANDLE: Self = Self(3224829972u32);
-                pub const ERROR_VID_INVALID_GPA_RANGE_HANDLE: Self = Self(3224829973u32);
-                pub const ERROR_VID_NO_MEMORY_BLOCK_NOTIFICATION_QUEUE: Self = Self(3224829974u32);
-                pub const ERROR_VID_MEMORY_BLOCK_LOCK_COUNT_EXCEEDED: Self = Self(3224829975u32);
-                pub const ERROR_VID_INVALID_PPM_HANDLE: Self = Self(3224829976u32);
-                pub const ERROR_VID_MBPS_ARE_LOCKED: Self = Self(3224829977u32);
-                pub const ERROR_VID_MESSAGE_QUEUE_CLOSED: Self = Self(3224829978u32);
-                pub const ERROR_VID_VIRTUAL_PROCESSOR_LIMIT_EXCEEDED: Self = Self(3224829979u32);
-                pub const ERROR_VID_STOP_PENDING: Self = Self(3224829980u32);
-                pub const ERROR_VID_INVALID_PROCESSOR_STATE: Self = Self(3224829981u32);
-                pub const ERROR_VID_EXCEEDED_KM_CONTEXT_COUNT_LIMIT: Self = Self(3224829982u32);
-                pub const ERROR_VID_KM_INTERFACE_ALREADY_INITIALIZED: Self = Self(3224829983u32);
-                pub const ERROR_VID_MB_PROPERTY_ALREADY_SET_RESET: Self = Self(3224829984u32);
-                pub const ERROR_VID_MMIO_RANGE_DESTROYED: Self = Self(3224829985u32);
-                pub const ERROR_VID_INVALID_CHILD_GPA_PAGE_SET: Self = Self(3224829986u32);
-                pub const ERROR_VID_RESERVE_PAGE_SET_IS_BEING_USED: Self = Self(3224829987u32);
-                pub const ERROR_VID_RESERVE_PAGE_SET_TOO_SMALL: Self = Self(3224829988u32);
-                pub const ERROR_VID_MBP_ALREADY_LOCKED_USING_RESERVED_PAGE: Self =
-                    Self(3224829989u32);
-                pub const ERROR_VID_MBP_COUNT_EXCEEDED_LIMIT: Self = Self(3224829990u32);
-                pub const ERROR_VID_SAVED_STATE_CORRUPT: Self = Self(3224829991u32);
-                pub const ERROR_VID_SAVED_STATE_UNRECOGNIZED_ITEM: Self = Self(3224829992u32);
-                pub const ERROR_VID_SAVED_STATE_INCOMPATIBLE: Self = Self(3224829993u32);
-                pub const ERROR_VID_VTL_ACCESS_DENIED: Self = Self(3224829994u32);
-                pub const ERROR_VMCOMPUTE_TERMINATED_DURING_START: Self = Self(3224830208u32);
-                pub const ERROR_VMCOMPUTE_IMAGE_MISMATCH: Self = Self(3224830209u32);
-                pub const ERROR_VMCOMPUTE_HYPERV_NOT_INSTALLED: Self = Self(3224830210u32);
-                pub const ERROR_VMCOMPUTE_OPERATION_PENDING: Self = Self(3224830211u32);
-                pub const ERROR_VMCOMPUTE_TOO_MANY_NOTIFICATIONS: Self = Self(3224830212u32);
-                pub const ERROR_VMCOMPUTE_INVALID_STATE: Self = Self(3224830213u32);
-                pub const ERROR_VMCOMPUTE_UNEXPECTED_EXIT: Self = Self(3224830214u32);
-                pub const ERROR_VMCOMPUTE_TERMINATED: Self = Self(3224830215u32);
-                pub const ERROR_VMCOMPUTE_CONNECT_FAILED: Self = Self(3224830216u32);
-                pub const ERROR_VMCOMPUTE_TIMEOUT: Self = Self(3224830217u32);
-                pub const ERROR_VMCOMPUTE_CONNECTION_CLOSED: Self = Self(3224830218u32);
-                pub const ERROR_VMCOMPUTE_UNKNOWN_MESSAGE: Self = Self(3224830219u32);
-                pub const ERROR_VMCOMPUTE_UNSUPPORTED_PROTOCOL_VERSION: Self = Self(3224830220u32);
-                pub const ERROR_VMCOMPUTE_INVALID_JSON: Self = Self(3224830221u32);
-                pub const ERROR_VMCOMPUTE_SYSTEM_NOT_FOUND: Self = Self(3224830222u32);
-                pub const ERROR_VMCOMPUTE_SYSTEM_ALREADY_EXISTS: Self = Self(3224830223u32);
-                pub const ERROR_VMCOMPUTE_SYSTEM_ALREADY_STOPPED: Self = Self(3224830224u32);
-                pub const ERROR_VMCOMPUTE_PROTOCOL_ERROR: Self = Self(3224830225u32);
-                pub const ERROR_VMCOMPUTE_INVALID_LAYER: Self = Self(3224830226u32);
-                pub const ERROR_VMCOMPUTE_WINDOWS_INSIDER_REQUIRED: Self = Self(3224830227u32);
-                pub const ERROR_VNET_VIRTUAL_SWITCH_NAME_NOT_FOUND: Self = Self(3224830464u32);
-                pub const ERROR_VID_REMOTE_NODE_PARENT_GPA_PAGES_USED: Self = Self(2151088129u32);
-                pub const ERROR_VSMB_SAVED_STATE_FILE_NOT_FOUND: Self = Self(3224830976u32);
-                pub const ERROR_VSMB_SAVED_STATE_CORRUPT: Self = Self(3224830977u32);
-                pub const ERROR_VOLMGR_INCOMPLETE_REGENERATION: Self = Self(2151153665u32);
-                pub const ERROR_VOLMGR_INCOMPLETE_DISK_MIGRATION: Self = Self(2151153666u32);
-                pub const ERROR_VOLMGR_DATABASE_FULL: Self = Self(3224895489u32);
-                pub const ERROR_VOLMGR_DISK_CONFIGURATION_CORRUPTED: Self = Self(3224895490u32);
-                pub const ERROR_VOLMGR_DISK_CONFIGURATION_NOT_IN_SYNC: Self = Self(3224895491u32);
-                pub const ERROR_VOLMGR_PACK_CONFIG_UPDATE_FAILED: Self = Self(3224895492u32);
-                pub const ERROR_VOLMGR_DISK_CONTAINS_NON_SIMPLE_VOLUME: Self = Self(3224895493u32);
-                pub const ERROR_VOLMGR_DISK_DUPLICATE: Self = Self(3224895494u32);
-                pub const ERROR_VOLMGR_DISK_DYNAMIC: Self = Self(3224895495u32);
-                pub const ERROR_VOLMGR_DISK_ID_INVALID: Self = Self(3224895496u32);
-                pub const ERROR_VOLMGR_DISK_INVALID: Self = Self(3224895497u32);
-                pub const ERROR_VOLMGR_DISK_LAST_VOTER: Self = Self(3224895498u32);
-                pub const ERROR_VOLMGR_DISK_LAYOUT_INVALID: Self = Self(3224895499u32);
-                pub const ERROR_VOLMGR_DISK_LAYOUT_NON_BASIC_BETWEEN_BASIC_PARTITIONS: Self =
-                    Self(3224895500u32);
-                pub const ERROR_VOLMGR_DISK_LAYOUT_NOT_CYLINDER_ALIGNED: Self = Self(3224895501u32);
-                pub const ERROR_VOLMGR_DISK_LAYOUT_PARTITIONS_TOO_SMALL: Self = Self(3224895502u32);
-                pub const ERROR_VOLMGR_DISK_LAYOUT_PRIMARY_BETWEEN_LOGICAL_PARTITIONS: Self =
-                    Self(3224895503u32);
-                pub const ERROR_VOLMGR_DISK_LAYOUT_TOO_MANY_PARTITIONS: Self = Self(3224895504u32);
-                pub const ERROR_VOLMGR_DISK_MISSING: Self = Self(3224895505u32);
-                pub const ERROR_VOLMGR_DISK_NOT_EMPTY: Self = Self(3224895506u32);
-                pub const ERROR_VOLMGR_DISK_NOT_ENOUGH_SPACE: Self = Self(3224895507u32);
-                pub const ERROR_VOLMGR_DISK_REVECTORING_FAILED: Self = Self(3224895508u32);
-                pub const ERROR_VOLMGR_DISK_SECTOR_SIZE_INVALID: Self = Self(3224895509u32);
-                pub const ERROR_VOLMGR_DISK_SET_NOT_CONTAINED: Self = Self(3224895510u32);
-                pub const ERROR_VOLMGR_DISK_USED_BY_MULTIPLE_MEMBERS: Self = Self(3224895511u32);
-                pub const ERROR_VOLMGR_DISK_USED_BY_MULTIPLE_PLEXES: Self = Self(3224895512u32);
-                pub const ERROR_VOLMGR_DYNAMIC_DISK_NOT_SUPPORTED: Self = Self(3224895513u32);
-                pub const ERROR_VOLMGR_EXTENT_ALREADY_USED: Self = Self(3224895514u32);
-                pub const ERROR_VOLMGR_EXTENT_NOT_CONTIGUOUS: Self = Self(3224895515u32);
-                pub const ERROR_VOLMGR_EXTENT_NOT_IN_PUBLIC_REGION: Self = Self(3224895516u32);
-                pub const ERROR_VOLMGR_EXTENT_NOT_SECTOR_ALIGNED: Self = Self(3224895517u32);
-                pub const ERROR_VOLMGR_EXTENT_OVERLAPS_EBR_PARTITION: Self = Self(3224895518u32);
-                pub const ERROR_VOLMGR_EXTENT_VOLUME_LENGTHS_DO_NOT_MATCH: Self =
-                    Self(3224895519u32);
-                pub const ERROR_VOLMGR_FAULT_TOLERANT_NOT_SUPPORTED: Self = Self(3224895520u32);
-                pub const ERROR_VOLMGR_INTERLEAVE_LENGTH_INVALID: Self = Self(3224895521u32);
-                pub const ERROR_VOLMGR_MAXIMUM_REGISTERED_USERS: Self = Self(3224895522u32);
-                pub const ERROR_VOLMGR_MEMBER_IN_SYNC: Self = Self(3224895523u32);
-                pub const ERROR_VOLMGR_MEMBER_INDEX_DUPLICATE: Self = Self(3224895524u32);
-                pub const ERROR_VOLMGR_MEMBER_INDEX_INVALID: Self = Self(3224895525u32);
-                pub const ERROR_VOLMGR_MEMBER_MISSING: Self = Self(3224895526u32);
-                pub const ERROR_VOLMGR_MEMBER_NOT_DETACHED: Self = Self(3224895527u32);
-                pub const ERROR_VOLMGR_MEMBER_REGENERATING: Self = Self(3224895528u32);
-                pub const ERROR_VOLMGR_ALL_DISKS_FAILED: Self = Self(3224895529u32);
-                pub const ERROR_VOLMGR_NO_REGISTERED_USERS: Self = Self(3224895530u32);
-                pub const ERROR_VOLMGR_NO_SUCH_USER: Self = Self(3224895531u32);
-                pub const ERROR_VOLMGR_NOTIFICATION_RESET: Self = Self(3224895532u32);
-                pub const ERROR_VOLMGR_NUMBER_OF_MEMBERS_INVALID: Self = Self(3224895533u32);
-                pub const ERROR_VOLMGR_NUMBER_OF_PLEXES_INVALID: Self = Self(3224895534u32);
-                pub const ERROR_VOLMGR_PACK_DUPLICATE: Self = Self(3224895535u32);
-                pub const ERROR_VOLMGR_PACK_ID_INVALID: Self = Self(3224895536u32);
-                pub const ERROR_VOLMGR_PACK_INVALID: Self = Self(3224895537u32);
-                pub const ERROR_VOLMGR_PACK_NAME_INVALID: Self = Self(3224895538u32);
-                pub const ERROR_VOLMGR_PACK_OFFLINE: Self = Self(3224895539u32);
-                pub const ERROR_VOLMGR_PACK_HAS_QUORUM: Self = Self(3224895540u32);
-                pub const ERROR_VOLMGR_PACK_WITHOUT_QUORUM: Self = Self(3224895541u32);
-                pub const ERROR_VOLMGR_PARTITION_STYLE_INVALID: Self = Self(3224895542u32);
-                pub const ERROR_VOLMGR_PARTITION_UPDATE_FAILED: Self = Self(3224895543u32);
-                pub const ERROR_VOLMGR_PLEX_IN_SYNC: Self = Self(3224895544u32);
-                pub const ERROR_VOLMGR_PLEX_INDEX_DUPLICATE: Self = Self(3224895545u32);
-                pub const ERROR_VOLMGR_PLEX_INDEX_INVALID: Self = Self(3224895546u32);
-                pub const ERROR_VOLMGR_PLEX_LAST_ACTIVE: Self = Self(3224895547u32);
-                pub const ERROR_VOLMGR_PLEX_MISSING: Self = Self(3224895548u32);
-                pub const ERROR_VOLMGR_PLEX_REGENERATING: Self = Self(3224895549u32);
-                pub const ERROR_VOLMGR_PLEX_TYPE_INVALID: Self = Self(3224895550u32);
-                pub const ERROR_VOLMGR_PLEX_NOT_RAID5: Self = Self(3224895551u32);
-                pub const ERROR_VOLMGR_PLEX_NOT_SIMPLE: Self = Self(3224895552u32);
-                pub const ERROR_VOLMGR_STRUCTURE_SIZE_INVALID: Self = Self(3224895553u32);
-                pub const ERROR_VOLMGR_TOO_MANY_NOTIFICATION_REQUESTS: Self = Self(3224895554u32);
-                pub const ERROR_VOLMGR_TRANSACTION_IN_PROGRESS: Self = Self(3224895555u32);
-                pub const ERROR_VOLMGR_UNEXPECTED_DISK_LAYOUT_CHANGE: Self = Self(3224895556u32);
-                pub const ERROR_VOLMGR_VOLUME_CONTAINS_MISSING_DISK: Self = Self(3224895557u32);
-                pub const ERROR_VOLMGR_VOLUME_ID_INVALID: Self = Self(3224895558u32);
-                pub const ERROR_VOLMGR_VOLUME_LENGTH_INVALID: Self = Self(3224895559u32);
-                pub const ERROR_VOLMGR_VOLUME_LENGTH_NOT_SECTOR_SIZE_MULTIPLE: Self =
-                    Self(3224895560u32);
-                pub const ERROR_VOLMGR_VOLUME_NOT_MIRRORED: Self = Self(3224895561u32);
-                pub const ERROR_VOLMGR_VOLUME_NOT_RETAINED: Self = Self(3224895562u32);
-                pub const ERROR_VOLMGR_VOLUME_OFFLINE: Self = Self(3224895563u32);
-                pub const ERROR_VOLMGR_VOLUME_RETAINED: Self = Self(3224895564u32);
-                pub const ERROR_VOLMGR_NUMBER_OF_EXTENTS_INVALID: Self = Self(3224895565u32);
-                pub const ERROR_VOLMGR_DIFFERENT_SECTOR_SIZE: Self = Self(3224895566u32);
-                pub const ERROR_VOLMGR_BAD_BOOT_DISK: Self = Self(3224895567u32);
-                pub const ERROR_VOLMGR_PACK_CONFIG_OFFLINE: Self = Self(3224895568u32);
-                pub const ERROR_VOLMGR_PACK_CONFIG_ONLINE: Self = Self(3224895569u32);
-                pub const ERROR_VOLMGR_NOT_PRIMARY_PACK: Self = Self(3224895570u32);
-                pub const ERROR_VOLMGR_PACK_LOG_UPDATE_FAILED: Self = Self(3224895571u32);
-                pub const ERROR_VOLMGR_NUMBER_OF_DISKS_IN_PLEX_INVALID: Self = Self(3224895572u32);
-                pub const ERROR_VOLMGR_NUMBER_OF_DISKS_IN_MEMBER_INVALID: Self =
-                    Self(3224895573u32);
-                pub const ERROR_VOLMGR_VOLUME_MIRRORED: Self = Self(3224895574u32);
-                pub const ERROR_VOLMGR_PLEX_NOT_SIMPLE_SPANNED: Self = Self(3224895575u32);
-                pub const ERROR_VOLMGR_NO_VALID_LOG_COPIES: Self = Self(3224895576u32);
-                pub const ERROR_VOLMGR_PRIMARY_PACK_PRESENT: Self = Self(3224895577u32);
-                pub const ERROR_VOLMGR_NUMBER_OF_DISKS_INVALID: Self = Self(3224895578u32);
-                pub const ERROR_VOLMGR_MIRROR_NOT_SUPPORTED: Self = Self(3224895579u32);
-                pub const ERROR_VOLMGR_RAID5_NOT_SUPPORTED: Self = Self(3224895580u32);
-                pub const ERROR_BCD_NOT_ALL_ENTRIES_IMPORTED: Self = Self(2151219201u32);
-                pub const ERROR_BCD_TOO_MANY_ELEMENTS: Self = Self(3224961026u32);
-                pub const ERROR_BCD_NOT_ALL_ENTRIES_SYNCHRONIZED: Self = Self(2151219203u32);
-                pub const ERROR_VHD_DRIVE_FOOTER_MISSING: Self = Self(3225026561u32);
-                pub const ERROR_VHD_DRIVE_FOOTER_CHECKSUM_MISMATCH: Self = Self(3225026562u32);
-                pub const ERROR_VHD_DRIVE_FOOTER_CORRUPT: Self = Self(3225026563u32);
-                pub const ERROR_VHD_FORMAT_UNKNOWN: Self = Self(3225026564u32);
-                pub const ERROR_VHD_FORMAT_UNSUPPORTED_VERSION: Self = Self(3225026565u32);
-                pub const ERROR_VHD_SPARSE_HEADER_CHECKSUM_MISMATCH: Self = Self(3225026566u32);
-                pub const ERROR_VHD_SPARSE_HEADER_UNSUPPORTED_VERSION: Self = Self(3225026567u32);
-                pub const ERROR_VHD_SPARSE_HEADER_CORRUPT: Self = Self(3225026568u32);
-                pub const ERROR_VHD_BLOCK_ALLOCATION_FAILURE: Self = Self(3225026569u32);
-                pub const ERROR_VHD_BLOCK_ALLOCATION_TABLE_CORRUPT: Self = Self(3225026570u32);
-                pub const ERROR_VHD_INVALID_BLOCK_SIZE: Self = Self(3225026571u32);
-                pub const ERROR_VHD_BITMAP_MISMATCH: Self = Self(3225026572u32);
-                pub const ERROR_VHD_PARENT_VHD_NOT_FOUND: Self = Self(3225026573u32);
-                pub const ERROR_VHD_CHILD_PARENT_ID_MISMATCH: Self = Self(3225026574u32);
-                pub const ERROR_VHD_CHILD_PARENT_TIMESTAMP_MISMATCH: Self = Self(3225026575u32);
-                pub const ERROR_VHD_METADATA_READ_FAILURE: Self = Self(3225026576u32);
-                pub const ERROR_VHD_METADATA_WRITE_FAILURE: Self = Self(3225026577u32);
-                pub const ERROR_VHD_INVALID_SIZE: Self = Self(3225026578u32);
-                pub const ERROR_VHD_INVALID_FILE_SIZE: Self = Self(3225026579u32);
-                pub const ERROR_VIRTDISK_PROVIDER_NOT_FOUND: Self = Self(3225026580u32);
-                pub const ERROR_VIRTDISK_NOT_VIRTUAL_DISK: Self = Self(3225026581u32);
-                pub const ERROR_VHD_PARENT_VHD_ACCESS_DENIED: Self = Self(3225026582u32);
-                pub const ERROR_VHD_CHILD_PARENT_SIZE_MISMATCH: Self = Self(3225026583u32);
-                pub const ERROR_VHD_DIFFERENCING_CHAIN_CYCLE_DETECTED: Self = Self(3225026584u32);
-                pub const ERROR_VHD_DIFFERENCING_CHAIN_ERROR_IN_PARENT: Self = Self(3225026585u32);
-                pub const ERROR_VIRTUAL_DISK_LIMITATION: Self = Self(3225026586u32);
-                pub const ERROR_VHD_INVALID_TYPE: Self = Self(3225026587u32);
-                pub const ERROR_VHD_INVALID_STATE: Self = Self(3225026588u32);
-                pub const ERROR_VIRTDISK_UNSUPPORTED_DISK_SECTOR_SIZE: Self = Self(3225026589u32);
-                pub const ERROR_VIRTDISK_DISK_ALREADY_OWNED: Self = Self(3225026590u32);
-                pub const ERROR_VIRTDISK_DISK_ONLINE_AND_WRITABLE: Self = Self(3225026591u32);
-                pub const ERROR_CTLOG_TRACKING_NOT_INITIALIZED: Self = Self(3225026592u32);
-                pub const ERROR_CTLOG_LOGFILE_SIZE_EXCEEDED_MAXSIZE: Self = Self(3225026593u32);
-                pub const ERROR_CTLOG_VHD_CHANGED_OFFLINE: Self = Self(3225026594u32);
-                pub const ERROR_CTLOG_INVALID_TRACKING_STATE: Self = Self(3225026595u32);
-                pub const ERROR_CTLOG_INCONSISTENT_TRACKING_FILE: Self = Self(3225026596u32);
-                pub const ERROR_VHD_RESIZE_WOULD_TRUNCATE_DATA: Self = Self(3225026597u32);
-                pub const ERROR_VHD_COULD_NOT_COMPUTE_MINIMUM_VIRTUAL_SIZE: Self =
-                    Self(3225026598u32);
-                pub const ERROR_VHD_ALREADY_AT_OR_BELOW_MINIMUM_VIRTUAL_SIZE: Self =
-                    Self(3225026599u32);
-                pub const ERROR_VHD_METADATA_FULL: Self = Self(3225026600u32);
-                pub const ERROR_VHD_INVALID_CHANGE_TRACKING_ID: Self = Self(3225026601u32);
-                pub const ERROR_VHD_CHANGE_TRACKING_DISABLED: Self = Self(3225026602u32);
-                pub const ERROR_VHD_MISSING_CHANGE_TRACKING_INFORMATION: Self = Self(3225026608u32);
-                pub const ERROR_QUERY_STORAGE_ERROR: Self = Self(2151284737u32);
-            }
-            impl ::std::convert::From<u32> for WIN32_ERROR {
-                fn from(value: u32) -> Self {
-                    Self(value)
-                }
-            }
-            unsafe impl ::windows::Abi for WIN32_ERROR {
-                type Abi = Self;
-            }
-            impl ::std::ops::BitOr for WIN32_ERROR {
-                type Output = Self;
-                fn bitor(self, rhs: Self) -> Self {
-                    Self(self.0 | rhs.0)
-                }
-            }
-            impl ::std::ops::BitAnd for WIN32_ERROR {
-                type Output = Self;
-                fn bitand(self, rhs: Self) -> Self {
-                    Self(self.0 & rhs.0)
-                }
-            }
-            impl ::std::ops::BitOrAssign for WIN32_ERROR {
-                fn bitor_assign(&mut self, rhs: Self) {
-                    self.0.bitor_assign(rhs.0)
-                }
-            }
-            impl ::std::ops::BitAndAssign for WIN32_ERROR {
-                fn bitand_assign(&mut self, rhs: Self) {
-                    self.0.bitand_assign(rhs.0)
-                }
-            }
-            pub unsafe fn GetLastError() -> WIN32_ERROR {
-                #[link(name = "KERNEL32")]
-                extern "system" {
-                    pub fn GetLastError() -> WIN32_ERROR;
-                }
-                GetLastError()
-            }
-        }
-        #[allow(
-            unused_variables,
-            non_upper_case_globals,
-            non_snake_case,
-            unused_unsafe,
-            non_camel_case_types,
-            dead_code,
-            clippy::all
-        )]
-        pub mod SystemServices {
-            #[repr(transparent)]
-            #[derive(
-                :: std :: clone :: Clone,
-                :: std :: marker :: Copy,
-                :: std :: cmp :: Eq,
-                :: std :: fmt :: Debug,
-            )]
-            pub struct PWSTR(pub *mut u16);
-            impl PWSTR {
-                pub const NULL: Self = Self(::std::ptr::null_mut());
-                pub fn is_null(&self) -> bool {
-                    self.0.is_null()
-                }
-            }
-            impl ::std::default::Default for PWSTR {
-                fn default() -> Self {
-                    Self(::std::ptr::null_mut())
-                }
-            }
-            impl ::std::cmp::PartialEq for PWSTR {
-                fn eq(&self, other: &Self) -> bool {
-                    self.0 == other.0
-                }
-            }
-            unsafe impl ::windows::Abi for PWSTR {
-                type Abi = Self;
-                fn drop_param(param: &mut ::windows::Param<Self>) {
-                    if let ::windows::Param::Boxed(value) = param {
-                        if !value.0.is_null() {
-                            unsafe {
-                                ::std::boxed::Box::from_raw(value.0);
-                            }
+                    ) -> u32 {
+                        #[link(name = "KERNEL32")]
+                        extern "system" {
+                            pub fn FormatMessageW(
+                                dwflags: FORMAT_MESSAGE_OPTIONS,
+                                lpsource: *const ::std::ffi::c_void,
+                                dwmessageid: u32,
+                                dwlanguageid: u32,
+                                lpbuffer: super::super::SystemServices::PWSTR,
+                                nsize: u32,
+                                arguments: *mut *mut i8,
+                            ) -> u32;
                         }
-                    }
-                }
-            }
-            impl<'a> ::windows::IntoParam<'a, PWSTR> for &'a str {
-                fn into_param(self) -> ::windows::Param<'a, PWSTR> {
-                    ::windows::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(
-                        self.encode_utf16()
-                            .chain(::std::iter::once(0))
-                            .collect::<std::vec::Vec<u16>>()
-                            .into_boxed_slice(),
-                    ) as _))
-                }
-            }
-            impl<'a> ::windows::IntoParam<'a, PWSTR> for String {
-                fn into_param(self) -> ::windows::Param<'a, PWSTR> {
-                    ::windows::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(
-                        self.encode_utf16()
-                            .chain(::std::iter::once(0))
-                            .collect::<std::vec::Vec<u16>>()
-                            .into_boxed_slice(),
-                    ) as _))
-                }
-            }
-            pub const CO_E_NOTINITIALIZED: ::windows::HRESULT =
-                ::windows::HRESULT(-2147221008i32 as _);
-            #[repr(transparent)]
-            #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
-            pub struct HANDLE(pub isize);
-            impl HANDLE {}
-            impl ::std::default::Default for HANDLE {
-                fn default() -> Self {
-                    Self(0)
-                }
-            }
-            impl HANDLE {
-                pub const NULL: Self = Self(0);
-                pub fn is_null(&self) -> bool {
-                    self.0 == 0
-                }
-            }
-            impl ::std::fmt::Debug for HANDLE {
-                fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                    fmt.debug_struct("HANDLE")
-                        .field("Value", &format_args!("{:?}", self.0))
-                        .finish()
-                }
-            }
-            impl ::std::cmp::PartialEq for HANDLE {
-                fn eq(&self, other: &Self) -> bool {
-                    self.0 == other.0
-                }
-            }
-            impl ::std::cmp::Eq for HANDLE {}
-            unsafe impl ::windows::Abi for HANDLE {
-                type Abi = Self;
-            }
-            impl HANDLE {
-                pub const INVALID: Self = Self(-1);
-                pub fn is_invalid(&self) -> bool {
-                    self.0 == -1
-                }
-            }
-            #[repr(transparent)]
-            #[derive(
-                :: std :: default :: Default,
-                :: std :: clone :: Clone,
-                :: std :: marker :: Copy,
-                :: std :: cmp :: PartialEq,
-                :: std :: cmp :: Eq,
-                :: std :: fmt :: Debug,
-            )]
-            pub struct BOOL(pub i32);
-            unsafe impl ::windows::Abi for BOOL {
-                type Abi = Self;
-            }
-            impl BOOL {
-                #[inline]
-                pub fn as_bool(self) -> bool {
-                    !(self.0 == 0)
-                }
-                #[inline]
-                pub fn ok(self) -> ::windows::Result<()> {
-                    if self.as_bool() {
-                        Ok(())
-                    } else {
-                        Err(::windows::HRESULT::from_thread().into())
-                    }
-                }
-                #[inline]
-                pub fn unwrap(self) {
-                    self.ok().unwrap();
-                }
-                #[inline]
-                pub fn expect(self, msg: &str) {
-                    self.ok().expect(msg);
-                }
-            }
-            impl ::std::convert::From<BOOL> for bool {
-                fn from(value: BOOL) -> Self {
-                    value.as_bool()
-                }
-            }
-            impl ::std::convert::From<&BOOL> for bool {
-                fn from(value: &BOOL) -> Self {
-                    value.as_bool()
-                }
-            }
-            impl ::std::convert::From<bool> for BOOL {
-                fn from(value: bool) -> Self {
-                    if value {
-                        BOOL(1)
-                    } else {
-                        BOOL(0)
-                    }
-                }
-            }
-            impl ::std::convert::From<&bool> for BOOL {
-                fn from(value: &bool) -> Self {
-                    (*value).into()
-                }
-            }
-            impl ::std::cmp::PartialEq<bool> for BOOL {
-                fn eq(&self, other: &bool) -> bool {
-                    self.as_bool() == *other
-                }
-            }
-            impl ::std::cmp::PartialEq<BOOL> for bool {
-                fn eq(&self, other: &BOOL) -> bool {
-                    *self == other.as_bool()
-                }
-            }
-            impl std::ops::Not for BOOL {
-                type Output = Self;
-                fn not(self) -> Self::Output {
-                    if self.as_bool() {
-                        BOOL(0)
-                    } else {
-                        BOOL(1)
-                    }
-                }
-            }
-            impl<'a> ::windows::IntoParam<'a, BOOL> for bool {
-                fn into_param(self) -> ::windows::Param<'a, BOOL> {
-                    ::windows::Param::Owned(self.into())
-                }
-            }
-            #[repr(C)]
-            #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
-            pub struct SECURITY_ATTRIBUTES {
-                pub nLength: u32,
-                pub lpSecurityDescriptor: *mut ::std::ffi::c_void,
-                pub bInheritHandle: BOOL,
-            }
-            impl SECURITY_ATTRIBUTES {}
-            impl ::std::default::Default for SECURITY_ATTRIBUTES {
-                fn default() -> Self {
-                    Self {
-                        nLength: 0,
-                        lpSecurityDescriptor: ::std::ptr::null_mut(),
-                        bInheritHandle: ::std::default::Default::default(),
-                    }
-                }
-            }
-            impl ::std::fmt::Debug for SECURITY_ATTRIBUTES {
-                fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                    fmt.debug_struct("SECURITY_ATTRIBUTES")
-                        .field("nLength", &format_args!("{:?}", self.nLength))
-                        .field(
-                            "lpSecurityDescriptor",
-                            &format_args!("{:?}", self.lpSecurityDescriptor),
+                        FormatMessageW(
+                            ::std::mem::transmute(dwflags),
+                            ::std::mem::transmute(lpsource),
+                            ::std::mem::transmute(dwmessageid),
+                            ::std::mem::transmute(dwlanguageid),
+                            ::std::mem::transmute(lpbuffer),
+                            ::std::mem::transmute(nsize),
+                            ::std::mem::transmute(arguments),
                         )
-                        .field("bInheritHandle", &format_args!("{:?}", self.bInheritHandle))
-                        .finish()
+                    }
+                    #[derive(
+                        :: std :: cmp :: PartialEq,
+                        :: std :: cmp :: Eq,
+                        :: std :: marker :: Copy,
+                        :: std :: clone :: Clone,
+                        :: std :: default :: Default,
+                        :: std :: fmt :: Debug,
+                    )]
+                    #[repr(transparent)]
+                    pub struct WIN32_ERROR(pub u32);
+                    impl WIN32_ERROR {
+                        pub const NO_ERROR: Self = Self(0u32);
+                        pub const ERROR_SUCCESS: Self = Self(0u32);
+                        pub const ERROR_INVALID_FUNCTION: Self = Self(1u32);
+                        pub const ERROR_FILE_NOT_FOUND: Self = Self(2u32);
+                        pub const ERROR_PATH_NOT_FOUND: Self = Self(3u32);
+                        pub const ERROR_TOO_MANY_OPEN_FILES: Self = Self(4u32);
+                        pub const ERROR_ACCESS_DENIED: Self = Self(5u32);
+                        pub const ERROR_INVALID_HANDLE: Self = Self(6u32);
+                        pub const ERROR_ARENA_TRASHED: Self = Self(7u32);
+                        pub const ERROR_NOT_ENOUGH_MEMORY: Self = Self(8u32);
+                        pub const ERROR_INVALID_BLOCK: Self = Self(9u32);
+                        pub const ERROR_BAD_ENVIRONMENT: Self = Self(10u32);
+                        pub const ERROR_BAD_FORMAT: Self = Self(11u32);
+                        pub const ERROR_INVALID_ACCESS: Self = Self(12u32);
+                        pub const ERROR_INVALID_DATA: Self = Self(13u32);
+                        pub const ERROR_OUTOFMEMORY: Self = Self(14u32);
+                        pub const ERROR_INVALID_DRIVE: Self = Self(15u32);
+                        pub const ERROR_CURRENT_DIRECTORY: Self = Self(16u32);
+                        pub const ERROR_NOT_SAME_DEVICE: Self = Self(17u32);
+                        pub const ERROR_NO_MORE_FILES: Self = Self(18u32);
+                        pub const ERROR_WRITE_PROTECT: Self = Self(19u32);
+                        pub const ERROR_BAD_UNIT: Self = Self(20u32);
+                        pub const ERROR_NOT_READY: Self = Self(21u32);
+                        pub const ERROR_BAD_COMMAND: Self = Self(22u32);
+                        pub const ERROR_CRC: Self = Self(23u32);
+                        pub const ERROR_BAD_LENGTH: Self = Self(24u32);
+                        pub const ERROR_SEEK: Self = Self(25u32);
+                        pub const ERROR_NOT_DOS_DISK: Self = Self(26u32);
+                        pub const ERROR_SECTOR_NOT_FOUND: Self = Self(27u32);
+                        pub const ERROR_OUT_OF_PAPER: Self = Self(28u32);
+                        pub const ERROR_WRITE_FAULT: Self = Self(29u32);
+                        pub const ERROR_READ_FAULT: Self = Self(30u32);
+                        pub const ERROR_GEN_FAILURE: Self = Self(31u32);
+                        pub const ERROR_SHARING_VIOLATION: Self = Self(32u32);
+                        pub const ERROR_LOCK_VIOLATION: Self = Self(33u32);
+                        pub const ERROR_WRONG_DISK: Self = Self(34u32);
+                        pub const ERROR_SHARING_BUFFER_EXCEEDED: Self = Self(36u32);
+                        pub const ERROR_HANDLE_EOF: Self = Self(38u32);
+                        pub const ERROR_HANDLE_DISK_FULL: Self = Self(39u32);
+                        pub const ERROR_NOT_SUPPORTED: Self = Self(50u32);
+                        pub const ERROR_REM_NOT_LIST: Self = Self(51u32);
+                        pub const ERROR_DUP_NAME: Self = Self(52u32);
+                        pub const ERROR_BAD_NETPATH: Self = Self(53u32);
+                        pub const ERROR_NETWORK_BUSY: Self = Self(54u32);
+                        pub const ERROR_DEV_NOT_EXIST: Self = Self(55u32);
+                        pub const ERROR_TOO_MANY_CMDS: Self = Self(56u32);
+                        pub const ERROR_ADAP_HDW_ERR: Self = Self(57u32);
+                        pub const ERROR_BAD_NET_RESP: Self = Self(58u32);
+                        pub const ERROR_UNEXP_NET_ERR: Self = Self(59u32);
+                        pub const ERROR_BAD_REM_ADAP: Self = Self(60u32);
+                        pub const ERROR_PRINTQ_FULL: Self = Self(61u32);
+                        pub const ERROR_NO_SPOOL_SPACE: Self = Self(62u32);
+                        pub const ERROR_PRINT_CANCELLED: Self = Self(63u32);
+                        pub const ERROR_NETNAME_DELETED: Self = Self(64u32);
+                        pub const ERROR_NETWORK_ACCESS_DENIED: Self = Self(65u32);
+                        pub const ERROR_BAD_DEV_TYPE: Self = Self(66u32);
+                        pub const ERROR_BAD_NET_NAME: Self = Self(67u32);
+                        pub const ERROR_TOO_MANY_NAMES: Self = Self(68u32);
+                        pub const ERROR_TOO_MANY_SESS: Self = Self(69u32);
+                        pub const ERROR_SHARING_PAUSED: Self = Self(70u32);
+                        pub const ERROR_REQ_NOT_ACCEP: Self = Self(71u32);
+                        pub const ERROR_REDIR_PAUSED: Self = Self(72u32);
+                        pub const ERROR_FILE_EXISTS: Self = Self(80u32);
+                        pub const ERROR_CANNOT_MAKE: Self = Self(82u32);
+                        pub const ERROR_FAIL_I24: Self = Self(83u32);
+                        pub const ERROR_OUT_OF_STRUCTURES: Self = Self(84u32);
+                        pub const ERROR_ALREADY_ASSIGNED: Self = Self(85u32);
+                        pub const ERROR_INVALID_PASSWORD: Self = Self(86u32);
+                        pub const ERROR_INVALID_PARAMETER: Self = Self(87u32);
+                        pub const ERROR_NET_WRITE_FAULT: Self = Self(88u32);
+                        pub const ERROR_NO_PROC_SLOTS: Self = Self(89u32);
+                        pub const ERROR_TOO_MANY_SEMAPHORES: Self = Self(100u32);
+                        pub const ERROR_EXCL_SEM_ALREADY_OWNED: Self = Self(101u32);
+                        pub const ERROR_SEM_IS_SET: Self = Self(102u32);
+                        pub const ERROR_TOO_MANY_SEM_REQUESTS: Self = Self(103u32);
+                        pub const ERROR_INVALID_AT_INTERRUPT_TIME: Self = Self(104u32);
+                        pub const ERROR_SEM_OWNER_DIED: Self = Self(105u32);
+                        pub const ERROR_SEM_USER_LIMIT: Self = Self(106u32);
+                        pub const ERROR_DISK_CHANGE: Self = Self(107u32);
+                        pub const ERROR_DRIVE_LOCKED: Self = Self(108u32);
+                        pub const ERROR_BROKEN_PIPE: Self = Self(109u32);
+                        pub const ERROR_OPEN_FAILED: Self = Self(110u32);
+                        pub const ERROR_BUFFER_OVERFLOW: Self = Self(111u32);
+                        pub const ERROR_DISK_FULL: Self = Self(112u32);
+                        pub const ERROR_NO_MORE_SEARCH_HANDLES: Self = Self(113u32);
+                        pub const ERROR_INVALID_TARGET_HANDLE: Self = Self(114u32);
+                        pub const ERROR_INVALID_CATEGORY: Self = Self(117u32);
+                        pub const ERROR_INVALID_VERIFY_SWITCH: Self = Self(118u32);
+                        pub const ERROR_BAD_DRIVER_LEVEL: Self = Self(119u32);
+                        pub const ERROR_CALL_NOT_IMPLEMENTED: Self = Self(120u32);
+                        pub const ERROR_SEM_TIMEOUT: Self = Self(121u32);
+                        pub const ERROR_INSUFFICIENT_BUFFER: Self = Self(122u32);
+                        pub const ERROR_INVALID_NAME: Self = Self(123u32);
+                        pub const ERROR_INVALID_LEVEL: Self = Self(124u32);
+                        pub const ERROR_NO_VOLUME_LABEL: Self = Self(125u32);
+                        pub const ERROR_MOD_NOT_FOUND: Self = Self(126u32);
+                        pub const ERROR_PROC_NOT_FOUND: Self = Self(127u32);
+                        pub const ERROR_WAIT_NO_CHILDREN: Self = Self(128u32);
+                        pub const ERROR_CHILD_NOT_COMPLETE: Self = Self(129u32);
+                        pub const ERROR_DIRECT_ACCESS_HANDLE: Self = Self(130u32);
+                        pub const ERROR_NEGATIVE_SEEK: Self = Self(131u32);
+                        pub const ERROR_SEEK_ON_DEVICE: Self = Self(132u32);
+                        pub const ERROR_IS_JOIN_TARGET: Self = Self(133u32);
+                        pub const ERROR_IS_JOINED: Self = Self(134u32);
+                        pub const ERROR_IS_SUBSTED: Self = Self(135u32);
+                        pub const ERROR_NOT_JOINED: Self = Self(136u32);
+                        pub const ERROR_NOT_SUBSTED: Self = Self(137u32);
+                        pub const ERROR_JOIN_TO_JOIN: Self = Self(138u32);
+                        pub const ERROR_SUBST_TO_SUBST: Self = Self(139u32);
+                        pub const ERROR_JOIN_TO_SUBST: Self = Self(140u32);
+                        pub const ERROR_SUBST_TO_JOIN: Self = Self(141u32);
+                        pub const ERROR_BUSY_DRIVE: Self = Self(142u32);
+                        pub const ERROR_SAME_DRIVE: Self = Self(143u32);
+                        pub const ERROR_DIR_NOT_ROOT: Self = Self(144u32);
+                        pub const ERROR_DIR_NOT_EMPTY: Self = Self(145u32);
+                        pub const ERROR_IS_SUBST_PATH: Self = Self(146u32);
+                        pub const ERROR_IS_JOIN_PATH: Self = Self(147u32);
+                        pub const ERROR_PATH_BUSY: Self = Self(148u32);
+                        pub const ERROR_IS_SUBST_TARGET: Self = Self(149u32);
+                        pub const ERROR_SYSTEM_TRACE: Self = Self(150u32);
+                        pub const ERROR_INVALID_EVENT_COUNT: Self = Self(151u32);
+                        pub const ERROR_TOO_MANY_MUXWAITERS: Self = Self(152u32);
+                        pub const ERROR_INVALID_LIST_FORMAT: Self = Self(153u32);
+                        pub const ERROR_LABEL_TOO_LONG: Self = Self(154u32);
+                        pub const ERROR_TOO_MANY_TCBS: Self = Self(155u32);
+                        pub const ERROR_SIGNAL_REFUSED: Self = Self(156u32);
+                        pub const ERROR_DISCARDED: Self = Self(157u32);
+                        pub const ERROR_NOT_LOCKED: Self = Self(158u32);
+                        pub const ERROR_BAD_THREADID_ADDR: Self = Self(159u32);
+                        pub const ERROR_BAD_ARGUMENTS: Self = Self(160u32);
+                        pub const ERROR_BAD_PATHNAME: Self = Self(161u32);
+                        pub const ERROR_SIGNAL_PENDING: Self = Self(162u32);
+                        pub const ERROR_MAX_THRDS_REACHED: Self = Self(164u32);
+                        pub const ERROR_LOCK_FAILED: Self = Self(167u32);
+                        pub const ERROR_BUSY: Self = Self(170u32);
+                        pub const ERROR_DEVICE_SUPPORT_IN_PROGRESS: Self = Self(171u32);
+                        pub const ERROR_CANCEL_VIOLATION: Self = Self(173u32);
+                        pub const ERROR_ATOMIC_LOCKS_NOT_SUPPORTED: Self = Self(174u32);
+                        pub const ERROR_INVALID_SEGMENT_NUMBER: Self = Self(180u32);
+                        pub const ERROR_INVALID_ORDINAL: Self = Self(182u32);
+                        pub const ERROR_ALREADY_EXISTS: Self = Self(183u32);
+                        pub const ERROR_INVALID_FLAG_NUMBER: Self = Self(186u32);
+                        pub const ERROR_SEM_NOT_FOUND: Self = Self(187u32);
+                        pub const ERROR_INVALID_STARTING_CODESEG: Self = Self(188u32);
+                        pub const ERROR_INVALID_STACKSEG: Self = Self(189u32);
+                        pub const ERROR_INVALID_MODULETYPE: Self = Self(190u32);
+                        pub const ERROR_INVALID_EXE_SIGNATURE: Self = Self(191u32);
+                        pub const ERROR_EXE_MARKED_INVALID: Self = Self(192u32);
+                        pub const ERROR_BAD_EXE_FORMAT: Self = Self(193u32);
+                        pub const ERROR_ITERATED_DATA_EXCEEDS_64k: Self = Self(194u32);
+                        pub const ERROR_INVALID_MINALLOCSIZE: Self = Self(195u32);
+                        pub const ERROR_DYNLINK_FROM_INVALID_RING: Self = Self(196u32);
+                        pub const ERROR_IOPL_NOT_ENABLED: Self = Self(197u32);
+                        pub const ERROR_INVALID_SEGDPL: Self = Self(198u32);
+                        pub const ERROR_AUTODATASEG_EXCEEDS_64k: Self = Self(199u32);
+                        pub const ERROR_RING2SEG_MUST_BE_MOVABLE: Self = Self(200u32);
+                        pub const ERROR_RELOC_CHAIN_XEEDS_SEGLIM: Self = Self(201u32);
+                        pub const ERROR_INFLOOP_IN_RELOC_CHAIN: Self = Self(202u32);
+                        pub const ERROR_ENVVAR_NOT_FOUND: Self = Self(203u32);
+                        pub const ERROR_NO_SIGNAL_SENT: Self = Self(205u32);
+                        pub const ERROR_FILENAME_EXCED_RANGE: Self = Self(206u32);
+                        pub const ERROR_RING2_STACK_IN_USE: Self = Self(207u32);
+                        pub const ERROR_META_EXPANSION_TOO_LONG: Self = Self(208u32);
+                        pub const ERROR_INVALID_SIGNAL_NUMBER: Self = Self(209u32);
+                        pub const ERROR_THREAD_1_INACTIVE: Self = Self(210u32);
+                        pub const ERROR_LOCKED: Self = Self(212u32);
+                        pub const ERROR_TOO_MANY_MODULES: Self = Self(214u32);
+                        pub const ERROR_NESTING_NOT_ALLOWED: Self = Self(215u32);
+                        pub const ERROR_EXE_MACHINE_TYPE_MISMATCH: Self = Self(216u32);
+                        pub const ERROR_EXE_CANNOT_MODIFY_SIGNED_BINARY: Self = Self(217u32);
+                        pub const ERROR_EXE_CANNOT_MODIFY_STRONG_SIGNED_BINARY: Self = Self(218u32);
+                        pub const ERROR_FILE_CHECKED_OUT: Self = Self(220u32);
+                        pub const ERROR_CHECKOUT_REQUIRED: Self = Self(221u32);
+                        pub const ERROR_BAD_FILE_TYPE: Self = Self(222u32);
+                        pub const ERROR_FILE_TOO_LARGE: Self = Self(223u32);
+                        pub const ERROR_FORMS_AUTH_REQUIRED: Self = Self(224u32);
+                        pub const ERROR_VIRUS_INFECTED: Self = Self(225u32);
+                        pub const ERROR_VIRUS_DELETED: Self = Self(226u32);
+                        pub const ERROR_PIPE_LOCAL: Self = Self(229u32);
+                        pub const ERROR_BAD_PIPE: Self = Self(230u32);
+                        pub const ERROR_PIPE_BUSY: Self = Self(231u32);
+                        pub const ERROR_NO_DATA: Self = Self(232u32);
+                        pub const ERROR_PIPE_NOT_CONNECTED: Self = Self(233u32);
+                        pub const ERROR_MORE_DATA: Self = Self(234u32);
+                        pub const ERROR_NO_WORK_DONE: Self = Self(235u32);
+                        pub const ERROR_VC_DISCONNECTED: Self = Self(240u32);
+                        pub const ERROR_INVALID_EA_NAME: Self = Self(254u32);
+                        pub const ERROR_EA_LIST_INCONSISTENT: Self = Self(255u32);
+                        pub const ERROR_NO_MORE_ITEMS: Self = Self(259u32);
+                        pub const ERROR_CANNOT_COPY: Self = Self(266u32);
+                        pub const ERROR_DIRECTORY: Self = Self(267u32);
+                        pub const ERROR_EAS_DIDNT_FIT: Self = Self(275u32);
+                        pub const ERROR_EA_FILE_CORRUPT: Self = Self(276u32);
+                        pub const ERROR_EA_TABLE_FULL: Self = Self(277u32);
+                        pub const ERROR_INVALID_EA_HANDLE: Self = Self(278u32);
+                        pub const ERROR_EAS_NOT_SUPPORTED: Self = Self(282u32);
+                        pub const ERROR_NOT_OWNER: Self = Self(288u32);
+                        pub const ERROR_TOO_MANY_POSTS: Self = Self(298u32);
+                        pub const ERROR_PARTIAL_COPY: Self = Self(299u32);
+                        pub const ERROR_OPLOCK_NOT_GRANTED: Self = Self(300u32);
+                        pub const ERROR_INVALID_OPLOCK_PROTOCOL: Self = Self(301u32);
+                        pub const ERROR_DISK_TOO_FRAGMENTED: Self = Self(302u32);
+                        pub const ERROR_DELETE_PENDING: Self = Self(303u32);
+                        pub const ERROR_INCOMPATIBLE_WITH_GLOBAL_SHORT_NAME_REGISTRY_SETTING: Self =
+                            Self(304u32);
+                        pub const ERROR_SHORT_NAMES_NOT_ENABLED_ON_VOLUME: Self = Self(305u32);
+                        pub const ERROR_SECURITY_STREAM_IS_INCONSISTENT: Self = Self(306u32);
+                        pub const ERROR_INVALID_LOCK_RANGE: Self = Self(307u32);
+                        pub const ERROR_IMAGE_SUBSYSTEM_NOT_PRESENT: Self = Self(308u32);
+                        pub const ERROR_NOTIFICATION_GUID_ALREADY_DEFINED: Self = Self(309u32);
+                        pub const ERROR_INVALID_EXCEPTION_HANDLER: Self = Self(310u32);
+                        pub const ERROR_DUPLICATE_PRIVILEGES: Self = Self(311u32);
+                        pub const ERROR_NO_RANGES_PROCESSED: Self = Self(312u32);
+                        pub const ERROR_NOT_ALLOWED_ON_SYSTEM_FILE: Self = Self(313u32);
+                        pub const ERROR_DISK_RESOURCES_EXHAUSTED: Self = Self(314u32);
+                        pub const ERROR_INVALID_TOKEN: Self = Self(315u32);
+                        pub const ERROR_DEVICE_FEATURE_NOT_SUPPORTED: Self = Self(316u32);
+                        pub const ERROR_MR_MID_NOT_FOUND: Self = Self(317u32);
+                        pub const ERROR_SCOPE_NOT_FOUND: Self = Self(318u32);
+                        pub const ERROR_UNDEFINED_SCOPE: Self = Self(319u32);
+                        pub const ERROR_INVALID_CAP: Self = Self(320u32);
+                        pub const ERROR_DEVICE_UNREACHABLE: Self = Self(321u32);
+                        pub const ERROR_DEVICE_NO_RESOURCES: Self = Self(322u32);
+                        pub const ERROR_DATA_CHECKSUM_ERROR: Self = Self(323u32);
+                        pub const ERROR_INTERMIXED_KERNEL_EA_OPERATION: Self = Self(324u32);
+                        pub const ERROR_FILE_LEVEL_TRIM_NOT_SUPPORTED: Self = Self(326u32);
+                        pub const ERROR_OFFSET_ALIGNMENT_VIOLATION: Self = Self(327u32);
+                        pub const ERROR_INVALID_FIELD_IN_PARAMETER_LIST: Self = Self(328u32);
+                        pub const ERROR_OPERATION_IN_PROGRESS: Self = Self(329u32);
+                        pub const ERROR_BAD_DEVICE_PATH: Self = Self(330u32);
+                        pub const ERROR_TOO_MANY_DESCRIPTORS: Self = Self(331u32);
+                        pub const ERROR_SCRUB_DATA_DISABLED: Self = Self(332u32);
+                        pub const ERROR_NOT_REDUNDANT_STORAGE: Self = Self(333u32);
+                        pub const ERROR_RESIDENT_FILE_NOT_SUPPORTED: Self = Self(334u32);
+                        pub const ERROR_COMPRESSED_FILE_NOT_SUPPORTED: Self = Self(335u32);
+                        pub const ERROR_DIRECTORY_NOT_SUPPORTED: Self = Self(336u32);
+                        pub const ERROR_NOT_READ_FROM_COPY: Self = Self(337u32);
+                        pub const ERROR_FT_WRITE_FAILURE: Self = Self(338u32);
+                        pub const ERROR_FT_DI_SCAN_REQUIRED: Self = Self(339u32);
+                        pub const ERROR_INVALID_KERNEL_INFO_VERSION: Self = Self(340u32);
+                        pub const ERROR_INVALID_PEP_INFO_VERSION: Self = Self(341u32);
+                        pub const ERROR_OBJECT_NOT_EXTERNALLY_BACKED: Self = Self(342u32);
+                        pub const ERROR_EXTERNAL_BACKING_PROVIDER_UNKNOWN: Self = Self(343u32);
+                        pub const ERROR_COMPRESSION_NOT_BENEFICIAL: Self = Self(344u32);
+                        pub const ERROR_STORAGE_TOPOLOGY_ID_MISMATCH: Self = Self(345u32);
+                        pub const ERROR_BLOCKED_BY_PARENTAL_CONTROLS: Self = Self(346u32);
+                        pub const ERROR_BLOCK_TOO_MANY_REFERENCES: Self = Self(347u32);
+                        pub const ERROR_MARKED_TO_DISALLOW_WRITES: Self = Self(348u32);
+                        pub const ERROR_ENCLAVE_FAILURE: Self = Self(349u32);
+                        pub const ERROR_FAIL_NOACTION_REBOOT: Self = Self(350u32);
+                        pub const ERROR_FAIL_SHUTDOWN: Self = Self(351u32);
+                        pub const ERROR_FAIL_RESTART: Self = Self(352u32);
+                        pub const ERROR_MAX_SESSIONS_REACHED: Self = Self(353u32);
+                        pub const ERROR_NETWORK_ACCESS_DENIED_EDP: Self = Self(354u32);
+                        pub const ERROR_DEVICE_HINT_NAME_BUFFER_TOO_SMALL: Self = Self(355u32);
+                        pub const ERROR_EDP_POLICY_DENIES_OPERATION: Self = Self(356u32);
+                        pub const ERROR_EDP_DPL_POLICY_CANT_BE_SATISFIED: Self = Self(357u32);
+                        pub const ERROR_CLOUD_FILE_SYNC_ROOT_METADATA_CORRUPT: Self = Self(358u32);
+                        pub const ERROR_DEVICE_IN_MAINTENANCE: Self = Self(359u32);
+                        pub const ERROR_NOT_SUPPORTED_ON_DAX: Self = Self(360u32);
+                        pub const ERROR_DAX_MAPPING_EXISTS: Self = Self(361u32);
+                        pub const ERROR_CLOUD_FILE_PROVIDER_NOT_RUNNING: Self = Self(362u32);
+                        pub const ERROR_CLOUD_FILE_METADATA_CORRUPT: Self = Self(363u32);
+                        pub const ERROR_CLOUD_FILE_METADATA_TOO_LARGE: Self = Self(364u32);
+                        pub const ERROR_CLOUD_FILE_PROPERTY_BLOB_TOO_LARGE: Self = Self(365u32);
+                        pub const ERROR_CLOUD_FILE_PROPERTY_BLOB_CHECKSUM_MISMATCH: Self =
+                            Self(366u32);
+                        pub const ERROR_CHILD_PROCESS_BLOCKED: Self = Self(367u32);
+                        pub const ERROR_STORAGE_LOST_DATA_PERSISTENCE: Self = Self(368u32);
+                        pub const ERROR_FILE_SYSTEM_VIRTUALIZATION_UNAVAILABLE: Self = Self(369u32);
+                        pub const ERROR_FILE_SYSTEM_VIRTUALIZATION_METADATA_CORRUPT: Self =
+                            Self(370u32);
+                        pub const ERROR_FILE_SYSTEM_VIRTUALIZATION_BUSY: Self = Self(371u32);
+                        pub const ERROR_FILE_SYSTEM_VIRTUALIZATION_PROVIDER_UNKNOWN: Self =
+                            Self(372u32);
+                        pub const ERROR_GDI_HANDLE_LEAK: Self = Self(373u32);
+                        pub const ERROR_CLOUD_FILE_TOO_MANY_PROPERTY_BLOBS: Self = Self(374u32);
+                        pub const ERROR_CLOUD_FILE_PROPERTY_VERSION_NOT_SUPPORTED: Self =
+                            Self(375u32);
+                        pub const ERROR_NOT_A_CLOUD_FILE: Self = Self(376u32);
+                        pub const ERROR_CLOUD_FILE_NOT_IN_SYNC: Self = Self(377u32);
+                        pub const ERROR_CLOUD_FILE_ALREADY_CONNECTED: Self = Self(378u32);
+                        pub const ERROR_CLOUD_FILE_NOT_SUPPORTED: Self = Self(379u32);
+                        pub const ERROR_CLOUD_FILE_INVALID_REQUEST: Self = Self(380u32);
+                        pub const ERROR_CLOUD_FILE_READ_ONLY_VOLUME: Self = Self(381u32);
+                        pub const ERROR_CLOUD_FILE_CONNECTED_PROVIDER_ONLY: Self = Self(382u32);
+                        pub const ERROR_CLOUD_FILE_VALIDATION_FAILED: Self = Self(383u32);
+                        pub const ERROR_SMB1_NOT_AVAILABLE: Self = Self(384u32);
+                        pub const ERROR_FILE_SYSTEM_VIRTUALIZATION_INVALID_OPERATION: Self =
+                            Self(385u32);
+                        pub const ERROR_CLOUD_FILE_AUTHENTICATION_FAILED: Self = Self(386u32);
+                        pub const ERROR_CLOUD_FILE_INSUFFICIENT_RESOURCES: Self = Self(387u32);
+                        pub const ERROR_CLOUD_FILE_NETWORK_UNAVAILABLE: Self = Self(388u32);
+                        pub const ERROR_CLOUD_FILE_UNSUCCESSFUL: Self = Self(389u32);
+                        pub const ERROR_CLOUD_FILE_NOT_UNDER_SYNC_ROOT: Self = Self(390u32);
+                        pub const ERROR_CLOUD_FILE_IN_USE: Self = Self(391u32);
+                        pub const ERROR_CLOUD_FILE_PINNED: Self = Self(392u32);
+                        pub const ERROR_CLOUD_FILE_REQUEST_ABORTED: Self = Self(393u32);
+                        pub const ERROR_CLOUD_FILE_PROPERTY_CORRUPT: Self = Self(394u32);
+                        pub const ERROR_CLOUD_FILE_ACCESS_DENIED: Self = Self(395u32);
+                        pub const ERROR_CLOUD_FILE_INCOMPATIBLE_HARDLINKS: Self = Self(396u32);
+                        pub const ERROR_CLOUD_FILE_PROPERTY_LOCK_CONFLICT: Self = Self(397u32);
+                        pub const ERROR_CLOUD_FILE_REQUEST_CANCELED: Self = Self(398u32);
+                        pub const ERROR_EXTERNAL_SYSKEY_NOT_SUPPORTED: Self = Self(399u32);
+                        pub const ERROR_THREAD_MODE_ALREADY_BACKGROUND: Self = Self(400u32);
+                        pub const ERROR_THREAD_MODE_NOT_BACKGROUND: Self = Self(401u32);
+                        pub const ERROR_PROCESS_MODE_ALREADY_BACKGROUND: Self = Self(402u32);
+                        pub const ERROR_PROCESS_MODE_NOT_BACKGROUND: Self = Self(403u32);
+                        pub const ERROR_CLOUD_FILE_PROVIDER_TERMINATED: Self = Self(404u32);
+                        pub const ERROR_NOT_A_CLOUD_SYNC_ROOT: Self = Self(405u32);
+                        pub const ERROR_FILE_PROTECTED_UNDER_DPL: Self = Self(406u32);
+                        pub const ERROR_VOLUME_NOT_CLUSTER_ALIGNED: Self = Self(407u32);
+                        pub const ERROR_NO_PHYSICALLY_ALIGNED_FREE_SPACE_FOUND: Self = Self(408u32);
+                        pub const ERROR_APPX_FILE_NOT_ENCRYPTED: Self = Self(409u32);
+                        pub const ERROR_RWRAW_ENCRYPTED_FILE_NOT_ENCRYPTED: Self = Self(410u32);
+                        pub const ERROR_RWRAW_ENCRYPTED_INVALID_EDATAINFO_FILEOFFSET: Self =
+                            Self(411u32);
+                        pub const ERROR_RWRAW_ENCRYPTED_INVALID_EDATAINFO_FILERANGE: Self =
+                            Self(412u32);
+                        pub const ERROR_RWRAW_ENCRYPTED_INVALID_EDATAINFO_PARAMETER: Self =
+                            Self(413u32);
+                        pub const ERROR_LINUX_SUBSYSTEM_NOT_PRESENT: Self = Self(414u32);
+                        pub const ERROR_FT_READ_FAILURE: Self = Self(415u32);
+                        pub const ERROR_STORAGE_RESERVE_ID_INVALID: Self = Self(416u32);
+                        pub const ERROR_STORAGE_RESERVE_DOES_NOT_EXIST: Self = Self(417u32);
+                        pub const ERROR_STORAGE_RESERVE_ALREADY_EXISTS: Self = Self(418u32);
+                        pub const ERROR_STORAGE_RESERVE_NOT_EMPTY: Self = Self(419u32);
+                        pub const ERROR_NOT_A_DAX_VOLUME: Self = Self(420u32);
+                        pub const ERROR_NOT_DAX_MAPPABLE: Self = Self(421u32);
+                        pub const ERROR_TIME_SENSITIVE_THREAD: Self = Self(422u32);
+                        pub const ERROR_DPL_NOT_SUPPORTED_FOR_USER: Self = Self(423u32);
+                        pub const ERROR_CASE_DIFFERING_NAMES_IN_DIR: Self = Self(424u32);
+                        pub const ERROR_FILE_NOT_SUPPORTED: Self = Self(425u32);
+                        pub const ERROR_CLOUD_FILE_REQUEST_TIMEOUT: Self = Self(426u32);
+                        pub const ERROR_NO_TASK_QUEUE: Self = Self(427u32);
+                        pub const ERROR_SRC_SRV_DLL_LOAD_FAILED: Self = Self(428u32);
+                        pub const ERROR_NOT_SUPPORTED_WITH_BTT: Self = Self(429u32);
+                        pub const ERROR_ENCRYPTION_DISABLED: Self = Self(430u32);
+                        pub const ERROR_ENCRYPTING_METADATA_DISALLOWED: Self = Self(431u32);
+                        pub const ERROR_CANT_CLEAR_ENCRYPTION_FLAG: Self = Self(432u32);
+                        pub const ERROR_NO_SUCH_DEVICE: Self = Self(433u32);
+                        pub const ERROR_CLOUD_FILE_DEHYDRATION_DISALLOWED: Self = Self(434u32);
+                        pub const ERROR_FILE_SNAP_IN_PROGRESS: Self = Self(435u32);
+                        pub const ERROR_FILE_SNAP_USER_SECTION_NOT_SUPPORTED: Self = Self(436u32);
+                        pub const ERROR_FILE_SNAP_MODIFY_NOT_SUPPORTED: Self = Self(437u32);
+                        pub const ERROR_FILE_SNAP_IO_NOT_COORDINATED: Self = Self(438u32);
+                        pub const ERROR_FILE_SNAP_UNEXPECTED_ERROR: Self = Self(439u32);
+                        pub const ERROR_FILE_SNAP_INVALID_PARAMETER: Self = Self(440u32);
+                        pub const ERROR_UNSATISFIED_DEPENDENCIES: Self = Self(441u32);
+                        pub const ERROR_CASE_SENSITIVE_PATH: Self = Self(442u32);
+                        pub const ERROR_UNEXPECTED_NTCACHEMANAGER_ERROR: Self = Self(443u32);
+                        pub const ERROR_CAPAUTHZ_NOT_DEVUNLOCKED: Self = Self(450u32);
+                        pub const ERROR_CAPAUTHZ_CHANGE_TYPE: Self = Self(451u32);
+                        pub const ERROR_CAPAUTHZ_NOT_PROVISIONED: Self = Self(452u32);
+                        pub const ERROR_CAPAUTHZ_NOT_AUTHORIZED: Self = Self(453u32);
+                        pub const ERROR_CAPAUTHZ_NO_POLICY: Self = Self(454u32);
+                        pub const ERROR_CAPAUTHZ_DB_CORRUPTED: Self = Self(455u32);
+                        pub const ERROR_CAPAUTHZ_SCCD_INVALID_CATALOG: Self = Self(456u32);
+                        pub const ERROR_CAPAUTHZ_SCCD_NO_AUTH_ENTITY: Self = Self(457u32);
+                        pub const ERROR_CAPAUTHZ_SCCD_PARSE_ERROR: Self = Self(458u32);
+                        pub const ERROR_CAPAUTHZ_SCCD_DEV_MODE_REQUIRED: Self = Self(459u32);
+                        pub const ERROR_CAPAUTHZ_SCCD_NO_CAPABILITY_MATCH: Self = Self(460u32);
+                        pub const ERROR_CIMFS_IMAGE_CORRUPT: Self = Self(470u32);
+                        pub const ERROR_PNP_QUERY_REMOVE_DEVICE_TIMEOUT: Self = Self(480u32);
+                        pub const ERROR_PNP_QUERY_REMOVE_RELATED_DEVICE_TIMEOUT: Self =
+                            Self(481u32);
+                        pub const ERROR_PNP_QUERY_REMOVE_UNRELATED_DEVICE_TIMEOUT: Self =
+                            Self(482u32);
+                        pub const ERROR_DEVICE_HARDWARE_ERROR: Self = Self(483u32);
+                        pub const ERROR_INVALID_ADDRESS: Self = Self(487u32);
+                        pub const ERROR_VRF_CFG_AND_IO_ENABLED: Self = Self(1183u32);
+                        pub const ERROR_PARTITION_TERMINATING: Self = Self(1184u32);
+                        pub const ERROR_USER_PROFILE_LOAD: Self = Self(500u32);
+                        pub const ERROR_ARITHMETIC_OVERFLOW: Self = Self(534u32);
+                        pub const ERROR_PIPE_CONNECTED: Self = Self(535u32);
+                        pub const ERROR_PIPE_LISTENING: Self = Self(536u32);
+                        pub const ERROR_VERIFIER_STOP: Self = Self(537u32);
+                        pub const ERROR_ABIOS_ERROR: Self = Self(538u32);
+                        pub const ERROR_WX86_WARNING: Self = Self(539u32);
+                        pub const ERROR_WX86_ERROR: Self = Self(540u32);
+                        pub const ERROR_TIMER_NOT_CANCELED: Self = Self(541u32);
+                        pub const ERROR_UNWIND: Self = Self(542u32);
+                        pub const ERROR_BAD_STACK: Self = Self(543u32);
+                        pub const ERROR_INVALID_UNWIND_TARGET: Self = Self(544u32);
+                        pub const ERROR_INVALID_PORT_ATTRIBUTES: Self = Self(545u32);
+                        pub const ERROR_PORT_MESSAGE_TOO_LONG: Self = Self(546u32);
+                        pub const ERROR_INVALID_QUOTA_LOWER: Self = Self(547u32);
+                        pub const ERROR_DEVICE_ALREADY_ATTACHED: Self = Self(548u32);
+                        pub const ERROR_INSTRUCTION_MISALIGNMENT: Self = Self(549u32);
+                        pub const ERROR_PROFILING_NOT_STARTED: Self = Self(550u32);
+                        pub const ERROR_PROFILING_NOT_STOPPED: Self = Self(551u32);
+                        pub const ERROR_COULD_NOT_INTERPRET: Self = Self(552u32);
+                        pub const ERROR_PROFILING_AT_LIMIT: Self = Self(553u32);
+                        pub const ERROR_CANT_WAIT: Self = Self(554u32);
+                        pub const ERROR_CANT_TERMINATE_SELF: Self = Self(555u32);
+                        pub const ERROR_UNEXPECTED_MM_CREATE_ERR: Self = Self(556u32);
+                        pub const ERROR_UNEXPECTED_MM_MAP_ERROR: Self = Self(557u32);
+                        pub const ERROR_UNEXPECTED_MM_EXTEND_ERR: Self = Self(558u32);
+                        pub const ERROR_BAD_FUNCTION_TABLE: Self = Self(559u32);
+                        pub const ERROR_NO_GUID_TRANSLATION: Self = Self(560u32);
+                        pub const ERROR_INVALID_LDT_SIZE: Self = Self(561u32);
+                        pub const ERROR_INVALID_LDT_OFFSET: Self = Self(563u32);
+                        pub const ERROR_INVALID_LDT_DESCRIPTOR: Self = Self(564u32);
+                        pub const ERROR_TOO_MANY_THREADS: Self = Self(565u32);
+                        pub const ERROR_THREAD_NOT_IN_PROCESS: Self = Self(566u32);
+                        pub const ERROR_PAGEFILE_QUOTA_EXCEEDED: Self = Self(567u32);
+                        pub const ERROR_LOGON_SERVER_CONFLICT: Self = Self(568u32);
+                        pub const ERROR_SYNCHRONIZATION_REQUIRED: Self = Self(569u32);
+                        pub const ERROR_NET_OPEN_FAILED: Self = Self(570u32);
+                        pub const ERROR_IO_PRIVILEGE_FAILED: Self = Self(571u32);
+                        pub const ERROR_CONTROL_C_EXIT: Self = Self(572u32);
+                        pub const ERROR_MISSING_SYSTEMFILE: Self = Self(573u32);
+                        pub const ERROR_UNHANDLED_EXCEPTION: Self = Self(574u32);
+                        pub const ERROR_APP_INIT_FAILURE: Self = Self(575u32);
+                        pub const ERROR_PAGEFILE_CREATE_FAILED: Self = Self(576u32);
+                        pub const ERROR_INVALID_IMAGE_HASH: Self = Self(577u32);
+                        pub const ERROR_NO_PAGEFILE: Self = Self(578u32);
+                        pub const ERROR_ILLEGAL_FLOAT_CONTEXT: Self = Self(579u32);
+                        pub const ERROR_NO_EVENT_PAIR: Self = Self(580u32);
+                        pub const ERROR_DOMAIN_CTRLR_CONFIG_ERROR: Self = Self(581u32);
+                        pub const ERROR_ILLEGAL_CHARACTER: Self = Self(582u32);
+                        pub const ERROR_UNDEFINED_CHARACTER: Self = Self(583u32);
+                        pub const ERROR_FLOPPY_VOLUME: Self = Self(584u32);
+                        pub const ERROR_BIOS_FAILED_TO_CONNECT_INTERRUPT: Self = Self(585u32);
+                        pub const ERROR_BACKUP_CONTROLLER: Self = Self(586u32);
+                        pub const ERROR_MUTANT_LIMIT_EXCEEDED: Self = Self(587u32);
+                        pub const ERROR_FS_DRIVER_REQUIRED: Self = Self(588u32);
+                        pub const ERROR_CANNOT_LOAD_REGISTRY_FILE: Self = Self(589u32);
+                        pub const ERROR_DEBUG_ATTACH_FAILED: Self = Self(590u32);
+                        pub const ERROR_SYSTEM_PROCESS_TERMINATED: Self = Self(591u32);
+                        pub const ERROR_DATA_NOT_ACCEPTED: Self = Self(592u32);
+                        pub const ERROR_VDM_HARD_ERROR: Self = Self(593u32);
+                        pub const ERROR_DRIVER_CANCEL_TIMEOUT: Self = Self(594u32);
+                        pub const ERROR_REPLY_MESSAGE_MISMATCH: Self = Self(595u32);
+                        pub const ERROR_LOST_WRITEBEHIND_DATA: Self = Self(596u32);
+                        pub const ERROR_CLIENT_SERVER_PARAMETERS_INVALID: Self = Self(597u32);
+                        pub const ERROR_NOT_TINY_STREAM: Self = Self(598u32);
+                        pub const ERROR_STACK_OVERFLOW_READ: Self = Self(599u32);
+                        pub const ERROR_CONVERT_TO_LARGE: Self = Self(600u32);
+                        pub const ERROR_FOUND_OUT_OF_SCOPE: Self = Self(601u32);
+                        pub const ERROR_ALLOCATE_BUCKET: Self = Self(602u32);
+                        pub const ERROR_MARSHALL_OVERFLOW: Self = Self(603u32);
+                        pub const ERROR_INVALID_VARIANT: Self = Self(604u32);
+                        pub const ERROR_BAD_COMPRESSION_BUFFER: Self = Self(605u32);
+                        pub const ERROR_AUDIT_FAILED: Self = Self(606u32);
+                        pub const ERROR_TIMER_RESOLUTION_NOT_SET: Self = Self(607u32);
+                        pub const ERROR_INSUFFICIENT_LOGON_INFO: Self = Self(608u32);
+                        pub const ERROR_BAD_DLL_ENTRYPOINT: Self = Self(609u32);
+                        pub const ERROR_BAD_SERVICE_ENTRYPOINT: Self = Self(610u32);
+                        pub const ERROR_IP_ADDRESS_CONFLICT1: Self = Self(611u32);
+                        pub const ERROR_IP_ADDRESS_CONFLICT2: Self = Self(612u32);
+                        pub const ERROR_REGISTRY_QUOTA_LIMIT: Self = Self(613u32);
+                        pub const ERROR_NO_CALLBACK_ACTIVE: Self = Self(614u32);
+                        pub const ERROR_PWD_TOO_SHORT: Self = Self(615u32);
+                        pub const ERROR_PWD_TOO_RECENT: Self = Self(616u32);
+                        pub const ERROR_PWD_HISTORY_CONFLICT: Self = Self(617u32);
+                        pub const ERROR_UNSUPPORTED_COMPRESSION: Self = Self(618u32);
+                        pub const ERROR_INVALID_HW_PROFILE: Self = Self(619u32);
+                        pub const ERROR_INVALID_PLUGPLAY_DEVICE_PATH: Self = Self(620u32);
+                        pub const ERROR_QUOTA_LIST_INCONSISTENT: Self = Self(621u32);
+                        pub const ERROR_EVALUATION_EXPIRATION: Self = Self(622u32);
+                        pub const ERROR_ILLEGAL_DLL_RELOCATION: Self = Self(623u32);
+                        pub const ERROR_DLL_INIT_FAILED_LOGOFF: Self = Self(624u32);
+                        pub const ERROR_VALIDATE_CONTINUE: Self = Self(625u32);
+                        pub const ERROR_NO_MORE_MATCHES: Self = Self(626u32);
+                        pub const ERROR_RANGE_LIST_CONFLICT: Self = Self(627u32);
+                        pub const ERROR_SERVER_SID_MISMATCH: Self = Self(628u32);
+                        pub const ERROR_CANT_ENABLE_DENY_ONLY: Self = Self(629u32);
+                        pub const ERROR_FLOAT_MULTIPLE_FAULTS: Self = Self(630u32);
+                        pub const ERROR_FLOAT_MULTIPLE_TRAPS: Self = Self(631u32);
+                        pub const ERROR_NOINTERFACE: Self = Self(632u32);
+                        pub const ERROR_DRIVER_FAILED_SLEEP: Self = Self(633u32);
+                        pub const ERROR_CORRUPT_SYSTEM_FILE: Self = Self(634u32);
+                        pub const ERROR_COMMITMENT_MINIMUM: Self = Self(635u32);
+                        pub const ERROR_PNP_RESTART_ENUMERATION: Self = Self(636u32);
+                        pub const ERROR_SYSTEM_IMAGE_BAD_SIGNATURE: Self = Self(637u32);
+                        pub const ERROR_PNP_REBOOT_REQUIRED: Self = Self(638u32);
+                        pub const ERROR_INSUFFICIENT_POWER: Self = Self(639u32);
+                        pub const ERROR_MULTIPLE_FAULT_VIOLATION: Self = Self(640u32);
+                        pub const ERROR_SYSTEM_SHUTDOWN: Self = Self(641u32);
+                        pub const ERROR_PORT_NOT_SET: Self = Self(642u32);
+                        pub const ERROR_DS_VERSION_CHECK_FAILURE: Self = Self(643u32);
+                        pub const ERROR_RANGE_NOT_FOUND: Self = Self(644u32);
+                        pub const ERROR_NOT_SAFE_MODE_DRIVER: Self = Self(646u32);
+                        pub const ERROR_FAILED_DRIVER_ENTRY: Self = Self(647u32);
+                        pub const ERROR_DEVICE_ENUMERATION_ERROR: Self = Self(648u32);
+                        pub const ERROR_MOUNT_POINT_NOT_RESOLVED: Self = Self(649u32);
+                        pub const ERROR_INVALID_DEVICE_OBJECT_PARAMETER: Self = Self(650u32);
+                        pub const ERROR_MCA_OCCURED: Self = Self(651u32);
+                        pub const ERROR_DRIVER_DATABASE_ERROR: Self = Self(652u32);
+                        pub const ERROR_SYSTEM_HIVE_TOO_LARGE: Self = Self(653u32);
+                        pub const ERROR_DRIVER_FAILED_PRIOR_UNLOAD: Self = Self(654u32);
+                        pub const ERROR_VOLSNAP_PREPARE_HIBERNATE: Self = Self(655u32);
+                        pub const ERROR_HIBERNATION_FAILURE: Self = Self(656u32);
+                        pub const ERROR_PWD_TOO_LONG: Self = Self(657u32);
+                        pub const ERROR_FILE_SYSTEM_LIMITATION: Self = Self(665u32);
+                        pub const ERROR_ASSERTION_FAILURE: Self = Self(668u32);
+                        pub const ERROR_ACPI_ERROR: Self = Self(669u32);
+                        pub const ERROR_WOW_ASSERTION: Self = Self(670u32);
+                        pub const ERROR_PNP_BAD_MPS_TABLE: Self = Self(671u32);
+                        pub const ERROR_PNP_TRANSLATION_FAILED: Self = Self(672u32);
+                        pub const ERROR_PNP_IRQ_TRANSLATION_FAILED: Self = Self(673u32);
+                        pub const ERROR_PNP_INVALID_ID: Self = Self(674u32);
+                        pub const ERROR_WAKE_SYSTEM_DEBUGGER: Self = Self(675u32);
+                        pub const ERROR_HANDLES_CLOSED: Self = Self(676u32);
+                        pub const ERROR_EXTRANEOUS_INFORMATION: Self = Self(677u32);
+                        pub const ERROR_RXACT_COMMIT_NECESSARY: Self = Self(678u32);
+                        pub const ERROR_MEDIA_CHECK: Self = Self(679u32);
+                        pub const ERROR_GUID_SUBSTITUTION_MADE: Self = Self(680u32);
+                        pub const ERROR_STOPPED_ON_SYMLINK: Self = Self(681u32);
+                        pub const ERROR_LONGJUMP: Self = Self(682u32);
+                        pub const ERROR_PLUGPLAY_QUERY_VETOED: Self = Self(683u32);
+                        pub const ERROR_UNWIND_CONSOLIDATE: Self = Self(684u32);
+                        pub const ERROR_REGISTRY_HIVE_RECOVERED: Self = Self(685u32);
+                        pub const ERROR_DLL_MIGHT_BE_INSECURE: Self = Self(686u32);
+                        pub const ERROR_DLL_MIGHT_BE_INCOMPATIBLE: Self = Self(687u32);
+                        pub const ERROR_DBG_EXCEPTION_NOT_HANDLED: Self = Self(688u32);
+                        pub const ERROR_DBG_REPLY_LATER: Self = Self(689u32);
+                        pub const ERROR_DBG_UNABLE_TO_PROVIDE_HANDLE: Self = Self(690u32);
+                        pub const ERROR_DBG_TERMINATE_THREAD: Self = Self(691u32);
+                        pub const ERROR_DBG_TERMINATE_PROCESS: Self = Self(692u32);
+                        pub const ERROR_DBG_CONTROL_C: Self = Self(693u32);
+                        pub const ERROR_DBG_PRINTEXCEPTION_C: Self = Self(694u32);
+                        pub const ERROR_DBG_RIPEXCEPTION: Self = Self(695u32);
+                        pub const ERROR_DBG_CONTROL_BREAK: Self = Self(696u32);
+                        pub const ERROR_DBG_COMMAND_EXCEPTION: Self = Self(697u32);
+                        pub const ERROR_OBJECT_NAME_EXISTS: Self = Self(698u32);
+                        pub const ERROR_THREAD_WAS_SUSPENDED: Self = Self(699u32);
+                        pub const ERROR_IMAGE_NOT_AT_BASE: Self = Self(700u32);
+                        pub const ERROR_RXACT_STATE_CREATED: Self = Self(701u32);
+                        pub const ERROR_SEGMENT_NOTIFICATION: Self = Self(702u32);
+                        pub const ERROR_BAD_CURRENT_DIRECTORY: Self = Self(703u32);
+                        pub const ERROR_FT_READ_RECOVERY_FROM_BACKUP: Self = Self(704u32);
+                        pub const ERROR_FT_WRITE_RECOVERY: Self = Self(705u32);
+                        pub const ERROR_IMAGE_MACHINE_TYPE_MISMATCH: Self = Self(706u32);
+                        pub const ERROR_RECEIVE_PARTIAL: Self = Self(707u32);
+                        pub const ERROR_RECEIVE_EXPEDITED: Self = Self(708u32);
+                        pub const ERROR_RECEIVE_PARTIAL_EXPEDITED: Self = Self(709u32);
+                        pub const ERROR_EVENT_DONE: Self = Self(710u32);
+                        pub const ERROR_EVENT_PENDING: Self = Self(711u32);
+                        pub const ERROR_CHECKING_FILE_SYSTEM: Self = Self(712u32);
+                        pub const ERROR_FATAL_APP_EXIT: Self = Self(713u32);
+                        pub const ERROR_PREDEFINED_HANDLE: Self = Self(714u32);
+                        pub const ERROR_WAS_UNLOCKED: Self = Self(715u32);
+                        pub const ERROR_SERVICE_NOTIFICATION: Self = Self(716u32);
+                        pub const ERROR_WAS_LOCKED: Self = Self(717u32);
+                        pub const ERROR_LOG_HARD_ERROR: Self = Self(718u32);
+                        pub const ERROR_ALREADY_WIN32: Self = Self(719u32);
+                        pub const ERROR_IMAGE_MACHINE_TYPE_MISMATCH_EXE: Self = Self(720u32);
+                        pub const ERROR_NO_YIELD_PERFORMED: Self = Self(721u32);
+                        pub const ERROR_TIMER_RESUME_IGNORED: Self = Self(722u32);
+                        pub const ERROR_ARBITRATION_UNHANDLED: Self = Self(723u32);
+                        pub const ERROR_CARDBUS_NOT_SUPPORTED: Self = Self(724u32);
+                        pub const ERROR_MP_PROCESSOR_MISMATCH: Self = Self(725u32);
+                        pub const ERROR_HIBERNATED: Self = Self(726u32);
+                        pub const ERROR_RESUME_HIBERNATION: Self = Self(727u32);
+                        pub const ERROR_FIRMWARE_UPDATED: Self = Self(728u32);
+                        pub const ERROR_DRIVERS_LEAKING_LOCKED_PAGES: Self = Self(729u32);
+                        pub const ERROR_WAKE_SYSTEM: Self = Self(730u32);
+                        pub const ERROR_WAIT_1: Self = Self(731u32);
+                        pub const ERROR_WAIT_2: Self = Self(732u32);
+                        pub const ERROR_WAIT_3: Self = Self(733u32);
+                        pub const ERROR_WAIT_63: Self = Self(734u32);
+                        pub const ERROR_ABANDONED_WAIT_0: Self = Self(735u32);
+                        pub const ERROR_ABANDONED_WAIT_63: Self = Self(736u32);
+                        pub const ERROR_USER_APC: Self = Self(737u32);
+                        pub const ERROR_KERNEL_APC: Self = Self(738u32);
+                        pub const ERROR_ALERTED: Self = Self(739u32);
+                        pub const ERROR_ELEVATION_REQUIRED: Self = Self(740u32);
+                        pub const ERROR_REPARSE: Self = Self(741u32);
+                        pub const ERROR_OPLOCK_BREAK_IN_PROGRESS: Self = Self(742u32);
+                        pub const ERROR_VOLUME_MOUNTED: Self = Self(743u32);
+                        pub const ERROR_RXACT_COMMITTED: Self = Self(744u32);
+                        pub const ERROR_NOTIFY_CLEANUP: Self = Self(745u32);
+                        pub const ERROR_PRIMARY_TRANSPORT_CONNECT_FAILED: Self = Self(746u32);
+                        pub const ERROR_PAGE_FAULT_TRANSITION: Self = Self(747u32);
+                        pub const ERROR_PAGE_FAULT_DEMAND_ZERO: Self = Self(748u32);
+                        pub const ERROR_PAGE_FAULT_COPY_ON_WRITE: Self = Self(749u32);
+                        pub const ERROR_PAGE_FAULT_GUARD_PAGE: Self = Self(750u32);
+                        pub const ERROR_PAGE_FAULT_PAGING_FILE: Self = Self(751u32);
+                        pub const ERROR_CACHE_PAGE_LOCKED: Self = Self(752u32);
+                        pub const ERROR_CRASH_DUMP: Self = Self(753u32);
+                        pub const ERROR_BUFFER_ALL_ZEROS: Self = Self(754u32);
+                        pub const ERROR_REPARSE_OBJECT: Self = Self(755u32);
+                        pub const ERROR_RESOURCE_REQUIREMENTS_CHANGED: Self = Self(756u32);
+                        pub const ERROR_TRANSLATION_COMPLETE: Self = Self(757u32);
+                        pub const ERROR_NOTHING_TO_TERMINATE: Self = Self(758u32);
+                        pub const ERROR_PROCESS_NOT_IN_JOB: Self = Self(759u32);
+                        pub const ERROR_PROCESS_IN_JOB: Self = Self(760u32);
+                        pub const ERROR_VOLSNAP_HIBERNATE_READY: Self = Self(761u32);
+                        pub const ERROR_FSFILTER_OP_COMPLETED_SUCCESSFULLY: Self = Self(762u32);
+                        pub const ERROR_INTERRUPT_VECTOR_ALREADY_CONNECTED: Self = Self(763u32);
+                        pub const ERROR_INTERRUPT_STILL_CONNECTED: Self = Self(764u32);
+                        pub const ERROR_WAIT_FOR_OPLOCK: Self = Self(765u32);
+                        pub const ERROR_DBG_EXCEPTION_HANDLED: Self = Self(766u32);
+                        pub const ERROR_DBG_CONTINUE: Self = Self(767u32);
+                        pub const ERROR_CALLBACK_POP_STACK: Self = Self(768u32);
+                        pub const ERROR_COMPRESSION_DISABLED: Self = Self(769u32);
+                        pub const ERROR_CANTFETCHBACKWARDS: Self = Self(770u32);
+                        pub const ERROR_CANTSCROLLBACKWARDS: Self = Self(771u32);
+                        pub const ERROR_ROWSNOTRELEASED: Self = Self(772u32);
+                        pub const ERROR_BAD_ACCESSOR_FLAGS: Self = Self(773u32);
+                        pub const ERROR_ERRORS_ENCOUNTERED: Self = Self(774u32);
+                        pub const ERROR_NOT_CAPABLE: Self = Self(775u32);
+                        pub const ERROR_REQUEST_OUT_OF_SEQUENCE: Self = Self(776u32);
+                        pub const ERROR_VERSION_PARSE_ERROR: Self = Self(777u32);
+                        pub const ERROR_BADSTARTPOSITION: Self = Self(778u32);
+                        pub const ERROR_MEMORY_HARDWARE: Self = Self(779u32);
+                        pub const ERROR_DISK_REPAIR_DISABLED: Self = Self(780u32);
+                        pub const ERROR_INSUFFICIENT_RESOURCE_FOR_SPECIFIED_SHARED_SECTION_SIZE:
+                            Self = Self(781u32);
+                        pub const ERROR_SYSTEM_POWERSTATE_TRANSITION: Self = Self(782u32);
+                        pub const ERROR_SYSTEM_POWERSTATE_COMPLEX_TRANSITION: Self = Self(783u32);
+                        pub const ERROR_MCA_EXCEPTION: Self = Self(784u32);
+                        pub const ERROR_ACCESS_AUDIT_BY_POLICY: Self = Self(785u32);
+                        pub const ERROR_ACCESS_DISABLED_NO_SAFER_UI_BY_POLICY: Self = Self(786u32);
+                        pub const ERROR_ABANDON_HIBERFILE: Self = Self(787u32);
+                        pub const ERROR_LOST_WRITEBEHIND_DATA_NETWORK_DISCONNECTED: Self =
+                            Self(788u32);
+                        pub const ERROR_LOST_WRITEBEHIND_DATA_NETWORK_SERVER_ERROR: Self =
+                            Self(789u32);
+                        pub const ERROR_LOST_WRITEBEHIND_DATA_LOCAL_DISK_ERROR: Self = Self(790u32);
+                        pub const ERROR_BAD_MCFG_TABLE: Self = Self(791u32);
+                        pub const ERROR_DISK_REPAIR_REDIRECTED: Self = Self(792u32);
+                        pub const ERROR_DISK_REPAIR_UNSUCCESSFUL: Self = Self(793u32);
+                        pub const ERROR_CORRUPT_LOG_OVERFULL: Self = Self(794u32);
+                        pub const ERROR_CORRUPT_LOG_CORRUPTED: Self = Self(795u32);
+                        pub const ERROR_CORRUPT_LOG_UNAVAILABLE: Self = Self(796u32);
+                        pub const ERROR_CORRUPT_LOG_DELETED_FULL: Self = Self(797u32);
+                        pub const ERROR_CORRUPT_LOG_CLEARED: Self = Self(798u32);
+                        pub const ERROR_ORPHAN_NAME_EXHAUSTED: Self = Self(799u32);
+                        pub const ERROR_OPLOCK_SWITCHED_TO_NEW_HANDLE: Self = Self(800u32);
+                        pub const ERROR_CANNOT_GRANT_REQUESTED_OPLOCK: Self = Self(801u32);
+                        pub const ERROR_CANNOT_BREAK_OPLOCK: Self = Self(802u32);
+                        pub const ERROR_OPLOCK_HANDLE_CLOSED: Self = Self(803u32);
+                        pub const ERROR_NO_ACE_CONDITION: Self = Self(804u32);
+                        pub const ERROR_INVALID_ACE_CONDITION: Self = Self(805u32);
+                        pub const ERROR_FILE_HANDLE_REVOKED: Self = Self(806u32);
+                        pub const ERROR_IMAGE_AT_DIFFERENT_BASE: Self = Self(807u32);
+                        pub const ERROR_ENCRYPTED_IO_NOT_POSSIBLE: Self = Self(808u32);
+                        pub const ERROR_FILE_METADATA_OPTIMIZATION_IN_PROGRESS: Self = Self(809u32);
+                        pub const ERROR_QUOTA_ACTIVITY: Self = Self(810u32);
+                        pub const ERROR_HANDLE_REVOKED: Self = Self(811u32);
+                        pub const ERROR_CALLBACK_INVOKE_INLINE: Self = Self(812u32);
+                        pub const ERROR_CPU_SET_INVALID: Self = Self(813u32);
+                        pub const ERROR_ENCLAVE_NOT_TERMINATED: Self = Self(814u32);
+                        pub const ERROR_ENCLAVE_VIOLATION: Self = Self(815u32);
+                        pub const ERROR_EA_ACCESS_DENIED: Self = Self(994u32);
+                        pub const ERROR_OPERATION_ABORTED: Self = Self(995u32);
+                        pub const ERROR_IO_INCOMPLETE: Self = Self(996u32);
+                        pub const ERROR_IO_PENDING: Self = Self(997u32);
+                        pub const ERROR_NOACCESS: Self = Self(998u32);
+                        pub const ERROR_SWAPERROR: Self = Self(999u32);
+                        pub const ERROR_STACK_OVERFLOW: Self = Self(1001u32);
+                        pub const ERROR_INVALID_MESSAGE: Self = Self(1002u32);
+                        pub const ERROR_CAN_NOT_COMPLETE: Self = Self(1003u32);
+                        pub const ERROR_INVALID_FLAGS: Self = Self(1004u32);
+                        pub const ERROR_UNRECOGNIZED_VOLUME: Self = Self(1005u32);
+                        pub const ERROR_FILE_INVALID: Self = Self(1006u32);
+                        pub const ERROR_FULLSCREEN_MODE: Self = Self(1007u32);
+                        pub const ERROR_NO_TOKEN: Self = Self(1008u32);
+                        pub const ERROR_BADDB: Self = Self(1009u32);
+                        pub const ERROR_BADKEY: Self = Self(1010u32);
+                        pub const ERROR_CANTOPEN: Self = Self(1011u32);
+                        pub const ERROR_CANTREAD: Self = Self(1012u32);
+                        pub const ERROR_CANTWRITE: Self = Self(1013u32);
+                        pub const ERROR_REGISTRY_RECOVERED: Self = Self(1014u32);
+                        pub const ERROR_REGISTRY_CORRUPT: Self = Self(1015u32);
+                        pub const ERROR_REGISTRY_IO_FAILED: Self = Self(1016u32);
+                        pub const ERROR_NOT_REGISTRY_FILE: Self = Self(1017u32);
+                        pub const ERROR_KEY_DELETED: Self = Self(1018u32);
+                        pub const ERROR_NO_LOG_SPACE: Self = Self(1019u32);
+                        pub const ERROR_KEY_HAS_CHILDREN: Self = Self(1020u32);
+                        pub const ERROR_CHILD_MUST_BE_VOLATILE: Self = Self(1021u32);
+                        pub const ERROR_NOTIFY_ENUM_DIR: Self = Self(1022u32);
+                        pub const ERROR_DEPENDENT_SERVICES_RUNNING: Self = Self(1051u32);
+                        pub const ERROR_INVALID_SERVICE_CONTROL: Self = Self(1052u32);
+                        pub const ERROR_SERVICE_REQUEST_TIMEOUT: Self = Self(1053u32);
+                        pub const ERROR_SERVICE_NO_THREAD: Self = Self(1054u32);
+                        pub const ERROR_SERVICE_DATABASE_LOCKED: Self = Self(1055u32);
+                        pub const ERROR_SERVICE_ALREADY_RUNNING: Self = Self(1056u32);
+                        pub const ERROR_INVALID_SERVICE_ACCOUNT: Self = Self(1057u32);
+                        pub const ERROR_SERVICE_DISABLED: Self = Self(1058u32);
+                        pub const ERROR_CIRCULAR_DEPENDENCY: Self = Self(1059u32);
+                        pub const ERROR_SERVICE_DOES_NOT_EXIST: Self = Self(1060u32);
+                        pub const ERROR_SERVICE_CANNOT_ACCEPT_CTRL: Self = Self(1061u32);
+                        pub const ERROR_SERVICE_NOT_ACTIVE: Self = Self(1062u32);
+                        pub const ERROR_FAILED_SERVICE_CONTROLLER_CONNECT: Self = Self(1063u32);
+                        pub const ERROR_EXCEPTION_IN_SERVICE: Self = Self(1064u32);
+                        pub const ERROR_DATABASE_DOES_NOT_EXIST: Self = Self(1065u32);
+                        pub const ERROR_SERVICE_SPECIFIC_ERROR: Self = Self(1066u32);
+                        pub const ERROR_PROCESS_ABORTED: Self = Self(1067u32);
+                        pub const ERROR_SERVICE_DEPENDENCY_FAIL: Self = Self(1068u32);
+                        pub const ERROR_SERVICE_LOGON_FAILED: Self = Self(1069u32);
+                        pub const ERROR_SERVICE_START_HANG: Self = Self(1070u32);
+                        pub const ERROR_INVALID_SERVICE_LOCK: Self = Self(1071u32);
+                        pub const ERROR_SERVICE_MARKED_FOR_DELETE: Self = Self(1072u32);
+                        pub const ERROR_SERVICE_EXISTS: Self = Self(1073u32);
+                        pub const ERROR_ALREADY_RUNNING_LKG: Self = Self(1074u32);
+                        pub const ERROR_SERVICE_DEPENDENCY_DELETED: Self = Self(1075u32);
+                        pub const ERROR_BOOT_ALREADY_ACCEPTED: Self = Self(1076u32);
+                        pub const ERROR_SERVICE_NEVER_STARTED: Self = Self(1077u32);
+                        pub const ERROR_DUPLICATE_SERVICE_NAME: Self = Self(1078u32);
+                        pub const ERROR_DIFFERENT_SERVICE_ACCOUNT: Self = Self(1079u32);
+                        pub const ERROR_CANNOT_DETECT_DRIVER_FAILURE: Self = Self(1080u32);
+                        pub const ERROR_CANNOT_DETECT_PROCESS_ABORT: Self = Self(1081u32);
+                        pub const ERROR_NO_RECOVERY_PROGRAM: Self = Self(1082u32);
+                        pub const ERROR_SERVICE_NOT_IN_EXE: Self = Self(1083u32);
+                        pub const ERROR_NOT_SAFEBOOT_SERVICE: Self = Self(1084u32);
+                        pub const ERROR_END_OF_MEDIA: Self = Self(1100u32);
+                        pub const ERROR_FILEMARK_DETECTED: Self = Self(1101u32);
+                        pub const ERROR_BEGINNING_OF_MEDIA: Self = Self(1102u32);
+                        pub const ERROR_SETMARK_DETECTED: Self = Self(1103u32);
+                        pub const ERROR_NO_DATA_DETECTED: Self = Self(1104u32);
+                        pub const ERROR_PARTITION_FAILURE: Self = Self(1105u32);
+                        pub const ERROR_INVALID_BLOCK_LENGTH: Self = Self(1106u32);
+                        pub const ERROR_DEVICE_NOT_PARTITIONED: Self = Self(1107u32);
+                        pub const ERROR_UNABLE_TO_LOCK_MEDIA: Self = Self(1108u32);
+                        pub const ERROR_UNABLE_TO_UNLOAD_MEDIA: Self = Self(1109u32);
+                        pub const ERROR_MEDIA_CHANGED: Self = Self(1110u32);
+                        pub const ERROR_BUS_RESET: Self = Self(1111u32);
+                        pub const ERROR_NO_MEDIA_IN_DRIVE: Self = Self(1112u32);
+                        pub const ERROR_NO_UNICODE_TRANSLATION: Self = Self(1113u32);
+                        pub const ERROR_DLL_INIT_FAILED: Self = Self(1114u32);
+                        pub const ERROR_SHUTDOWN_IN_PROGRESS: Self = Self(1115u32);
+                        pub const ERROR_NO_SHUTDOWN_IN_PROGRESS: Self = Self(1116u32);
+                        pub const ERROR_IO_DEVICE: Self = Self(1117u32);
+                        pub const ERROR_SERIAL_NO_DEVICE: Self = Self(1118u32);
+                        pub const ERROR_IRQ_BUSY: Self = Self(1119u32);
+                        pub const ERROR_MORE_WRITES: Self = Self(1120u32);
+                        pub const ERROR_COUNTER_TIMEOUT: Self = Self(1121u32);
+                        pub const ERROR_FLOPPY_ID_MARK_NOT_FOUND: Self = Self(1122u32);
+                        pub const ERROR_FLOPPY_WRONG_CYLINDER: Self = Self(1123u32);
+                        pub const ERROR_FLOPPY_UNKNOWN_ERROR: Self = Self(1124u32);
+                        pub const ERROR_FLOPPY_BAD_REGISTERS: Self = Self(1125u32);
+                        pub const ERROR_DISK_RECALIBRATE_FAILED: Self = Self(1126u32);
+                        pub const ERROR_DISK_OPERATION_FAILED: Self = Self(1127u32);
+                        pub const ERROR_DISK_RESET_FAILED: Self = Self(1128u32);
+                        pub const ERROR_EOM_OVERFLOW: Self = Self(1129u32);
+                        pub const ERROR_NOT_ENOUGH_SERVER_MEMORY: Self = Self(1130u32);
+                        pub const ERROR_POSSIBLE_DEADLOCK: Self = Self(1131u32);
+                        pub const ERROR_MAPPED_ALIGNMENT: Self = Self(1132u32);
+                        pub const ERROR_SET_POWER_STATE_VETOED: Self = Self(1140u32);
+                        pub const ERROR_SET_POWER_STATE_FAILED: Self = Self(1141u32);
+                        pub const ERROR_TOO_MANY_LINKS: Self = Self(1142u32);
+                        pub const ERROR_OLD_WIN_VERSION: Self = Self(1150u32);
+                        pub const ERROR_APP_WRONG_OS: Self = Self(1151u32);
+                        pub const ERROR_SINGLE_INSTANCE_APP: Self = Self(1152u32);
+                        pub const ERROR_RMODE_APP: Self = Self(1153u32);
+                        pub const ERROR_INVALID_DLL: Self = Self(1154u32);
+                        pub const ERROR_NO_ASSOCIATION: Self = Self(1155u32);
+                        pub const ERROR_DDE_FAIL: Self = Self(1156u32);
+                        pub const ERROR_DLL_NOT_FOUND: Self = Self(1157u32);
+                        pub const ERROR_NO_MORE_USER_HANDLES: Self = Self(1158u32);
+                        pub const ERROR_MESSAGE_SYNC_ONLY: Self = Self(1159u32);
+                        pub const ERROR_SOURCE_ELEMENT_EMPTY: Self = Self(1160u32);
+                        pub const ERROR_DESTINATION_ELEMENT_FULL: Self = Self(1161u32);
+                        pub const ERROR_ILLEGAL_ELEMENT_ADDRESS: Self = Self(1162u32);
+                        pub const ERROR_MAGAZINE_NOT_PRESENT: Self = Self(1163u32);
+                        pub const ERROR_DEVICE_REINITIALIZATION_NEEDED: Self = Self(1164u32);
+                        pub const ERROR_DEVICE_REQUIRES_CLEANING: Self = Self(1165u32);
+                        pub const ERROR_DEVICE_DOOR_OPEN: Self = Self(1166u32);
+                        pub const ERROR_DEVICE_NOT_CONNECTED: Self = Self(1167u32);
+                        pub const ERROR_NOT_FOUND: Self = Self(1168u32);
+                        pub const ERROR_NO_MATCH: Self = Self(1169u32);
+                        pub const ERROR_SET_NOT_FOUND: Self = Self(1170u32);
+                        pub const ERROR_POINT_NOT_FOUND: Self = Self(1171u32);
+                        pub const ERROR_NO_TRACKING_SERVICE: Self = Self(1172u32);
+                        pub const ERROR_NO_VOLUME_ID: Self = Self(1173u32);
+                        pub const ERROR_UNABLE_TO_REMOVE_REPLACED: Self = Self(1175u32);
+                        pub const ERROR_UNABLE_TO_MOVE_REPLACEMENT: Self = Self(1176u32);
+                        pub const ERROR_UNABLE_TO_MOVE_REPLACEMENT_2: Self = Self(1177u32);
+                        pub const ERROR_JOURNAL_DELETE_IN_PROGRESS: Self = Self(1178u32);
+                        pub const ERROR_JOURNAL_NOT_ACTIVE: Self = Self(1179u32);
+                        pub const ERROR_POTENTIAL_FILE_FOUND: Self = Self(1180u32);
+                        pub const ERROR_JOURNAL_ENTRY_DELETED: Self = Self(1181u32);
+                        pub const ERROR_SHUTDOWN_IS_SCHEDULED: Self = Self(1190u32);
+                        pub const ERROR_SHUTDOWN_USERS_LOGGED_ON: Self = Self(1191u32);
+                        pub const ERROR_BAD_DEVICE: Self = Self(1200u32);
+                        pub const ERROR_CONNECTION_UNAVAIL: Self = Self(1201u32);
+                        pub const ERROR_DEVICE_ALREADY_REMEMBERED: Self = Self(1202u32);
+                        pub const ERROR_NO_NET_OR_BAD_PATH: Self = Self(1203u32);
+                        pub const ERROR_BAD_PROVIDER: Self = Self(1204u32);
+                        pub const ERROR_CANNOT_OPEN_PROFILE: Self = Self(1205u32);
+                        pub const ERROR_BAD_PROFILE: Self = Self(1206u32);
+                        pub const ERROR_NOT_CONTAINER: Self = Self(1207u32);
+                        pub const ERROR_EXTENDED_ERROR: Self = Self(1208u32);
+                        pub const ERROR_INVALID_GROUPNAME: Self = Self(1209u32);
+                        pub const ERROR_INVALID_COMPUTERNAME: Self = Self(1210u32);
+                        pub const ERROR_INVALID_EVENTNAME: Self = Self(1211u32);
+                        pub const ERROR_INVALID_DOMAINNAME: Self = Self(1212u32);
+                        pub const ERROR_INVALID_SERVICENAME: Self = Self(1213u32);
+                        pub const ERROR_INVALID_NETNAME: Self = Self(1214u32);
+                        pub const ERROR_INVALID_SHARENAME: Self = Self(1215u32);
+                        pub const ERROR_INVALID_PASSWORDNAME: Self = Self(1216u32);
+                        pub const ERROR_INVALID_MESSAGENAME: Self = Self(1217u32);
+                        pub const ERROR_INVALID_MESSAGEDEST: Self = Self(1218u32);
+                        pub const ERROR_SESSION_CREDENTIAL_CONFLICT: Self = Self(1219u32);
+                        pub const ERROR_REMOTE_SESSION_LIMIT_EXCEEDED: Self = Self(1220u32);
+                        pub const ERROR_DUP_DOMAINNAME: Self = Self(1221u32);
+                        pub const ERROR_NO_NETWORK: Self = Self(1222u32);
+                        pub const ERROR_CANCELLED: Self = Self(1223u32);
+                        pub const ERROR_USER_MAPPED_FILE: Self = Self(1224u32);
+                        pub const ERROR_CONNECTION_REFUSED: Self = Self(1225u32);
+                        pub const ERROR_GRACEFUL_DISCONNECT: Self = Self(1226u32);
+                        pub const ERROR_ADDRESS_ALREADY_ASSOCIATED: Self = Self(1227u32);
+                        pub const ERROR_ADDRESS_NOT_ASSOCIATED: Self = Self(1228u32);
+                        pub const ERROR_CONNECTION_INVALID: Self = Self(1229u32);
+                        pub const ERROR_CONNECTION_ACTIVE: Self = Self(1230u32);
+                        pub const ERROR_NETWORK_UNREACHABLE: Self = Self(1231u32);
+                        pub const ERROR_HOST_UNREACHABLE: Self = Self(1232u32);
+                        pub const ERROR_PROTOCOL_UNREACHABLE: Self = Self(1233u32);
+                        pub const ERROR_PORT_UNREACHABLE: Self = Self(1234u32);
+                        pub const ERROR_REQUEST_ABORTED: Self = Self(1235u32);
+                        pub const ERROR_CONNECTION_ABORTED: Self = Self(1236u32);
+                        pub const ERROR_RETRY: Self = Self(1237u32);
+                        pub const ERROR_CONNECTION_COUNT_LIMIT: Self = Self(1238u32);
+                        pub const ERROR_LOGIN_TIME_RESTRICTION: Self = Self(1239u32);
+                        pub const ERROR_LOGIN_WKSTA_RESTRICTION: Self = Self(1240u32);
+                        pub const ERROR_INCORRECT_ADDRESS: Self = Self(1241u32);
+                        pub const ERROR_ALREADY_REGISTERED: Self = Self(1242u32);
+                        pub const ERROR_SERVICE_NOT_FOUND: Self = Self(1243u32);
+                        pub const ERROR_NOT_AUTHENTICATED: Self = Self(1244u32);
+                        pub const ERROR_NOT_LOGGED_ON: Self = Self(1245u32);
+                        pub const ERROR_CONTINUE: Self = Self(1246u32);
+                        pub const ERROR_ALREADY_INITIALIZED: Self = Self(1247u32);
+                        pub const ERROR_NO_MORE_DEVICES: Self = Self(1248u32);
+                        pub const ERROR_NO_SUCH_SITE: Self = Self(1249u32);
+                        pub const ERROR_DOMAIN_CONTROLLER_EXISTS: Self = Self(1250u32);
+                        pub const ERROR_ONLY_IF_CONNECTED: Self = Self(1251u32);
+                        pub const ERROR_OVERRIDE_NOCHANGES: Self = Self(1252u32);
+                        pub const ERROR_BAD_USER_PROFILE: Self = Self(1253u32);
+                        pub const ERROR_NOT_SUPPORTED_ON_SBS: Self = Self(1254u32);
+                        pub const ERROR_SERVER_SHUTDOWN_IN_PROGRESS: Self = Self(1255u32);
+                        pub const ERROR_HOST_DOWN: Self = Self(1256u32);
+                        pub const ERROR_NON_ACCOUNT_SID: Self = Self(1257u32);
+                        pub const ERROR_NON_DOMAIN_SID: Self = Self(1258u32);
+                        pub const ERROR_APPHELP_BLOCK: Self = Self(1259u32);
+                        pub const ERROR_ACCESS_DISABLED_BY_POLICY: Self = Self(1260u32);
+                        pub const ERROR_REG_NAT_CONSUMPTION: Self = Self(1261u32);
+                        pub const ERROR_CSCSHARE_OFFLINE: Self = Self(1262u32);
+                        pub const ERROR_PKINIT_FAILURE: Self = Self(1263u32);
+                        pub const ERROR_SMARTCARD_SUBSYSTEM_FAILURE: Self = Self(1264u32);
+                        pub const ERROR_DOWNGRADE_DETECTED: Self = Self(1265u32);
+                        pub const ERROR_MACHINE_LOCKED: Self = Self(1271u32);
+                        pub const ERROR_SMB_GUEST_LOGON_BLOCKED: Self = Self(1272u32);
+                        pub const ERROR_CALLBACK_SUPPLIED_INVALID_DATA: Self = Self(1273u32);
+                        pub const ERROR_SYNC_FOREGROUND_REFRESH_REQUIRED: Self = Self(1274u32);
+                        pub const ERROR_DRIVER_BLOCKED: Self = Self(1275u32);
+                        pub const ERROR_INVALID_IMPORT_OF_NON_DLL: Self = Self(1276u32);
+                        pub const ERROR_ACCESS_DISABLED_WEBBLADE: Self = Self(1277u32);
+                        pub const ERROR_ACCESS_DISABLED_WEBBLADE_TAMPER: Self = Self(1278u32);
+                        pub const ERROR_RECOVERY_FAILURE: Self = Self(1279u32);
+                        pub const ERROR_ALREADY_FIBER: Self = Self(1280u32);
+                        pub const ERROR_ALREADY_THREAD: Self = Self(1281u32);
+                        pub const ERROR_STACK_BUFFER_OVERRUN: Self = Self(1282u32);
+                        pub const ERROR_PARAMETER_QUOTA_EXCEEDED: Self = Self(1283u32);
+                        pub const ERROR_DEBUGGER_INACTIVE: Self = Self(1284u32);
+                        pub const ERROR_DELAY_LOAD_FAILED: Self = Self(1285u32);
+                        pub const ERROR_VDM_DISALLOWED: Self = Self(1286u32);
+                        pub const ERROR_UNIDENTIFIED_ERROR: Self = Self(1287u32);
+                        pub const ERROR_INVALID_CRUNTIME_PARAMETER: Self = Self(1288u32);
+                        pub const ERROR_BEYOND_VDL: Self = Self(1289u32);
+                        pub const ERROR_INCOMPATIBLE_SERVICE_SID_TYPE: Self = Self(1290u32);
+                        pub const ERROR_DRIVER_PROCESS_TERMINATED: Self = Self(1291u32);
+                        pub const ERROR_IMPLEMENTATION_LIMIT: Self = Self(1292u32);
+                        pub const ERROR_PROCESS_IS_PROTECTED: Self = Self(1293u32);
+                        pub const ERROR_SERVICE_NOTIFY_CLIENT_LAGGING: Self = Self(1294u32);
+                        pub const ERROR_DISK_QUOTA_EXCEEDED: Self = Self(1295u32);
+                        pub const ERROR_CONTENT_BLOCKED: Self = Self(1296u32);
+                        pub const ERROR_INCOMPATIBLE_SERVICE_PRIVILEGE: Self = Self(1297u32);
+                        pub const ERROR_APP_HANG: Self = Self(1298u32);
+                        pub const ERROR_INVALID_LABEL: Self = Self(1299u32);
+                        pub const ERROR_NOT_ALL_ASSIGNED: Self = Self(1300u32);
+                        pub const ERROR_SOME_NOT_MAPPED: Self = Self(1301u32);
+                        pub const ERROR_NO_QUOTAS_FOR_ACCOUNT: Self = Self(1302u32);
+                        pub const ERROR_LOCAL_USER_SESSION_KEY: Self = Self(1303u32);
+                        pub const ERROR_NULL_LM_PASSWORD: Self = Self(1304u32);
+                        pub const ERROR_UNKNOWN_REVISION: Self = Self(1305u32);
+                        pub const ERROR_REVISION_MISMATCH: Self = Self(1306u32);
+                        pub const ERROR_INVALID_OWNER: Self = Self(1307u32);
+                        pub const ERROR_INVALID_PRIMARY_GROUP: Self = Self(1308u32);
+                        pub const ERROR_NO_IMPERSONATION_TOKEN: Self = Self(1309u32);
+                        pub const ERROR_CANT_DISABLE_MANDATORY: Self = Self(1310u32);
+                        pub const ERROR_NO_LOGON_SERVERS: Self = Self(1311u32);
+                        pub const ERROR_NO_SUCH_LOGON_SESSION: Self = Self(1312u32);
+                        pub const ERROR_NO_SUCH_PRIVILEGE: Self = Self(1313u32);
+                        pub const ERROR_PRIVILEGE_NOT_HELD: Self = Self(1314u32);
+                        pub const ERROR_INVALID_ACCOUNT_NAME: Self = Self(1315u32);
+                        pub const ERROR_USER_EXISTS: Self = Self(1316u32);
+                        pub const ERROR_NO_SUCH_USER: Self = Self(1317u32);
+                        pub const ERROR_GROUP_EXISTS: Self = Self(1318u32);
+                        pub const ERROR_NO_SUCH_GROUP: Self = Self(1319u32);
+                        pub const ERROR_MEMBER_IN_GROUP: Self = Self(1320u32);
+                        pub const ERROR_MEMBER_NOT_IN_GROUP: Self = Self(1321u32);
+                        pub const ERROR_LAST_ADMIN: Self = Self(1322u32);
+                        pub const ERROR_WRONG_PASSWORD: Self = Self(1323u32);
+                        pub const ERROR_ILL_FORMED_PASSWORD: Self = Self(1324u32);
+                        pub const ERROR_PASSWORD_RESTRICTION: Self = Self(1325u32);
+                        pub const ERROR_LOGON_FAILURE: Self = Self(1326u32);
+                        pub const ERROR_ACCOUNT_RESTRICTION: Self = Self(1327u32);
+                        pub const ERROR_INVALID_LOGON_HOURS: Self = Self(1328u32);
+                        pub const ERROR_INVALID_WORKSTATION: Self = Self(1329u32);
+                        pub const ERROR_PASSWORD_EXPIRED: Self = Self(1330u32);
+                        pub const ERROR_ACCOUNT_DISABLED: Self = Self(1331u32);
+                        pub const ERROR_NONE_MAPPED: Self = Self(1332u32);
+                        pub const ERROR_TOO_MANY_LUIDS_REQUESTED: Self = Self(1333u32);
+                        pub const ERROR_LUIDS_EXHAUSTED: Self = Self(1334u32);
+                        pub const ERROR_INVALID_SUB_AUTHORITY: Self = Self(1335u32);
+                        pub const ERROR_INVALID_ACL: Self = Self(1336u32);
+                        pub const ERROR_INVALID_SID: Self = Self(1337u32);
+                        pub const ERROR_INVALID_SECURITY_DESCR: Self = Self(1338u32);
+                        pub const ERROR_BAD_INHERITANCE_ACL: Self = Self(1340u32);
+                        pub const ERROR_SERVER_DISABLED: Self = Self(1341u32);
+                        pub const ERROR_SERVER_NOT_DISABLED: Self = Self(1342u32);
+                        pub const ERROR_INVALID_ID_AUTHORITY: Self = Self(1343u32);
+                        pub const ERROR_ALLOTTED_SPACE_EXCEEDED: Self = Self(1344u32);
+                        pub const ERROR_INVALID_GROUP_ATTRIBUTES: Self = Self(1345u32);
+                        pub const ERROR_BAD_IMPERSONATION_LEVEL: Self = Self(1346u32);
+                        pub const ERROR_CANT_OPEN_ANONYMOUS: Self = Self(1347u32);
+                        pub const ERROR_BAD_VALIDATION_CLASS: Self = Self(1348u32);
+                        pub const ERROR_BAD_TOKEN_TYPE: Self = Self(1349u32);
+                        pub const ERROR_NO_SECURITY_ON_OBJECT: Self = Self(1350u32);
+                        pub const ERROR_CANT_ACCESS_DOMAIN_INFO: Self = Self(1351u32);
+                        pub const ERROR_INVALID_SERVER_STATE: Self = Self(1352u32);
+                        pub const ERROR_INVALID_DOMAIN_STATE: Self = Self(1353u32);
+                        pub const ERROR_INVALID_DOMAIN_ROLE: Self = Self(1354u32);
+                        pub const ERROR_NO_SUCH_DOMAIN: Self = Self(1355u32);
+                        pub const ERROR_DOMAIN_EXISTS: Self = Self(1356u32);
+                        pub const ERROR_DOMAIN_LIMIT_EXCEEDED: Self = Self(1357u32);
+                        pub const ERROR_INTERNAL_DB_CORRUPTION: Self = Self(1358u32);
+                        pub const ERROR_INTERNAL_ERROR: Self = Self(1359u32);
+                        pub const ERROR_GENERIC_NOT_MAPPED: Self = Self(1360u32);
+                        pub const ERROR_BAD_DESCRIPTOR_FORMAT: Self = Self(1361u32);
+                        pub const ERROR_NOT_LOGON_PROCESS: Self = Self(1362u32);
+                        pub const ERROR_LOGON_SESSION_EXISTS: Self = Self(1363u32);
+                        pub const ERROR_NO_SUCH_PACKAGE: Self = Self(1364u32);
+                        pub const ERROR_BAD_LOGON_SESSION_STATE: Self = Self(1365u32);
+                        pub const ERROR_LOGON_SESSION_COLLISION: Self = Self(1366u32);
+                        pub const ERROR_INVALID_LOGON_TYPE: Self = Self(1367u32);
+                        pub const ERROR_CANNOT_IMPERSONATE: Self = Self(1368u32);
+                        pub const ERROR_RXACT_INVALID_STATE: Self = Self(1369u32);
+                        pub const ERROR_RXACT_COMMIT_FAILURE: Self = Self(1370u32);
+                        pub const ERROR_SPECIAL_ACCOUNT: Self = Self(1371u32);
+                        pub const ERROR_SPECIAL_GROUP: Self = Self(1372u32);
+                        pub const ERROR_SPECIAL_USER: Self = Self(1373u32);
+                        pub const ERROR_MEMBERS_PRIMARY_GROUP: Self = Self(1374u32);
+                        pub const ERROR_TOKEN_ALREADY_IN_USE: Self = Self(1375u32);
+                        pub const ERROR_NO_SUCH_ALIAS: Self = Self(1376u32);
+                        pub const ERROR_MEMBER_NOT_IN_ALIAS: Self = Self(1377u32);
+                        pub const ERROR_MEMBER_IN_ALIAS: Self = Self(1378u32);
+                        pub const ERROR_ALIAS_EXISTS: Self = Self(1379u32);
+                        pub const ERROR_LOGON_NOT_GRANTED: Self = Self(1380u32);
+                        pub const ERROR_TOO_MANY_SECRETS: Self = Self(1381u32);
+                        pub const ERROR_SECRET_TOO_LONG: Self = Self(1382u32);
+                        pub const ERROR_INTERNAL_DB_ERROR: Self = Self(1383u32);
+                        pub const ERROR_TOO_MANY_CONTEXT_IDS: Self = Self(1384u32);
+                        pub const ERROR_LOGON_TYPE_NOT_GRANTED: Self = Self(1385u32);
+                        pub const ERROR_NT_CROSS_ENCRYPTION_REQUIRED: Self = Self(1386u32);
+                        pub const ERROR_NO_SUCH_MEMBER: Self = Self(1387u32);
+                        pub const ERROR_INVALID_MEMBER: Self = Self(1388u32);
+                        pub const ERROR_TOO_MANY_SIDS: Self = Self(1389u32);
+                        pub const ERROR_LM_CROSS_ENCRYPTION_REQUIRED: Self = Self(1390u32);
+                        pub const ERROR_NO_INHERITANCE: Self = Self(1391u32);
+                        pub const ERROR_FILE_CORRUPT: Self = Self(1392u32);
+                        pub const ERROR_DISK_CORRUPT: Self = Self(1393u32);
+                        pub const ERROR_NO_USER_SESSION_KEY: Self = Self(1394u32);
+                        pub const ERROR_LICENSE_QUOTA_EXCEEDED: Self = Self(1395u32);
+                        pub const ERROR_WRONG_TARGET_NAME: Self = Self(1396u32);
+                        pub const ERROR_MUTUAL_AUTH_FAILED: Self = Self(1397u32);
+                        pub const ERROR_TIME_SKEW: Self = Self(1398u32);
+                        pub const ERROR_CURRENT_DOMAIN_NOT_ALLOWED: Self = Self(1399u32);
+                        pub const ERROR_INVALID_WINDOW_HANDLE: Self = Self(1400u32);
+                        pub const ERROR_INVALID_MENU_HANDLE: Self = Self(1401u32);
+                        pub const ERROR_INVALID_CURSOR_HANDLE: Self = Self(1402u32);
+                        pub const ERROR_INVALID_ACCEL_HANDLE: Self = Self(1403u32);
+                        pub const ERROR_INVALID_HOOK_HANDLE: Self = Self(1404u32);
+                        pub const ERROR_INVALID_DWP_HANDLE: Self = Self(1405u32);
+                        pub const ERROR_TLW_WITH_WSCHILD: Self = Self(1406u32);
+                        pub const ERROR_CANNOT_FIND_WND_CLASS: Self = Self(1407u32);
+                        pub const ERROR_WINDOW_OF_OTHER_THREAD: Self = Self(1408u32);
+                        pub const ERROR_HOTKEY_ALREADY_REGISTERED: Self = Self(1409u32);
+                        pub const ERROR_CLASS_ALREADY_EXISTS: Self = Self(1410u32);
+                        pub const ERROR_CLASS_DOES_NOT_EXIST: Self = Self(1411u32);
+                        pub const ERROR_CLASS_HAS_WINDOWS: Self = Self(1412u32);
+                        pub const ERROR_INVALID_INDEX: Self = Self(1413u32);
+                        pub const ERROR_INVALID_ICON_HANDLE: Self = Self(1414u32);
+                        pub const ERROR_PRIVATE_DIALOG_INDEX: Self = Self(1415u32);
+                        pub const ERROR_LISTBOX_ID_NOT_FOUND: Self = Self(1416u32);
+                        pub const ERROR_NO_WILDCARD_CHARACTERS: Self = Self(1417u32);
+                        pub const ERROR_CLIPBOARD_NOT_OPEN: Self = Self(1418u32);
+                        pub const ERROR_HOTKEY_NOT_REGISTERED: Self = Self(1419u32);
+                        pub const ERROR_WINDOW_NOT_DIALOG: Self = Self(1420u32);
+                        pub const ERROR_CONTROL_ID_NOT_FOUND: Self = Self(1421u32);
+                        pub const ERROR_INVALID_COMBOBOX_MESSAGE: Self = Self(1422u32);
+                        pub const ERROR_WINDOW_NOT_COMBOBOX: Self = Self(1423u32);
+                        pub const ERROR_INVALID_EDIT_HEIGHT: Self = Self(1424u32);
+                        pub const ERROR_DC_NOT_FOUND: Self = Self(1425u32);
+                        pub const ERROR_INVALID_HOOK_FILTER: Self = Self(1426u32);
+                        pub const ERROR_INVALID_FILTER_PROC: Self = Self(1427u32);
+                        pub const ERROR_HOOK_NEEDS_HMOD: Self = Self(1428u32);
+                        pub const ERROR_GLOBAL_ONLY_HOOK: Self = Self(1429u32);
+                        pub const ERROR_JOURNAL_HOOK_SET: Self = Self(1430u32);
+                        pub const ERROR_HOOK_NOT_INSTALLED: Self = Self(1431u32);
+                        pub const ERROR_INVALID_LB_MESSAGE: Self = Self(1432u32);
+                        pub const ERROR_SETCOUNT_ON_BAD_LB: Self = Self(1433u32);
+                        pub const ERROR_LB_WITHOUT_TABSTOPS: Self = Self(1434u32);
+                        pub const ERROR_DESTROY_OBJECT_OF_OTHER_THREAD: Self = Self(1435u32);
+                        pub const ERROR_CHILD_WINDOW_MENU: Self = Self(1436u32);
+                        pub const ERROR_NO_SYSTEM_MENU: Self = Self(1437u32);
+                        pub const ERROR_INVALID_MSGBOX_STYLE: Self = Self(1438u32);
+                        pub const ERROR_INVALID_SPI_VALUE: Self = Self(1439u32);
+                        pub const ERROR_SCREEN_ALREADY_LOCKED: Self = Self(1440u32);
+                        pub const ERROR_HWNDS_HAVE_DIFF_PARENT: Self = Self(1441u32);
+                        pub const ERROR_NOT_CHILD_WINDOW: Self = Self(1442u32);
+                        pub const ERROR_INVALID_GW_COMMAND: Self = Self(1443u32);
+                        pub const ERROR_INVALID_THREAD_ID: Self = Self(1444u32);
+                        pub const ERROR_NON_MDICHILD_WINDOW: Self = Self(1445u32);
+                        pub const ERROR_POPUP_ALREADY_ACTIVE: Self = Self(1446u32);
+                        pub const ERROR_NO_SCROLLBARS: Self = Self(1447u32);
+                        pub const ERROR_INVALID_SCROLLBAR_RANGE: Self = Self(1448u32);
+                        pub const ERROR_INVALID_SHOWWIN_COMMAND: Self = Self(1449u32);
+                        pub const ERROR_NO_SYSTEM_RESOURCES: Self = Self(1450u32);
+                        pub const ERROR_NONPAGED_SYSTEM_RESOURCES: Self = Self(1451u32);
+                        pub const ERROR_PAGED_SYSTEM_RESOURCES: Self = Self(1452u32);
+                        pub const ERROR_WORKING_SET_QUOTA: Self = Self(1453u32);
+                        pub const ERROR_PAGEFILE_QUOTA: Self = Self(1454u32);
+                        pub const ERROR_COMMITMENT_LIMIT: Self = Self(1455u32);
+                        pub const ERROR_MENU_ITEM_NOT_FOUND: Self = Self(1456u32);
+                        pub const ERROR_INVALID_KEYBOARD_HANDLE: Self = Self(1457u32);
+                        pub const ERROR_HOOK_TYPE_NOT_ALLOWED: Self = Self(1458u32);
+                        pub const ERROR_REQUIRES_INTERACTIVE_WINDOWSTATION: Self = Self(1459u32);
+                        pub const ERROR_TIMEOUT: Self = Self(1460u32);
+                        pub const ERROR_INVALID_MONITOR_HANDLE: Self = Self(1461u32);
+                        pub const ERROR_INCORRECT_SIZE: Self = Self(1462u32);
+                        pub const ERROR_SYMLINK_CLASS_DISABLED: Self = Self(1463u32);
+                        pub const ERROR_SYMLINK_NOT_SUPPORTED: Self = Self(1464u32);
+                        pub const ERROR_XML_PARSE_ERROR: Self = Self(1465u32);
+                        pub const ERROR_XMLDSIG_ERROR: Self = Self(1466u32);
+                        pub const ERROR_RESTART_APPLICATION: Self = Self(1467u32);
+                        pub const ERROR_WRONG_COMPARTMENT: Self = Self(1468u32);
+                        pub const ERROR_AUTHIP_FAILURE: Self = Self(1469u32);
+                        pub const ERROR_NO_NVRAM_RESOURCES: Self = Self(1470u32);
+                        pub const ERROR_NOT_GUI_PROCESS: Self = Self(1471u32);
+                        pub const ERROR_EVENTLOG_FILE_CORRUPT: Self = Self(1500u32);
+                        pub const ERROR_EVENTLOG_CANT_START: Self = Self(1501u32);
+                        pub const ERROR_LOG_FILE_FULL: Self = Self(1502u32);
+                        pub const ERROR_EVENTLOG_FILE_CHANGED: Self = Self(1503u32);
+                        pub const ERROR_CONTAINER_ASSIGNED: Self = Self(1504u32);
+                        pub const ERROR_JOB_NO_CONTAINER: Self = Self(1505u32);
+                        pub const ERROR_INVALID_TASK_NAME: Self = Self(1550u32);
+                        pub const ERROR_INVALID_TASK_INDEX: Self = Self(1551u32);
+                        pub const ERROR_THREAD_ALREADY_IN_TASK: Self = Self(1552u32);
+                        pub const ERROR_INSTALL_SERVICE_FAILURE: Self = Self(1601u32);
+                        pub const ERROR_INSTALL_USEREXIT: Self = Self(1602u32);
+                        pub const ERROR_INSTALL_FAILURE: Self = Self(1603u32);
+                        pub const ERROR_INSTALL_SUSPEND: Self = Self(1604u32);
+                        pub const ERROR_UNKNOWN_PRODUCT: Self = Self(1605u32);
+                        pub const ERROR_UNKNOWN_FEATURE: Self = Self(1606u32);
+                        pub const ERROR_UNKNOWN_COMPONENT: Self = Self(1607u32);
+                        pub const ERROR_UNKNOWN_PROPERTY: Self = Self(1608u32);
+                        pub const ERROR_INVALID_HANDLE_STATE: Self = Self(1609u32);
+                        pub const ERROR_BAD_CONFIGURATION: Self = Self(1610u32);
+                        pub const ERROR_INDEX_ABSENT: Self = Self(1611u32);
+                        pub const ERROR_INSTALL_SOURCE_ABSENT: Self = Self(1612u32);
+                        pub const ERROR_INSTALL_PACKAGE_VERSION: Self = Self(1613u32);
+                        pub const ERROR_PRODUCT_UNINSTALLED: Self = Self(1614u32);
+                        pub const ERROR_BAD_QUERY_SYNTAX: Self = Self(1615u32);
+                        pub const ERROR_INVALID_FIELD: Self = Self(1616u32);
+                        pub const ERROR_DEVICE_REMOVED: Self = Self(1617u32);
+                        pub const ERROR_INSTALL_ALREADY_RUNNING: Self = Self(1618u32);
+                        pub const ERROR_INSTALL_PACKAGE_OPEN_FAILED: Self = Self(1619u32);
+                        pub const ERROR_INSTALL_PACKAGE_INVALID: Self = Self(1620u32);
+                        pub const ERROR_INSTALL_UI_FAILURE: Self = Self(1621u32);
+                        pub const ERROR_INSTALL_LOG_FAILURE: Self = Self(1622u32);
+                        pub const ERROR_INSTALL_LANGUAGE_UNSUPPORTED: Self = Self(1623u32);
+                        pub const ERROR_INSTALL_TRANSFORM_FAILURE: Self = Self(1624u32);
+                        pub const ERROR_INSTALL_PACKAGE_REJECTED: Self = Self(1625u32);
+                        pub const ERROR_FUNCTION_NOT_CALLED: Self = Self(1626u32);
+                        pub const ERROR_FUNCTION_FAILED: Self = Self(1627u32);
+                        pub const ERROR_INVALID_TABLE: Self = Self(1628u32);
+                        pub const ERROR_DATATYPE_MISMATCH: Self = Self(1629u32);
+                        pub const ERROR_UNSUPPORTED_TYPE: Self = Self(1630u32);
+                        pub const ERROR_CREATE_FAILED: Self = Self(1631u32);
+                        pub const ERROR_INSTALL_TEMP_UNWRITABLE: Self = Self(1632u32);
+                        pub const ERROR_INSTALL_PLATFORM_UNSUPPORTED: Self = Self(1633u32);
+                        pub const ERROR_INSTALL_NOTUSED: Self = Self(1634u32);
+                        pub const ERROR_PATCH_PACKAGE_OPEN_FAILED: Self = Self(1635u32);
+                        pub const ERROR_PATCH_PACKAGE_INVALID: Self = Self(1636u32);
+                        pub const ERROR_PATCH_PACKAGE_UNSUPPORTED: Self = Self(1637u32);
+                        pub const ERROR_PRODUCT_VERSION: Self = Self(1638u32);
+                        pub const ERROR_INVALID_COMMAND_LINE: Self = Self(1639u32);
+                        pub const ERROR_INSTALL_REMOTE_DISALLOWED: Self = Self(1640u32);
+                        pub const ERROR_SUCCESS_REBOOT_INITIATED: Self = Self(1641u32);
+                        pub const ERROR_PATCH_TARGET_NOT_FOUND: Self = Self(1642u32);
+                        pub const ERROR_PATCH_PACKAGE_REJECTED: Self = Self(1643u32);
+                        pub const ERROR_INSTALL_TRANSFORM_REJECTED: Self = Self(1644u32);
+                        pub const ERROR_INSTALL_REMOTE_PROHIBITED: Self = Self(1645u32);
+                        pub const ERROR_PATCH_REMOVAL_UNSUPPORTED: Self = Self(1646u32);
+                        pub const ERROR_UNKNOWN_PATCH: Self = Self(1647u32);
+                        pub const ERROR_PATCH_NO_SEQUENCE: Self = Self(1648u32);
+                        pub const ERROR_PATCH_REMOVAL_DISALLOWED: Self = Self(1649u32);
+                        pub const ERROR_INVALID_PATCH_XML: Self = Self(1650u32);
+                        pub const ERROR_PATCH_MANAGED_ADVERTISED_PRODUCT: Self = Self(1651u32);
+                        pub const ERROR_INSTALL_SERVICE_SAFEBOOT: Self = Self(1652u32);
+                        pub const ERROR_FAIL_FAST_EXCEPTION: Self = Self(1653u32);
+                        pub const ERROR_INSTALL_REJECTED: Self = Self(1654u32);
+                        pub const ERROR_DYNAMIC_CODE_BLOCKED: Self = Self(1655u32);
+                        pub const ERROR_NOT_SAME_OBJECT: Self = Self(1656u32);
+                        pub const ERROR_STRICT_CFG_VIOLATION: Self = Self(1657u32);
+                        pub const ERROR_SET_CONTEXT_DENIED: Self = Self(1660u32);
+                        pub const ERROR_CROSS_PARTITION_VIOLATION: Self = Self(1661u32);
+                        pub const ERROR_RETURN_ADDRESS_HIJACK_ATTEMPT: Self = Self(1662u32);
+                        pub const ERROR_INVALID_USER_BUFFER: Self = Self(1784u32);
+                        pub const ERROR_UNRECOGNIZED_MEDIA: Self = Self(1785u32);
+                        pub const ERROR_NO_TRUST_LSA_SECRET: Self = Self(1786u32);
+                        pub const ERROR_NO_TRUST_SAM_ACCOUNT: Self = Self(1787u32);
+                        pub const ERROR_TRUSTED_DOMAIN_FAILURE: Self = Self(1788u32);
+                        pub const ERROR_TRUSTED_RELATIONSHIP_FAILURE: Self = Self(1789u32);
+                        pub const ERROR_TRUST_FAILURE: Self = Self(1790u32);
+                        pub const ERROR_NETLOGON_NOT_STARTED: Self = Self(1792u32);
+                        pub const ERROR_ACCOUNT_EXPIRED: Self = Self(1793u32);
+                        pub const ERROR_REDIRECTOR_HAS_OPEN_HANDLES: Self = Self(1794u32);
+                        pub const ERROR_PRINTER_DRIVER_ALREADY_INSTALLED: Self = Self(1795u32);
+                        pub const ERROR_UNKNOWN_PORT: Self = Self(1796u32);
+                        pub const ERROR_UNKNOWN_PRINTER_DRIVER: Self = Self(1797u32);
+                        pub const ERROR_UNKNOWN_PRINTPROCESSOR: Self = Self(1798u32);
+                        pub const ERROR_INVALID_SEPARATOR_FILE: Self = Self(1799u32);
+                        pub const ERROR_INVALID_PRIORITY: Self = Self(1800u32);
+                        pub const ERROR_INVALID_PRINTER_NAME: Self = Self(1801u32);
+                        pub const ERROR_PRINTER_ALREADY_EXISTS: Self = Self(1802u32);
+                        pub const ERROR_INVALID_PRINTER_COMMAND: Self = Self(1803u32);
+                        pub const ERROR_INVALID_DATATYPE: Self = Self(1804u32);
+                        pub const ERROR_INVALID_ENVIRONMENT: Self = Self(1805u32);
+                        pub const ERROR_NOLOGON_INTERDOMAIN_TRUST_ACCOUNT: Self = Self(1807u32);
+                        pub const ERROR_NOLOGON_WORKSTATION_TRUST_ACCOUNT: Self = Self(1808u32);
+                        pub const ERROR_NOLOGON_SERVER_TRUST_ACCOUNT: Self = Self(1809u32);
+                        pub const ERROR_DOMAIN_TRUST_INCONSISTENT: Self = Self(1810u32);
+                        pub const ERROR_SERVER_HAS_OPEN_HANDLES: Self = Self(1811u32);
+                        pub const ERROR_RESOURCE_DATA_NOT_FOUND: Self = Self(1812u32);
+                        pub const ERROR_RESOURCE_TYPE_NOT_FOUND: Self = Self(1813u32);
+                        pub const ERROR_RESOURCE_NAME_NOT_FOUND: Self = Self(1814u32);
+                        pub const ERROR_RESOURCE_LANG_NOT_FOUND: Self = Self(1815u32);
+                        pub const ERROR_NOT_ENOUGH_QUOTA: Self = Self(1816u32);
+                        pub const ERROR_INVALID_TIME: Self = Self(1901u32);
+                        pub const ERROR_INVALID_FORM_NAME: Self = Self(1902u32);
+                        pub const ERROR_INVALID_FORM_SIZE: Self = Self(1903u32);
+                        pub const ERROR_ALREADY_WAITING: Self = Self(1904u32);
+                        pub const ERROR_PRINTER_DELETED: Self = Self(1905u32);
+                        pub const ERROR_INVALID_PRINTER_STATE: Self = Self(1906u32);
+                        pub const ERROR_PASSWORD_MUST_CHANGE: Self = Self(1907u32);
+                        pub const ERROR_DOMAIN_CONTROLLER_NOT_FOUND: Self = Self(1908u32);
+                        pub const ERROR_ACCOUNT_LOCKED_OUT: Self = Self(1909u32);
+                        pub const ERROR_NO_SITENAME: Self = Self(1919u32);
+                        pub const ERROR_CANT_ACCESS_FILE: Self = Self(1920u32);
+                        pub const ERROR_CANT_RESOLVE_FILENAME: Self = Self(1921u32);
+                        pub const ERROR_KM_DRIVER_BLOCKED: Self = Self(1930u32);
+                        pub const ERROR_CONTEXT_EXPIRED: Self = Self(1931u32);
+                        pub const ERROR_PER_USER_TRUST_QUOTA_EXCEEDED: Self = Self(1932u32);
+                        pub const ERROR_ALL_USER_TRUST_QUOTA_EXCEEDED: Self = Self(1933u32);
+                        pub const ERROR_USER_DELETE_TRUST_QUOTA_EXCEEDED: Self = Self(1934u32);
+                        pub const ERROR_AUTHENTICATION_FIREWALL_FAILED: Self = Self(1935u32);
+                        pub const ERROR_REMOTE_PRINT_CONNECTIONS_BLOCKED: Self = Self(1936u32);
+                        pub const ERROR_NTLM_BLOCKED: Self = Self(1937u32);
+                        pub const ERROR_PASSWORD_CHANGE_REQUIRED: Self = Self(1938u32);
+                        pub const ERROR_LOST_MODE_LOGON_RESTRICTION: Self = Self(1939u32);
+                        pub const ERROR_INVALID_PIXEL_FORMAT: Self = Self(2000u32);
+                        pub const ERROR_BAD_DRIVER: Self = Self(2001u32);
+                        pub const ERROR_INVALID_WINDOW_STYLE: Self = Self(2002u32);
+                        pub const ERROR_METAFILE_NOT_SUPPORTED: Self = Self(2003u32);
+                        pub const ERROR_TRANSFORM_NOT_SUPPORTED: Self = Self(2004u32);
+                        pub const ERROR_CLIPPING_NOT_SUPPORTED: Self = Self(2005u32);
+                        pub const ERROR_INVALID_CMM: Self = Self(2010u32);
+                        pub const ERROR_INVALID_PROFILE: Self = Self(2011u32);
+                        pub const ERROR_TAG_NOT_FOUND: Self = Self(2012u32);
+                        pub const ERROR_TAG_NOT_PRESENT: Self = Self(2013u32);
+                        pub const ERROR_DUPLICATE_TAG: Self = Self(2014u32);
+                        pub const ERROR_PROFILE_NOT_ASSOCIATED_WITH_DEVICE: Self = Self(2015u32);
+                        pub const ERROR_PROFILE_NOT_FOUND: Self = Self(2016u32);
+                        pub const ERROR_INVALID_COLORSPACE: Self = Self(2017u32);
+                        pub const ERROR_ICM_NOT_ENABLED: Self = Self(2018u32);
+                        pub const ERROR_DELETING_ICM_XFORM: Self = Self(2019u32);
+                        pub const ERROR_INVALID_TRANSFORM: Self = Self(2020u32);
+                        pub const ERROR_COLORSPACE_MISMATCH: Self = Self(2021u32);
+                        pub const ERROR_INVALID_COLORINDEX: Self = Self(2022u32);
+                        pub const ERROR_PROFILE_DOES_NOT_MATCH_DEVICE: Self = Self(2023u32);
+                        pub const ERROR_CONNECTED_OTHER_PASSWORD: Self = Self(2108u32);
+                        pub const ERROR_CONNECTED_OTHER_PASSWORD_DEFAULT: Self = Self(2109u32);
+                        pub const ERROR_BAD_USERNAME: Self = Self(2202u32);
+                        pub const ERROR_NOT_CONNECTED: Self = Self(2250u32);
+                        pub const ERROR_OPEN_FILES: Self = Self(2401u32);
+                        pub const ERROR_ACTIVE_CONNECTIONS: Self = Self(2402u32);
+                        pub const ERROR_DEVICE_IN_USE: Self = Self(2404u32);
+                        pub const ERROR_UNKNOWN_PRINT_MONITOR: Self = Self(3000u32);
+                        pub const ERROR_PRINTER_DRIVER_IN_USE: Self = Self(3001u32);
+                        pub const ERROR_SPOOL_FILE_NOT_FOUND: Self = Self(3002u32);
+                        pub const ERROR_SPL_NO_STARTDOC: Self = Self(3003u32);
+                        pub const ERROR_SPL_NO_ADDJOB: Self = Self(3004u32);
+                        pub const ERROR_PRINT_PROCESSOR_ALREADY_INSTALLED: Self = Self(3005u32);
+                        pub const ERROR_PRINT_MONITOR_ALREADY_INSTALLED: Self = Self(3006u32);
+                        pub const ERROR_INVALID_PRINT_MONITOR: Self = Self(3007u32);
+                        pub const ERROR_PRINT_MONITOR_IN_USE: Self = Self(3008u32);
+                        pub const ERROR_PRINTER_HAS_JOBS_QUEUED: Self = Self(3009u32);
+                        pub const ERROR_SUCCESS_REBOOT_REQUIRED: Self = Self(3010u32);
+                        pub const ERROR_SUCCESS_RESTART_REQUIRED: Self = Self(3011u32);
+                        pub const ERROR_PRINTER_NOT_FOUND: Self = Self(3012u32);
+                        pub const ERROR_PRINTER_DRIVER_WARNED: Self = Self(3013u32);
+                        pub const ERROR_PRINTER_DRIVER_BLOCKED: Self = Self(3014u32);
+                        pub const ERROR_PRINTER_DRIVER_PACKAGE_IN_USE: Self = Self(3015u32);
+                        pub const ERROR_CORE_DRIVER_PACKAGE_NOT_FOUND: Self = Self(3016u32);
+                        pub const ERROR_FAIL_REBOOT_REQUIRED: Self = Self(3017u32);
+                        pub const ERROR_FAIL_REBOOT_INITIATED: Self = Self(3018u32);
+                        pub const ERROR_PRINTER_DRIVER_DOWNLOAD_NEEDED: Self = Self(3019u32);
+                        pub const ERROR_PRINT_JOB_RESTART_REQUIRED: Self = Self(3020u32);
+                        pub const ERROR_INVALID_PRINTER_DRIVER_MANIFEST: Self = Self(3021u32);
+                        pub const ERROR_PRINTER_NOT_SHAREABLE: Self = Self(3022u32);
+                        pub const ERROR_REQUEST_PAUSED: Self = Self(3050u32);
+                        pub const ERROR_APPEXEC_CONDITION_NOT_SATISFIED: Self = Self(3060u32);
+                        pub const ERROR_APPEXEC_HANDLE_INVALIDATED: Self = Self(3061u32);
+                        pub const ERROR_APPEXEC_INVALID_HOST_GENERATION: Self = Self(3062u32);
+                        pub const ERROR_APPEXEC_UNEXPECTED_PROCESS_REGISTRATION: Self =
+                            Self(3063u32);
+                        pub const ERROR_APPEXEC_INVALID_HOST_STATE: Self = Self(3064u32);
+                        pub const ERROR_APPEXEC_NO_DONOR: Self = Self(3065u32);
+                        pub const ERROR_APPEXEC_HOST_ID_MISMATCH: Self = Self(3066u32);
+                        pub const ERROR_APPEXEC_UNKNOWN_USER: Self = Self(3067u32);
+                        pub const ERROR_IO_REISSUE_AS_CACHED: Self = Self(3950u32);
+                        pub const ERROR_WINS_INTERNAL: Self = Self(4000u32);
+                        pub const ERROR_CAN_NOT_DEL_LOCAL_WINS: Self = Self(4001u32);
+                        pub const ERROR_STATIC_INIT: Self = Self(4002u32);
+                        pub const ERROR_INC_BACKUP: Self = Self(4003u32);
+                        pub const ERROR_FULL_BACKUP: Self = Self(4004u32);
+                        pub const ERROR_REC_NON_EXISTENT: Self = Self(4005u32);
+                        pub const ERROR_RPL_NOT_ALLOWED: Self = Self(4006u32);
+                        pub const ERROR_DHCP_ADDRESS_CONFLICT: Self = Self(4100u32);
+                        pub const ERROR_WMI_GUID_NOT_FOUND: Self = Self(4200u32);
+                        pub const ERROR_WMI_INSTANCE_NOT_FOUND: Self = Self(4201u32);
+                        pub const ERROR_WMI_ITEMID_NOT_FOUND: Self = Self(4202u32);
+                        pub const ERROR_WMI_TRY_AGAIN: Self = Self(4203u32);
+                        pub const ERROR_WMI_DP_NOT_FOUND: Self = Self(4204u32);
+                        pub const ERROR_WMI_UNRESOLVED_INSTANCE_REF: Self = Self(4205u32);
+                        pub const ERROR_WMI_ALREADY_ENABLED: Self = Self(4206u32);
+                        pub const ERROR_WMI_GUID_DISCONNECTED: Self = Self(4207u32);
+                        pub const ERROR_WMI_SERVER_UNAVAILABLE: Self = Self(4208u32);
+                        pub const ERROR_WMI_DP_FAILED: Self = Self(4209u32);
+                        pub const ERROR_WMI_INVALID_MOF: Self = Self(4210u32);
+                        pub const ERROR_WMI_INVALID_REGINFO: Self = Self(4211u32);
+                        pub const ERROR_WMI_ALREADY_DISABLED: Self = Self(4212u32);
+                        pub const ERROR_WMI_READ_ONLY: Self = Self(4213u32);
+                        pub const ERROR_WMI_SET_FAILURE: Self = Self(4214u32);
+                        pub const ERROR_NOT_APPCONTAINER: Self = Self(4250u32);
+                        pub const ERROR_APPCONTAINER_REQUIRED: Self = Self(4251u32);
+                        pub const ERROR_NOT_SUPPORTED_IN_APPCONTAINER: Self = Self(4252u32);
+                        pub const ERROR_INVALID_PACKAGE_SID_LENGTH: Self = Self(4253u32);
+                        pub const ERROR_INVALID_MEDIA: Self = Self(4300u32);
+                        pub const ERROR_INVALID_LIBRARY: Self = Self(4301u32);
+                        pub const ERROR_INVALID_MEDIA_POOL: Self = Self(4302u32);
+                        pub const ERROR_DRIVE_MEDIA_MISMATCH: Self = Self(4303u32);
+                        pub const ERROR_MEDIA_OFFLINE: Self = Self(4304u32);
+                        pub const ERROR_LIBRARY_OFFLINE: Self = Self(4305u32);
+                        pub const ERROR_EMPTY: Self = Self(4306u32);
+                        pub const ERROR_NOT_EMPTY: Self = Self(4307u32);
+                        pub const ERROR_MEDIA_UNAVAILABLE: Self = Self(4308u32);
+                        pub const ERROR_RESOURCE_DISABLED: Self = Self(4309u32);
+                        pub const ERROR_INVALID_CLEANER: Self = Self(4310u32);
+                        pub const ERROR_UNABLE_TO_CLEAN: Self = Self(4311u32);
+                        pub const ERROR_OBJECT_NOT_FOUND: Self = Self(4312u32);
+                        pub const ERROR_DATABASE_FAILURE: Self = Self(4313u32);
+                        pub const ERROR_DATABASE_FULL: Self = Self(4314u32);
+                        pub const ERROR_MEDIA_INCOMPATIBLE: Self = Self(4315u32);
+                        pub const ERROR_RESOURCE_NOT_PRESENT: Self = Self(4316u32);
+                        pub const ERROR_INVALID_OPERATION: Self = Self(4317u32);
+                        pub const ERROR_MEDIA_NOT_AVAILABLE: Self = Self(4318u32);
+                        pub const ERROR_DEVICE_NOT_AVAILABLE: Self = Self(4319u32);
+                        pub const ERROR_REQUEST_REFUSED: Self = Self(4320u32);
+                        pub const ERROR_INVALID_DRIVE_OBJECT: Self = Self(4321u32);
+                        pub const ERROR_LIBRARY_FULL: Self = Self(4322u32);
+                        pub const ERROR_MEDIUM_NOT_ACCESSIBLE: Self = Self(4323u32);
+                        pub const ERROR_UNABLE_TO_LOAD_MEDIUM: Self = Self(4324u32);
+                        pub const ERROR_UNABLE_TO_INVENTORY_DRIVE: Self = Self(4325u32);
+                        pub const ERROR_UNABLE_TO_INVENTORY_SLOT: Self = Self(4326u32);
+                        pub const ERROR_UNABLE_TO_INVENTORY_TRANSPORT: Self = Self(4327u32);
+                        pub const ERROR_TRANSPORT_FULL: Self = Self(4328u32);
+                        pub const ERROR_CONTROLLING_IEPORT: Self = Self(4329u32);
+                        pub const ERROR_UNABLE_TO_EJECT_MOUNTED_MEDIA: Self = Self(4330u32);
+                        pub const ERROR_CLEANER_SLOT_SET: Self = Self(4331u32);
+                        pub const ERROR_CLEANER_SLOT_NOT_SET: Self = Self(4332u32);
+                        pub const ERROR_CLEANER_CARTRIDGE_SPENT: Self = Self(4333u32);
+                        pub const ERROR_UNEXPECTED_OMID: Self = Self(4334u32);
+                        pub const ERROR_CANT_DELETE_LAST_ITEM: Self = Self(4335u32);
+                        pub const ERROR_MESSAGE_EXCEEDS_MAX_SIZE: Self = Self(4336u32);
+                        pub const ERROR_VOLUME_CONTAINS_SYS_FILES: Self = Self(4337u32);
+                        pub const ERROR_INDIGENOUS_TYPE: Self = Self(4338u32);
+                        pub const ERROR_NO_SUPPORTING_DRIVES: Self = Self(4339u32);
+                        pub const ERROR_CLEANER_CARTRIDGE_INSTALLED: Self = Self(4340u32);
+                        pub const ERROR_IEPORT_FULL: Self = Self(4341u32);
+                        pub const ERROR_FILE_OFFLINE: Self = Self(4350u32);
+                        pub const ERROR_REMOTE_STORAGE_NOT_ACTIVE: Self = Self(4351u32);
+                        pub const ERROR_REMOTE_STORAGE_MEDIA_ERROR: Self = Self(4352u32);
+                        pub const ERROR_NOT_A_REPARSE_POINT: Self = Self(4390u32);
+                        pub const ERROR_REPARSE_ATTRIBUTE_CONFLICT: Self = Self(4391u32);
+                        pub const ERROR_INVALID_REPARSE_DATA: Self = Self(4392u32);
+                        pub const ERROR_REPARSE_TAG_INVALID: Self = Self(4393u32);
+                        pub const ERROR_REPARSE_TAG_MISMATCH: Self = Self(4394u32);
+                        pub const ERROR_REPARSE_POINT_ENCOUNTERED: Self = Self(4395u32);
+                        pub const ERROR_APP_DATA_NOT_FOUND: Self = Self(4400u32);
+                        pub const ERROR_APP_DATA_EXPIRED: Self = Self(4401u32);
+                        pub const ERROR_APP_DATA_CORRUPT: Self = Self(4402u32);
+                        pub const ERROR_APP_DATA_LIMIT_EXCEEDED: Self = Self(4403u32);
+                        pub const ERROR_APP_DATA_REBOOT_REQUIRED: Self = Self(4404u32);
+                        pub const ERROR_SECUREBOOT_ROLLBACK_DETECTED: Self = Self(4420u32);
+                        pub const ERROR_SECUREBOOT_POLICY_VIOLATION: Self = Self(4421u32);
+                        pub const ERROR_SECUREBOOT_INVALID_POLICY: Self = Self(4422u32);
+                        pub const ERROR_SECUREBOOT_POLICY_PUBLISHER_NOT_FOUND: Self = Self(4423u32);
+                        pub const ERROR_SECUREBOOT_POLICY_NOT_SIGNED: Self = Self(4424u32);
+                        pub const ERROR_SECUREBOOT_NOT_ENABLED: Self = Self(4425u32);
+                        pub const ERROR_SECUREBOOT_FILE_REPLACED: Self = Self(4426u32);
+                        pub const ERROR_SECUREBOOT_POLICY_NOT_AUTHORIZED: Self = Self(4427u32);
+                        pub const ERROR_SECUREBOOT_POLICY_UNKNOWN: Self = Self(4428u32);
+                        pub const ERROR_SECUREBOOT_POLICY_MISSING_ANTIROLLBACKVERSION: Self =
+                            Self(4429u32);
+                        pub const ERROR_SECUREBOOT_PLATFORM_ID_MISMATCH: Self = Self(4430u32);
+                        pub const ERROR_SECUREBOOT_POLICY_ROLLBACK_DETECTED: Self = Self(4431u32);
+                        pub const ERROR_SECUREBOOT_POLICY_UPGRADE_MISMATCH: Self = Self(4432u32);
+                        pub const ERROR_SECUREBOOT_REQUIRED_POLICY_FILE_MISSING: Self =
+                            Self(4433u32);
+                        pub const ERROR_SECUREBOOT_NOT_BASE_POLICY: Self = Self(4434u32);
+                        pub const ERROR_SECUREBOOT_NOT_SUPPLEMENTAL_POLICY: Self = Self(4435u32);
+                        pub const ERROR_OFFLOAD_READ_FLT_NOT_SUPPORTED: Self = Self(4440u32);
+                        pub const ERROR_OFFLOAD_WRITE_FLT_NOT_SUPPORTED: Self = Self(4441u32);
+                        pub const ERROR_OFFLOAD_READ_FILE_NOT_SUPPORTED: Self = Self(4442u32);
+                        pub const ERROR_OFFLOAD_WRITE_FILE_NOT_SUPPORTED: Self = Self(4443u32);
+                        pub const ERROR_ALREADY_HAS_STREAM_ID: Self = Self(4444u32);
+                        pub const ERROR_SMR_GARBAGE_COLLECTION_REQUIRED: Self = Self(4445u32);
+                        pub const ERROR_WOF_WIM_HEADER_CORRUPT: Self = Self(4446u32);
+                        pub const ERROR_WOF_WIM_RESOURCE_TABLE_CORRUPT: Self = Self(4447u32);
+                        pub const ERROR_WOF_FILE_RESOURCE_TABLE_CORRUPT: Self = Self(4448u32);
+                        pub const ERROR_VOLUME_NOT_SIS_ENABLED: Self = Self(4500u32);
+                        pub const ERROR_SYSTEM_INTEGRITY_ROLLBACK_DETECTED: Self = Self(4550u32);
+                        pub const ERROR_SYSTEM_INTEGRITY_POLICY_VIOLATION: Self = Self(4551u32);
+                        pub const ERROR_SYSTEM_INTEGRITY_INVALID_POLICY: Self = Self(4552u32);
+                        pub const ERROR_SYSTEM_INTEGRITY_POLICY_NOT_SIGNED: Self = Self(4553u32);
+                        pub const ERROR_SYSTEM_INTEGRITY_TOO_MANY_POLICIES: Self = Self(4554u32);
+                        pub const ERROR_SYSTEM_INTEGRITY_SUPPLEMENTAL_POLICY_NOT_AUTHORIZED: Self =
+                            Self(4555u32);
+                        pub const ERROR_VSM_NOT_INITIALIZED: Self = Self(4560u32);
+                        pub const ERROR_VSM_DMA_PROTECTION_NOT_IN_USE: Self = Self(4561u32);
+                        pub const ERROR_PLATFORM_MANIFEST_NOT_AUTHORIZED: Self = Self(4570u32);
+                        pub const ERROR_PLATFORM_MANIFEST_INVALID: Self = Self(4571u32);
+                        pub const ERROR_PLATFORM_MANIFEST_FILE_NOT_AUTHORIZED: Self = Self(4572u32);
+                        pub const ERROR_PLATFORM_MANIFEST_CATALOG_NOT_AUTHORIZED: Self =
+                            Self(4573u32);
+                        pub const ERROR_PLATFORM_MANIFEST_BINARY_ID_NOT_FOUND: Self = Self(4574u32);
+                        pub const ERROR_PLATFORM_MANIFEST_NOT_ACTIVE: Self = Self(4575u32);
+                        pub const ERROR_PLATFORM_MANIFEST_NOT_SIGNED: Self = Self(4576u32);
+                        pub const ERROR_DEPENDENT_RESOURCE_EXISTS: Self = Self(5001u32);
+                        pub const ERROR_DEPENDENCY_NOT_FOUND: Self = Self(5002u32);
+                        pub const ERROR_DEPENDENCY_ALREADY_EXISTS: Self = Self(5003u32);
+                        pub const ERROR_RESOURCE_NOT_ONLINE: Self = Self(5004u32);
+                        pub const ERROR_HOST_NODE_NOT_AVAILABLE: Self = Self(5005u32);
+                        pub const ERROR_RESOURCE_NOT_AVAILABLE: Self = Self(5006u32);
+                        pub const ERROR_RESOURCE_NOT_FOUND: Self = Self(5007u32);
+                        pub const ERROR_SHUTDOWN_CLUSTER: Self = Self(5008u32);
+                        pub const ERROR_CANT_EVICT_ACTIVE_NODE: Self = Self(5009u32);
+                        pub const ERROR_OBJECT_ALREADY_EXISTS: Self = Self(5010u32);
+                        pub const ERROR_OBJECT_IN_LIST: Self = Self(5011u32);
+                        pub const ERROR_GROUP_NOT_AVAILABLE: Self = Self(5012u32);
+                        pub const ERROR_GROUP_NOT_FOUND: Self = Self(5013u32);
+                        pub const ERROR_GROUP_NOT_ONLINE: Self = Self(5014u32);
+                        pub const ERROR_HOST_NODE_NOT_RESOURCE_OWNER: Self = Self(5015u32);
+                        pub const ERROR_HOST_NODE_NOT_GROUP_OWNER: Self = Self(5016u32);
+                        pub const ERROR_RESMON_CREATE_FAILED: Self = Self(5017u32);
+                        pub const ERROR_RESMON_ONLINE_FAILED: Self = Self(5018u32);
+                        pub const ERROR_RESOURCE_ONLINE: Self = Self(5019u32);
+                        pub const ERROR_QUORUM_RESOURCE: Self = Self(5020u32);
+                        pub const ERROR_NOT_QUORUM_CAPABLE: Self = Self(5021u32);
+                        pub const ERROR_CLUSTER_SHUTTING_DOWN: Self = Self(5022u32);
+                        pub const ERROR_INVALID_STATE: Self = Self(5023u32);
+                        pub const ERROR_RESOURCE_PROPERTIES_STORED: Self = Self(5024u32);
+                        pub const ERROR_NOT_QUORUM_CLASS: Self = Self(5025u32);
+                        pub const ERROR_CORE_RESOURCE: Self = Self(5026u32);
+                        pub const ERROR_QUORUM_RESOURCE_ONLINE_FAILED: Self = Self(5027u32);
+                        pub const ERROR_QUORUMLOG_OPEN_FAILED: Self = Self(5028u32);
+                        pub const ERROR_CLUSTERLOG_CORRUPT: Self = Self(5029u32);
+                        pub const ERROR_CLUSTERLOG_RECORD_EXCEEDS_MAXSIZE: Self = Self(5030u32);
+                        pub const ERROR_CLUSTERLOG_EXCEEDS_MAXSIZE: Self = Self(5031u32);
+                        pub const ERROR_CLUSTERLOG_CHKPOINT_NOT_FOUND: Self = Self(5032u32);
+                        pub const ERROR_CLUSTERLOG_NOT_ENOUGH_SPACE: Self = Self(5033u32);
+                        pub const ERROR_QUORUM_OWNER_ALIVE: Self = Self(5034u32);
+                        pub const ERROR_NETWORK_NOT_AVAILABLE: Self = Self(5035u32);
+                        pub const ERROR_NODE_NOT_AVAILABLE: Self = Self(5036u32);
+                        pub const ERROR_ALL_NODES_NOT_AVAILABLE: Self = Self(5037u32);
+                        pub const ERROR_RESOURCE_FAILED: Self = Self(5038u32);
+                        pub const ERROR_CLUSTER_INVALID_NODE: Self = Self(5039u32);
+                        pub const ERROR_CLUSTER_NODE_EXISTS: Self = Self(5040u32);
+                        pub const ERROR_CLUSTER_JOIN_IN_PROGRESS: Self = Self(5041u32);
+                        pub const ERROR_CLUSTER_NODE_NOT_FOUND: Self = Self(5042u32);
+                        pub const ERROR_CLUSTER_LOCAL_NODE_NOT_FOUND: Self = Self(5043u32);
+                        pub const ERROR_CLUSTER_NETWORK_EXISTS: Self = Self(5044u32);
+                        pub const ERROR_CLUSTER_NETWORK_NOT_FOUND: Self = Self(5045u32);
+                        pub const ERROR_CLUSTER_NETINTERFACE_EXISTS: Self = Self(5046u32);
+                        pub const ERROR_CLUSTER_NETINTERFACE_NOT_FOUND: Self = Self(5047u32);
+                        pub const ERROR_CLUSTER_INVALID_REQUEST: Self = Self(5048u32);
+                        pub const ERROR_CLUSTER_INVALID_NETWORK_PROVIDER: Self = Self(5049u32);
+                        pub const ERROR_CLUSTER_NODE_DOWN: Self = Self(5050u32);
+                        pub const ERROR_CLUSTER_NODE_UNREACHABLE: Self = Self(5051u32);
+                        pub const ERROR_CLUSTER_NODE_NOT_MEMBER: Self = Self(5052u32);
+                        pub const ERROR_CLUSTER_JOIN_NOT_IN_PROGRESS: Self = Self(5053u32);
+                        pub const ERROR_CLUSTER_INVALID_NETWORK: Self = Self(5054u32);
+                        pub const ERROR_CLUSTER_NODE_UP: Self = Self(5056u32);
+                        pub const ERROR_CLUSTER_IPADDR_IN_USE: Self = Self(5057u32);
+                        pub const ERROR_CLUSTER_NODE_NOT_PAUSED: Self = Self(5058u32);
+                        pub const ERROR_CLUSTER_NO_SECURITY_CONTEXT: Self = Self(5059u32);
+                        pub const ERROR_CLUSTER_NETWORK_NOT_INTERNAL: Self = Self(5060u32);
+                        pub const ERROR_CLUSTER_NODE_ALREADY_UP: Self = Self(5061u32);
+                        pub const ERROR_CLUSTER_NODE_ALREADY_DOWN: Self = Self(5062u32);
+                        pub const ERROR_CLUSTER_NETWORK_ALREADY_ONLINE: Self = Self(5063u32);
+                        pub const ERROR_CLUSTER_NETWORK_ALREADY_OFFLINE: Self = Self(5064u32);
+                        pub const ERROR_CLUSTER_NODE_ALREADY_MEMBER: Self = Self(5065u32);
+                        pub const ERROR_CLUSTER_LAST_INTERNAL_NETWORK: Self = Self(5066u32);
+                        pub const ERROR_CLUSTER_NETWORK_HAS_DEPENDENTS: Self = Self(5067u32);
+                        pub const ERROR_INVALID_OPERATION_ON_QUORUM: Self = Self(5068u32);
+                        pub const ERROR_DEPENDENCY_NOT_ALLOWED: Self = Self(5069u32);
+                        pub const ERROR_CLUSTER_NODE_PAUSED: Self = Self(5070u32);
+                        pub const ERROR_NODE_CANT_HOST_RESOURCE: Self = Self(5071u32);
+                        pub const ERROR_CLUSTER_NODE_NOT_READY: Self = Self(5072u32);
+                        pub const ERROR_CLUSTER_NODE_SHUTTING_DOWN: Self = Self(5073u32);
+                        pub const ERROR_CLUSTER_JOIN_ABORTED: Self = Self(5074u32);
+                        pub const ERROR_CLUSTER_INCOMPATIBLE_VERSIONS: Self = Self(5075u32);
+                        pub const ERROR_CLUSTER_MAXNUM_OF_RESOURCES_EXCEEDED: Self = Self(5076u32);
+                        pub const ERROR_CLUSTER_SYSTEM_CONFIG_CHANGED: Self = Self(5077u32);
+                        pub const ERROR_CLUSTER_RESOURCE_TYPE_NOT_FOUND: Self = Self(5078u32);
+                        pub const ERROR_CLUSTER_RESTYPE_NOT_SUPPORTED: Self = Self(5079u32);
+                        pub const ERROR_CLUSTER_RESNAME_NOT_FOUND: Self = Self(5080u32);
+                        pub const ERROR_CLUSTER_NO_RPC_PACKAGES_REGISTERED: Self = Self(5081u32);
+                        pub const ERROR_CLUSTER_OWNER_NOT_IN_PREFLIST: Self = Self(5082u32);
+                        pub const ERROR_CLUSTER_DATABASE_SEQMISMATCH: Self = Self(5083u32);
+                        pub const ERROR_RESMON_INVALID_STATE: Self = Self(5084u32);
+                        pub const ERROR_CLUSTER_GUM_NOT_LOCKER: Self = Self(5085u32);
+                        pub const ERROR_QUORUM_DISK_NOT_FOUND: Self = Self(5086u32);
+                        pub const ERROR_DATABASE_BACKUP_CORRUPT: Self = Self(5087u32);
+                        pub const ERROR_CLUSTER_NODE_ALREADY_HAS_DFS_ROOT: Self = Self(5088u32);
+                        pub const ERROR_RESOURCE_PROPERTY_UNCHANGEABLE: Self = Self(5089u32);
+                        pub const ERROR_NO_ADMIN_ACCESS_POINT: Self = Self(5090u32);
+                        pub const ERROR_CLUSTER_MEMBERSHIP_INVALID_STATE: Self = Self(5890u32);
+                        pub const ERROR_CLUSTER_QUORUMLOG_NOT_FOUND: Self = Self(5891u32);
+                        pub const ERROR_CLUSTER_MEMBERSHIP_HALT: Self = Self(5892u32);
+                        pub const ERROR_CLUSTER_INSTANCE_ID_MISMATCH: Self = Self(5893u32);
+                        pub const ERROR_CLUSTER_NETWORK_NOT_FOUND_FOR_IP: Self = Self(5894u32);
+                        pub const ERROR_CLUSTER_PROPERTY_DATA_TYPE_MISMATCH: Self = Self(5895u32);
+                        pub const ERROR_CLUSTER_EVICT_WITHOUT_CLEANUP: Self = Self(5896u32);
+                        pub const ERROR_CLUSTER_PARAMETER_MISMATCH: Self = Self(5897u32);
+                        pub const ERROR_NODE_CANNOT_BE_CLUSTERED: Self = Self(5898u32);
+                        pub const ERROR_CLUSTER_WRONG_OS_VERSION: Self = Self(5899u32);
+                        pub const ERROR_CLUSTER_CANT_CREATE_DUP_CLUSTER_NAME: Self = Self(5900u32);
+                        pub const ERROR_CLUSCFG_ALREADY_COMMITTED: Self = Self(5901u32);
+                        pub const ERROR_CLUSCFG_ROLLBACK_FAILED: Self = Self(5902u32);
+                        pub const ERROR_CLUSCFG_SYSTEM_DISK_DRIVE_LETTER_CONFLICT: Self =
+                            Self(5903u32);
+                        pub const ERROR_CLUSTER_OLD_VERSION: Self = Self(5904u32);
+                        pub const ERROR_CLUSTER_MISMATCHED_COMPUTER_ACCT_NAME: Self = Self(5905u32);
+                        pub const ERROR_CLUSTER_NO_NET_ADAPTERS: Self = Self(5906u32);
+                        pub const ERROR_CLUSTER_POISONED: Self = Self(5907u32);
+                        pub const ERROR_CLUSTER_GROUP_MOVING: Self = Self(5908u32);
+                        pub const ERROR_CLUSTER_RESOURCE_TYPE_BUSY: Self = Self(5909u32);
+                        pub const ERROR_RESOURCE_CALL_TIMED_OUT: Self = Self(5910u32);
+                        pub const ERROR_INVALID_CLUSTER_IPV6_ADDRESS: Self = Self(5911u32);
+                        pub const ERROR_CLUSTER_INTERNAL_INVALID_FUNCTION: Self = Self(5912u32);
+                        pub const ERROR_CLUSTER_PARAMETER_OUT_OF_BOUNDS: Self = Self(5913u32);
+                        pub const ERROR_CLUSTER_PARTIAL_SEND: Self = Self(5914u32);
+                        pub const ERROR_CLUSTER_REGISTRY_INVALID_FUNCTION: Self = Self(5915u32);
+                        pub const ERROR_CLUSTER_INVALID_STRING_TERMINATION: Self = Self(5916u32);
+                        pub const ERROR_CLUSTER_INVALID_STRING_FORMAT: Self = Self(5917u32);
+                        pub const ERROR_CLUSTER_DATABASE_TRANSACTION_IN_PROGRESS: Self =
+                            Self(5918u32);
+                        pub const ERROR_CLUSTER_DATABASE_TRANSACTION_NOT_IN_PROGRESS: Self =
+                            Self(5919u32);
+                        pub const ERROR_CLUSTER_NULL_DATA: Self = Self(5920u32);
+                        pub const ERROR_CLUSTER_PARTIAL_READ: Self = Self(5921u32);
+                        pub const ERROR_CLUSTER_PARTIAL_WRITE: Self = Self(5922u32);
+                        pub const ERROR_CLUSTER_CANT_DESERIALIZE_DATA: Self = Self(5923u32);
+                        pub const ERROR_DEPENDENT_RESOURCE_PROPERTY_CONFLICT: Self = Self(5924u32);
+                        pub const ERROR_CLUSTER_NO_QUORUM: Self = Self(5925u32);
+                        pub const ERROR_CLUSTER_INVALID_IPV6_NETWORK: Self = Self(5926u32);
+                        pub const ERROR_CLUSTER_INVALID_IPV6_TUNNEL_NETWORK: Self = Self(5927u32);
+                        pub const ERROR_QUORUM_NOT_ALLOWED_IN_THIS_GROUP: Self = Self(5928u32);
+                        pub const ERROR_DEPENDENCY_TREE_TOO_COMPLEX: Self = Self(5929u32);
+                        pub const ERROR_EXCEPTION_IN_RESOURCE_CALL: Self = Self(5930u32);
+                        pub const ERROR_CLUSTER_RHS_FAILED_INITIALIZATION: Self = Self(5931u32);
+                        pub const ERROR_CLUSTER_NOT_INSTALLED: Self = Self(5932u32);
+                        pub const ERROR_CLUSTER_RESOURCES_MUST_BE_ONLINE_ON_THE_SAME_NODE: Self =
+                            Self(5933u32);
+                        pub const ERROR_CLUSTER_MAX_NODES_IN_CLUSTER: Self = Self(5934u32);
+                        pub const ERROR_CLUSTER_TOO_MANY_NODES: Self = Self(5935u32);
+                        pub const ERROR_CLUSTER_OBJECT_ALREADY_USED: Self = Self(5936u32);
+                        pub const ERROR_NONCORE_GROUPS_FOUND: Self = Self(5937u32);
+                        pub const ERROR_FILE_SHARE_RESOURCE_CONFLICT: Self = Self(5938u32);
+                        pub const ERROR_CLUSTER_EVICT_INVALID_REQUEST: Self = Self(5939u32);
+                        pub const ERROR_CLUSTER_SINGLETON_RESOURCE: Self = Self(5940u32);
+                        pub const ERROR_CLUSTER_GROUP_SINGLETON_RESOURCE: Self = Self(5941u32);
+                        pub const ERROR_CLUSTER_RESOURCE_PROVIDER_FAILED: Self = Self(5942u32);
+                        pub const ERROR_CLUSTER_RESOURCE_CONFIGURATION_ERROR: Self = Self(5943u32);
+                        pub const ERROR_CLUSTER_GROUP_BUSY: Self = Self(5944u32);
+                        pub const ERROR_CLUSTER_NOT_SHARED_VOLUME: Self = Self(5945u32);
+                        pub const ERROR_CLUSTER_INVALID_SECURITY_DESCRIPTOR: Self = Self(5946u32);
+                        pub const ERROR_CLUSTER_SHARED_VOLUMES_IN_USE: Self = Self(5947u32);
+                        pub const ERROR_CLUSTER_USE_SHARED_VOLUMES_API: Self = Self(5948u32);
+                        pub const ERROR_CLUSTER_BACKUP_IN_PROGRESS: Self = Self(5949u32);
+                        pub const ERROR_NON_CSV_PATH: Self = Self(5950u32);
+                        pub const ERROR_CSV_VOLUME_NOT_LOCAL: Self = Self(5951u32);
+                        pub const ERROR_CLUSTER_WATCHDOG_TERMINATING: Self = Self(5952u32);
+                        pub const ERROR_CLUSTER_RESOURCE_VETOED_MOVE_INCOMPATIBLE_NODES: Self =
+                            Self(5953u32);
+                        pub const ERROR_CLUSTER_INVALID_NODE_WEIGHT: Self = Self(5954u32);
+                        pub const ERROR_CLUSTER_RESOURCE_VETOED_CALL: Self = Self(5955u32);
+                        pub const ERROR_RESMON_SYSTEM_RESOURCES_LACKING: Self = Self(5956u32);
+                        pub const ERROR_CLUSTER_RESOURCE_VETOED_MOVE_NOT_ENOUGH_RESOURCES_ON_DESTINATION : Self = Self ( 5957u32 ) ;
+                        pub const ERROR_CLUSTER_RESOURCE_VETOED_MOVE_NOT_ENOUGH_RESOURCES_ON_SOURCE : Self = Self ( 5958u32 ) ;
+                        pub const ERROR_CLUSTER_GROUP_QUEUED: Self = Self(5959u32);
+                        pub const ERROR_CLUSTER_RESOURCE_LOCKED_STATUS: Self = Self(5960u32);
+                        pub const ERROR_CLUSTER_SHARED_VOLUME_FAILOVER_NOT_ALLOWED: Self =
+                            Self(5961u32);
+                        pub const ERROR_CLUSTER_NODE_DRAIN_IN_PROGRESS: Self = Self(5962u32);
+                        pub const ERROR_CLUSTER_DISK_NOT_CONNECTED: Self = Self(5963u32);
+                        pub const ERROR_DISK_NOT_CSV_CAPABLE: Self = Self(5964u32);
+                        pub const ERROR_RESOURCE_NOT_IN_AVAILABLE_STORAGE: Self = Self(5965u32);
+                        pub const ERROR_CLUSTER_SHARED_VOLUME_REDIRECTED: Self = Self(5966u32);
+                        pub const ERROR_CLUSTER_SHARED_VOLUME_NOT_REDIRECTED: Self = Self(5967u32);
+                        pub const ERROR_CLUSTER_CANNOT_RETURN_PROPERTIES: Self = Self(5968u32);
+                        pub const ERROR_CLUSTER_RESOURCE_CONTAINS_UNSUPPORTED_DIFF_AREA_FOR_SHARED_VOLUMES : Self = Self ( 5969u32 ) ;
+                        pub const ERROR_CLUSTER_RESOURCE_IS_IN_MAINTENANCE_MODE: Self =
+                            Self(5970u32);
+                        pub const ERROR_CLUSTER_AFFINITY_CONFLICT: Self = Self(5971u32);
+                        pub const ERROR_CLUSTER_RESOURCE_IS_REPLICA_VIRTUAL_MACHINE: Self =
+                            Self(5972u32);
+                        pub const ERROR_CLUSTER_UPGRADE_INCOMPATIBLE_VERSIONS: Self = Self(5973u32);
+                        pub const ERROR_CLUSTER_UPGRADE_FIX_QUORUM_NOT_SUPPORTED: Self =
+                            Self(5974u32);
+                        pub const ERROR_CLUSTER_UPGRADE_RESTART_REQUIRED: Self = Self(5975u32);
+                        pub const ERROR_CLUSTER_UPGRADE_IN_PROGRESS: Self = Self(5976u32);
+                        pub const ERROR_CLUSTER_UPGRADE_INCOMPLETE: Self = Self(5977u32);
+                        pub const ERROR_CLUSTER_NODE_IN_GRACE_PERIOD: Self = Self(5978u32);
+                        pub const ERROR_CLUSTER_CSV_IO_PAUSE_TIMEOUT: Self = Self(5979u32);
+                        pub const ERROR_NODE_NOT_ACTIVE_CLUSTER_MEMBER: Self = Self(5980u32);
+                        pub const ERROR_CLUSTER_RESOURCE_NOT_MONITORED: Self = Self(5981u32);
+                        pub const ERROR_CLUSTER_RESOURCE_DOES_NOT_SUPPORT_UNMONITORED: Self =
+                            Self(5982u32);
+                        pub const ERROR_CLUSTER_RESOURCE_IS_REPLICATED: Self = Self(5983u32);
+                        pub const ERROR_CLUSTER_NODE_ISOLATED: Self = Self(5984u32);
+                        pub const ERROR_CLUSTER_NODE_QUARANTINED: Self = Self(5985u32);
+                        pub const ERROR_CLUSTER_DATABASE_UPDATE_CONDITION_FAILED: Self =
+                            Self(5986u32);
+                        pub const ERROR_CLUSTER_SPACE_DEGRADED: Self = Self(5987u32);
+                        pub const ERROR_CLUSTER_TOKEN_DELEGATION_NOT_SUPPORTED: Self =
+                            Self(5988u32);
+                        pub const ERROR_CLUSTER_CSV_INVALID_HANDLE: Self = Self(5989u32);
+                        pub const ERROR_CLUSTER_CSV_SUPPORTED_ONLY_ON_COORDINATOR: Self =
+                            Self(5990u32);
+                        pub const ERROR_GROUPSET_NOT_AVAILABLE: Self = Self(5991u32);
+                        pub const ERROR_GROUPSET_NOT_FOUND: Self = Self(5992u32);
+                        pub const ERROR_GROUPSET_CANT_PROVIDE: Self = Self(5993u32);
+                        pub const ERROR_CLUSTER_FAULT_DOMAIN_PARENT_NOT_FOUND: Self = Self(5994u32);
+                        pub const ERROR_CLUSTER_FAULT_DOMAIN_INVALID_HIERARCHY: Self =
+                            Self(5995u32);
+                        pub const ERROR_CLUSTER_FAULT_DOMAIN_FAILED_S2D_VALIDATION: Self =
+                            Self(5996u32);
+                        pub const ERROR_CLUSTER_FAULT_DOMAIN_S2D_CONNECTIVITY_LOSS: Self =
+                            Self(5997u32);
+                        pub const ERROR_CLUSTER_INVALID_INFRASTRUCTURE_FILESERVER_NAME: Self =
+                            Self(5998u32);
+                        pub const ERROR_CLUSTERSET_MANAGEMENT_CLUSTER_UNREACHABLE: Self =
+                            Self(5999u32);
+                        pub const ERROR_ENCRYPTION_FAILED: Self = Self(6000u32);
+                        pub const ERROR_DECRYPTION_FAILED: Self = Self(6001u32);
+                        pub const ERROR_FILE_ENCRYPTED: Self = Self(6002u32);
+                        pub const ERROR_NO_RECOVERY_POLICY: Self = Self(6003u32);
+                        pub const ERROR_NO_EFS: Self = Self(6004u32);
+                        pub const ERROR_WRONG_EFS: Self = Self(6005u32);
+                        pub const ERROR_NO_USER_KEYS: Self = Self(6006u32);
+                        pub const ERROR_FILE_NOT_ENCRYPTED: Self = Self(6007u32);
+                        pub const ERROR_NOT_EXPORT_FORMAT: Self = Self(6008u32);
+                        pub const ERROR_FILE_READ_ONLY: Self = Self(6009u32);
+                        pub const ERROR_DIR_EFS_DISALLOWED: Self = Self(6010u32);
+                        pub const ERROR_EFS_SERVER_NOT_TRUSTED: Self = Self(6011u32);
+                        pub const ERROR_BAD_RECOVERY_POLICY: Self = Self(6012u32);
+                        pub const ERROR_EFS_ALG_BLOB_TOO_BIG: Self = Self(6013u32);
+                        pub const ERROR_VOLUME_NOT_SUPPORT_EFS: Self = Self(6014u32);
+                        pub const ERROR_EFS_DISABLED: Self = Self(6015u32);
+                        pub const ERROR_EFS_VERSION_NOT_SUPPORT: Self = Self(6016u32);
+                        pub const ERROR_CS_ENCRYPTION_INVALID_SERVER_RESPONSE: Self = Self(6017u32);
+                        pub const ERROR_CS_ENCRYPTION_UNSUPPORTED_SERVER: Self = Self(6018u32);
+                        pub const ERROR_CS_ENCRYPTION_EXISTING_ENCRYPTED_FILE: Self = Self(6019u32);
+                        pub const ERROR_CS_ENCRYPTION_NEW_ENCRYPTED_FILE: Self = Self(6020u32);
+                        pub const ERROR_CS_ENCRYPTION_FILE_NOT_CSE: Self = Self(6021u32);
+                        pub const ERROR_ENCRYPTION_POLICY_DENIES_OPERATION: Self = Self(6022u32);
+                        pub const ERROR_WIP_ENCRYPTION_FAILED: Self = Self(6023u32);
+                        pub const ERROR_NO_BROWSER_SERVERS_FOUND: Self = Self(6118u32);
+                        pub const ERROR_CLUSTER_OBJECT_IS_CLUSTER_SET_VM: Self = Self(6250u32);
+                        pub const ERROR_LOG_SECTOR_INVALID: Self = Self(6600u32);
+                        pub const ERROR_LOG_SECTOR_PARITY_INVALID: Self = Self(6601u32);
+                        pub const ERROR_LOG_SECTOR_REMAPPED: Self = Self(6602u32);
+                        pub const ERROR_LOG_BLOCK_INCOMPLETE: Self = Self(6603u32);
+                        pub const ERROR_LOG_INVALID_RANGE: Self = Self(6604u32);
+                        pub const ERROR_LOG_BLOCKS_EXHAUSTED: Self = Self(6605u32);
+                        pub const ERROR_LOG_READ_CONTEXT_INVALID: Self = Self(6606u32);
+                        pub const ERROR_LOG_RESTART_INVALID: Self = Self(6607u32);
+                        pub const ERROR_LOG_BLOCK_VERSION: Self = Self(6608u32);
+                        pub const ERROR_LOG_BLOCK_INVALID: Self = Self(6609u32);
+                        pub const ERROR_LOG_READ_MODE_INVALID: Self = Self(6610u32);
+                        pub const ERROR_LOG_NO_RESTART: Self = Self(6611u32);
+                        pub const ERROR_LOG_METADATA_CORRUPT: Self = Self(6612u32);
+                        pub const ERROR_LOG_METADATA_INVALID: Self = Self(6613u32);
+                        pub const ERROR_LOG_METADATA_INCONSISTENT: Self = Self(6614u32);
+                        pub const ERROR_LOG_RESERVATION_INVALID: Self = Self(6615u32);
+                        pub const ERROR_LOG_CANT_DELETE: Self = Self(6616u32);
+                        pub const ERROR_LOG_CONTAINER_LIMIT_EXCEEDED: Self = Self(6617u32);
+                        pub const ERROR_LOG_START_OF_LOG: Self = Self(6618u32);
+                        pub const ERROR_LOG_POLICY_ALREADY_INSTALLED: Self = Self(6619u32);
+                        pub const ERROR_LOG_POLICY_NOT_INSTALLED: Self = Self(6620u32);
+                        pub const ERROR_LOG_POLICY_INVALID: Self = Self(6621u32);
+                        pub const ERROR_LOG_POLICY_CONFLICT: Self = Self(6622u32);
+                        pub const ERROR_LOG_PINNED_ARCHIVE_TAIL: Self = Self(6623u32);
+                        pub const ERROR_LOG_RECORD_NONEXISTENT: Self = Self(6624u32);
+                        pub const ERROR_LOG_RECORDS_RESERVED_INVALID: Self = Self(6625u32);
+                        pub const ERROR_LOG_SPACE_RESERVED_INVALID: Self = Self(6626u32);
+                        pub const ERROR_LOG_TAIL_INVALID: Self = Self(6627u32);
+                        pub const ERROR_LOG_FULL: Self = Self(6628u32);
+                        pub const ERROR_COULD_NOT_RESIZE_LOG: Self = Self(6629u32);
+                        pub const ERROR_LOG_MULTIPLEXED: Self = Self(6630u32);
+                        pub const ERROR_LOG_DEDICATED: Self = Self(6631u32);
+                        pub const ERROR_LOG_ARCHIVE_NOT_IN_PROGRESS: Self = Self(6632u32);
+                        pub const ERROR_LOG_ARCHIVE_IN_PROGRESS: Self = Self(6633u32);
+                        pub const ERROR_LOG_EPHEMERAL: Self = Self(6634u32);
+                        pub const ERROR_LOG_NOT_ENOUGH_CONTAINERS: Self = Self(6635u32);
+                        pub const ERROR_LOG_CLIENT_ALREADY_REGISTERED: Self = Self(6636u32);
+                        pub const ERROR_LOG_CLIENT_NOT_REGISTERED: Self = Self(6637u32);
+                        pub const ERROR_LOG_FULL_HANDLER_IN_PROGRESS: Self = Self(6638u32);
+                        pub const ERROR_LOG_CONTAINER_READ_FAILED: Self = Self(6639u32);
+                        pub const ERROR_LOG_CONTAINER_WRITE_FAILED: Self = Self(6640u32);
+                        pub const ERROR_LOG_CONTAINER_OPEN_FAILED: Self = Self(6641u32);
+                        pub const ERROR_LOG_CONTAINER_STATE_INVALID: Self = Self(6642u32);
+                        pub const ERROR_LOG_STATE_INVALID: Self = Self(6643u32);
+                        pub const ERROR_LOG_PINNED: Self = Self(6644u32);
+                        pub const ERROR_LOG_METADATA_FLUSH_FAILED: Self = Self(6645u32);
+                        pub const ERROR_LOG_INCONSISTENT_SECURITY: Self = Self(6646u32);
+                        pub const ERROR_LOG_APPENDED_FLUSH_FAILED: Self = Self(6647u32);
+                        pub const ERROR_LOG_PINNED_RESERVATION: Self = Self(6648u32);
+                        pub const ERROR_INVALID_TRANSACTION: Self = Self(6700u32);
+                        pub const ERROR_TRANSACTION_NOT_ACTIVE: Self = Self(6701u32);
+                        pub const ERROR_TRANSACTION_REQUEST_NOT_VALID: Self = Self(6702u32);
+                        pub const ERROR_TRANSACTION_NOT_REQUESTED: Self = Self(6703u32);
+                        pub const ERROR_TRANSACTION_ALREADY_ABORTED: Self = Self(6704u32);
+                        pub const ERROR_TRANSACTION_ALREADY_COMMITTED: Self = Self(6705u32);
+                        pub const ERROR_TM_INITIALIZATION_FAILED: Self = Self(6706u32);
+                        pub const ERROR_RESOURCEMANAGER_READ_ONLY: Self = Self(6707u32);
+                        pub const ERROR_TRANSACTION_NOT_JOINED: Self = Self(6708u32);
+                        pub const ERROR_TRANSACTION_SUPERIOR_EXISTS: Self = Self(6709u32);
+                        pub const ERROR_CRM_PROTOCOL_ALREADY_EXISTS: Self = Self(6710u32);
+                        pub const ERROR_TRANSACTION_PROPAGATION_FAILED: Self = Self(6711u32);
+                        pub const ERROR_CRM_PROTOCOL_NOT_FOUND: Self = Self(6712u32);
+                        pub const ERROR_TRANSACTION_INVALID_MARSHALL_BUFFER: Self = Self(6713u32);
+                        pub const ERROR_CURRENT_TRANSACTION_NOT_VALID: Self = Self(6714u32);
+                        pub const ERROR_TRANSACTION_NOT_FOUND: Self = Self(6715u32);
+                        pub const ERROR_RESOURCEMANAGER_NOT_FOUND: Self = Self(6716u32);
+                        pub const ERROR_ENLISTMENT_NOT_FOUND: Self = Self(6717u32);
+                        pub const ERROR_TRANSACTIONMANAGER_NOT_FOUND: Self = Self(6718u32);
+                        pub const ERROR_TRANSACTIONMANAGER_NOT_ONLINE: Self = Self(6719u32);
+                        pub const ERROR_TRANSACTIONMANAGER_RECOVERY_NAME_COLLISION: Self =
+                            Self(6720u32);
+                        pub const ERROR_TRANSACTION_NOT_ROOT: Self = Self(6721u32);
+                        pub const ERROR_TRANSACTION_OBJECT_EXPIRED: Self = Self(6722u32);
+                        pub const ERROR_TRANSACTION_RESPONSE_NOT_ENLISTED: Self = Self(6723u32);
+                        pub const ERROR_TRANSACTION_RECORD_TOO_LONG: Self = Self(6724u32);
+                        pub const ERROR_IMPLICIT_TRANSACTION_NOT_SUPPORTED: Self = Self(6725u32);
+                        pub const ERROR_TRANSACTION_INTEGRITY_VIOLATED: Self = Self(6726u32);
+                        pub const ERROR_TRANSACTIONMANAGER_IDENTITY_MISMATCH: Self = Self(6727u32);
+                        pub const ERROR_RM_CANNOT_BE_FROZEN_FOR_SNAPSHOT: Self = Self(6728u32);
+                        pub const ERROR_TRANSACTION_MUST_WRITETHROUGH: Self = Self(6729u32);
+                        pub const ERROR_TRANSACTION_NO_SUPERIOR: Self = Self(6730u32);
+                        pub const ERROR_HEURISTIC_DAMAGE_POSSIBLE: Self = Self(6731u32);
+                        pub const ERROR_TRANSACTIONAL_CONFLICT: Self = Self(6800u32);
+                        pub const ERROR_RM_NOT_ACTIVE: Self = Self(6801u32);
+                        pub const ERROR_RM_METADATA_CORRUPT: Self = Self(6802u32);
+                        pub const ERROR_DIRECTORY_NOT_RM: Self = Self(6803u32);
+                        pub const ERROR_TRANSACTIONS_UNSUPPORTED_REMOTE: Self = Self(6805u32);
+                        pub const ERROR_LOG_RESIZE_INVALID_SIZE: Self = Self(6806u32);
+                        pub const ERROR_OBJECT_NO_LONGER_EXISTS: Self = Self(6807u32);
+                        pub const ERROR_STREAM_MINIVERSION_NOT_FOUND: Self = Self(6808u32);
+                        pub const ERROR_STREAM_MINIVERSION_NOT_VALID: Self = Self(6809u32);
+                        pub const ERROR_MINIVERSION_INACCESSIBLE_FROM_SPECIFIED_TRANSACTION: Self =
+                            Self(6810u32);
+                        pub const ERROR_CANT_OPEN_MINIVERSION_WITH_MODIFY_INTENT: Self =
+                            Self(6811u32);
+                        pub const ERROR_CANT_CREATE_MORE_STREAM_MINIVERSIONS: Self = Self(6812u32);
+                        pub const ERROR_REMOTE_FILE_VERSION_MISMATCH: Self = Self(6814u32);
+                        pub const ERROR_HANDLE_NO_LONGER_VALID: Self = Self(6815u32);
+                        pub const ERROR_NO_TXF_METADATA: Self = Self(6816u32);
+                        pub const ERROR_LOG_CORRUPTION_DETECTED: Self = Self(6817u32);
+                        pub const ERROR_CANT_RECOVER_WITH_HANDLE_OPEN: Self = Self(6818u32);
+                        pub const ERROR_RM_DISCONNECTED: Self = Self(6819u32);
+                        pub const ERROR_ENLISTMENT_NOT_SUPERIOR: Self = Self(6820u32);
+                        pub const ERROR_RECOVERY_NOT_NEEDED: Self = Self(6821u32);
+                        pub const ERROR_RM_ALREADY_STARTED: Self = Self(6822u32);
+                        pub const ERROR_FILE_IDENTITY_NOT_PERSISTENT: Self = Self(6823u32);
+                        pub const ERROR_CANT_BREAK_TRANSACTIONAL_DEPENDENCY: Self = Self(6824u32);
+                        pub const ERROR_CANT_CROSS_RM_BOUNDARY: Self = Self(6825u32);
+                        pub const ERROR_TXF_DIR_NOT_EMPTY: Self = Self(6826u32);
+                        pub const ERROR_INDOUBT_TRANSACTIONS_EXIST: Self = Self(6827u32);
+                        pub const ERROR_TM_VOLATILE: Self = Self(6828u32);
+                        pub const ERROR_ROLLBACK_TIMER_EXPIRED: Self = Self(6829u32);
+                        pub const ERROR_TXF_ATTRIBUTE_CORRUPT: Self = Self(6830u32);
+                        pub const ERROR_EFS_NOT_ALLOWED_IN_TRANSACTION: Self = Self(6831u32);
+                        pub const ERROR_TRANSACTIONAL_OPEN_NOT_ALLOWED: Self = Self(6832u32);
+                        pub const ERROR_LOG_GROWTH_FAILED: Self = Self(6833u32);
+                        pub const ERROR_TRANSACTED_MAPPING_UNSUPPORTED_REMOTE: Self = Self(6834u32);
+                        pub const ERROR_TXF_METADATA_ALREADY_PRESENT: Self = Self(6835u32);
+                        pub const ERROR_TRANSACTION_SCOPE_CALLBACKS_NOT_SET: Self = Self(6836u32);
+                        pub const ERROR_TRANSACTION_REQUIRED_PROMOTION: Self = Self(6837u32);
+                        pub const ERROR_CANNOT_EXECUTE_FILE_IN_TRANSACTION: Self = Self(6838u32);
+                        pub const ERROR_TRANSACTIONS_NOT_FROZEN: Self = Self(6839u32);
+                        pub const ERROR_TRANSACTION_FREEZE_IN_PROGRESS: Self = Self(6840u32);
+                        pub const ERROR_NOT_SNAPSHOT_VOLUME: Self = Self(6841u32);
+                        pub const ERROR_NO_SAVEPOINT_WITH_OPEN_FILES: Self = Self(6842u32);
+                        pub const ERROR_DATA_LOST_REPAIR: Self = Self(6843u32);
+                        pub const ERROR_SPARSE_NOT_ALLOWED_IN_TRANSACTION: Self = Self(6844u32);
+                        pub const ERROR_TM_IDENTITY_MISMATCH: Self = Self(6845u32);
+                        pub const ERROR_FLOATED_SECTION: Self = Self(6846u32);
+                        pub const ERROR_CANNOT_ACCEPT_TRANSACTED_WORK: Self = Self(6847u32);
+                        pub const ERROR_CANNOT_ABORT_TRANSACTIONS: Self = Self(6848u32);
+                        pub const ERROR_BAD_CLUSTERS: Self = Self(6849u32);
+                        pub const ERROR_COMPRESSION_NOT_ALLOWED_IN_TRANSACTION: Self =
+                            Self(6850u32);
+                        pub const ERROR_VOLUME_DIRTY: Self = Self(6851u32);
+                        pub const ERROR_NO_LINK_TRACKING_IN_TRANSACTION: Self = Self(6852u32);
+                        pub const ERROR_OPERATION_NOT_SUPPORTED_IN_TRANSACTION: Self =
+                            Self(6853u32);
+                        pub const ERROR_EXPIRED_HANDLE: Self = Self(6854u32);
+                        pub const ERROR_TRANSACTION_NOT_ENLISTED: Self = Self(6855u32);
+                        pub const ERROR_CTX_WINSTATION_NAME_INVALID: Self = Self(7001u32);
+                        pub const ERROR_CTX_INVALID_PD: Self = Self(7002u32);
+                        pub const ERROR_CTX_PD_NOT_FOUND: Self = Self(7003u32);
+                        pub const ERROR_CTX_WD_NOT_FOUND: Self = Self(7004u32);
+                        pub const ERROR_CTX_CANNOT_MAKE_EVENTLOG_ENTRY: Self = Self(7005u32);
+                        pub const ERROR_CTX_SERVICE_NAME_COLLISION: Self = Self(7006u32);
+                        pub const ERROR_CTX_CLOSE_PENDING: Self = Self(7007u32);
+                        pub const ERROR_CTX_NO_OUTBUF: Self = Self(7008u32);
+                        pub const ERROR_CTX_MODEM_INF_NOT_FOUND: Self = Self(7009u32);
+                        pub const ERROR_CTX_INVALID_MODEMNAME: Self = Self(7010u32);
+                        pub const ERROR_CTX_MODEM_RESPONSE_ERROR: Self = Self(7011u32);
+                        pub const ERROR_CTX_MODEM_RESPONSE_TIMEOUT: Self = Self(7012u32);
+                        pub const ERROR_CTX_MODEM_RESPONSE_NO_CARRIER: Self = Self(7013u32);
+                        pub const ERROR_CTX_MODEM_RESPONSE_NO_DIALTONE: Self = Self(7014u32);
+                        pub const ERROR_CTX_MODEM_RESPONSE_BUSY: Self = Self(7015u32);
+                        pub const ERROR_CTX_MODEM_RESPONSE_VOICE: Self = Self(7016u32);
+                        pub const ERROR_CTX_TD_ERROR: Self = Self(7017u32);
+                        pub const ERROR_CTX_WINSTATION_NOT_FOUND: Self = Self(7022u32);
+                        pub const ERROR_CTX_WINSTATION_ALREADY_EXISTS: Self = Self(7023u32);
+                        pub const ERROR_CTX_WINSTATION_BUSY: Self = Self(7024u32);
+                        pub const ERROR_CTX_BAD_VIDEO_MODE: Self = Self(7025u32);
+                        pub const ERROR_CTX_GRAPHICS_INVALID: Self = Self(7035u32);
+                        pub const ERROR_CTX_LOGON_DISABLED: Self = Self(7037u32);
+                        pub const ERROR_CTX_NOT_CONSOLE: Self = Self(7038u32);
+                        pub const ERROR_CTX_CLIENT_QUERY_TIMEOUT: Self = Self(7040u32);
+                        pub const ERROR_CTX_CONSOLE_DISCONNECT: Self = Self(7041u32);
+                        pub const ERROR_CTX_CONSOLE_CONNECT: Self = Self(7042u32);
+                        pub const ERROR_CTX_SHADOW_DENIED: Self = Self(7044u32);
+                        pub const ERROR_CTX_WINSTATION_ACCESS_DENIED: Self = Self(7045u32);
+                        pub const ERROR_CTX_INVALID_WD: Self = Self(7049u32);
+                        pub const ERROR_CTX_SHADOW_INVALID: Self = Self(7050u32);
+                        pub const ERROR_CTX_SHADOW_DISABLED: Self = Self(7051u32);
+                        pub const ERROR_CTX_CLIENT_LICENSE_IN_USE: Self = Self(7052u32);
+                        pub const ERROR_CTX_CLIENT_LICENSE_NOT_SET: Self = Self(7053u32);
+                        pub const ERROR_CTX_LICENSE_NOT_AVAILABLE: Self = Self(7054u32);
+                        pub const ERROR_CTX_LICENSE_CLIENT_INVALID: Self = Self(7055u32);
+                        pub const ERROR_CTX_LICENSE_EXPIRED: Self = Self(7056u32);
+                        pub const ERROR_CTX_SHADOW_NOT_RUNNING: Self = Self(7057u32);
+                        pub const ERROR_CTX_SHADOW_ENDED_BY_MODE_CHANGE: Self = Self(7058u32);
+                        pub const ERROR_ACTIVATION_COUNT_EXCEEDED: Self = Self(7059u32);
+                        pub const ERROR_CTX_WINSTATIONS_DISABLED: Self = Self(7060u32);
+                        pub const ERROR_CTX_ENCRYPTION_LEVEL_REQUIRED: Self = Self(7061u32);
+                        pub const ERROR_CTX_SESSION_IN_USE: Self = Self(7062u32);
+                        pub const ERROR_CTX_NO_FORCE_LOGOFF: Self = Self(7063u32);
+                        pub const ERROR_CTX_ACCOUNT_RESTRICTION: Self = Self(7064u32);
+                        pub const ERROR_RDP_PROTOCOL_ERROR: Self = Self(7065u32);
+                        pub const ERROR_CTX_CDM_CONNECT: Self = Self(7066u32);
+                        pub const ERROR_CTX_CDM_DISCONNECT: Self = Self(7067u32);
+                        pub const ERROR_CTX_SECURITY_LAYER_ERROR: Self = Self(7068u32);
+                        pub const ERROR_TS_INCOMPATIBLE_SESSIONS: Self = Self(7069u32);
+                        pub const ERROR_TS_VIDEO_SUBSYSTEM_ERROR: Self = Self(7070u32);
+                        pub const ERROR_DS_NOT_INSTALLED: Self = Self(8200u32);
+                        pub const ERROR_DS_MEMBERSHIP_EVALUATED_LOCALLY: Self = Self(8201u32);
+                        pub const ERROR_DS_NO_ATTRIBUTE_OR_VALUE: Self = Self(8202u32);
+                        pub const ERROR_DS_INVALID_ATTRIBUTE_SYNTAX: Self = Self(8203u32);
+                        pub const ERROR_DS_ATTRIBUTE_TYPE_UNDEFINED: Self = Self(8204u32);
+                        pub const ERROR_DS_ATTRIBUTE_OR_VALUE_EXISTS: Self = Self(8205u32);
+                        pub const ERROR_DS_BUSY: Self = Self(8206u32);
+                        pub const ERROR_DS_UNAVAILABLE: Self = Self(8207u32);
+                        pub const ERROR_DS_NO_RIDS_ALLOCATED: Self = Self(8208u32);
+                        pub const ERROR_DS_NO_MORE_RIDS: Self = Self(8209u32);
+                        pub const ERROR_DS_INCORRECT_ROLE_OWNER: Self = Self(8210u32);
+                        pub const ERROR_DS_RIDMGR_INIT_ERROR: Self = Self(8211u32);
+                        pub const ERROR_DS_OBJ_CLASS_VIOLATION: Self = Self(8212u32);
+                        pub const ERROR_DS_CANT_ON_NON_LEAF: Self = Self(8213u32);
+                        pub const ERROR_DS_CANT_ON_RDN: Self = Self(8214u32);
+                        pub const ERROR_DS_CANT_MOD_OBJ_CLASS: Self = Self(8215u32);
+                        pub const ERROR_DS_CROSS_DOM_MOVE_ERROR: Self = Self(8216u32);
+                        pub const ERROR_DS_GC_NOT_AVAILABLE: Self = Self(8217u32);
+                        pub const ERROR_SHARED_POLICY: Self = Self(8218u32);
+                        pub const ERROR_POLICY_OBJECT_NOT_FOUND: Self = Self(8219u32);
+                        pub const ERROR_POLICY_ONLY_IN_DS: Self = Self(8220u32);
+                        pub const ERROR_PROMOTION_ACTIVE: Self = Self(8221u32);
+                        pub const ERROR_NO_PROMOTION_ACTIVE: Self = Self(8222u32);
+                        pub const ERROR_DS_OPERATIONS_ERROR: Self = Self(8224u32);
+                        pub const ERROR_DS_PROTOCOL_ERROR: Self = Self(8225u32);
+                        pub const ERROR_DS_TIMELIMIT_EXCEEDED: Self = Self(8226u32);
+                        pub const ERROR_DS_SIZELIMIT_EXCEEDED: Self = Self(8227u32);
+                        pub const ERROR_DS_ADMIN_LIMIT_EXCEEDED: Self = Self(8228u32);
+                        pub const ERROR_DS_COMPARE_FALSE: Self = Self(8229u32);
+                        pub const ERROR_DS_COMPARE_TRUE: Self = Self(8230u32);
+                        pub const ERROR_DS_AUTH_METHOD_NOT_SUPPORTED: Self = Self(8231u32);
+                        pub const ERROR_DS_STRONG_AUTH_REQUIRED: Self = Self(8232u32);
+                        pub const ERROR_DS_INAPPROPRIATE_AUTH: Self = Self(8233u32);
+                        pub const ERROR_DS_AUTH_UNKNOWN: Self = Self(8234u32);
+                        pub const ERROR_DS_REFERRAL: Self = Self(8235u32);
+                        pub const ERROR_DS_UNAVAILABLE_CRIT_EXTENSION: Self = Self(8236u32);
+                        pub const ERROR_DS_CONFIDENTIALITY_REQUIRED: Self = Self(8237u32);
+                        pub const ERROR_DS_INAPPROPRIATE_MATCHING: Self = Self(8238u32);
+                        pub const ERROR_DS_CONSTRAINT_VIOLATION: Self = Self(8239u32);
+                        pub const ERROR_DS_NO_SUCH_OBJECT: Self = Self(8240u32);
+                        pub const ERROR_DS_ALIAS_PROBLEM: Self = Self(8241u32);
+                        pub const ERROR_DS_INVALID_DN_SYNTAX: Self = Self(8242u32);
+                        pub const ERROR_DS_IS_LEAF: Self = Self(8243u32);
+                        pub const ERROR_DS_ALIAS_DEREF_PROBLEM: Self = Self(8244u32);
+                        pub const ERROR_DS_UNWILLING_TO_PERFORM: Self = Self(8245u32);
+                        pub const ERROR_DS_LOOP_DETECT: Self = Self(8246u32);
+                        pub const ERROR_DS_NAMING_VIOLATION: Self = Self(8247u32);
+                        pub const ERROR_DS_OBJECT_RESULTS_TOO_LARGE: Self = Self(8248u32);
+                        pub const ERROR_DS_AFFECTS_MULTIPLE_DSAS: Self = Self(8249u32);
+                        pub const ERROR_DS_SERVER_DOWN: Self = Self(8250u32);
+                        pub const ERROR_DS_LOCAL_ERROR: Self = Self(8251u32);
+                        pub const ERROR_DS_ENCODING_ERROR: Self = Self(8252u32);
+                        pub const ERROR_DS_DECODING_ERROR: Self = Self(8253u32);
+                        pub const ERROR_DS_FILTER_UNKNOWN: Self = Self(8254u32);
+                        pub const ERROR_DS_PARAM_ERROR: Self = Self(8255u32);
+                        pub const ERROR_DS_NOT_SUPPORTED: Self = Self(8256u32);
+                        pub const ERROR_DS_NO_RESULTS_RETURNED: Self = Self(8257u32);
+                        pub const ERROR_DS_CONTROL_NOT_FOUND: Self = Self(8258u32);
+                        pub const ERROR_DS_CLIENT_LOOP: Self = Self(8259u32);
+                        pub const ERROR_DS_REFERRAL_LIMIT_EXCEEDED: Self = Self(8260u32);
+                        pub const ERROR_DS_SORT_CONTROL_MISSING: Self = Self(8261u32);
+                        pub const ERROR_DS_OFFSET_RANGE_ERROR: Self = Self(8262u32);
+                        pub const ERROR_DS_RIDMGR_DISABLED: Self = Self(8263u32);
+                        pub const ERROR_DS_ROOT_MUST_BE_NC: Self = Self(8301u32);
+                        pub const ERROR_DS_ADD_REPLICA_INHIBITED: Self = Self(8302u32);
+                        pub const ERROR_DS_ATT_NOT_DEF_IN_SCHEMA: Self = Self(8303u32);
+                        pub const ERROR_DS_MAX_OBJ_SIZE_EXCEEDED: Self = Self(8304u32);
+                        pub const ERROR_DS_OBJ_STRING_NAME_EXISTS: Self = Self(8305u32);
+                        pub const ERROR_DS_NO_RDN_DEFINED_IN_SCHEMA: Self = Self(8306u32);
+                        pub const ERROR_DS_RDN_DOESNT_MATCH_SCHEMA: Self = Self(8307u32);
+                        pub const ERROR_DS_NO_REQUESTED_ATTS_FOUND: Self = Self(8308u32);
+                        pub const ERROR_DS_USER_BUFFER_TO_SMALL: Self = Self(8309u32);
+                        pub const ERROR_DS_ATT_IS_NOT_ON_OBJ: Self = Self(8310u32);
+                        pub const ERROR_DS_ILLEGAL_MOD_OPERATION: Self = Self(8311u32);
+                        pub const ERROR_DS_OBJ_TOO_LARGE: Self = Self(8312u32);
+                        pub const ERROR_DS_BAD_INSTANCE_TYPE: Self = Self(8313u32);
+                        pub const ERROR_DS_MASTERDSA_REQUIRED: Self = Self(8314u32);
+                        pub const ERROR_DS_OBJECT_CLASS_REQUIRED: Self = Self(8315u32);
+                        pub const ERROR_DS_MISSING_REQUIRED_ATT: Self = Self(8316u32);
+                        pub const ERROR_DS_ATT_NOT_DEF_FOR_CLASS: Self = Self(8317u32);
+                        pub const ERROR_DS_ATT_ALREADY_EXISTS: Self = Self(8318u32);
+                        pub const ERROR_DS_CANT_ADD_ATT_VALUES: Self = Self(8320u32);
+                        pub const ERROR_DS_SINGLE_VALUE_CONSTRAINT: Self = Self(8321u32);
+                        pub const ERROR_DS_RANGE_CONSTRAINT: Self = Self(8322u32);
+                        pub const ERROR_DS_ATT_VAL_ALREADY_EXISTS: Self = Self(8323u32);
+                        pub const ERROR_DS_CANT_REM_MISSING_ATT: Self = Self(8324u32);
+                        pub const ERROR_DS_CANT_REM_MISSING_ATT_VAL: Self = Self(8325u32);
+                        pub const ERROR_DS_ROOT_CANT_BE_SUBREF: Self = Self(8326u32);
+                        pub const ERROR_DS_NO_CHAINING: Self = Self(8327u32);
+                        pub const ERROR_DS_NO_CHAINED_EVAL: Self = Self(8328u32);
+                        pub const ERROR_DS_NO_PARENT_OBJECT: Self = Self(8329u32);
+                        pub const ERROR_DS_PARENT_IS_AN_ALIAS: Self = Self(8330u32);
+                        pub const ERROR_DS_CANT_MIX_MASTER_AND_REPS: Self = Self(8331u32);
+                        pub const ERROR_DS_CHILDREN_EXIST: Self = Self(8332u32);
+                        pub const ERROR_DS_OBJ_NOT_FOUND: Self = Self(8333u32);
+                        pub const ERROR_DS_ALIASED_OBJ_MISSING: Self = Self(8334u32);
+                        pub const ERROR_DS_BAD_NAME_SYNTAX: Self = Self(8335u32);
+                        pub const ERROR_DS_ALIAS_POINTS_TO_ALIAS: Self = Self(8336u32);
+                        pub const ERROR_DS_CANT_DEREF_ALIAS: Self = Self(8337u32);
+                        pub const ERROR_DS_OUT_OF_SCOPE: Self = Self(8338u32);
+                        pub const ERROR_DS_OBJECT_BEING_REMOVED: Self = Self(8339u32);
+                        pub const ERROR_DS_CANT_DELETE_DSA_OBJ: Self = Self(8340u32);
+                        pub const ERROR_DS_GENERIC_ERROR: Self = Self(8341u32);
+                        pub const ERROR_DS_DSA_MUST_BE_INT_MASTER: Self = Self(8342u32);
+                        pub const ERROR_DS_CLASS_NOT_DSA: Self = Self(8343u32);
+                        pub const ERROR_DS_INSUFF_ACCESS_RIGHTS: Self = Self(8344u32);
+                        pub const ERROR_DS_ILLEGAL_SUPERIOR: Self = Self(8345u32);
+                        pub const ERROR_DS_ATTRIBUTE_OWNED_BY_SAM: Self = Self(8346u32);
+                        pub const ERROR_DS_NAME_TOO_MANY_PARTS: Self = Self(8347u32);
+                        pub const ERROR_DS_NAME_TOO_LONG: Self = Self(8348u32);
+                        pub const ERROR_DS_NAME_VALUE_TOO_LONG: Self = Self(8349u32);
+                        pub const ERROR_DS_NAME_UNPARSEABLE: Self = Self(8350u32);
+                        pub const ERROR_DS_NAME_TYPE_UNKNOWN: Self = Self(8351u32);
+                        pub const ERROR_DS_NOT_AN_OBJECT: Self = Self(8352u32);
+                        pub const ERROR_DS_SEC_DESC_TOO_SHORT: Self = Self(8353u32);
+                        pub const ERROR_DS_SEC_DESC_INVALID: Self = Self(8354u32);
+                        pub const ERROR_DS_NO_DELETED_NAME: Self = Self(8355u32);
+                        pub const ERROR_DS_SUBREF_MUST_HAVE_PARENT: Self = Self(8356u32);
+                        pub const ERROR_DS_NCNAME_MUST_BE_NC: Self = Self(8357u32);
+                        pub const ERROR_DS_CANT_ADD_SYSTEM_ONLY: Self = Self(8358u32);
+                        pub const ERROR_DS_CLASS_MUST_BE_CONCRETE: Self = Self(8359u32);
+                        pub const ERROR_DS_INVALID_DMD: Self = Self(8360u32);
+                        pub const ERROR_DS_OBJ_GUID_EXISTS: Self = Self(8361u32);
+                        pub const ERROR_DS_NOT_ON_BACKLINK: Self = Self(8362u32);
+                        pub const ERROR_DS_NO_CROSSREF_FOR_NC: Self = Self(8363u32);
+                        pub const ERROR_DS_SHUTTING_DOWN: Self = Self(8364u32);
+                        pub const ERROR_DS_UNKNOWN_OPERATION: Self = Self(8365u32);
+                        pub const ERROR_DS_INVALID_ROLE_OWNER: Self = Self(8366u32);
+                        pub const ERROR_DS_COULDNT_CONTACT_FSMO: Self = Self(8367u32);
+                        pub const ERROR_DS_CROSS_NC_DN_RENAME: Self = Self(8368u32);
+                        pub const ERROR_DS_CANT_MOD_SYSTEM_ONLY: Self = Self(8369u32);
+                        pub const ERROR_DS_REPLICATOR_ONLY: Self = Self(8370u32);
+                        pub const ERROR_DS_OBJ_CLASS_NOT_DEFINED: Self = Self(8371u32);
+                        pub const ERROR_DS_OBJ_CLASS_NOT_SUBCLASS: Self = Self(8372u32);
+                        pub const ERROR_DS_NAME_REFERENCE_INVALID: Self = Self(8373u32);
+                        pub const ERROR_DS_CROSS_REF_EXISTS: Self = Self(8374u32);
+                        pub const ERROR_DS_CANT_DEL_MASTER_CROSSREF: Self = Self(8375u32);
+                        pub const ERROR_DS_SUBTREE_NOTIFY_NOT_NC_HEAD: Self = Self(8376u32);
+                        pub const ERROR_DS_NOTIFY_FILTER_TOO_COMPLEX: Self = Self(8377u32);
+                        pub const ERROR_DS_DUP_RDN: Self = Self(8378u32);
+                        pub const ERROR_DS_DUP_OID: Self = Self(8379u32);
+                        pub const ERROR_DS_DUP_MAPI_ID: Self = Self(8380u32);
+                        pub const ERROR_DS_DUP_SCHEMA_ID_GUID: Self = Self(8381u32);
+                        pub const ERROR_DS_DUP_LDAP_DISPLAY_NAME: Self = Self(8382u32);
+                        pub const ERROR_DS_SEMANTIC_ATT_TEST: Self = Self(8383u32);
+                        pub const ERROR_DS_SYNTAX_MISMATCH: Self = Self(8384u32);
+                        pub const ERROR_DS_EXISTS_IN_MUST_HAVE: Self = Self(8385u32);
+                        pub const ERROR_DS_EXISTS_IN_MAY_HAVE: Self = Self(8386u32);
+                        pub const ERROR_DS_NONEXISTENT_MAY_HAVE: Self = Self(8387u32);
+                        pub const ERROR_DS_NONEXISTENT_MUST_HAVE: Self = Self(8388u32);
+                        pub const ERROR_DS_AUX_CLS_TEST_FAIL: Self = Self(8389u32);
+                        pub const ERROR_DS_NONEXISTENT_POSS_SUP: Self = Self(8390u32);
+                        pub const ERROR_DS_SUB_CLS_TEST_FAIL: Self = Self(8391u32);
+                        pub const ERROR_DS_BAD_RDN_ATT_ID_SYNTAX: Self = Self(8392u32);
+                        pub const ERROR_DS_EXISTS_IN_AUX_CLS: Self = Self(8393u32);
+                        pub const ERROR_DS_EXISTS_IN_SUB_CLS: Self = Self(8394u32);
+                        pub const ERROR_DS_EXISTS_IN_POSS_SUP: Self = Self(8395u32);
+                        pub const ERROR_DS_RECALCSCHEMA_FAILED: Self = Self(8396u32);
+                        pub const ERROR_DS_TREE_DELETE_NOT_FINISHED: Self = Self(8397u32);
+                        pub const ERROR_DS_CANT_DELETE: Self = Self(8398u32);
+                        pub const ERROR_DS_ATT_SCHEMA_REQ_ID: Self = Self(8399u32);
+                        pub const ERROR_DS_BAD_ATT_SCHEMA_SYNTAX: Self = Self(8400u32);
+                        pub const ERROR_DS_CANT_CACHE_ATT: Self = Self(8401u32);
+                        pub const ERROR_DS_CANT_CACHE_CLASS: Self = Self(8402u32);
+                        pub const ERROR_DS_CANT_REMOVE_ATT_CACHE: Self = Self(8403u32);
+                        pub const ERROR_DS_CANT_REMOVE_CLASS_CACHE: Self = Self(8404u32);
+                        pub const ERROR_DS_CANT_RETRIEVE_DN: Self = Self(8405u32);
+                        pub const ERROR_DS_MISSING_SUPREF: Self = Self(8406u32);
+                        pub const ERROR_DS_CANT_RETRIEVE_INSTANCE: Self = Self(8407u32);
+                        pub const ERROR_DS_CODE_INCONSISTENCY: Self = Self(8408u32);
+                        pub const ERROR_DS_DATABASE_ERROR: Self = Self(8409u32);
+                        pub const ERROR_DS_GOVERNSID_MISSING: Self = Self(8410u32);
+                        pub const ERROR_DS_MISSING_EXPECTED_ATT: Self = Self(8411u32);
+                        pub const ERROR_DS_NCNAME_MISSING_CR_REF: Self = Self(8412u32);
+                        pub const ERROR_DS_SECURITY_CHECKING_ERROR: Self = Self(8413u32);
+                        pub const ERROR_DS_SCHEMA_NOT_LOADED: Self = Self(8414u32);
+                        pub const ERROR_DS_SCHEMA_ALLOC_FAILED: Self = Self(8415u32);
+                        pub const ERROR_DS_ATT_SCHEMA_REQ_SYNTAX: Self = Self(8416u32);
+                        pub const ERROR_DS_GCVERIFY_ERROR: Self = Self(8417u32);
+                        pub const ERROR_DS_DRA_SCHEMA_MISMATCH: Self = Self(8418u32);
+                        pub const ERROR_DS_CANT_FIND_DSA_OBJ: Self = Self(8419u32);
+                        pub const ERROR_DS_CANT_FIND_EXPECTED_NC: Self = Self(8420u32);
+                        pub const ERROR_DS_CANT_FIND_NC_IN_CACHE: Self = Self(8421u32);
+                        pub const ERROR_DS_CANT_RETRIEVE_CHILD: Self = Self(8422u32);
+                        pub const ERROR_DS_SECURITY_ILLEGAL_MODIFY: Self = Self(8423u32);
+                        pub const ERROR_DS_CANT_REPLACE_HIDDEN_REC: Self = Self(8424u32);
+                        pub const ERROR_DS_BAD_HIERARCHY_FILE: Self = Self(8425u32);
+                        pub const ERROR_DS_BUILD_HIERARCHY_TABLE_FAILED: Self = Self(8426u32);
+                        pub const ERROR_DS_CONFIG_PARAM_MISSING: Self = Self(8427u32);
+                        pub const ERROR_DS_COUNTING_AB_INDICES_FAILED: Self = Self(8428u32);
+                        pub const ERROR_DS_HIERARCHY_TABLE_MALLOC_FAILED: Self = Self(8429u32);
+                        pub const ERROR_DS_INTERNAL_FAILURE: Self = Self(8430u32);
+                        pub const ERROR_DS_UNKNOWN_ERROR: Self = Self(8431u32);
+                        pub const ERROR_DS_ROOT_REQUIRES_CLASS_TOP: Self = Self(8432u32);
+                        pub const ERROR_DS_REFUSING_FSMO_ROLES: Self = Self(8433u32);
+                        pub const ERROR_DS_MISSING_FSMO_SETTINGS: Self = Self(8434u32);
+                        pub const ERROR_DS_UNABLE_TO_SURRENDER_ROLES: Self = Self(8435u32);
+                        pub const ERROR_DS_DRA_GENERIC: Self = Self(8436u32);
+                        pub const ERROR_DS_DRA_INVALID_PARAMETER: Self = Self(8437u32);
+                        pub const ERROR_DS_DRA_BUSY: Self = Self(8438u32);
+                        pub const ERROR_DS_DRA_BAD_DN: Self = Self(8439u32);
+                        pub const ERROR_DS_DRA_BAD_NC: Self = Self(8440u32);
+                        pub const ERROR_DS_DRA_DN_EXISTS: Self = Self(8441u32);
+                        pub const ERROR_DS_DRA_INTERNAL_ERROR: Self = Self(8442u32);
+                        pub const ERROR_DS_DRA_INCONSISTENT_DIT: Self = Self(8443u32);
+                        pub const ERROR_DS_DRA_CONNECTION_FAILED: Self = Self(8444u32);
+                        pub const ERROR_DS_DRA_BAD_INSTANCE_TYPE: Self = Self(8445u32);
+                        pub const ERROR_DS_DRA_OUT_OF_MEM: Self = Self(8446u32);
+                        pub const ERROR_DS_DRA_MAIL_PROBLEM: Self = Self(8447u32);
+                        pub const ERROR_DS_DRA_REF_ALREADY_EXISTS: Self = Self(8448u32);
+                        pub const ERROR_DS_DRA_REF_NOT_FOUND: Self = Self(8449u32);
+                        pub const ERROR_DS_DRA_OBJ_IS_REP_SOURCE: Self = Self(8450u32);
+                        pub const ERROR_DS_DRA_DB_ERROR: Self = Self(8451u32);
+                        pub const ERROR_DS_DRA_NO_REPLICA: Self = Self(8452u32);
+                        pub const ERROR_DS_DRA_ACCESS_DENIED: Self = Self(8453u32);
+                        pub const ERROR_DS_DRA_NOT_SUPPORTED: Self = Self(8454u32);
+                        pub const ERROR_DS_DRA_RPC_CANCELLED: Self = Self(8455u32);
+                        pub const ERROR_DS_DRA_SOURCE_DISABLED: Self = Self(8456u32);
+                        pub const ERROR_DS_DRA_SINK_DISABLED: Self = Self(8457u32);
+                        pub const ERROR_DS_DRA_NAME_COLLISION: Self = Self(8458u32);
+                        pub const ERROR_DS_DRA_SOURCE_REINSTALLED: Self = Self(8459u32);
+                        pub const ERROR_DS_DRA_MISSING_PARENT: Self = Self(8460u32);
+                        pub const ERROR_DS_DRA_PREEMPTED: Self = Self(8461u32);
+                        pub const ERROR_DS_DRA_ABANDON_SYNC: Self = Self(8462u32);
+                        pub const ERROR_DS_DRA_SHUTDOWN: Self = Self(8463u32);
+                        pub const ERROR_DS_DRA_INCOMPATIBLE_PARTIAL_SET: Self = Self(8464u32);
+                        pub const ERROR_DS_DRA_SOURCE_IS_PARTIAL_REPLICA: Self = Self(8465u32);
+                        pub const ERROR_DS_DRA_EXTN_CONNECTION_FAILED: Self = Self(8466u32);
+                        pub const ERROR_DS_INSTALL_SCHEMA_MISMATCH: Self = Self(8467u32);
+                        pub const ERROR_DS_DUP_LINK_ID: Self = Self(8468u32);
+                        pub const ERROR_DS_NAME_ERROR_RESOLVING: Self = Self(8469u32);
+                        pub const ERROR_DS_NAME_ERROR_NOT_FOUND: Self = Self(8470u32);
+                        pub const ERROR_DS_NAME_ERROR_NOT_UNIQUE: Self = Self(8471u32);
+                        pub const ERROR_DS_NAME_ERROR_NO_MAPPING: Self = Self(8472u32);
+                        pub const ERROR_DS_NAME_ERROR_DOMAIN_ONLY: Self = Self(8473u32);
+                        pub const ERROR_DS_NAME_ERROR_NO_SYNTACTICAL_MAPPING: Self = Self(8474u32);
+                        pub const ERROR_DS_CONSTRUCTED_ATT_MOD: Self = Self(8475u32);
+                        pub const ERROR_DS_WRONG_OM_OBJ_CLASS: Self = Self(8476u32);
+                        pub const ERROR_DS_DRA_REPL_PENDING: Self = Self(8477u32);
+                        pub const ERROR_DS_DS_REQUIRED: Self = Self(8478u32);
+                        pub const ERROR_DS_INVALID_LDAP_DISPLAY_NAME: Self = Self(8479u32);
+                        pub const ERROR_DS_NON_BASE_SEARCH: Self = Self(8480u32);
+                        pub const ERROR_DS_CANT_RETRIEVE_ATTS: Self = Self(8481u32);
+                        pub const ERROR_DS_BACKLINK_WITHOUT_LINK: Self = Self(8482u32);
+                        pub const ERROR_DS_EPOCH_MISMATCH: Self = Self(8483u32);
+                        pub const ERROR_DS_SRC_NAME_MISMATCH: Self = Self(8484u32);
+                        pub const ERROR_DS_SRC_AND_DST_NC_IDENTICAL: Self = Self(8485u32);
+                        pub const ERROR_DS_DST_NC_MISMATCH: Self = Self(8486u32);
+                        pub const ERROR_DS_NOT_AUTHORITIVE_FOR_DST_NC: Self = Self(8487u32);
+                        pub const ERROR_DS_SRC_GUID_MISMATCH: Self = Self(8488u32);
+                        pub const ERROR_DS_CANT_MOVE_DELETED_OBJECT: Self = Self(8489u32);
+                        pub const ERROR_DS_PDC_OPERATION_IN_PROGRESS: Self = Self(8490u32);
+                        pub const ERROR_DS_CROSS_DOMAIN_CLEANUP_REQD: Self = Self(8491u32);
+                        pub const ERROR_DS_ILLEGAL_XDOM_MOVE_OPERATION: Self = Self(8492u32);
+                        pub const ERROR_DS_CANT_WITH_ACCT_GROUP_MEMBERSHPS: Self = Self(8493u32);
+                        pub const ERROR_DS_NC_MUST_HAVE_NC_PARENT: Self = Self(8494u32);
+                        pub const ERROR_DS_CR_IMPOSSIBLE_TO_VALIDATE: Self = Self(8495u32);
+                        pub const ERROR_DS_DST_DOMAIN_NOT_NATIVE: Self = Self(8496u32);
+                        pub const ERROR_DS_MISSING_INFRASTRUCTURE_CONTAINER: Self = Self(8497u32);
+                        pub const ERROR_DS_CANT_MOVE_ACCOUNT_GROUP: Self = Self(8498u32);
+                        pub const ERROR_DS_CANT_MOVE_RESOURCE_GROUP: Self = Self(8499u32);
+                        pub const ERROR_DS_INVALID_SEARCH_FLAG: Self = Self(8500u32);
+                        pub const ERROR_DS_NO_TREE_DELETE_ABOVE_NC: Self = Self(8501u32);
+                        pub const ERROR_DS_COULDNT_LOCK_TREE_FOR_DELETE: Self = Self(8502u32);
+                        pub const ERROR_DS_COULDNT_IDENTIFY_OBJECTS_FOR_TREE_DELETE: Self =
+                            Self(8503u32);
+                        pub const ERROR_DS_SAM_INIT_FAILURE: Self = Self(8504u32);
+                        pub const ERROR_DS_SENSITIVE_GROUP_VIOLATION: Self = Self(8505u32);
+                        pub const ERROR_DS_CANT_MOD_PRIMARYGROUPID: Self = Self(8506u32);
+                        pub const ERROR_DS_ILLEGAL_BASE_SCHEMA_MOD: Self = Self(8507u32);
+                        pub const ERROR_DS_NONSAFE_SCHEMA_CHANGE: Self = Self(8508u32);
+                        pub const ERROR_DS_SCHEMA_UPDATE_DISALLOWED: Self = Self(8509u32);
+                        pub const ERROR_DS_CANT_CREATE_UNDER_SCHEMA: Self = Self(8510u32);
+                        pub const ERROR_DS_INSTALL_NO_SRC_SCH_VERSION: Self = Self(8511u32);
+                        pub const ERROR_DS_INSTALL_NO_SCH_VERSION_IN_INIFILE: Self = Self(8512u32);
+                        pub const ERROR_DS_INVALID_GROUP_TYPE: Self = Self(8513u32);
+                        pub const ERROR_DS_NO_NEST_GLOBALGROUP_IN_MIXEDDOMAIN: Self = Self(8514u32);
+                        pub const ERROR_DS_NO_NEST_LOCALGROUP_IN_MIXEDDOMAIN: Self = Self(8515u32);
+                        pub const ERROR_DS_GLOBAL_CANT_HAVE_LOCAL_MEMBER: Self = Self(8516u32);
+                        pub const ERROR_DS_GLOBAL_CANT_HAVE_UNIVERSAL_MEMBER: Self = Self(8517u32);
+                        pub const ERROR_DS_UNIVERSAL_CANT_HAVE_LOCAL_MEMBER: Self = Self(8518u32);
+                        pub const ERROR_DS_GLOBAL_CANT_HAVE_CROSSDOMAIN_MEMBER: Self =
+                            Self(8519u32);
+                        pub const ERROR_DS_LOCAL_CANT_HAVE_CROSSDOMAIN_LOCAL_MEMBER: Self =
+                            Self(8520u32);
+                        pub const ERROR_DS_HAVE_PRIMARY_MEMBERS: Self = Self(8521u32);
+                        pub const ERROR_DS_STRING_SD_CONVERSION_FAILED: Self = Self(8522u32);
+                        pub const ERROR_DS_NAMING_MASTER_GC: Self = Self(8523u32);
+                        pub const ERROR_DS_DNS_LOOKUP_FAILURE: Self = Self(8524u32);
+                        pub const ERROR_DS_COULDNT_UPDATE_SPNS: Self = Self(8525u32);
+                        pub const ERROR_DS_CANT_RETRIEVE_SD: Self = Self(8526u32);
+                        pub const ERROR_DS_KEY_NOT_UNIQUE: Self = Self(8527u32);
+                        pub const ERROR_DS_WRONG_LINKED_ATT_SYNTAX: Self = Self(8528u32);
+                        pub const ERROR_DS_SAM_NEED_BOOTKEY_PASSWORD: Self = Self(8529u32);
+                        pub const ERROR_DS_SAM_NEED_BOOTKEY_FLOPPY: Self = Self(8530u32);
+                        pub const ERROR_DS_CANT_START: Self = Self(8531u32);
+                        pub const ERROR_DS_INIT_FAILURE: Self = Self(8532u32);
+                        pub const ERROR_DS_NO_PKT_PRIVACY_ON_CONNECTION: Self = Self(8533u32);
+                        pub const ERROR_DS_SOURCE_DOMAIN_IN_FOREST: Self = Self(8534u32);
+                        pub const ERROR_DS_DESTINATION_DOMAIN_NOT_IN_FOREST: Self = Self(8535u32);
+                        pub const ERROR_DS_DESTINATION_AUDITING_NOT_ENABLED: Self = Self(8536u32);
+                        pub const ERROR_DS_CANT_FIND_DC_FOR_SRC_DOMAIN: Self = Self(8537u32);
+                        pub const ERROR_DS_SRC_OBJ_NOT_GROUP_OR_USER: Self = Self(8538u32);
+                        pub const ERROR_DS_SRC_SID_EXISTS_IN_FOREST: Self = Self(8539u32);
+                        pub const ERROR_DS_SRC_AND_DST_OBJECT_CLASS_MISMATCH: Self = Self(8540u32);
+                        pub const ERROR_SAM_INIT_FAILURE: Self = Self(8541u32);
+                        pub const ERROR_DS_DRA_SCHEMA_INFO_SHIP: Self = Self(8542u32);
+                        pub const ERROR_DS_DRA_SCHEMA_CONFLICT: Self = Self(8543u32);
+                        pub const ERROR_DS_DRA_EARLIER_SCHEMA_CONFLICT: Self = Self(8544u32);
+                        pub const ERROR_DS_DRA_OBJ_NC_MISMATCH: Self = Self(8545u32);
+                        pub const ERROR_DS_NC_STILL_HAS_DSAS: Self = Self(8546u32);
+                        pub const ERROR_DS_GC_REQUIRED: Self = Self(8547u32);
+                        pub const ERROR_DS_LOCAL_MEMBER_OF_LOCAL_ONLY: Self = Self(8548u32);
+                        pub const ERROR_DS_NO_FPO_IN_UNIVERSAL_GROUPS: Self = Self(8549u32);
+                        pub const ERROR_DS_CANT_ADD_TO_GC: Self = Self(8550u32);
+                        pub const ERROR_DS_NO_CHECKPOINT_WITH_PDC: Self = Self(8551u32);
+                        pub const ERROR_DS_SOURCE_AUDITING_NOT_ENABLED: Self = Self(8552u32);
+                        pub const ERROR_DS_CANT_CREATE_IN_NONDOMAIN_NC: Self = Self(8553u32);
+                        pub const ERROR_DS_INVALID_NAME_FOR_SPN: Self = Self(8554u32);
+                        pub const ERROR_DS_FILTER_USES_CONTRUCTED_ATTRS: Self = Self(8555u32);
+                        pub const ERROR_DS_UNICODEPWD_NOT_IN_QUOTES: Self = Self(8556u32);
+                        pub const ERROR_DS_MACHINE_ACCOUNT_QUOTA_EXCEEDED: Self = Self(8557u32);
+                        pub const ERROR_DS_MUST_BE_RUN_ON_DST_DC: Self = Self(8558u32);
+                        pub const ERROR_DS_SRC_DC_MUST_BE_SP4_OR_GREATER: Self = Self(8559u32);
+                        pub const ERROR_DS_CANT_TREE_DELETE_CRITICAL_OBJ: Self = Self(8560u32);
+                        pub const ERROR_DS_INIT_FAILURE_CONSOLE: Self = Self(8561u32);
+                        pub const ERROR_DS_SAM_INIT_FAILURE_CONSOLE: Self = Self(8562u32);
+                        pub const ERROR_DS_FOREST_VERSION_TOO_HIGH: Self = Self(8563u32);
+                        pub const ERROR_DS_DOMAIN_VERSION_TOO_HIGH: Self = Self(8564u32);
+                        pub const ERROR_DS_FOREST_VERSION_TOO_LOW: Self = Self(8565u32);
+                        pub const ERROR_DS_DOMAIN_VERSION_TOO_LOW: Self = Self(8566u32);
+                        pub const ERROR_DS_INCOMPATIBLE_VERSION: Self = Self(8567u32);
+                        pub const ERROR_DS_LOW_DSA_VERSION: Self = Self(8568u32);
+                        pub const ERROR_DS_NO_BEHAVIOR_VERSION_IN_MIXEDDOMAIN: Self = Self(8569u32);
+                        pub const ERROR_DS_NOT_SUPPORTED_SORT_ORDER: Self = Self(8570u32);
+                        pub const ERROR_DS_NAME_NOT_UNIQUE: Self = Self(8571u32);
+                        pub const ERROR_DS_MACHINE_ACCOUNT_CREATED_PRENT4: Self = Self(8572u32);
+                        pub const ERROR_DS_OUT_OF_VERSION_STORE: Self = Self(8573u32);
+                        pub const ERROR_DS_INCOMPATIBLE_CONTROLS_USED: Self = Self(8574u32);
+                        pub const ERROR_DS_NO_REF_DOMAIN: Self = Self(8575u32);
+                        pub const ERROR_DS_RESERVED_LINK_ID: Self = Self(8576u32);
+                        pub const ERROR_DS_LINK_ID_NOT_AVAILABLE: Self = Self(8577u32);
+                        pub const ERROR_DS_AG_CANT_HAVE_UNIVERSAL_MEMBER: Self = Self(8578u32);
+                        pub const ERROR_DS_MODIFYDN_DISALLOWED_BY_INSTANCE_TYPE: Self =
+                            Self(8579u32);
+                        pub const ERROR_DS_NO_OBJECT_MOVE_IN_SCHEMA_NC: Self = Self(8580u32);
+                        pub const ERROR_DS_MODIFYDN_DISALLOWED_BY_FLAG: Self = Self(8581u32);
+                        pub const ERROR_DS_MODIFYDN_WRONG_GRANDPARENT: Self = Self(8582u32);
+                        pub const ERROR_DS_NAME_ERROR_TRUST_REFERRAL: Self = Self(8583u32);
+                        pub const ERROR_NOT_SUPPORTED_ON_STANDARD_SERVER: Self = Self(8584u32);
+                        pub const ERROR_DS_CANT_ACCESS_REMOTE_PART_OF_AD: Self = Self(8585u32);
+                        pub const ERROR_DS_CR_IMPOSSIBLE_TO_VALIDATE_V2: Self = Self(8586u32);
+                        pub const ERROR_DS_THREAD_LIMIT_EXCEEDED: Self = Self(8587u32);
+                        pub const ERROR_DS_NOT_CLOSEST: Self = Self(8588u32);
+                        pub const ERROR_DS_CANT_DERIVE_SPN_WITHOUT_SERVER_REF: Self = Self(8589u32);
+                        pub const ERROR_DS_SINGLE_USER_MODE_FAILED: Self = Self(8590u32);
+                        pub const ERROR_DS_NTDSCRIPT_SYNTAX_ERROR: Self = Self(8591u32);
+                        pub const ERROR_DS_NTDSCRIPT_PROCESS_ERROR: Self = Self(8592u32);
+                        pub const ERROR_DS_DIFFERENT_REPL_EPOCHS: Self = Self(8593u32);
+                        pub const ERROR_DS_DRS_EXTENSIONS_CHANGED: Self = Self(8594u32);
+                        pub const ERROR_DS_REPLICA_SET_CHANGE_NOT_ALLOWED_ON_DISABLED_CR: Self =
+                            Self(8595u32);
+                        pub const ERROR_DS_NO_MSDS_INTID: Self = Self(8596u32);
+                        pub const ERROR_DS_DUP_MSDS_INTID: Self = Self(8597u32);
+                        pub const ERROR_DS_EXISTS_IN_RDNATTID: Self = Self(8598u32);
+                        pub const ERROR_DS_AUTHORIZATION_FAILED: Self = Self(8599u32);
+                        pub const ERROR_DS_INVALID_SCRIPT: Self = Self(8600u32);
+                        pub const ERROR_DS_REMOTE_CROSSREF_OP_FAILED: Self = Self(8601u32);
+                        pub const ERROR_DS_CROSS_REF_BUSY: Self = Self(8602u32);
+                        pub const ERROR_DS_CANT_DERIVE_SPN_FOR_DELETED_DOMAIN: Self = Self(8603u32);
+                        pub const ERROR_DS_CANT_DEMOTE_WITH_WRITEABLE_NC: Self = Self(8604u32);
+                        pub const ERROR_DS_DUPLICATE_ID_FOUND: Self = Self(8605u32);
+                        pub const ERROR_DS_INSUFFICIENT_ATTR_TO_CREATE_OBJECT: Self = Self(8606u32);
+                        pub const ERROR_DS_GROUP_CONVERSION_ERROR: Self = Self(8607u32);
+                        pub const ERROR_DS_CANT_MOVE_APP_BASIC_GROUP: Self = Self(8608u32);
+                        pub const ERROR_DS_CANT_MOVE_APP_QUERY_GROUP: Self = Self(8609u32);
+                        pub const ERROR_DS_ROLE_NOT_VERIFIED: Self = Self(8610u32);
+                        pub const ERROR_DS_WKO_CONTAINER_CANNOT_BE_SPECIAL: Self = Self(8611u32);
+                        pub const ERROR_DS_DOMAIN_RENAME_IN_PROGRESS: Self = Self(8612u32);
+                        pub const ERROR_DS_EXISTING_AD_CHILD_NC: Self = Self(8613u32);
+                        pub const ERROR_DS_REPL_LIFETIME_EXCEEDED: Self = Self(8614u32);
+                        pub const ERROR_DS_DISALLOWED_IN_SYSTEM_CONTAINER: Self = Self(8615u32);
+                        pub const ERROR_DS_LDAP_SEND_QUEUE_FULL: Self = Self(8616u32);
+                        pub const ERROR_DS_DRA_OUT_SCHEDULE_WINDOW: Self = Self(8617u32);
+                        pub const ERROR_DS_POLICY_NOT_KNOWN: Self = Self(8618u32);
+                        pub const ERROR_NO_SITE_SETTINGS_OBJECT: Self = Self(8619u32);
+                        pub const ERROR_NO_SECRETS: Self = Self(8620u32);
+                        pub const ERROR_NO_WRITABLE_DC_FOUND: Self = Self(8621u32);
+                        pub const ERROR_DS_NO_SERVER_OBJECT: Self = Self(8622u32);
+                        pub const ERROR_DS_NO_NTDSA_OBJECT: Self = Self(8623u32);
+                        pub const ERROR_DS_NON_ASQ_SEARCH: Self = Self(8624u32);
+                        pub const ERROR_DS_AUDIT_FAILURE: Self = Self(8625u32);
+                        pub const ERROR_DS_INVALID_SEARCH_FLAG_SUBTREE: Self = Self(8626u32);
+                        pub const ERROR_DS_INVALID_SEARCH_FLAG_TUPLE: Self = Self(8627u32);
+                        pub const ERROR_DS_HIERARCHY_TABLE_TOO_DEEP: Self = Self(8628u32);
+                        pub const ERROR_DS_DRA_CORRUPT_UTD_VECTOR: Self = Self(8629u32);
+                        pub const ERROR_DS_DRA_SECRETS_DENIED: Self = Self(8630u32);
+                        pub const ERROR_DS_RESERVED_MAPI_ID: Self = Self(8631u32);
+                        pub const ERROR_DS_MAPI_ID_NOT_AVAILABLE: Self = Self(8632u32);
+                        pub const ERROR_DS_DRA_MISSING_KRBTGT_SECRET: Self = Self(8633u32);
+                        pub const ERROR_DS_DOMAIN_NAME_EXISTS_IN_FOREST: Self = Self(8634u32);
+                        pub const ERROR_DS_FLAT_NAME_EXISTS_IN_FOREST: Self = Self(8635u32);
+                        pub const ERROR_INVALID_USER_PRINCIPAL_NAME: Self = Self(8636u32);
+                        pub const ERROR_DS_OID_MAPPED_GROUP_CANT_HAVE_MEMBERS: Self = Self(8637u32);
+                        pub const ERROR_DS_OID_NOT_FOUND: Self = Self(8638u32);
+                        pub const ERROR_DS_DRA_RECYCLED_TARGET: Self = Self(8639u32);
+                        pub const ERROR_DS_DISALLOWED_NC_REDIRECT: Self = Self(8640u32);
+                        pub const ERROR_DS_HIGH_ADLDS_FFL: Self = Self(8641u32);
+                        pub const ERROR_DS_HIGH_DSA_VERSION: Self = Self(8642u32);
+                        pub const ERROR_DS_LOW_ADLDS_FFL: Self = Self(8643u32);
+                        pub const ERROR_DOMAIN_SID_SAME_AS_LOCAL_WORKSTATION: Self = Self(8644u32);
+                        pub const ERROR_DS_UNDELETE_SAM_VALIDATION_FAILED: Self = Self(8645u32);
+                        pub const ERROR_INCORRECT_ACCOUNT_TYPE: Self = Self(8646u32);
+                        pub const ERROR_DS_SPN_VALUE_NOT_UNIQUE_IN_FOREST: Self = Self(8647u32);
+                        pub const ERROR_DS_UPN_VALUE_NOT_UNIQUE_IN_FOREST: Self = Self(8648u32);
+                        pub const ERROR_DS_MISSING_FOREST_TRUST: Self = Self(8649u32);
+                        pub const ERROR_DS_VALUE_KEY_NOT_UNIQUE: Self = Self(8650u32);
+                        pub const DNS_ERROR_RESPONSE_CODES_BASE: Self = Self(9000u32);
+                        pub const DNS_ERROR_RCODE_NO_ERROR: Self = Self(0u32);
+                        pub const DNS_ERROR_MASK: Self = Self(9000u32);
+                        pub const DNS_ERROR_RCODE_FORMAT_ERROR: Self = Self(9001u32);
+                        pub const DNS_ERROR_RCODE_SERVER_FAILURE: Self = Self(9002u32);
+                        pub const DNS_ERROR_RCODE_NAME_ERROR: Self = Self(9003u32);
+                        pub const DNS_ERROR_RCODE_NOT_IMPLEMENTED: Self = Self(9004u32);
+                        pub const DNS_ERROR_RCODE_REFUSED: Self = Self(9005u32);
+                        pub const DNS_ERROR_RCODE_YXDOMAIN: Self = Self(9006u32);
+                        pub const DNS_ERROR_RCODE_YXRRSET: Self = Self(9007u32);
+                        pub const DNS_ERROR_RCODE_NXRRSET: Self = Self(9008u32);
+                        pub const DNS_ERROR_RCODE_NOTAUTH: Self = Self(9009u32);
+                        pub const DNS_ERROR_RCODE_NOTZONE: Self = Self(9010u32);
+                        pub const DNS_ERROR_RCODE_BADSIG: Self = Self(9016u32);
+                        pub const DNS_ERROR_RCODE_BADKEY: Self = Self(9017u32);
+                        pub const DNS_ERROR_RCODE_BADTIME: Self = Self(9018u32);
+                        pub const DNS_ERROR_RCODE_LAST: Self = Self(9018u32);
+                        pub const DNS_ERROR_DNSSEC_BASE: Self = Self(9100u32);
+                        pub const DNS_ERROR_KEYMASTER_REQUIRED: Self = Self(9101u32);
+                        pub const DNS_ERROR_NOT_ALLOWED_ON_SIGNED_ZONE: Self = Self(9102u32);
+                        pub const DNS_ERROR_NSEC3_INCOMPATIBLE_WITH_RSA_SHA1: Self = Self(9103u32);
+                        pub const DNS_ERROR_NOT_ENOUGH_SIGNING_KEY_DESCRIPTORS: Self =
+                            Self(9104u32);
+                        pub const DNS_ERROR_UNSUPPORTED_ALGORITHM: Self = Self(9105u32);
+                        pub const DNS_ERROR_INVALID_KEY_SIZE: Self = Self(9106u32);
+                        pub const DNS_ERROR_SIGNING_KEY_NOT_ACCESSIBLE: Self = Self(9107u32);
+                        pub const DNS_ERROR_KSP_DOES_NOT_SUPPORT_PROTECTION: Self = Self(9108u32);
+                        pub const DNS_ERROR_UNEXPECTED_DATA_PROTECTION_ERROR: Self = Self(9109u32);
+                        pub const DNS_ERROR_UNEXPECTED_CNG_ERROR: Self = Self(9110u32);
+                        pub const DNS_ERROR_UNKNOWN_SIGNING_PARAMETER_VERSION: Self = Self(9111u32);
+                        pub const DNS_ERROR_KSP_NOT_ACCESSIBLE: Self = Self(9112u32);
+                        pub const DNS_ERROR_TOO_MANY_SKDS: Self = Self(9113u32);
+                        pub const DNS_ERROR_INVALID_ROLLOVER_PERIOD: Self = Self(9114u32);
+                        pub const DNS_ERROR_INVALID_INITIAL_ROLLOVER_OFFSET: Self = Self(9115u32);
+                        pub const DNS_ERROR_ROLLOVER_IN_PROGRESS: Self = Self(9116u32);
+                        pub const DNS_ERROR_STANDBY_KEY_NOT_PRESENT: Self = Self(9117u32);
+                        pub const DNS_ERROR_NOT_ALLOWED_ON_ZSK: Self = Self(9118u32);
+                        pub const DNS_ERROR_NOT_ALLOWED_ON_ACTIVE_SKD: Self = Self(9119u32);
+                        pub const DNS_ERROR_ROLLOVER_ALREADY_QUEUED: Self = Self(9120u32);
+                        pub const DNS_ERROR_NOT_ALLOWED_ON_UNSIGNED_ZONE: Self = Self(9121u32);
+                        pub const DNS_ERROR_BAD_KEYMASTER: Self = Self(9122u32);
+                        pub const DNS_ERROR_INVALID_SIGNATURE_VALIDITY_PERIOD: Self = Self(9123u32);
+                        pub const DNS_ERROR_INVALID_NSEC3_ITERATION_COUNT: Self = Self(9124u32);
+                        pub const DNS_ERROR_DNSSEC_IS_DISABLED: Self = Self(9125u32);
+                        pub const DNS_ERROR_INVALID_XML: Self = Self(9126u32);
+                        pub const DNS_ERROR_NO_VALID_TRUST_ANCHORS: Self = Self(9127u32);
+                        pub const DNS_ERROR_ROLLOVER_NOT_POKEABLE: Self = Self(9128u32);
+                        pub const DNS_ERROR_NSEC3_NAME_COLLISION: Self = Self(9129u32);
+                        pub const DNS_ERROR_NSEC_INCOMPATIBLE_WITH_NSEC3_RSA_SHA1: Self =
+                            Self(9130u32);
+                        pub const DNS_ERROR_PACKET_FMT_BASE: Self = Self(9500u32);
+                        pub const DNS_ERROR_BAD_PACKET: Self = Self(9502u32);
+                        pub const DNS_ERROR_NO_PACKET: Self = Self(9503u32);
+                        pub const DNS_ERROR_RCODE: Self = Self(9504u32);
+                        pub const DNS_ERROR_UNSECURE_PACKET: Self = Self(9505u32);
+                        pub const DNS_ERROR_NO_MEMORY: Self = Self(14u32);
+                        pub const DNS_ERROR_INVALID_NAME: Self = Self(123u32);
+                        pub const DNS_ERROR_INVALID_DATA: Self = Self(13u32);
+                        pub const DNS_ERROR_GENERAL_API_BASE: Self = Self(9550u32);
+                        pub const DNS_ERROR_INVALID_TYPE: Self = Self(9551u32);
+                        pub const DNS_ERROR_INVALID_IP_ADDRESS: Self = Self(9552u32);
+                        pub const DNS_ERROR_INVALID_PROPERTY: Self = Self(9553u32);
+                        pub const DNS_ERROR_TRY_AGAIN_LATER: Self = Self(9554u32);
+                        pub const DNS_ERROR_NOT_UNIQUE: Self = Self(9555u32);
+                        pub const DNS_ERROR_NON_RFC_NAME: Self = Self(9556u32);
+                        pub const DNS_ERROR_INVALID_NAME_CHAR: Self = Self(9560u32);
+                        pub const DNS_ERROR_NUMERIC_NAME: Self = Self(9561u32);
+                        pub const DNS_ERROR_NOT_ALLOWED_ON_ROOT_SERVER: Self = Self(9562u32);
+                        pub const DNS_ERROR_NOT_ALLOWED_UNDER_DELEGATION: Self = Self(9563u32);
+                        pub const DNS_ERROR_CANNOT_FIND_ROOT_HINTS: Self = Self(9564u32);
+                        pub const DNS_ERROR_INCONSISTENT_ROOT_HINTS: Self = Self(9565u32);
+                        pub const DNS_ERROR_DWORD_VALUE_TOO_SMALL: Self = Self(9566u32);
+                        pub const DNS_ERROR_DWORD_VALUE_TOO_LARGE: Self = Self(9567u32);
+                        pub const DNS_ERROR_BACKGROUND_LOADING: Self = Self(9568u32);
+                        pub const DNS_ERROR_NOT_ALLOWED_ON_RODC: Self = Self(9569u32);
+                        pub const DNS_ERROR_NOT_ALLOWED_UNDER_DNAME: Self = Self(9570u32);
+                        pub const DNS_ERROR_DELEGATION_REQUIRED: Self = Self(9571u32);
+                        pub const DNS_ERROR_INVALID_POLICY_TABLE: Self = Self(9572u32);
+                        pub const DNS_ERROR_ADDRESS_REQUIRED: Self = Self(9573u32);
+                        pub const DNS_ERROR_ZONE_BASE: Self = Self(9600u32);
+                        pub const DNS_ERROR_ZONE_DOES_NOT_EXIST: Self = Self(9601u32);
+                        pub const DNS_ERROR_NO_ZONE_INFO: Self = Self(9602u32);
+                        pub const DNS_ERROR_INVALID_ZONE_OPERATION: Self = Self(9603u32);
+                        pub const DNS_ERROR_ZONE_CONFIGURATION_ERROR: Self = Self(9604u32);
+                        pub const DNS_ERROR_ZONE_HAS_NO_SOA_RECORD: Self = Self(9605u32);
+                        pub const DNS_ERROR_ZONE_HAS_NO_NS_RECORDS: Self = Self(9606u32);
+                        pub const DNS_ERROR_ZONE_LOCKED: Self = Self(9607u32);
+                        pub const DNS_ERROR_ZONE_CREATION_FAILED: Self = Self(9608u32);
+                        pub const DNS_ERROR_ZONE_ALREADY_EXISTS: Self = Self(9609u32);
+                        pub const DNS_ERROR_AUTOZONE_ALREADY_EXISTS: Self = Self(9610u32);
+                        pub const DNS_ERROR_INVALID_ZONE_TYPE: Self = Self(9611u32);
+                        pub const DNS_ERROR_SECONDARY_REQUIRES_MASTER_IP: Self = Self(9612u32);
+                        pub const DNS_ERROR_ZONE_NOT_SECONDARY: Self = Self(9613u32);
+                        pub const DNS_ERROR_NEED_SECONDARY_ADDRESSES: Self = Self(9614u32);
+                        pub const DNS_ERROR_WINS_INIT_FAILED: Self = Self(9615u32);
+                        pub const DNS_ERROR_NEED_WINS_SERVERS: Self = Self(9616u32);
+                        pub const DNS_ERROR_NBSTAT_INIT_FAILED: Self = Self(9617u32);
+                        pub const DNS_ERROR_SOA_DELETE_INVALID: Self = Self(9618u32);
+                        pub const DNS_ERROR_FORWARDER_ALREADY_EXISTS: Self = Self(9619u32);
+                        pub const DNS_ERROR_ZONE_REQUIRES_MASTER_IP: Self = Self(9620u32);
+                        pub const DNS_ERROR_ZONE_IS_SHUTDOWN: Self = Self(9621u32);
+                        pub const DNS_ERROR_ZONE_LOCKED_FOR_SIGNING: Self = Self(9622u32);
+                        pub const DNS_ERROR_DATAFILE_BASE: Self = Self(9650u32);
+                        pub const DNS_ERROR_PRIMARY_REQUIRES_DATAFILE: Self = Self(9651u32);
+                        pub const DNS_ERROR_INVALID_DATAFILE_NAME: Self = Self(9652u32);
+                        pub const DNS_ERROR_DATAFILE_OPEN_FAILURE: Self = Self(9653u32);
+                        pub const DNS_ERROR_FILE_WRITEBACK_FAILED: Self = Self(9654u32);
+                        pub const DNS_ERROR_DATAFILE_PARSING: Self = Self(9655u32);
+                        pub const DNS_ERROR_DATABASE_BASE: Self = Self(9700u32);
+                        pub const DNS_ERROR_RECORD_DOES_NOT_EXIST: Self = Self(9701u32);
+                        pub const DNS_ERROR_RECORD_FORMAT: Self = Self(9702u32);
+                        pub const DNS_ERROR_NODE_CREATION_FAILED: Self = Self(9703u32);
+                        pub const DNS_ERROR_UNKNOWN_RECORD_TYPE: Self = Self(9704u32);
+                        pub const DNS_ERROR_RECORD_TIMED_OUT: Self = Self(9705u32);
+                        pub const DNS_ERROR_NAME_NOT_IN_ZONE: Self = Self(9706u32);
+                        pub const DNS_ERROR_CNAME_LOOP: Self = Self(9707u32);
+                        pub const DNS_ERROR_NODE_IS_CNAME: Self = Self(9708u32);
+                        pub const DNS_ERROR_CNAME_COLLISION: Self = Self(9709u32);
+                        pub const DNS_ERROR_RECORD_ONLY_AT_ZONE_ROOT: Self = Self(9710u32);
+                        pub const DNS_ERROR_RECORD_ALREADY_EXISTS: Self = Self(9711u32);
+                        pub const DNS_ERROR_SECONDARY_DATA: Self = Self(9712u32);
+                        pub const DNS_ERROR_NO_CREATE_CACHE_DATA: Self = Self(9713u32);
+                        pub const DNS_ERROR_NAME_DOES_NOT_EXIST: Self = Self(9714u32);
+                        pub const DNS_ERROR_DS_UNAVAILABLE: Self = Self(9717u32);
+                        pub const DNS_ERROR_DS_ZONE_ALREADY_EXISTS: Self = Self(9718u32);
+                        pub const DNS_ERROR_NO_BOOTFILE_IF_DS_ZONE: Self = Self(9719u32);
+                        pub const DNS_ERROR_NODE_IS_DNAME: Self = Self(9720u32);
+                        pub const DNS_ERROR_DNAME_COLLISION: Self = Self(9721u32);
+                        pub const DNS_ERROR_ALIAS_LOOP: Self = Self(9722u32);
+                        pub const DNS_ERROR_OPERATION_BASE: Self = Self(9750u32);
+                        pub const DNS_ERROR_AXFR: Self = Self(9752u32);
+                        pub const DNS_ERROR_SECURE_BASE: Self = Self(9800u32);
+                        pub const DNS_ERROR_SETUP_BASE: Self = Self(9850u32);
+                        pub const DNS_ERROR_NO_TCPIP: Self = Self(9851u32);
+                        pub const DNS_ERROR_NO_DNS_SERVERS: Self = Self(9852u32);
+                        pub const DNS_ERROR_DP_BASE: Self = Self(9900u32);
+                        pub const DNS_ERROR_DP_DOES_NOT_EXIST: Self = Self(9901u32);
+                        pub const DNS_ERROR_DP_ALREADY_EXISTS: Self = Self(9902u32);
+                        pub const DNS_ERROR_DP_NOT_ENLISTED: Self = Self(9903u32);
+                        pub const DNS_ERROR_DP_ALREADY_ENLISTED: Self = Self(9904u32);
+                        pub const DNS_ERROR_DP_NOT_AVAILABLE: Self = Self(9905u32);
+                        pub const DNS_ERROR_DP_FSMO_ERROR: Self = Self(9906u32);
+                        pub const DNS_ERROR_RRL_NOT_ENABLED: Self = Self(9911u32);
+                        pub const DNS_ERROR_RRL_INVALID_WINDOW_SIZE: Self = Self(9912u32);
+                        pub const DNS_ERROR_RRL_INVALID_IPV4_PREFIX: Self = Self(9913u32);
+                        pub const DNS_ERROR_RRL_INVALID_IPV6_PREFIX: Self = Self(9914u32);
+                        pub const DNS_ERROR_RRL_INVALID_TC_RATE: Self = Self(9915u32);
+                        pub const DNS_ERROR_RRL_INVALID_LEAK_RATE: Self = Self(9916u32);
+                        pub const DNS_ERROR_RRL_LEAK_RATE_LESSTHAN_TC_RATE: Self = Self(9917u32);
+                        pub const DNS_ERROR_VIRTUALIZATION_INSTANCE_ALREADY_EXISTS: Self =
+                            Self(9921u32);
+                        pub const DNS_ERROR_VIRTUALIZATION_INSTANCE_DOES_NOT_EXIST: Self =
+                            Self(9922u32);
+                        pub const DNS_ERROR_VIRTUALIZATION_TREE_LOCKED: Self = Self(9923u32);
+                        pub const DNS_ERROR_INVAILD_VIRTUALIZATION_INSTANCE_NAME: Self =
+                            Self(9924u32);
+                        pub const DNS_ERROR_DEFAULT_VIRTUALIZATION_INSTANCE: Self = Self(9925u32);
+                        pub const DNS_ERROR_ZONESCOPE_ALREADY_EXISTS: Self = Self(9951u32);
+                        pub const DNS_ERROR_ZONESCOPE_DOES_NOT_EXIST: Self = Self(9952u32);
+                        pub const DNS_ERROR_DEFAULT_ZONESCOPE: Self = Self(9953u32);
+                        pub const DNS_ERROR_INVALID_ZONESCOPE_NAME: Self = Self(9954u32);
+                        pub const DNS_ERROR_NOT_ALLOWED_WITH_ZONESCOPES: Self = Self(9955u32);
+                        pub const DNS_ERROR_LOAD_ZONESCOPE_FAILED: Self = Self(9956u32);
+                        pub const DNS_ERROR_ZONESCOPE_FILE_WRITEBACK_FAILED: Self = Self(9957u32);
+                        pub const DNS_ERROR_INVALID_SCOPE_NAME: Self = Self(9958u32);
+                        pub const DNS_ERROR_SCOPE_DOES_NOT_EXIST: Self = Self(9959u32);
+                        pub const DNS_ERROR_DEFAULT_SCOPE: Self = Self(9960u32);
+                        pub const DNS_ERROR_INVALID_SCOPE_OPERATION: Self = Self(9961u32);
+                        pub const DNS_ERROR_SCOPE_LOCKED: Self = Self(9962u32);
+                        pub const DNS_ERROR_SCOPE_ALREADY_EXISTS: Self = Self(9963u32);
+                        pub const DNS_ERROR_POLICY_ALREADY_EXISTS: Self = Self(9971u32);
+                        pub const DNS_ERROR_POLICY_DOES_NOT_EXIST: Self = Self(9972u32);
+                        pub const DNS_ERROR_POLICY_INVALID_CRITERIA: Self = Self(9973u32);
+                        pub const DNS_ERROR_POLICY_INVALID_SETTINGS: Self = Self(9974u32);
+                        pub const DNS_ERROR_CLIENT_SUBNET_IS_ACCESSED: Self = Self(9975u32);
+                        pub const DNS_ERROR_CLIENT_SUBNET_DOES_NOT_EXIST: Self = Self(9976u32);
+                        pub const DNS_ERROR_CLIENT_SUBNET_ALREADY_EXISTS: Self = Self(9977u32);
+                        pub const DNS_ERROR_SUBNET_DOES_NOT_EXIST: Self = Self(9978u32);
+                        pub const DNS_ERROR_SUBNET_ALREADY_EXISTS: Self = Self(9979u32);
+                        pub const DNS_ERROR_POLICY_LOCKED: Self = Self(9980u32);
+                        pub const DNS_ERROR_POLICY_INVALID_WEIGHT: Self = Self(9981u32);
+                        pub const DNS_ERROR_POLICY_INVALID_NAME: Self = Self(9982u32);
+                        pub const DNS_ERROR_POLICY_MISSING_CRITERIA: Self = Self(9983u32);
+                        pub const DNS_ERROR_INVALID_CLIENT_SUBNET_NAME: Self = Self(9984u32);
+                        pub const DNS_ERROR_POLICY_PROCESSING_ORDER_INVALID: Self = Self(9985u32);
+                        pub const DNS_ERROR_POLICY_SCOPE_MISSING: Self = Self(9986u32);
+                        pub const DNS_ERROR_POLICY_SCOPE_NOT_ALLOWED: Self = Self(9987u32);
+                        pub const DNS_ERROR_SERVERSCOPE_IS_REFERENCED: Self = Self(9988u32);
+                        pub const DNS_ERROR_ZONESCOPE_IS_REFERENCED: Self = Self(9989u32);
+                        pub const DNS_ERROR_POLICY_INVALID_CRITERIA_CLIENT_SUBNET: Self =
+                            Self(9990u32);
+                        pub const DNS_ERROR_POLICY_INVALID_CRITERIA_TRANSPORT_PROTOCOL: Self =
+                            Self(9991u32);
+                        pub const DNS_ERROR_POLICY_INVALID_CRITERIA_NETWORK_PROTOCOL: Self =
+                            Self(9992u32);
+                        pub const DNS_ERROR_POLICY_INVALID_CRITERIA_INTERFACE: Self = Self(9993u32);
+                        pub const DNS_ERROR_POLICY_INVALID_CRITERIA_FQDN: Self = Self(9994u32);
+                        pub const DNS_ERROR_POLICY_INVALID_CRITERIA_QUERY_TYPE: Self =
+                            Self(9995u32);
+                        pub const DNS_ERROR_POLICY_INVALID_CRITERIA_TIME_OF_DAY: Self =
+                            Self(9996u32);
+                        pub const ERROR_IPSEC_QM_POLICY_EXISTS: Self = Self(13000u32);
+                        pub const ERROR_IPSEC_QM_POLICY_NOT_FOUND: Self = Self(13001u32);
+                        pub const ERROR_IPSEC_QM_POLICY_IN_USE: Self = Self(13002u32);
+                        pub const ERROR_IPSEC_MM_POLICY_EXISTS: Self = Self(13003u32);
+                        pub const ERROR_IPSEC_MM_POLICY_NOT_FOUND: Self = Self(13004u32);
+                        pub const ERROR_IPSEC_MM_POLICY_IN_USE: Self = Self(13005u32);
+                        pub const ERROR_IPSEC_MM_FILTER_EXISTS: Self = Self(13006u32);
+                        pub const ERROR_IPSEC_MM_FILTER_NOT_FOUND: Self = Self(13007u32);
+                        pub const ERROR_IPSEC_TRANSPORT_FILTER_EXISTS: Self = Self(13008u32);
+                        pub const ERROR_IPSEC_TRANSPORT_FILTER_NOT_FOUND: Self = Self(13009u32);
+                        pub const ERROR_IPSEC_MM_AUTH_EXISTS: Self = Self(13010u32);
+                        pub const ERROR_IPSEC_MM_AUTH_NOT_FOUND: Self = Self(13011u32);
+                        pub const ERROR_IPSEC_MM_AUTH_IN_USE: Self = Self(13012u32);
+                        pub const ERROR_IPSEC_DEFAULT_MM_POLICY_NOT_FOUND: Self = Self(13013u32);
+                        pub const ERROR_IPSEC_DEFAULT_MM_AUTH_NOT_FOUND: Self = Self(13014u32);
+                        pub const ERROR_IPSEC_DEFAULT_QM_POLICY_NOT_FOUND: Self = Self(13015u32);
+                        pub const ERROR_IPSEC_TUNNEL_FILTER_EXISTS: Self = Self(13016u32);
+                        pub const ERROR_IPSEC_TUNNEL_FILTER_NOT_FOUND: Self = Self(13017u32);
+                        pub const ERROR_IPSEC_MM_FILTER_PENDING_DELETION: Self = Self(13018u32);
+                        pub const ERROR_IPSEC_TRANSPORT_FILTER_PENDING_DELETION: Self =
+                            Self(13019u32);
+                        pub const ERROR_IPSEC_TUNNEL_FILTER_PENDING_DELETION: Self = Self(13020u32);
+                        pub const ERROR_IPSEC_MM_POLICY_PENDING_DELETION: Self = Self(13021u32);
+                        pub const ERROR_IPSEC_MM_AUTH_PENDING_DELETION: Self = Self(13022u32);
+                        pub const ERROR_IPSEC_QM_POLICY_PENDING_DELETION: Self = Self(13023u32);
+                        pub const ERROR_IPSEC_IKE_NEG_STATUS_BEGIN: Self = Self(13800u32);
+                        pub const ERROR_IPSEC_IKE_AUTH_FAIL: Self = Self(13801u32);
+                        pub const ERROR_IPSEC_IKE_ATTRIB_FAIL: Self = Self(13802u32);
+                        pub const ERROR_IPSEC_IKE_NEGOTIATION_PENDING: Self = Self(13803u32);
+                        pub const ERROR_IPSEC_IKE_GENERAL_PROCESSING_ERROR: Self = Self(13804u32);
+                        pub const ERROR_IPSEC_IKE_TIMED_OUT: Self = Self(13805u32);
+                        pub const ERROR_IPSEC_IKE_NO_CERT: Self = Self(13806u32);
+                        pub const ERROR_IPSEC_IKE_SA_DELETED: Self = Self(13807u32);
+                        pub const ERROR_IPSEC_IKE_SA_REAPED: Self = Self(13808u32);
+                        pub const ERROR_IPSEC_IKE_MM_ACQUIRE_DROP: Self = Self(13809u32);
+                        pub const ERROR_IPSEC_IKE_QM_ACQUIRE_DROP: Self = Self(13810u32);
+                        pub const ERROR_IPSEC_IKE_QUEUE_DROP_MM: Self = Self(13811u32);
+                        pub const ERROR_IPSEC_IKE_QUEUE_DROP_NO_MM: Self = Self(13812u32);
+                        pub const ERROR_IPSEC_IKE_DROP_NO_RESPONSE: Self = Self(13813u32);
+                        pub const ERROR_IPSEC_IKE_MM_DELAY_DROP: Self = Self(13814u32);
+                        pub const ERROR_IPSEC_IKE_QM_DELAY_DROP: Self = Self(13815u32);
+                        pub const ERROR_IPSEC_IKE_ERROR: Self = Self(13816u32);
+                        pub const ERROR_IPSEC_IKE_CRL_FAILED: Self = Self(13817u32);
+                        pub const ERROR_IPSEC_IKE_INVALID_KEY_USAGE: Self = Self(13818u32);
+                        pub const ERROR_IPSEC_IKE_INVALID_CERT_TYPE: Self = Self(13819u32);
+                        pub const ERROR_IPSEC_IKE_NO_PRIVATE_KEY: Self = Self(13820u32);
+                        pub const ERROR_IPSEC_IKE_SIMULTANEOUS_REKEY: Self = Self(13821u32);
+                        pub const ERROR_IPSEC_IKE_DH_FAIL: Self = Self(13822u32);
+                        pub const ERROR_IPSEC_IKE_CRITICAL_PAYLOAD_NOT_RECOGNIZED: Self =
+                            Self(13823u32);
+                        pub const ERROR_IPSEC_IKE_INVALID_HEADER: Self = Self(13824u32);
+                        pub const ERROR_IPSEC_IKE_NO_POLICY: Self = Self(13825u32);
+                        pub const ERROR_IPSEC_IKE_INVALID_SIGNATURE: Self = Self(13826u32);
+                        pub const ERROR_IPSEC_IKE_KERBEROS_ERROR: Self = Self(13827u32);
+                        pub const ERROR_IPSEC_IKE_NO_PUBLIC_KEY: Self = Self(13828u32);
+                        pub const ERROR_IPSEC_IKE_PROCESS_ERR: Self = Self(13829u32);
+                        pub const ERROR_IPSEC_IKE_PROCESS_ERR_SA: Self = Self(13830u32);
+                        pub const ERROR_IPSEC_IKE_PROCESS_ERR_PROP: Self = Self(13831u32);
+                        pub const ERROR_IPSEC_IKE_PROCESS_ERR_TRANS: Self = Self(13832u32);
+                        pub const ERROR_IPSEC_IKE_PROCESS_ERR_KE: Self = Self(13833u32);
+                        pub const ERROR_IPSEC_IKE_PROCESS_ERR_ID: Self = Self(13834u32);
+                        pub const ERROR_IPSEC_IKE_PROCESS_ERR_CERT: Self = Self(13835u32);
+                        pub const ERROR_IPSEC_IKE_PROCESS_ERR_CERT_REQ: Self = Self(13836u32);
+                        pub const ERROR_IPSEC_IKE_PROCESS_ERR_HASH: Self = Self(13837u32);
+                        pub const ERROR_IPSEC_IKE_PROCESS_ERR_SIG: Self = Self(13838u32);
+                        pub const ERROR_IPSEC_IKE_PROCESS_ERR_NONCE: Self = Self(13839u32);
+                        pub const ERROR_IPSEC_IKE_PROCESS_ERR_NOTIFY: Self = Self(13840u32);
+                        pub const ERROR_IPSEC_IKE_PROCESS_ERR_DELETE: Self = Self(13841u32);
+                        pub const ERROR_IPSEC_IKE_PROCESS_ERR_VENDOR: Self = Self(13842u32);
+                        pub const ERROR_IPSEC_IKE_INVALID_PAYLOAD: Self = Self(13843u32);
+                        pub const ERROR_IPSEC_IKE_LOAD_SOFT_SA: Self = Self(13844u32);
+                        pub const ERROR_IPSEC_IKE_SOFT_SA_TORN_DOWN: Self = Self(13845u32);
+                        pub const ERROR_IPSEC_IKE_INVALID_COOKIE: Self = Self(13846u32);
+                        pub const ERROR_IPSEC_IKE_NO_PEER_CERT: Self = Self(13847u32);
+                        pub const ERROR_IPSEC_IKE_PEER_CRL_FAILED: Self = Self(13848u32);
+                        pub const ERROR_IPSEC_IKE_POLICY_CHANGE: Self = Self(13849u32);
+                        pub const ERROR_IPSEC_IKE_NO_MM_POLICY: Self = Self(13850u32);
+                        pub const ERROR_IPSEC_IKE_NOTCBPRIV: Self = Self(13851u32);
+                        pub const ERROR_IPSEC_IKE_SECLOADFAIL: Self = Self(13852u32);
+                        pub const ERROR_IPSEC_IKE_FAILSSPINIT: Self = Self(13853u32);
+                        pub const ERROR_IPSEC_IKE_FAILQUERYSSP: Self = Self(13854u32);
+                        pub const ERROR_IPSEC_IKE_SRVACQFAIL: Self = Self(13855u32);
+                        pub const ERROR_IPSEC_IKE_SRVQUERYCRED: Self = Self(13856u32);
+                        pub const ERROR_IPSEC_IKE_GETSPIFAIL: Self = Self(13857u32);
+                        pub const ERROR_IPSEC_IKE_INVALID_FILTER: Self = Self(13858u32);
+                        pub const ERROR_IPSEC_IKE_OUT_OF_MEMORY: Self = Self(13859u32);
+                        pub const ERROR_IPSEC_IKE_ADD_UPDATE_KEY_FAILED: Self = Self(13860u32);
+                        pub const ERROR_IPSEC_IKE_INVALID_POLICY: Self = Self(13861u32);
+                        pub const ERROR_IPSEC_IKE_UNKNOWN_DOI: Self = Self(13862u32);
+                        pub const ERROR_IPSEC_IKE_INVALID_SITUATION: Self = Self(13863u32);
+                        pub const ERROR_IPSEC_IKE_DH_FAILURE: Self = Self(13864u32);
+                        pub const ERROR_IPSEC_IKE_INVALID_GROUP: Self = Self(13865u32);
+                        pub const ERROR_IPSEC_IKE_ENCRYPT: Self = Self(13866u32);
+                        pub const ERROR_IPSEC_IKE_DECRYPT: Self = Self(13867u32);
+                        pub const ERROR_IPSEC_IKE_POLICY_MATCH: Self = Self(13868u32);
+                        pub const ERROR_IPSEC_IKE_UNSUPPORTED_ID: Self = Self(13869u32);
+                        pub const ERROR_IPSEC_IKE_INVALID_HASH: Self = Self(13870u32);
+                        pub const ERROR_IPSEC_IKE_INVALID_HASH_ALG: Self = Self(13871u32);
+                        pub const ERROR_IPSEC_IKE_INVALID_HASH_SIZE: Self = Self(13872u32);
+                        pub const ERROR_IPSEC_IKE_INVALID_ENCRYPT_ALG: Self = Self(13873u32);
+                        pub const ERROR_IPSEC_IKE_INVALID_AUTH_ALG: Self = Self(13874u32);
+                        pub const ERROR_IPSEC_IKE_INVALID_SIG: Self = Self(13875u32);
+                        pub const ERROR_IPSEC_IKE_LOAD_FAILED: Self = Self(13876u32);
+                        pub const ERROR_IPSEC_IKE_RPC_DELETE: Self = Self(13877u32);
+                        pub const ERROR_IPSEC_IKE_BENIGN_REINIT: Self = Self(13878u32);
+                        pub const ERROR_IPSEC_IKE_INVALID_RESPONDER_LIFETIME_NOTIFY: Self =
+                            Self(13879u32);
+                        pub const ERROR_IPSEC_IKE_INVALID_MAJOR_VERSION: Self = Self(13880u32);
+                        pub const ERROR_IPSEC_IKE_INVALID_CERT_KEYLEN: Self = Self(13881u32);
+                        pub const ERROR_IPSEC_IKE_MM_LIMIT: Self = Self(13882u32);
+                        pub const ERROR_IPSEC_IKE_NEGOTIATION_DISABLED: Self = Self(13883u32);
+                        pub const ERROR_IPSEC_IKE_QM_LIMIT: Self = Self(13884u32);
+                        pub const ERROR_IPSEC_IKE_MM_EXPIRED: Self = Self(13885u32);
+                        pub const ERROR_IPSEC_IKE_PEER_MM_ASSUMED_INVALID: Self = Self(13886u32);
+                        pub const ERROR_IPSEC_IKE_CERT_CHAIN_POLICY_MISMATCH: Self = Self(13887u32);
+                        pub const ERROR_IPSEC_IKE_UNEXPECTED_MESSAGE_ID: Self = Self(13888u32);
+                        pub const ERROR_IPSEC_IKE_INVALID_AUTH_PAYLOAD: Self = Self(13889u32);
+                        pub const ERROR_IPSEC_IKE_DOS_COOKIE_SENT: Self = Self(13890u32);
+                        pub const ERROR_IPSEC_IKE_SHUTTING_DOWN: Self = Self(13891u32);
+                        pub const ERROR_IPSEC_IKE_CGA_AUTH_FAILED: Self = Self(13892u32);
+                        pub const ERROR_IPSEC_IKE_PROCESS_ERR_NATOA: Self = Self(13893u32);
+                        pub const ERROR_IPSEC_IKE_INVALID_MM_FOR_QM: Self = Self(13894u32);
+                        pub const ERROR_IPSEC_IKE_QM_EXPIRED: Self = Self(13895u32);
+                        pub const ERROR_IPSEC_IKE_TOO_MANY_FILTERS: Self = Self(13896u32);
+                        pub const ERROR_IPSEC_IKE_NEG_STATUS_END: Self = Self(13897u32);
+                        pub const ERROR_IPSEC_IKE_KILL_DUMMY_NAP_TUNNEL: Self = Self(13898u32);
+                        pub const ERROR_IPSEC_IKE_INNER_IP_ASSIGNMENT_FAILURE: Self =
+                            Self(13899u32);
+                        pub const ERROR_IPSEC_IKE_REQUIRE_CP_PAYLOAD_MISSING: Self = Self(13900u32);
+                        pub const ERROR_IPSEC_KEY_MODULE_IMPERSONATION_NEGOTIATION_PENDING: Self =
+                            Self(13901u32);
+                        pub const ERROR_IPSEC_IKE_COEXISTENCE_SUPPRESS: Self = Self(13902u32);
+                        pub const ERROR_IPSEC_IKE_RATELIMIT_DROP: Self = Self(13903u32);
+                        pub const ERROR_IPSEC_IKE_PEER_DOESNT_SUPPORT_MOBIKE: Self = Self(13904u32);
+                        pub const ERROR_IPSEC_IKE_AUTHORIZATION_FAILURE: Self = Self(13905u32);
+                        pub const ERROR_IPSEC_IKE_STRONG_CRED_AUTHORIZATION_FAILURE: Self =
+                            Self(13906u32);
+                        pub const ERROR_IPSEC_IKE_AUTHORIZATION_FAILURE_WITH_OPTIONAL_RETRY: Self =
+                            Self(13907u32);
+                        pub const ERROR_IPSEC_IKE_STRONG_CRED_AUTHORIZATION_AND_CERTMAP_FAILURE:
+                            Self = Self(13908u32);
+                        pub const ERROR_IPSEC_IKE_NEG_STATUS_EXTENDED_END: Self = Self(13909u32);
+                        pub const ERROR_IPSEC_BAD_SPI: Self = Self(13910u32);
+                        pub const ERROR_IPSEC_SA_LIFETIME_EXPIRED: Self = Self(13911u32);
+                        pub const ERROR_IPSEC_WRONG_SA: Self = Self(13912u32);
+                        pub const ERROR_IPSEC_REPLAY_CHECK_FAILED: Self = Self(13913u32);
+                        pub const ERROR_IPSEC_INVALID_PACKET: Self = Self(13914u32);
+                        pub const ERROR_IPSEC_INTEGRITY_CHECK_FAILED: Self = Self(13915u32);
+                        pub const ERROR_IPSEC_CLEAR_TEXT_DROP: Self = Self(13916u32);
+                        pub const ERROR_IPSEC_AUTH_FIREWALL_DROP: Self = Self(13917u32);
+                        pub const ERROR_IPSEC_THROTTLE_DROP: Self = Self(13918u32);
+                        pub const ERROR_IPSEC_DOSP_BLOCK: Self = Self(13925u32);
+                        pub const ERROR_IPSEC_DOSP_RECEIVED_MULTICAST: Self = Self(13926u32);
+                        pub const ERROR_IPSEC_DOSP_INVALID_PACKET: Self = Self(13927u32);
+                        pub const ERROR_IPSEC_DOSP_STATE_LOOKUP_FAILED: Self = Self(13928u32);
+                        pub const ERROR_IPSEC_DOSP_MAX_ENTRIES: Self = Self(13929u32);
+                        pub const ERROR_IPSEC_DOSP_KEYMOD_NOT_ALLOWED: Self = Self(13930u32);
+                        pub const ERROR_IPSEC_DOSP_NOT_INSTALLED: Self = Self(13931u32);
+                        pub const ERROR_IPSEC_DOSP_MAX_PER_IP_RATELIMIT_QUEUES: Self =
+                            Self(13932u32);
+                        pub const ERROR_SXS_SECTION_NOT_FOUND: Self = Self(14000u32);
+                        pub const ERROR_SXS_CANT_GEN_ACTCTX: Self = Self(14001u32);
+                        pub const ERROR_SXS_INVALID_ACTCTXDATA_FORMAT: Self = Self(14002u32);
+                        pub const ERROR_SXS_ASSEMBLY_NOT_FOUND: Self = Self(14003u32);
+                        pub const ERROR_SXS_MANIFEST_FORMAT_ERROR: Self = Self(14004u32);
+                        pub const ERROR_SXS_MANIFEST_PARSE_ERROR: Self = Self(14005u32);
+                        pub const ERROR_SXS_ACTIVATION_CONTEXT_DISABLED: Self = Self(14006u32);
+                        pub const ERROR_SXS_KEY_NOT_FOUND: Self = Self(14007u32);
+                        pub const ERROR_SXS_VERSION_CONFLICT: Self = Self(14008u32);
+                        pub const ERROR_SXS_WRONG_SECTION_TYPE: Self = Self(14009u32);
+                        pub const ERROR_SXS_THREAD_QUERIES_DISABLED: Self = Self(14010u32);
+                        pub const ERROR_SXS_PROCESS_DEFAULT_ALREADY_SET: Self = Self(14011u32);
+                        pub const ERROR_SXS_UNKNOWN_ENCODING_GROUP: Self = Self(14012u32);
+                        pub const ERROR_SXS_UNKNOWN_ENCODING: Self = Self(14013u32);
+                        pub const ERROR_SXS_INVALID_XML_NAMESPACE_URI: Self = Self(14014u32);
+                        pub const ERROR_SXS_ROOT_MANIFEST_DEPENDENCY_NOT_INSTALLED: Self =
+                            Self(14015u32);
+                        pub const ERROR_SXS_LEAF_MANIFEST_DEPENDENCY_NOT_INSTALLED: Self =
+                            Self(14016u32);
+                        pub const ERROR_SXS_INVALID_ASSEMBLY_IDENTITY_ATTRIBUTE: Self =
+                            Self(14017u32);
+                        pub const ERROR_SXS_MANIFEST_MISSING_REQUIRED_DEFAULT_NAMESPACE: Self =
+                            Self(14018u32);
+                        pub const ERROR_SXS_MANIFEST_INVALID_REQUIRED_DEFAULT_NAMESPACE: Self =
+                            Self(14019u32);
+                        pub const ERROR_SXS_PRIVATE_MANIFEST_CROSS_PATH_WITH_REPARSE_POINT: Self =
+                            Self(14020u32);
+                        pub const ERROR_SXS_DUPLICATE_DLL_NAME: Self = Self(14021u32);
+                        pub const ERROR_SXS_DUPLICATE_WINDOWCLASS_NAME: Self = Self(14022u32);
+                        pub const ERROR_SXS_DUPLICATE_CLSID: Self = Self(14023u32);
+                        pub const ERROR_SXS_DUPLICATE_IID: Self = Self(14024u32);
+                        pub const ERROR_SXS_DUPLICATE_TLBID: Self = Self(14025u32);
+                        pub const ERROR_SXS_DUPLICATE_PROGID: Self = Self(14026u32);
+                        pub const ERROR_SXS_DUPLICATE_ASSEMBLY_NAME: Self = Self(14027u32);
+                        pub const ERROR_SXS_FILE_HASH_MISMATCH: Self = Self(14028u32);
+                        pub const ERROR_SXS_POLICY_PARSE_ERROR: Self = Self(14029u32);
+                        pub const ERROR_SXS_XML_E_MISSINGQUOTE: Self = Self(14030u32);
+                        pub const ERROR_SXS_XML_E_COMMENTSYNTAX: Self = Self(14031u32);
+                        pub const ERROR_SXS_XML_E_BADSTARTNAMECHAR: Self = Self(14032u32);
+                        pub const ERROR_SXS_XML_E_BADNAMECHAR: Self = Self(14033u32);
+                        pub const ERROR_SXS_XML_E_BADCHARINSTRING: Self = Self(14034u32);
+                        pub const ERROR_SXS_XML_E_XMLDECLSYNTAX: Self = Self(14035u32);
+                        pub const ERROR_SXS_XML_E_BADCHARDATA: Self = Self(14036u32);
+                        pub const ERROR_SXS_XML_E_MISSINGWHITESPACE: Self = Self(14037u32);
+                        pub const ERROR_SXS_XML_E_EXPECTINGTAGEND: Self = Self(14038u32);
+                        pub const ERROR_SXS_XML_E_MISSINGSEMICOLON: Self = Self(14039u32);
+                        pub const ERROR_SXS_XML_E_UNBALANCEDPAREN: Self = Self(14040u32);
+                        pub const ERROR_SXS_XML_E_INTERNALERROR: Self = Self(14041u32);
+                        pub const ERROR_SXS_XML_E_UNEXPECTED_WHITESPACE: Self = Self(14042u32);
+                        pub const ERROR_SXS_XML_E_INCOMPLETE_ENCODING: Self = Self(14043u32);
+                        pub const ERROR_SXS_XML_E_MISSING_PAREN: Self = Self(14044u32);
+                        pub const ERROR_SXS_XML_E_EXPECTINGCLOSEQUOTE: Self = Self(14045u32);
+                        pub const ERROR_SXS_XML_E_MULTIPLE_COLONS: Self = Self(14046u32);
+                        pub const ERROR_SXS_XML_E_INVALID_DECIMAL: Self = Self(14047u32);
+                        pub const ERROR_SXS_XML_E_INVALID_HEXIDECIMAL: Self = Self(14048u32);
+                        pub const ERROR_SXS_XML_E_INVALID_UNICODE: Self = Self(14049u32);
+                        pub const ERROR_SXS_XML_E_WHITESPACEORQUESTIONMARK: Self = Self(14050u32);
+                        pub const ERROR_SXS_XML_E_UNEXPECTEDENDTAG: Self = Self(14051u32);
+                        pub const ERROR_SXS_XML_E_UNCLOSEDTAG: Self = Self(14052u32);
+                        pub const ERROR_SXS_XML_E_DUPLICATEATTRIBUTE: Self = Self(14053u32);
+                        pub const ERROR_SXS_XML_E_MULTIPLEROOTS: Self = Self(14054u32);
+                        pub const ERROR_SXS_XML_E_INVALIDATROOTLEVEL: Self = Self(14055u32);
+                        pub const ERROR_SXS_XML_E_BADXMLDECL: Self = Self(14056u32);
+                        pub const ERROR_SXS_XML_E_MISSINGROOT: Self = Self(14057u32);
+                        pub const ERROR_SXS_XML_E_UNEXPECTEDEOF: Self = Self(14058u32);
+                        pub const ERROR_SXS_XML_E_BADPEREFINSUBSET: Self = Self(14059u32);
+                        pub const ERROR_SXS_XML_E_UNCLOSEDSTARTTAG: Self = Self(14060u32);
+                        pub const ERROR_SXS_XML_E_UNCLOSEDENDTAG: Self = Self(14061u32);
+                        pub const ERROR_SXS_XML_E_UNCLOSEDSTRING: Self = Self(14062u32);
+                        pub const ERROR_SXS_XML_E_UNCLOSEDCOMMENT: Self = Self(14063u32);
+                        pub const ERROR_SXS_XML_E_UNCLOSEDDECL: Self = Self(14064u32);
+                        pub const ERROR_SXS_XML_E_UNCLOSEDCDATA: Self = Self(14065u32);
+                        pub const ERROR_SXS_XML_E_RESERVEDNAMESPACE: Self = Self(14066u32);
+                        pub const ERROR_SXS_XML_E_INVALIDENCODING: Self = Self(14067u32);
+                        pub const ERROR_SXS_XML_E_INVALIDSWITCH: Self = Self(14068u32);
+                        pub const ERROR_SXS_XML_E_BADXMLCASE: Self = Self(14069u32);
+                        pub const ERROR_SXS_XML_E_INVALID_STANDALONE: Self = Self(14070u32);
+                        pub const ERROR_SXS_XML_E_UNEXPECTED_STANDALONE: Self = Self(14071u32);
+                        pub const ERROR_SXS_XML_E_INVALID_VERSION: Self = Self(14072u32);
+                        pub const ERROR_SXS_XML_E_MISSINGEQUALS: Self = Self(14073u32);
+                        pub const ERROR_SXS_PROTECTION_RECOVERY_FAILED: Self = Self(14074u32);
+                        pub const ERROR_SXS_PROTECTION_PUBLIC_KEY_TOO_SHORT: Self = Self(14075u32);
+                        pub const ERROR_SXS_PROTECTION_CATALOG_NOT_VALID: Self = Self(14076u32);
+                        pub const ERROR_SXS_UNTRANSLATABLE_HRESULT: Self = Self(14077u32);
+                        pub const ERROR_SXS_PROTECTION_CATALOG_FILE_MISSING: Self = Self(14078u32);
+                        pub const ERROR_SXS_MISSING_ASSEMBLY_IDENTITY_ATTRIBUTE: Self =
+                            Self(14079u32);
+                        pub const ERROR_SXS_INVALID_ASSEMBLY_IDENTITY_ATTRIBUTE_NAME: Self =
+                            Self(14080u32);
+                        pub const ERROR_SXS_ASSEMBLY_MISSING: Self = Self(14081u32);
+                        pub const ERROR_SXS_CORRUPT_ACTIVATION_STACK: Self = Self(14082u32);
+                        pub const ERROR_SXS_CORRUPTION: Self = Self(14083u32);
+                        pub const ERROR_SXS_EARLY_DEACTIVATION: Self = Self(14084u32);
+                        pub const ERROR_SXS_INVALID_DEACTIVATION: Self = Self(14085u32);
+                        pub const ERROR_SXS_MULTIPLE_DEACTIVATION: Self = Self(14086u32);
+                        pub const ERROR_SXS_PROCESS_TERMINATION_REQUESTED: Self = Self(14087u32);
+                        pub const ERROR_SXS_RELEASE_ACTIVATION_CONTEXT: Self = Self(14088u32);
+                        pub const ERROR_SXS_SYSTEM_DEFAULT_ACTIVATION_CONTEXT_EMPTY: Self =
+                            Self(14089u32);
+                        pub const ERROR_SXS_INVALID_IDENTITY_ATTRIBUTE_VALUE: Self = Self(14090u32);
+                        pub const ERROR_SXS_INVALID_IDENTITY_ATTRIBUTE_NAME: Self = Self(14091u32);
+                        pub const ERROR_SXS_IDENTITY_DUPLICATE_ATTRIBUTE: Self = Self(14092u32);
+                        pub const ERROR_SXS_IDENTITY_PARSE_ERROR: Self = Self(14093u32);
+                        pub const ERROR_MALFORMED_SUBSTITUTION_STRING: Self = Self(14094u32);
+                        pub const ERROR_SXS_INCORRECT_PUBLIC_KEY_TOKEN: Self = Self(14095u32);
+                        pub const ERROR_UNMAPPED_SUBSTITUTION_STRING: Self = Self(14096u32);
+                        pub const ERROR_SXS_ASSEMBLY_NOT_LOCKED: Self = Self(14097u32);
+                        pub const ERROR_SXS_COMPONENT_STORE_CORRUPT: Self = Self(14098u32);
+                        pub const ERROR_ADVANCED_INSTALLER_FAILED: Self = Self(14099u32);
+                        pub const ERROR_XML_ENCODING_MISMATCH: Self = Self(14100u32);
+                        pub const ERROR_SXS_MANIFEST_IDENTITY_SAME_BUT_CONTENTS_DIFFERENT: Self =
+                            Self(14101u32);
+                        pub const ERROR_SXS_IDENTITIES_DIFFERENT: Self = Self(14102u32);
+                        pub const ERROR_SXS_ASSEMBLY_IS_NOT_A_DEPLOYMENT: Self = Self(14103u32);
+                        pub const ERROR_SXS_FILE_NOT_PART_OF_ASSEMBLY: Self = Self(14104u32);
+                        pub const ERROR_SXS_MANIFEST_TOO_BIG: Self = Self(14105u32);
+                        pub const ERROR_SXS_SETTING_NOT_REGISTERED: Self = Self(14106u32);
+                        pub const ERROR_SXS_TRANSACTION_CLOSURE_INCOMPLETE: Self = Self(14107u32);
+                        pub const ERROR_SMI_PRIMITIVE_INSTALLER_FAILED: Self = Self(14108u32);
+                        pub const ERROR_GENERIC_COMMAND_FAILED: Self = Self(14109u32);
+                        pub const ERROR_SXS_FILE_HASH_MISSING: Self = Self(14110u32);
+                        pub const ERROR_SXS_DUPLICATE_ACTIVATABLE_CLASS: Self = Self(14111u32);
+                        pub const ERROR_EVT_INVALID_CHANNEL_PATH: Self = Self(15000u32);
+                        pub const ERROR_EVT_INVALID_QUERY: Self = Self(15001u32);
+                        pub const ERROR_EVT_PUBLISHER_METADATA_NOT_FOUND: Self = Self(15002u32);
+                        pub const ERROR_EVT_EVENT_TEMPLATE_NOT_FOUND: Self = Self(15003u32);
+                        pub const ERROR_EVT_INVALID_PUBLISHER_NAME: Self = Self(15004u32);
+                        pub const ERROR_EVT_INVALID_EVENT_DATA: Self = Self(15005u32);
+                        pub const ERROR_EVT_CHANNEL_NOT_FOUND: Self = Self(15007u32);
+                        pub const ERROR_EVT_MALFORMED_XML_TEXT: Self = Self(15008u32);
+                        pub const ERROR_EVT_SUBSCRIPTION_TO_DIRECT_CHANNEL: Self = Self(15009u32);
+                        pub const ERROR_EVT_CONFIGURATION_ERROR: Self = Self(15010u32);
+                        pub const ERROR_EVT_QUERY_RESULT_STALE: Self = Self(15011u32);
+                        pub const ERROR_EVT_QUERY_RESULT_INVALID_POSITION: Self = Self(15012u32);
+                        pub const ERROR_EVT_NON_VALIDATING_MSXML: Self = Self(15013u32);
+                        pub const ERROR_EVT_FILTER_ALREADYSCOPED: Self = Self(15014u32);
+                        pub const ERROR_EVT_FILTER_NOTELTSET: Self = Self(15015u32);
+                        pub const ERROR_EVT_FILTER_INVARG: Self = Self(15016u32);
+                        pub const ERROR_EVT_FILTER_INVTEST: Self = Self(15017u32);
+                        pub const ERROR_EVT_FILTER_INVTYPE: Self = Self(15018u32);
+                        pub const ERROR_EVT_FILTER_PARSEERR: Self = Self(15019u32);
+                        pub const ERROR_EVT_FILTER_UNSUPPORTEDOP: Self = Self(15020u32);
+                        pub const ERROR_EVT_FILTER_UNEXPECTEDTOKEN: Self = Self(15021u32);
+                        pub const ERROR_EVT_INVALID_OPERATION_OVER_ENABLED_DIRECT_CHANNEL: Self =
+                            Self(15022u32);
+                        pub const ERROR_EVT_INVALID_CHANNEL_PROPERTY_VALUE: Self = Self(15023u32);
+                        pub const ERROR_EVT_INVALID_PUBLISHER_PROPERTY_VALUE: Self = Self(15024u32);
+                        pub const ERROR_EVT_CHANNEL_CANNOT_ACTIVATE: Self = Self(15025u32);
+                        pub const ERROR_EVT_FILTER_TOO_COMPLEX: Self = Self(15026u32);
+                        pub const ERROR_EVT_MESSAGE_NOT_FOUND: Self = Self(15027u32);
+                        pub const ERROR_EVT_MESSAGE_ID_NOT_FOUND: Self = Self(15028u32);
+                        pub const ERROR_EVT_UNRESOLVED_VALUE_INSERT: Self = Self(15029u32);
+                        pub const ERROR_EVT_UNRESOLVED_PARAMETER_INSERT: Self = Self(15030u32);
+                        pub const ERROR_EVT_MAX_INSERTS_REACHED: Self = Self(15031u32);
+                        pub const ERROR_EVT_EVENT_DEFINITION_NOT_FOUND: Self = Self(15032u32);
+                        pub const ERROR_EVT_MESSAGE_LOCALE_NOT_FOUND: Self = Self(15033u32);
+                        pub const ERROR_EVT_VERSION_TOO_OLD: Self = Self(15034u32);
+                        pub const ERROR_EVT_VERSION_TOO_NEW: Self = Self(15035u32);
+                        pub const ERROR_EVT_CANNOT_OPEN_CHANNEL_OF_QUERY: Self = Self(15036u32);
+                        pub const ERROR_EVT_PUBLISHER_DISABLED: Self = Self(15037u32);
+                        pub const ERROR_EVT_FILTER_OUT_OF_RANGE: Self = Self(15038u32);
+                        pub const ERROR_EC_SUBSCRIPTION_CANNOT_ACTIVATE: Self = Self(15080u32);
+                        pub const ERROR_EC_LOG_DISABLED: Self = Self(15081u32);
+                        pub const ERROR_EC_CIRCULAR_FORWARDING: Self = Self(15082u32);
+                        pub const ERROR_EC_CREDSTORE_FULL: Self = Self(15083u32);
+                        pub const ERROR_EC_CRED_NOT_FOUND: Self = Self(15084u32);
+                        pub const ERROR_EC_NO_ACTIVE_CHANNEL: Self = Self(15085u32);
+                        pub const ERROR_MUI_FILE_NOT_FOUND: Self = Self(15100u32);
+                        pub const ERROR_MUI_INVALID_FILE: Self = Self(15101u32);
+                        pub const ERROR_MUI_INVALID_RC_CONFIG: Self = Self(15102u32);
+                        pub const ERROR_MUI_INVALID_LOCALE_NAME: Self = Self(15103u32);
+                        pub const ERROR_MUI_INVALID_ULTIMATEFALLBACK_NAME: Self = Self(15104u32);
+                        pub const ERROR_MUI_FILE_NOT_LOADED: Self = Self(15105u32);
+                        pub const ERROR_RESOURCE_ENUM_USER_STOP: Self = Self(15106u32);
+                        pub const ERROR_MUI_INTLSETTINGS_UILANG_NOT_INSTALLED: Self =
+                            Self(15107u32);
+                        pub const ERROR_MUI_INTLSETTINGS_INVALID_LOCALE_NAME: Self = Self(15108u32);
+                        pub const ERROR_MRM_RUNTIME_NO_DEFAULT_OR_NEUTRAL_RESOURCE: Self =
+                            Self(15110u32);
+                        pub const ERROR_MRM_INVALID_PRICONFIG: Self = Self(15111u32);
+                        pub const ERROR_MRM_INVALID_FILE_TYPE: Self = Self(15112u32);
+                        pub const ERROR_MRM_UNKNOWN_QUALIFIER: Self = Self(15113u32);
+                        pub const ERROR_MRM_INVALID_QUALIFIER_VALUE: Self = Self(15114u32);
+                        pub const ERROR_MRM_NO_CANDIDATE: Self = Self(15115u32);
+                        pub const ERROR_MRM_NO_MATCH_OR_DEFAULT_CANDIDATE: Self = Self(15116u32);
+                        pub const ERROR_MRM_RESOURCE_TYPE_MISMATCH: Self = Self(15117u32);
+                        pub const ERROR_MRM_DUPLICATE_MAP_NAME: Self = Self(15118u32);
+                        pub const ERROR_MRM_DUPLICATE_ENTRY: Self = Self(15119u32);
+                        pub const ERROR_MRM_INVALID_RESOURCE_IDENTIFIER: Self = Self(15120u32);
+                        pub const ERROR_MRM_FILEPATH_TOO_LONG: Self = Self(15121u32);
+                        pub const ERROR_MRM_UNSUPPORTED_DIRECTORY_TYPE: Self = Self(15122u32);
+                        pub const ERROR_MRM_INVALID_PRI_FILE: Self = Self(15126u32);
+                        pub const ERROR_MRM_NAMED_RESOURCE_NOT_FOUND: Self = Self(15127u32);
+                        pub const ERROR_MRM_MAP_NOT_FOUND: Self = Self(15135u32);
+                        pub const ERROR_MRM_UNSUPPORTED_PROFILE_TYPE: Self = Self(15136u32);
+                        pub const ERROR_MRM_INVALID_QUALIFIER_OPERATOR: Self = Self(15137u32);
+                        pub const ERROR_MRM_INDETERMINATE_QUALIFIER_VALUE: Self = Self(15138u32);
+                        pub const ERROR_MRM_AUTOMERGE_ENABLED: Self = Self(15139u32);
+                        pub const ERROR_MRM_TOO_MANY_RESOURCES: Self = Self(15140u32);
+                        pub const ERROR_MRM_UNSUPPORTED_FILE_TYPE_FOR_MERGE: Self = Self(15141u32);
+                        pub const ERROR_MRM_UNSUPPORTED_FILE_TYPE_FOR_LOAD_UNLOAD_PRI_FILE: Self =
+                            Self(15142u32);
+                        pub const ERROR_MRM_NO_CURRENT_VIEW_ON_THREAD: Self = Self(15143u32);
+                        pub const ERROR_DIFFERENT_PROFILE_RESOURCE_MANAGER_EXIST: Self =
+                            Self(15144u32);
+                        pub const ERROR_OPERATION_NOT_ALLOWED_FROM_SYSTEM_COMPONENT: Self =
+                            Self(15145u32);
+                        pub const ERROR_MRM_DIRECT_REF_TO_NON_DEFAULT_RESOURCE: Self =
+                            Self(15146u32);
+                        pub const ERROR_MRM_GENERATION_COUNT_MISMATCH: Self = Self(15147u32);
+                        pub const ERROR_PRI_MERGE_VERSION_MISMATCH: Self = Self(15148u32);
+                        pub const ERROR_PRI_MERGE_MISSING_SCHEMA: Self = Self(15149u32);
+                        pub const ERROR_PRI_MERGE_LOAD_FILE_FAILED: Self = Self(15150u32);
+                        pub const ERROR_PRI_MERGE_ADD_FILE_FAILED: Self = Self(15151u32);
+                        pub const ERROR_PRI_MERGE_WRITE_FILE_FAILED: Self = Self(15152u32);
+                        pub const ERROR_PRI_MERGE_MULTIPLE_PACKAGE_FAMILIES_NOT_ALLOWED: Self =
+                            Self(15153u32);
+                        pub const ERROR_PRI_MERGE_MULTIPLE_MAIN_PACKAGES_NOT_ALLOWED: Self =
+                            Self(15154u32);
+                        pub const ERROR_PRI_MERGE_BUNDLE_PACKAGES_NOT_ALLOWED: Self =
+                            Self(15155u32);
+                        pub const ERROR_PRI_MERGE_MAIN_PACKAGE_REQUIRED: Self = Self(15156u32);
+                        pub const ERROR_PRI_MERGE_RESOURCE_PACKAGE_REQUIRED: Self = Self(15157u32);
+                        pub const ERROR_PRI_MERGE_INVALID_FILE_NAME: Self = Self(15158u32);
+                        pub const ERROR_MRM_PACKAGE_NOT_FOUND: Self = Self(15159u32);
+                        pub const ERROR_MRM_MISSING_DEFAULT_LANGUAGE: Self = Self(15160u32);
+                        pub const ERROR_MCA_INVALID_CAPABILITIES_STRING: Self = Self(15200u32);
+                        pub const ERROR_MCA_INVALID_VCP_VERSION: Self = Self(15201u32);
+                        pub const ERROR_MCA_MONITOR_VIOLATES_MCCS_SPECIFICATION: Self =
+                            Self(15202u32);
+                        pub const ERROR_MCA_MCCS_VERSION_MISMATCH: Self = Self(15203u32);
+                        pub const ERROR_MCA_UNSUPPORTED_MCCS_VERSION: Self = Self(15204u32);
+                        pub const ERROR_MCA_INTERNAL_ERROR: Self = Self(15205u32);
+                        pub const ERROR_MCA_INVALID_TECHNOLOGY_TYPE_RETURNED: Self = Self(15206u32);
+                        pub const ERROR_MCA_UNSUPPORTED_COLOR_TEMPERATURE: Self = Self(15207u32);
+                        pub const ERROR_AMBIGUOUS_SYSTEM_DEVICE: Self = Self(15250u32);
+                        pub const ERROR_SYSTEM_DEVICE_NOT_FOUND: Self = Self(15299u32);
+                        pub const ERROR_HASH_NOT_SUPPORTED: Self = Self(15300u32);
+                        pub const ERROR_HASH_NOT_PRESENT: Self = Self(15301u32);
+                        pub const ERROR_SECONDARY_IC_PROVIDER_NOT_REGISTERED: Self = Self(15321u32);
+                        pub const ERROR_GPIO_CLIENT_INFORMATION_INVALID: Self = Self(15322u32);
+                        pub const ERROR_GPIO_VERSION_NOT_SUPPORTED: Self = Self(15323u32);
+                        pub const ERROR_GPIO_INVALID_REGISTRATION_PACKET: Self = Self(15324u32);
+                        pub const ERROR_GPIO_OPERATION_DENIED: Self = Self(15325u32);
+                        pub const ERROR_GPIO_INCOMPATIBLE_CONNECT_MODE: Self = Self(15326u32);
+                        pub const ERROR_GPIO_INTERRUPT_ALREADY_UNMASKED: Self = Self(15327u32);
+                        pub const ERROR_CANNOT_SWITCH_RUNLEVEL: Self = Self(15400u32);
+                        pub const ERROR_INVALID_RUNLEVEL_SETTING: Self = Self(15401u32);
+                        pub const ERROR_RUNLEVEL_SWITCH_TIMEOUT: Self = Self(15402u32);
+                        pub const ERROR_RUNLEVEL_SWITCH_AGENT_TIMEOUT: Self = Self(15403u32);
+                        pub const ERROR_RUNLEVEL_SWITCH_IN_PROGRESS: Self = Self(15404u32);
+                        pub const ERROR_SERVICES_FAILED_AUTOSTART: Self = Self(15405u32);
+                        pub const ERROR_COM_TASK_STOP_PENDING: Self = Self(15501u32);
+                        pub const ERROR_INSTALL_OPEN_PACKAGE_FAILED: Self = Self(15600u32);
+                        pub const ERROR_INSTALL_PACKAGE_NOT_FOUND: Self = Self(15601u32);
+                        pub const ERROR_INSTALL_INVALID_PACKAGE: Self = Self(15602u32);
+                        pub const ERROR_INSTALL_RESOLVE_DEPENDENCY_FAILED: Self = Self(15603u32);
+                        pub const ERROR_INSTALL_OUT_OF_DISK_SPACE: Self = Self(15604u32);
+                        pub const ERROR_INSTALL_NETWORK_FAILURE: Self = Self(15605u32);
+                        pub const ERROR_INSTALL_REGISTRATION_FAILURE: Self = Self(15606u32);
+                        pub const ERROR_INSTALL_DEREGISTRATION_FAILURE: Self = Self(15607u32);
+                        pub const ERROR_INSTALL_CANCEL: Self = Self(15608u32);
+                        pub const ERROR_INSTALL_FAILED: Self = Self(15609u32);
+                        pub const ERROR_REMOVE_FAILED: Self = Self(15610u32);
+                        pub const ERROR_PACKAGE_ALREADY_EXISTS: Self = Self(15611u32);
+                        pub const ERROR_NEEDS_REMEDIATION: Self = Self(15612u32);
+                        pub const ERROR_INSTALL_PREREQUISITE_FAILED: Self = Self(15613u32);
+                        pub const ERROR_PACKAGE_REPOSITORY_CORRUPTED: Self = Self(15614u32);
+                        pub const ERROR_INSTALL_POLICY_FAILURE: Self = Self(15615u32);
+                        pub const ERROR_PACKAGE_UPDATING: Self = Self(15616u32);
+                        pub const ERROR_DEPLOYMENT_BLOCKED_BY_POLICY: Self = Self(15617u32);
+                        pub const ERROR_PACKAGES_IN_USE: Self = Self(15618u32);
+                        pub const ERROR_RECOVERY_FILE_CORRUPT: Self = Self(15619u32);
+                        pub const ERROR_INVALID_STAGED_SIGNATURE: Self = Self(15620u32);
+                        pub const ERROR_DELETING_EXISTING_APPLICATIONDATA_STORE_FAILED: Self =
+                            Self(15621u32);
+                        pub const ERROR_INSTALL_PACKAGE_DOWNGRADE: Self = Self(15622u32);
+                        pub const ERROR_SYSTEM_NEEDS_REMEDIATION: Self = Self(15623u32);
+                        pub const ERROR_APPX_INTEGRITY_FAILURE_CLR_NGEN: Self = Self(15624u32);
+                        pub const ERROR_RESILIENCY_FILE_CORRUPT: Self = Self(15625u32);
+                        pub const ERROR_INSTALL_FIREWALL_SERVICE_NOT_RUNNING: Self = Self(15626u32);
+                        pub const ERROR_PACKAGE_MOVE_FAILED: Self = Self(15627u32);
+                        pub const ERROR_INSTALL_VOLUME_NOT_EMPTY: Self = Self(15628u32);
+                        pub const ERROR_INSTALL_VOLUME_OFFLINE: Self = Self(15629u32);
+                        pub const ERROR_INSTALL_VOLUME_CORRUPT: Self = Self(15630u32);
+                        pub const ERROR_NEEDS_REGISTRATION: Self = Self(15631u32);
+                        pub const ERROR_INSTALL_WRONG_PROCESSOR_ARCHITECTURE: Self = Self(15632u32);
+                        pub const ERROR_DEV_SIDELOAD_LIMIT_EXCEEDED: Self = Self(15633u32);
+                        pub const ERROR_INSTALL_OPTIONAL_PACKAGE_REQUIRES_MAIN_PACKAGE: Self =
+                            Self(15634u32);
+                        pub const ERROR_PACKAGE_NOT_SUPPORTED_ON_FILESYSTEM: Self = Self(15635u32);
+                        pub const ERROR_PACKAGE_MOVE_BLOCKED_BY_STREAMING: Self = Self(15636u32);
+                        pub const ERROR_INSTALL_OPTIONAL_PACKAGE_APPLICATIONID_NOT_UNIQUE: Self =
+                            Self(15637u32);
+                        pub const ERROR_PACKAGE_STAGING_ONHOLD: Self = Self(15638u32);
+                        pub const ERROR_INSTALL_INVALID_RELATED_SET_UPDATE: Self = Self(15639u32);
+                        pub const ERROR_INSTALL_OPTIONAL_PACKAGE_REQUIRES_MAIN_PACKAGE_FULLTRUST_CAPABILITY : Self = Self ( 15640u32 ) ;
+                        pub const ERROR_DEPLOYMENT_BLOCKED_BY_USER_LOG_OFF: Self = Self(15641u32);
+                        pub const ERROR_PROVISION_OPTIONAL_PACKAGE_REQUIRES_MAIN_PACKAGE_PROVISIONED : Self = Self ( 15642u32 ) ;
+                        pub const ERROR_PACKAGES_REPUTATION_CHECK_FAILED: Self = Self(15643u32);
+                        pub const ERROR_PACKAGES_REPUTATION_CHECK_TIMEDOUT: Self = Self(15644u32);
+                        pub const ERROR_DEPLOYMENT_OPTION_NOT_SUPPORTED: Self = Self(15645u32);
+                        pub const ERROR_APPINSTALLER_ACTIVATION_BLOCKED: Self = Self(15646u32);
+                        pub const ERROR_REGISTRATION_FROM_REMOTE_DRIVE_NOT_SUPPORTED: Self =
+                            Self(15647u32);
+                        pub const ERROR_APPX_RAW_DATA_WRITE_FAILED: Self = Self(15648u32);
+                        pub const ERROR_DEPLOYMENT_BLOCKED_BY_VOLUME_POLICY_PACKAGE: Self =
+                            Self(15649u32);
+                        pub const ERROR_DEPLOYMENT_BLOCKED_BY_VOLUME_POLICY_MACHINE: Self =
+                            Self(15650u32);
+                        pub const ERROR_DEPLOYMENT_BLOCKED_BY_PROFILE_POLICY: Self = Self(15651u32);
+                        pub const ERROR_DEPLOYMENT_FAILED_CONFLICTING_MUTABLE_PACKAGE_DIRECTORY:
+                            Self = Self(15652u32);
+                        pub const ERROR_SINGLETON_RESOURCE_INSTALLED_IN_ACTIVE_USER: Self =
+                            Self(15653u32);
+                        pub const ERROR_DIFFERENT_VERSION_OF_PACKAGED_SERVICE_INSTALLED: Self =
+                            Self(15654u32);
+                        pub const ERROR_SERVICE_EXISTS_AS_NON_PACKAGED_SERVICE: Self =
+                            Self(15655u32);
+                        pub const ERROR_PACKAGED_SERVICE_REQUIRES_ADMIN_PRIVILEGES: Self =
+                            Self(15656u32);
+                        pub const ERROR_REDIRECTION_TO_DEFAULT_ACCOUNT_NOT_ALLOWED: Self =
+                            Self(15657u32);
+                        pub const ERROR_PACKAGE_LACKS_CAPABILITY_TO_DEPLOY_ON_HOST: Self =
+                            Self(15658u32);
+                        pub const ERROR_UNSIGNED_PACKAGE_INVALID_CONTENT: Self = Self(15659u32);
+                        pub const ERROR_UNSIGNED_PACKAGE_INVALID_PUBLISHER_NAMESPACE: Self =
+                            Self(15660u32);
+                        pub const ERROR_SIGNED_PACKAGE_INVALID_PUBLISHER_NAMESPACE: Self =
+                            Self(15661u32);
+                        pub const ERROR_PACKAGE_EXTERNAL_LOCATION_NOT_ALLOWED: Self =
+                            Self(15662u32);
+                        pub const ERROR_INSTALL_FULLTRUST_HOSTRUNTIME_REQUIRES_MAIN_PACKAGE_FULLTRUST_CAPABILITY : Self = Self ( 15663u32 ) ;
+                        pub const ERROR_STATE_LOAD_STORE_FAILED: Self = Self(15800u32);
+                        pub const ERROR_STATE_GET_VERSION_FAILED: Self = Self(15801u32);
+                        pub const ERROR_STATE_SET_VERSION_FAILED: Self = Self(15802u32);
+                        pub const ERROR_STATE_STRUCTURED_RESET_FAILED: Self = Self(15803u32);
+                        pub const ERROR_STATE_OPEN_CONTAINER_FAILED: Self = Self(15804u32);
+                        pub const ERROR_STATE_CREATE_CONTAINER_FAILED: Self = Self(15805u32);
+                        pub const ERROR_STATE_DELETE_CONTAINER_FAILED: Self = Self(15806u32);
+                        pub const ERROR_STATE_READ_SETTING_FAILED: Self = Self(15807u32);
+                        pub const ERROR_STATE_WRITE_SETTING_FAILED: Self = Self(15808u32);
+                        pub const ERROR_STATE_DELETE_SETTING_FAILED: Self = Self(15809u32);
+                        pub const ERROR_STATE_QUERY_SETTING_FAILED: Self = Self(15810u32);
+                        pub const ERROR_STATE_READ_COMPOSITE_SETTING_FAILED: Self = Self(15811u32);
+                        pub const ERROR_STATE_WRITE_COMPOSITE_SETTING_FAILED: Self = Self(15812u32);
+                        pub const ERROR_STATE_ENUMERATE_CONTAINER_FAILED: Self = Self(15813u32);
+                        pub const ERROR_STATE_ENUMERATE_SETTINGS_FAILED: Self = Self(15814u32);
+                        pub const ERROR_STATE_COMPOSITE_SETTING_VALUE_SIZE_LIMIT_EXCEEDED: Self =
+                            Self(15815u32);
+                        pub const ERROR_STATE_SETTING_VALUE_SIZE_LIMIT_EXCEEDED: Self =
+                            Self(15816u32);
+                        pub const ERROR_STATE_SETTING_NAME_SIZE_LIMIT_EXCEEDED: Self =
+                            Self(15817u32);
+                        pub const ERROR_STATE_CONTAINER_NAME_SIZE_LIMIT_EXCEEDED: Self =
+                            Self(15818u32);
+                        pub const ERROR_API_UNAVAILABLE: Self = Self(15841u32);
+                        pub const ERROR_NDIS_INTERFACE_CLOSING: Self = Self(2150891522u32);
+                        pub const ERROR_NDIS_BAD_VERSION: Self = Self(2150891524u32);
+                        pub const ERROR_NDIS_BAD_CHARACTERISTICS: Self = Self(2150891525u32);
+                        pub const ERROR_NDIS_ADAPTER_NOT_FOUND: Self = Self(2150891526u32);
+                        pub const ERROR_NDIS_OPEN_FAILED: Self = Self(2150891527u32);
+                        pub const ERROR_NDIS_DEVICE_FAILED: Self = Self(2150891528u32);
+                        pub const ERROR_NDIS_MULTICAST_FULL: Self = Self(2150891529u32);
+                        pub const ERROR_NDIS_MULTICAST_EXISTS: Self = Self(2150891530u32);
+                        pub const ERROR_NDIS_MULTICAST_NOT_FOUND: Self = Self(2150891531u32);
+                        pub const ERROR_NDIS_REQUEST_ABORTED: Self = Self(2150891532u32);
+                        pub const ERROR_NDIS_RESET_IN_PROGRESS: Self = Self(2150891533u32);
+                        pub const ERROR_NDIS_NOT_SUPPORTED: Self = Self(2150891707u32);
+                        pub const ERROR_NDIS_INVALID_PACKET: Self = Self(2150891535u32);
+                        pub const ERROR_NDIS_ADAPTER_NOT_READY: Self = Self(2150891537u32);
+                        pub const ERROR_NDIS_INVALID_LENGTH: Self = Self(2150891540u32);
+                        pub const ERROR_NDIS_INVALID_DATA: Self = Self(2150891541u32);
+                        pub const ERROR_NDIS_BUFFER_TOO_SHORT: Self = Self(2150891542u32);
+                        pub const ERROR_NDIS_INVALID_OID: Self = Self(2150891543u32);
+                        pub const ERROR_NDIS_ADAPTER_REMOVED: Self = Self(2150891544u32);
+                        pub const ERROR_NDIS_UNSUPPORTED_MEDIA: Self = Self(2150891545u32);
+                        pub const ERROR_NDIS_GROUP_ADDRESS_IN_USE: Self = Self(2150891546u32);
+                        pub const ERROR_NDIS_FILE_NOT_FOUND: Self = Self(2150891547u32);
+                        pub const ERROR_NDIS_ERROR_READING_FILE: Self = Self(2150891548u32);
+                        pub const ERROR_NDIS_ALREADY_MAPPED: Self = Self(2150891549u32);
+                        pub const ERROR_NDIS_RESOURCE_CONFLICT: Self = Self(2150891550u32);
+                        pub const ERROR_NDIS_MEDIA_DISCONNECTED: Self = Self(2150891551u32);
+                        pub const ERROR_NDIS_INVALID_ADDRESS: Self = Self(2150891554u32);
+                        pub const ERROR_NDIS_INVALID_DEVICE_REQUEST: Self = Self(2150891536u32);
+                        pub const ERROR_NDIS_PAUSED: Self = Self(2150891562u32);
+                        pub const ERROR_NDIS_INTERFACE_NOT_FOUND: Self = Self(2150891563u32);
+                        pub const ERROR_NDIS_UNSUPPORTED_REVISION: Self = Self(2150891564u32);
+                        pub const ERROR_NDIS_INVALID_PORT: Self = Self(2150891565u32);
+                        pub const ERROR_NDIS_INVALID_PORT_STATE: Self = Self(2150891566u32);
+                        pub const ERROR_NDIS_LOW_POWER_STATE: Self = Self(2150891567u32);
+                        pub const ERROR_NDIS_REINIT_REQUIRED: Self = Self(2150891568u32);
+                        pub const ERROR_NDIS_NO_QUEUES: Self = Self(2150891569u32);
+                        pub const ERROR_NDIS_DOT11_AUTO_CONFIG_ENABLED: Self = Self(2150899712u32);
+                        pub const ERROR_NDIS_DOT11_MEDIA_IN_USE: Self = Self(2150899713u32);
+                        pub const ERROR_NDIS_DOT11_POWER_STATE_INVALID: Self = Self(2150899714u32);
+                        pub const ERROR_NDIS_PM_WOL_PATTERN_LIST_FULL: Self = Self(2150899715u32);
+                        pub const ERROR_NDIS_PM_PROTOCOL_OFFLOAD_LIST_FULL: Self =
+                            Self(2150899716u32);
+                        pub const ERROR_NDIS_DOT11_AP_CHANNEL_CURRENTLY_NOT_AVAILABLE: Self =
+                            Self(2150899717u32);
+                        pub const ERROR_NDIS_DOT11_AP_BAND_CURRENTLY_NOT_AVAILABLE: Self =
+                            Self(2150899718u32);
+                        pub const ERROR_NDIS_DOT11_AP_CHANNEL_NOT_ALLOWED: Self =
+                            Self(2150899719u32);
+                        pub const ERROR_NDIS_DOT11_AP_BAND_NOT_ALLOWED: Self = Self(2150899720u32);
+                        pub const ERROR_NDIS_INDICATION_REQUIRED: Self = Self(3407873u32);
+                        pub const ERROR_NDIS_OFFLOAD_POLICY: Self = Self(3224637455u32);
+                        pub const ERROR_NDIS_OFFLOAD_CONNECTION_REJECTED: Self =
+                            Self(3224637458u32);
+                        pub const ERROR_NDIS_OFFLOAD_PATH_REJECTED: Self = Self(3224637459u32);
+                        pub const ERROR_HV_INVALID_HYPERCALL_CODE: Self = Self(3224698882u32);
+                        pub const ERROR_HV_INVALID_HYPERCALL_INPUT: Self = Self(3224698883u32);
+                        pub const ERROR_HV_INVALID_ALIGNMENT: Self = Self(3224698884u32);
+                        pub const ERROR_HV_INVALID_PARAMETER: Self = Self(3224698885u32);
+                        pub const ERROR_HV_ACCESS_DENIED: Self = Self(3224698886u32);
+                        pub const ERROR_HV_INVALID_PARTITION_STATE: Self = Self(3224698887u32);
+                        pub const ERROR_HV_OPERATION_DENIED: Self = Self(3224698888u32);
+                        pub const ERROR_HV_UNKNOWN_PROPERTY: Self = Self(3224698889u32);
+                        pub const ERROR_HV_PROPERTY_VALUE_OUT_OF_RANGE: Self = Self(3224698890u32);
+                        pub const ERROR_HV_INSUFFICIENT_MEMORY: Self = Self(3224698891u32);
+                        pub const ERROR_HV_PARTITION_TOO_DEEP: Self = Self(3224698892u32);
+                        pub const ERROR_HV_INVALID_PARTITION_ID: Self = Self(3224698893u32);
+                        pub const ERROR_HV_INVALID_VP_INDEX: Self = Self(3224698894u32);
+                        pub const ERROR_HV_INVALID_PORT_ID: Self = Self(3224698897u32);
+                        pub const ERROR_HV_INVALID_CONNECTION_ID: Self = Self(3224698898u32);
+                        pub const ERROR_HV_INSUFFICIENT_BUFFERS: Self = Self(3224698899u32);
+                        pub const ERROR_HV_NOT_ACKNOWLEDGED: Self = Self(3224698900u32);
+                        pub const ERROR_HV_INVALID_VP_STATE: Self = Self(3224698901u32);
+                        pub const ERROR_HV_ACKNOWLEDGED: Self = Self(3224698902u32);
+                        pub const ERROR_HV_INVALID_SAVE_RESTORE_STATE: Self = Self(3224698903u32);
+                        pub const ERROR_HV_INVALID_SYNIC_STATE: Self = Self(3224698904u32);
+                        pub const ERROR_HV_OBJECT_IN_USE: Self = Self(3224698905u32);
+                        pub const ERROR_HV_INVALID_PROXIMITY_DOMAIN_INFO: Self =
+                            Self(3224698906u32);
+                        pub const ERROR_HV_NO_DATA: Self = Self(3224698907u32);
+                        pub const ERROR_HV_INACTIVE: Self = Self(3224698908u32);
+                        pub const ERROR_HV_NO_RESOURCES: Self = Self(3224698909u32);
+                        pub const ERROR_HV_FEATURE_UNAVAILABLE: Self = Self(3224698910u32);
+                        pub const ERROR_HV_INSUFFICIENT_BUFFER: Self = Self(3224698931u32);
+                        pub const ERROR_HV_INSUFFICIENT_DEVICE_DOMAINS: Self = Self(3224698936u32);
+                        pub const ERROR_HV_CPUID_FEATURE_VALIDATION: Self = Self(3224698940u32);
+                        pub const ERROR_HV_CPUID_XSAVE_FEATURE_VALIDATION: Self =
+                            Self(3224698941u32);
+                        pub const ERROR_HV_PROCESSOR_STARTUP_TIMEOUT: Self = Self(3224698942u32);
+                        pub const ERROR_HV_SMX_ENABLED: Self = Self(3224698943u32);
+                        pub const ERROR_HV_INVALID_LP_INDEX: Self = Self(3224698945u32);
+                        pub const ERROR_HV_INVALID_REGISTER_VALUE: Self = Self(3224698960u32);
+                        pub const ERROR_HV_INVALID_VTL_STATE: Self = Self(3224698961u32);
+                        pub const ERROR_HV_NX_NOT_DETECTED: Self = Self(3224698965u32);
+                        pub const ERROR_HV_INVALID_DEVICE_ID: Self = Self(3224698967u32);
+                        pub const ERROR_HV_INVALID_DEVICE_STATE: Self = Self(3224698968u32);
+                        pub const ERROR_HV_PENDING_PAGE_REQUESTS: Self = Self(3473497u32);
+                        pub const ERROR_HV_PAGE_REQUEST_INVALID: Self = Self(3224698976u32);
+                        pub const ERROR_HV_INVALID_CPU_GROUP_ID: Self = Self(3224698991u32);
+                        pub const ERROR_HV_INVALID_CPU_GROUP_STATE: Self = Self(3224698992u32);
+                        pub const ERROR_HV_OPERATION_FAILED: Self = Self(3224698993u32);
+                        pub const ERROR_HV_NOT_ALLOWED_WITH_NESTED_VIRT_ACTIVE: Self =
+                            Self(3224698994u32);
+                        pub const ERROR_HV_INSUFFICIENT_ROOT_MEMORY: Self = Self(3224698995u32);
+                        pub const ERROR_HV_EVENT_BUFFER_ALREADY_FREED: Self = Self(3224698996u32);
+                        pub const ERROR_HV_INSUFFICIENT_CONTIGUOUS_MEMORY: Self =
+                            Self(3224698997u32);
+                        pub const ERROR_HV_NOT_PRESENT: Self = Self(3224702976u32);
+                        pub const ERROR_VID_DUPLICATE_HANDLER: Self = Self(3224829953u32);
+                        pub const ERROR_VID_TOO_MANY_HANDLERS: Self = Self(3224829954u32);
+                        pub const ERROR_VID_QUEUE_FULL: Self = Self(3224829955u32);
+                        pub const ERROR_VID_HANDLER_NOT_PRESENT: Self = Self(3224829956u32);
+                        pub const ERROR_VID_INVALID_OBJECT_NAME: Self = Self(3224829957u32);
+                        pub const ERROR_VID_PARTITION_NAME_TOO_LONG: Self = Self(3224829958u32);
+                        pub const ERROR_VID_MESSAGE_QUEUE_NAME_TOO_LONG: Self = Self(3224829959u32);
+                        pub const ERROR_VID_PARTITION_ALREADY_EXISTS: Self = Self(3224829960u32);
+                        pub const ERROR_VID_PARTITION_DOES_NOT_EXIST: Self = Self(3224829961u32);
+                        pub const ERROR_VID_PARTITION_NAME_NOT_FOUND: Self = Self(3224829962u32);
+                        pub const ERROR_VID_MESSAGE_QUEUE_ALREADY_EXISTS: Self =
+                            Self(3224829963u32);
+                        pub const ERROR_VID_EXCEEDED_MBP_ENTRY_MAP_LIMIT: Self =
+                            Self(3224829964u32);
+                        pub const ERROR_VID_MB_STILL_REFERENCED: Self = Self(3224829965u32);
+                        pub const ERROR_VID_CHILD_GPA_PAGE_SET_CORRUPTED: Self =
+                            Self(3224829966u32);
+                        pub const ERROR_VID_INVALID_NUMA_SETTINGS: Self = Self(3224829967u32);
+                        pub const ERROR_VID_INVALID_NUMA_NODE_INDEX: Self = Self(3224829968u32);
+                        pub const ERROR_VID_NOTIFICATION_QUEUE_ALREADY_ASSOCIATED: Self =
+                            Self(3224829969u32);
+                        pub const ERROR_VID_INVALID_MEMORY_BLOCK_HANDLE: Self = Self(3224829970u32);
+                        pub const ERROR_VID_PAGE_RANGE_OVERFLOW: Self = Self(3224829971u32);
+                        pub const ERROR_VID_INVALID_MESSAGE_QUEUE_HANDLE: Self =
+                            Self(3224829972u32);
+                        pub const ERROR_VID_INVALID_GPA_RANGE_HANDLE: Self = Self(3224829973u32);
+                        pub const ERROR_VID_NO_MEMORY_BLOCK_NOTIFICATION_QUEUE: Self =
+                            Self(3224829974u32);
+                        pub const ERROR_VID_MEMORY_BLOCK_LOCK_COUNT_EXCEEDED: Self =
+                            Self(3224829975u32);
+                        pub const ERROR_VID_INVALID_PPM_HANDLE: Self = Self(3224829976u32);
+                        pub const ERROR_VID_MBPS_ARE_LOCKED: Self = Self(3224829977u32);
+                        pub const ERROR_VID_MESSAGE_QUEUE_CLOSED: Self = Self(3224829978u32);
+                        pub const ERROR_VID_VIRTUAL_PROCESSOR_LIMIT_EXCEEDED: Self =
+                            Self(3224829979u32);
+                        pub const ERROR_VID_STOP_PENDING: Self = Self(3224829980u32);
+                        pub const ERROR_VID_INVALID_PROCESSOR_STATE: Self = Self(3224829981u32);
+                        pub const ERROR_VID_EXCEEDED_KM_CONTEXT_COUNT_LIMIT: Self =
+                            Self(3224829982u32);
+                        pub const ERROR_VID_KM_INTERFACE_ALREADY_INITIALIZED: Self =
+                            Self(3224829983u32);
+                        pub const ERROR_VID_MB_PROPERTY_ALREADY_SET_RESET: Self =
+                            Self(3224829984u32);
+                        pub const ERROR_VID_MMIO_RANGE_DESTROYED: Self = Self(3224829985u32);
+                        pub const ERROR_VID_INVALID_CHILD_GPA_PAGE_SET: Self = Self(3224829986u32);
+                        pub const ERROR_VID_RESERVE_PAGE_SET_IS_BEING_USED: Self =
+                            Self(3224829987u32);
+                        pub const ERROR_VID_RESERVE_PAGE_SET_TOO_SMALL: Self = Self(3224829988u32);
+                        pub const ERROR_VID_MBP_ALREADY_LOCKED_USING_RESERVED_PAGE: Self =
+                            Self(3224829989u32);
+                        pub const ERROR_VID_MBP_COUNT_EXCEEDED_LIMIT: Self = Self(3224829990u32);
+                        pub const ERROR_VID_SAVED_STATE_CORRUPT: Self = Self(3224829991u32);
+                        pub const ERROR_VID_SAVED_STATE_UNRECOGNIZED_ITEM: Self =
+                            Self(3224829992u32);
+                        pub const ERROR_VID_SAVED_STATE_INCOMPATIBLE: Self = Self(3224829993u32);
+                        pub const ERROR_VID_VTL_ACCESS_DENIED: Self = Self(3224829994u32);
+                        pub const ERROR_VMCOMPUTE_TERMINATED_DURING_START: Self =
+                            Self(3224830208u32);
+                        pub const ERROR_VMCOMPUTE_IMAGE_MISMATCH: Self = Self(3224830209u32);
+                        pub const ERROR_VMCOMPUTE_HYPERV_NOT_INSTALLED: Self = Self(3224830210u32);
+                        pub const ERROR_VMCOMPUTE_OPERATION_PENDING: Self = Self(3224830211u32);
+                        pub const ERROR_VMCOMPUTE_TOO_MANY_NOTIFICATIONS: Self =
+                            Self(3224830212u32);
+                        pub const ERROR_VMCOMPUTE_INVALID_STATE: Self = Self(3224830213u32);
+                        pub const ERROR_VMCOMPUTE_UNEXPECTED_EXIT: Self = Self(3224830214u32);
+                        pub const ERROR_VMCOMPUTE_TERMINATED: Self = Self(3224830215u32);
+                        pub const ERROR_VMCOMPUTE_CONNECT_FAILED: Self = Self(3224830216u32);
+                        pub const ERROR_VMCOMPUTE_TIMEOUT: Self = Self(3224830217u32);
+                        pub const ERROR_VMCOMPUTE_CONNECTION_CLOSED: Self = Self(3224830218u32);
+                        pub const ERROR_VMCOMPUTE_UNKNOWN_MESSAGE: Self = Self(3224830219u32);
+                        pub const ERROR_VMCOMPUTE_UNSUPPORTED_PROTOCOL_VERSION: Self =
+                            Self(3224830220u32);
+                        pub const ERROR_VMCOMPUTE_INVALID_JSON: Self = Self(3224830221u32);
+                        pub const ERROR_VMCOMPUTE_SYSTEM_NOT_FOUND: Self = Self(3224830222u32);
+                        pub const ERROR_VMCOMPUTE_SYSTEM_ALREADY_EXISTS: Self = Self(3224830223u32);
+                        pub const ERROR_VMCOMPUTE_SYSTEM_ALREADY_STOPPED: Self =
+                            Self(3224830224u32);
+                        pub const ERROR_VMCOMPUTE_PROTOCOL_ERROR: Self = Self(3224830225u32);
+                        pub const ERROR_VMCOMPUTE_INVALID_LAYER: Self = Self(3224830226u32);
+                        pub const ERROR_VMCOMPUTE_WINDOWS_INSIDER_REQUIRED: Self =
+                            Self(3224830227u32);
+                        pub const ERROR_VNET_VIRTUAL_SWITCH_NAME_NOT_FOUND: Self =
+                            Self(3224830464u32);
+                        pub const ERROR_VID_REMOTE_NODE_PARENT_GPA_PAGES_USED: Self =
+                            Self(2151088129u32);
+                        pub const ERROR_VSMB_SAVED_STATE_FILE_NOT_FOUND: Self = Self(3224830976u32);
+                        pub const ERROR_VSMB_SAVED_STATE_CORRUPT: Self = Self(3224830977u32);
+                        pub const ERROR_VOLMGR_INCOMPLETE_REGENERATION: Self = Self(2151153665u32);
+                        pub const ERROR_VOLMGR_INCOMPLETE_DISK_MIGRATION: Self =
+                            Self(2151153666u32);
+                        pub const ERROR_VOLMGR_DATABASE_FULL: Self = Self(3224895489u32);
+                        pub const ERROR_VOLMGR_DISK_CONFIGURATION_CORRUPTED: Self =
+                            Self(3224895490u32);
+                        pub const ERROR_VOLMGR_DISK_CONFIGURATION_NOT_IN_SYNC: Self =
+                            Self(3224895491u32);
+                        pub const ERROR_VOLMGR_PACK_CONFIG_UPDATE_FAILED: Self =
+                            Self(3224895492u32);
+                        pub const ERROR_VOLMGR_DISK_CONTAINS_NON_SIMPLE_VOLUME: Self =
+                            Self(3224895493u32);
+                        pub const ERROR_VOLMGR_DISK_DUPLICATE: Self = Self(3224895494u32);
+                        pub const ERROR_VOLMGR_DISK_DYNAMIC: Self = Self(3224895495u32);
+                        pub const ERROR_VOLMGR_DISK_ID_INVALID: Self = Self(3224895496u32);
+                        pub const ERROR_VOLMGR_DISK_INVALID: Self = Self(3224895497u32);
+                        pub const ERROR_VOLMGR_DISK_LAST_VOTER: Self = Self(3224895498u32);
+                        pub const ERROR_VOLMGR_DISK_LAYOUT_INVALID: Self = Self(3224895499u32);
+                        pub const ERROR_VOLMGR_DISK_LAYOUT_NON_BASIC_BETWEEN_BASIC_PARTITIONS:
+                            Self = Self(3224895500u32);
+                        pub const ERROR_VOLMGR_DISK_LAYOUT_NOT_CYLINDER_ALIGNED: Self =
+                            Self(3224895501u32);
+                        pub const ERROR_VOLMGR_DISK_LAYOUT_PARTITIONS_TOO_SMALL: Self =
+                            Self(3224895502u32);
+                        pub const ERROR_VOLMGR_DISK_LAYOUT_PRIMARY_BETWEEN_LOGICAL_PARTITIONS:
+                            Self = Self(3224895503u32);
+                        pub const ERROR_VOLMGR_DISK_LAYOUT_TOO_MANY_PARTITIONS: Self =
+                            Self(3224895504u32);
+                        pub const ERROR_VOLMGR_DISK_MISSING: Self = Self(3224895505u32);
+                        pub const ERROR_VOLMGR_DISK_NOT_EMPTY: Self = Self(3224895506u32);
+                        pub const ERROR_VOLMGR_DISK_NOT_ENOUGH_SPACE: Self = Self(3224895507u32);
+                        pub const ERROR_VOLMGR_DISK_REVECTORING_FAILED: Self = Self(3224895508u32);
+                        pub const ERROR_VOLMGR_DISK_SECTOR_SIZE_INVALID: Self = Self(3224895509u32);
+                        pub const ERROR_VOLMGR_DISK_SET_NOT_CONTAINED: Self = Self(3224895510u32);
+                        pub const ERROR_VOLMGR_DISK_USED_BY_MULTIPLE_MEMBERS: Self =
+                            Self(3224895511u32);
+                        pub const ERROR_VOLMGR_DISK_USED_BY_MULTIPLE_PLEXES: Self =
+                            Self(3224895512u32);
+                        pub const ERROR_VOLMGR_DYNAMIC_DISK_NOT_SUPPORTED: Self =
+                            Self(3224895513u32);
+                        pub const ERROR_VOLMGR_EXTENT_ALREADY_USED: Self = Self(3224895514u32);
+                        pub const ERROR_VOLMGR_EXTENT_NOT_CONTIGUOUS: Self = Self(3224895515u32);
+                        pub const ERROR_VOLMGR_EXTENT_NOT_IN_PUBLIC_REGION: Self =
+                            Self(3224895516u32);
+                        pub const ERROR_VOLMGR_EXTENT_NOT_SECTOR_ALIGNED: Self =
+                            Self(3224895517u32);
+                        pub const ERROR_VOLMGR_EXTENT_OVERLAPS_EBR_PARTITION: Self =
+                            Self(3224895518u32);
+                        pub const ERROR_VOLMGR_EXTENT_VOLUME_LENGTHS_DO_NOT_MATCH: Self =
+                            Self(3224895519u32);
+                        pub const ERROR_VOLMGR_FAULT_TOLERANT_NOT_SUPPORTED: Self =
+                            Self(3224895520u32);
+                        pub const ERROR_VOLMGR_INTERLEAVE_LENGTH_INVALID: Self =
+                            Self(3224895521u32);
+                        pub const ERROR_VOLMGR_MAXIMUM_REGISTERED_USERS: Self = Self(3224895522u32);
+                        pub const ERROR_VOLMGR_MEMBER_IN_SYNC: Self = Self(3224895523u32);
+                        pub const ERROR_VOLMGR_MEMBER_INDEX_DUPLICATE: Self = Self(3224895524u32);
+                        pub const ERROR_VOLMGR_MEMBER_INDEX_INVALID: Self = Self(3224895525u32);
+                        pub const ERROR_VOLMGR_MEMBER_MISSING: Self = Self(3224895526u32);
+                        pub const ERROR_VOLMGR_MEMBER_NOT_DETACHED: Self = Self(3224895527u32);
+                        pub const ERROR_VOLMGR_MEMBER_REGENERATING: Self = Self(3224895528u32);
+                        pub const ERROR_VOLMGR_ALL_DISKS_FAILED: Self = Self(3224895529u32);
+                        pub const ERROR_VOLMGR_NO_REGISTERED_USERS: Self = Self(3224895530u32);
+                        pub const ERROR_VOLMGR_NO_SUCH_USER: Self = Self(3224895531u32);
+                        pub const ERROR_VOLMGR_NOTIFICATION_RESET: Self = Self(3224895532u32);
+                        pub const ERROR_VOLMGR_NUMBER_OF_MEMBERS_INVALID: Self =
+                            Self(3224895533u32);
+                        pub const ERROR_VOLMGR_NUMBER_OF_PLEXES_INVALID: Self = Self(3224895534u32);
+                        pub const ERROR_VOLMGR_PACK_DUPLICATE: Self = Self(3224895535u32);
+                        pub const ERROR_VOLMGR_PACK_ID_INVALID: Self = Self(3224895536u32);
+                        pub const ERROR_VOLMGR_PACK_INVALID: Self = Self(3224895537u32);
+                        pub const ERROR_VOLMGR_PACK_NAME_INVALID: Self = Self(3224895538u32);
+                        pub const ERROR_VOLMGR_PACK_OFFLINE: Self = Self(3224895539u32);
+                        pub const ERROR_VOLMGR_PACK_HAS_QUORUM: Self = Self(3224895540u32);
+                        pub const ERROR_VOLMGR_PACK_WITHOUT_QUORUM: Self = Self(3224895541u32);
+                        pub const ERROR_VOLMGR_PARTITION_STYLE_INVALID: Self = Self(3224895542u32);
+                        pub const ERROR_VOLMGR_PARTITION_UPDATE_FAILED: Self = Self(3224895543u32);
+                        pub const ERROR_VOLMGR_PLEX_IN_SYNC: Self = Self(3224895544u32);
+                        pub const ERROR_VOLMGR_PLEX_INDEX_DUPLICATE: Self = Self(3224895545u32);
+                        pub const ERROR_VOLMGR_PLEX_INDEX_INVALID: Self = Self(3224895546u32);
+                        pub const ERROR_VOLMGR_PLEX_LAST_ACTIVE: Self = Self(3224895547u32);
+                        pub const ERROR_VOLMGR_PLEX_MISSING: Self = Self(3224895548u32);
+                        pub const ERROR_VOLMGR_PLEX_REGENERATING: Self = Self(3224895549u32);
+                        pub const ERROR_VOLMGR_PLEX_TYPE_INVALID: Self = Self(3224895550u32);
+                        pub const ERROR_VOLMGR_PLEX_NOT_RAID5: Self = Self(3224895551u32);
+                        pub const ERROR_VOLMGR_PLEX_NOT_SIMPLE: Self = Self(3224895552u32);
+                        pub const ERROR_VOLMGR_STRUCTURE_SIZE_INVALID: Self = Self(3224895553u32);
+                        pub const ERROR_VOLMGR_TOO_MANY_NOTIFICATION_REQUESTS: Self =
+                            Self(3224895554u32);
+                        pub const ERROR_VOLMGR_TRANSACTION_IN_PROGRESS: Self = Self(3224895555u32);
+                        pub const ERROR_VOLMGR_UNEXPECTED_DISK_LAYOUT_CHANGE: Self =
+                            Self(3224895556u32);
+                        pub const ERROR_VOLMGR_VOLUME_CONTAINS_MISSING_DISK: Self =
+                            Self(3224895557u32);
+                        pub const ERROR_VOLMGR_VOLUME_ID_INVALID: Self = Self(3224895558u32);
+                        pub const ERROR_VOLMGR_VOLUME_LENGTH_INVALID: Self = Self(3224895559u32);
+                        pub const ERROR_VOLMGR_VOLUME_LENGTH_NOT_SECTOR_SIZE_MULTIPLE: Self =
+                            Self(3224895560u32);
+                        pub const ERROR_VOLMGR_VOLUME_NOT_MIRRORED: Self = Self(3224895561u32);
+                        pub const ERROR_VOLMGR_VOLUME_NOT_RETAINED: Self = Self(3224895562u32);
+                        pub const ERROR_VOLMGR_VOLUME_OFFLINE: Self = Self(3224895563u32);
+                        pub const ERROR_VOLMGR_VOLUME_RETAINED: Self = Self(3224895564u32);
+                        pub const ERROR_VOLMGR_NUMBER_OF_EXTENTS_INVALID: Self =
+                            Self(3224895565u32);
+                        pub const ERROR_VOLMGR_DIFFERENT_SECTOR_SIZE: Self = Self(3224895566u32);
+                        pub const ERROR_VOLMGR_BAD_BOOT_DISK: Self = Self(3224895567u32);
+                        pub const ERROR_VOLMGR_PACK_CONFIG_OFFLINE: Self = Self(3224895568u32);
+                        pub const ERROR_VOLMGR_PACK_CONFIG_ONLINE: Self = Self(3224895569u32);
+                        pub const ERROR_VOLMGR_NOT_PRIMARY_PACK: Self = Self(3224895570u32);
+                        pub const ERROR_VOLMGR_PACK_LOG_UPDATE_FAILED: Self = Self(3224895571u32);
+                        pub const ERROR_VOLMGR_NUMBER_OF_DISKS_IN_PLEX_INVALID: Self =
+                            Self(3224895572u32);
+                        pub const ERROR_VOLMGR_NUMBER_OF_DISKS_IN_MEMBER_INVALID: Self =
+                            Self(3224895573u32);
+                        pub const ERROR_VOLMGR_VOLUME_MIRRORED: Self = Self(3224895574u32);
+                        pub const ERROR_VOLMGR_PLEX_NOT_SIMPLE_SPANNED: Self = Self(3224895575u32);
+                        pub const ERROR_VOLMGR_NO_VALID_LOG_COPIES: Self = Self(3224895576u32);
+                        pub const ERROR_VOLMGR_PRIMARY_PACK_PRESENT: Self = Self(3224895577u32);
+                        pub const ERROR_VOLMGR_NUMBER_OF_DISKS_INVALID: Self = Self(3224895578u32);
+                        pub const ERROR_VOLMGR_MIRROR_NOT_SUPPORTED: Self = Self(3224895579u32);
+                        pub const ERROR_VOLMGR_RAID5_NOT_SUPPORTED: Self = Self(3224895580u32);
+                        pub const ERROR_BCD_NOT_ALL_ENTRIES_IMPORTED: Self = Self(2151219201u32);
+                        pub const ERROR_BCD_TOO_MANY_ELEMENTS: Self = Self(3224961026u32);
+                        pub const ERROR_BCD_NOT_ALL_ENTRIES_SYNCHRONIZED: Self =
+                            Self(2151219203u32);
+                        pub const ERROR_VHD_DRIVE_FOOTER_MISSING: Self = Self(3225026561u32);
+                        pub const ERROR_VHD_DRIVE_FOOTER_CHECKSUM_MISMATCH: Self =
+                            Self(3225026562u32);
+                        pub const ERROR_VHD_DRIVE_FOOTER_CORRUPT: Self = Self(3225026563u32);
+                        pub const ERROR_VHD_FORMAT_UNKNOWN: Self = Self(3225026564u32);
+                        pub const ERROR_VHD_FORMAT_UNSUPPORTED_VERSION: Self = Self(3225026565u32);
+                        pub const ERROR_VHD_SPARSE_HEADER_CHECKSUM_MISMATCH: Self =
+                            Self(3225026566u32);
+                        pub const ERROR_VHD_SPARSE_HEADER_UNSUPPORTED_VERSION: Self =
+                            Self(3225026567u32);
+                        pub const ERROR_VHD_SPARSE_HEADER_CORRUPT: Self = Self(3225026568u32);
+                        pub const ERROR_VHD_BLOCK_ALLOCATION_FAILURE: Self = Self(3225026569u32);
+                        pub const ERROR_VHD_BLOCK_ALLOCATION_TABLE_CORRUPT: Self =
+                            Self(3225026570u32);
+                        pub const ERROR_VHD_INVALID_BLOCK_SIZE: Self = Self(3225026571u32);
+                        pub const ERROR_VHD_BITMAP_MISMATCH: Self = Self(3225026572u32);
+                        pub const ERROR_VHD_PARENT_VHD_NOT_FOUND: Self = Self(3225026573u32);
+                        pub const ERROR_VHD_CHILD_PARENT_ID_MISMATCH: Self = Self(3225026574u32);
+                        pub const ERROR_VHD_CHILD_PARENT_TIMESTAMP_MISMATCH: Self =
+                            Self(3225026575u32);
+                        pub const ERROR_VHD_METADATA_READ_FAILURE: Self = Self(3225026576u32);
+                        pub const ERROR_VHD_METADATA_WRITE_FAILURE: Self = Self(3225026577u32);
+                        pub const ERROR_VHD_INVALID_SIZE: Self = Self(3225026578u32);
+                        pub const ERROR_VHD_INVALID_FILE_SIZE: Self = Self(3225026579u32);
+                        pub const ERROR_VIRTDISK_PROVIDER_NOT_FOUND: Self = Self(3225026580u32);
+                        pub const ERROR_VIRTDISK_NOT_VIRTUAL_DISK: Self = Self(3225026581u32);
+                        pub const ERROR_VHD_PARENT_VHD_ACCESS_DENIED: Self = Self(3225026582u32);
+                        pub const ERROR_VHD_CHILD_PARENT_SIZE_MISMATCH: Self = Self(3225026583u32);
+                        pub const ERROR_VHD_DIFFERENCING_CHAIN_CYCLE_DETECTED: Self =
+                            Self(3225026584u32);
+                        pub const ERROR_VHD_DIFFERENCING_CHAIN_ERROR_IN_PARENT: Self =
+                            Self(3225026585u32);
+                        pub const ERROR_VIRTUAL_DISK_LIMITATION: Self = Self(3225026586u32);
+                        pub const ERROR_VHD_INVALID_TYPE: Self = Self(3225026587u32);
+                        pub const ERROR_VHD_INVALID_STATE: Self = Self(3225026588u32);
+                        pub const ERROR_VIRTDISK_UNSUPPORTED_DISK_SECTOR_SIZE: Self =
+                            Self(3225026589u32);
+                        pub const ERROR_VIRTDISK_DISK_ALREADY_OWNED: Self = Self(3225026590u32);
+                        pub const ERROR_VIRTDISK_DISK_ONLINE_AND_WRITABLE: Self =
+                            Self(3225026591u32);
+                        pub const ERROR_CTLOG_TRACKING_NOT_INITIALIZED: Self = Self(3225026592u32);
+                        pub const ERROR_CTLOG_LOGFILE_SIZE_EXCEEDED_MAXSIZE: Self =
+                            Self(3225026593u32);
+                        pub const ERROR_CTLOG_VHD_CHANGED_OFFLINE: Self = Self(3225026594u32);
+                        pub const ERROR_CTLOG_INVALID_TRACKING_STATE: Self = Self(3225026595u32);
+                        pub const ERROR_CTLOG_INCONSISTENT_TRACKING_FILE: Self =
+                            Self(3225026596u32);
+                        pub const ERROR_VHD_RESIZE_WOULD_TRUNCATE_DATA: Self = Self(3225026597u32);
+                        pub const ERROR_VHD_COULD_NOT_COMPUTE_MINIMUM_VIRTUAL_SIZE: Self =
+                            Self(3225026598u32);
+                        pub const ERROR_VHD_ALREADY_AT_OR_BELOW_MINIMUM_VIRTUAL_SIZE: Self =
+                            Self(3225026599u32);
+                        pub const ERROR_VHD_METADATA_FULL: Self = Self(3225026600u32);
+                        pub const ERROR_VHD_INVALID_CHANGE_TRACKING_ID: Self = Self(3225026601u32);
+                        pub const ERROR_VHD_CHANGE_TRACKING_DISABLED: Self = Self(3225026602u32);
+                        pub const ERROR_VHD_MISSING_CHANGE_TRACKING_INFORMATION: Self =
+                            Self(3225026608u32);
+                        pub const ERROR_QUERY_STORAGE_ERROR: Self = Self(2151284737u32);
+                    }
+                    impl ::std::convert::From<u32> for WIN32_ERROR {
+                        fn from(value: u32) -> Self {
+                            Self(value)
+                        }
+                    }
+                    unsafe impl ::windows::Abi for WIN32_ERROR {
+                        type Abi = Self;
+                    }
+                    impl ::std::ops::BitOr for WIN32_ERROR {
+                        type Output = Self;
+                        fn bitor(self, rhs: Self) -> Self {
+                            Self(self.0 | rhs.0)
+                        }
+                    }
+                    impl ::std::ops::BitAnd for WIN32_ERROR {
+                        type Output = Self;
+                        fn bitand(self, rhs: Self) -> Self {
+                            Self(self.0 & rhs.0)
+                        }
+                    }
+                    impl ::std::ops::BitOrAssign for WIN32_ERROR {
+                        fn bitor_assign(&mut self, rhs: Self) {
+                            self.0.bitor_assign(rhs.0)
+                        }
+                    }
+                    impl ::std::ops::BitAndAssign for WIN32_ERROR {
+                        fn bitand_assign(&mut self, rhs: Self) {
+                            self.0.bitand_assign(rhs.0)
+                        }
+                    }
+                    pub unsafe fn GetLastError() -> WIN32_ERROR {
+                        #[link(name = "KERNEL32")]
+                        extern "system" {
+                            pub fn GetLastError() -> WIN32_ERROR;
+                        }
+                        GetLastError()
+                    }
                 }
             }
-            impl ::std::cmp::PartialEq for SECURITY_ATTRIBUTES {
-                fn eq(&self, other: &Self) -> bool {
-                    self.nLength == other.nLength
-                        && self.lpSecurityDescriptor == other.lpSecurityDescriptor
-                        && self.bInheritHandle == other.bInheritHandle
-                }
-            }
-            impl ::std::cmp::Eq for SECURITY_ATTRIBUTES {}
-            unsafe impl ::windows::Abi for SECURITY_ATTRIBUTES {
-                type Abi = Self;
-            }
-            #[repr(transparent)]
-            #[derive(
-                :: std :: clone :: Clone,
-                :: std :: marker :: Copy,
-                :: std :: cmp :: Eq,
-                :: std :: fmt :: Debug,
+            #[allow(
+                unused_variables,
+                non_upper_case_globals,
+                non_snake_case,
+                unused_unsafe,
+                non_camel_case_types,
+                dead_code,
+                clippy::all
             )]
-            pub struct PSTR(pub *mut u8);
-            impl PSTR {
-                pub const NULL: Self = Self(::std::ptr::null_mut());
-                pub fn is_null(&self) -> bool {
-                    self.0.is_null()
+            pub mod Memory {
+                #[repr(transparent)]
+                #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
+                pub struct HeapHandle(pub isize);
+                impl HeapHandle {}
+                impl ::std::default::Default for HeapHandle {
+                    fn default() -> Self {
+                        Self(0)
+                    }
+                }
+                impl HeapHandle {
+                    pub const NULL: Self = Self(0);
+                    pub fn is_null(&self) -> bool {
+                        self.0 == 0
+                    }
+                }
+                impl ::std::fmt::Debug for HeapHandle {
+                    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                        fmt.debug_struct("HeapHandle")
+                            .field("Value", &format_args!("{:?}", self.0))
+                            .finish()
+                    }
+                }
+                impl ::std::cmp::PartialEq for HeapHandle {
+                    fn eq(&self, other: &Self) -> bool {
+                        self.0 == other.0
+                    }
+                }
+                impl ::std::cmp::Eq for HeapHandle {}
+                unsafe impl ::windows::Abi for HeapHandle {
+                    type Abi = Self;
+                }
+                pub unsafe fn GetProcessHeap() -> HeapHandle {
+                    #[link(name = "KERNEL32")]
+                    extern "system" {
+                        pub fn GetProcessHeap() -> HeapHandle;
+                    }
+                    GetProcessHeap()
+                }
+                #[derive(
+                    :: std :: cmp :: PartialEq,
+                    :: std :: cmp :: Eq,
+                    :: std :: marker :: Copy,
+                    :: std :: clone :: Clone,
+                    :: std :: default :: Default,
+                    :: std :: fmt :: Debug,
+                )]
+                #[repr(transparent)]
+                pub struct HEAP_FLAGS(pub u32);
+                impl HEAP_FLAGS {
+                    pub const HEAP_NONE: Self = Self(0u32);
+                    pub const HEAP_NO_SERIALIZE: Self = Self(1u32);
+                    pub const HEAP_GROWABLE: Self = Self(2u32);
+                    pub const HEAP_GENERATE_EXCEPTIONS: Self = Self(4u32);
+                    pub const HEAP_ZERO_MEMORY: Self = Self(8u32);
+                    pub const HEAP_REALLOC_IN_PLACE_ONLY: Self = Self(16u32);
+                    pub const HEAP_TAIL_CHECKING_ENABLED: Self = Self(32u32);
+                    pub const HEAP_FREE_CHECKING_ENABLED: Self = Self(64u32);
+                    pub const HEAP_DISABLE_COALESCE_ON_FREE: Self = Self(128u32);
+                    pub const HEAP_CREATE_ALIGN_16: Self = Self(65536u32);
+                    pub const HEAP_CREATE_ENABLE_TRACING: Self = Self(131072u32);
+                    pub const HEAP_CREATE_ENABLE_EXECUTE: Self = Self(262144u32);
+                    pub const HEAP_MAXIMUM_TAG: Self = Self(4095u32);
+                    pub const HEAP_PSEUDO_TAG_FLAG: Self = Self(32768u32);
+                    pub const HEAP_TAG_SHIFT: Self = Self(18u32);
+                    pub const HEAP_CREATE_SEGMENT_HEAP: Self = Self(256u32);
+                    pub const HEAP_CREATE_HARDENED: Self = Self(512u32);
+                }
+                impl ::std::convert::From<u32> for HEAP_FLAGS {
+                    fn from(value: u32) -> Self {
+                        Self(value)
+                    }
+                }
+                unsafe impl ::windows::Abi for HEAP_FLAGS {
+                    type Abi = Self;
+                }
+                impl ::std::ops::BitOr for HEAP_FLAGS {
+                    type Output = Self;
+                    fn bitor(self, rhs: Self) -> Self {
+                        Self(self.0 | rhs.0)
+                    }
+                }
+                impl ::std::ops::BitAnd for HEAP_FLAGS {
+                    type Output = Self;
+                    fn bitand(self, rhs: Self) -> Self {
+                        Self(self.0 & rhs.0)
+                    }
+                }
+                impl ::std::ops::BitOrAssign for HEAP_FLAGS {
+                    fn bitor_assign(&mut self, rhs: Self) {
+                        self.0.bitor_assign(rhs.0)
+                    }
+                }
+                impl ::std::ops::BitAndAssign for HEAP_FLAGS {
+                    fn bitand_assign(&mut self, rhs: Self) {
+                        self.0.bitand_assign(rhs.0)
+                    }
+                }
+                pub unsafe fn HeapAlloc<'a>(
+                    hheap: impl ::windows::IntoParam<'a, HeapHandle>,
+                    dwflags: HEAP_FLAGS,
+                    dwbytes: usize,
+                ) -> *mut ::std::ffi::c_void {
+                    #[link(name = "KERNEL32")]
+                    extern "system" {
+                        pub fn HeapAlloc(
+                            hheap: HeapHandle,
+                            dwflags: HEAP_FLAGS,
+                            dwbytes: usize,
+                        ) -> *mut ::std::ffi::c_void;
+                    }
+                    HeapAlloc(
+                        hheap.into_param().abi(),
+                        ::std::mem::transmute(dwflags),
+                        ::std::mem::transmute(dwbytes),
+                    )
+                }
+                pub unsafe fn HeapFree<'a>(
+                    hheap: impl ::windows::IntoParam<'a, HeapHandle>,
+                    dwflags: HEAP_FLAGS,
+                    lpmem: *mut ::std::ffi::c_void,
+                ) -> super::SystemServices::BOOL {
+                    #[link(name = "KERNEL32")]
+                    extern "system" {
+                        pub fn HeapFree(
+                            hheap: HeapHandle,
+                            dwflags: HEAP_FLAGS,
+                            lpmem: *mut ::std::ffi::c_void,
+                        ) -> super::SystemServices::BOOL;
+                    }
+                    HeapFree(
+                        hheap.into_param().abi(),
+                        ::std::mem::transmute(dwflags),
+                        ::std::mem::transmute(lpmem),
+                    )
                 }
             }
-            impl ::std::default::Default for PSTR {
-                fn default() -> Self {
-                    Self(::std::ptr::null_mut())
+            #[allow(
+                unused_variables,
+                non_upper_case_globals,
+                non_snake_case,
+                unused_unsafe,
+                non_camel_case_types,
+                dead_code,
+                clippy::all
+            )]
+            pub mod OleAutomation {
+                pub unsafe fn SysFreeString<'a>(bstrstring: impl ::windows::IntoParam<'a, BSTR>) {
+                    #[link(name = "OLEAUT32")]
+                    extern "system" {
+                        pub fn SysFreeString(bstrstring: BSTR_abi);
+                    }
+                    SysFreeString(bstrstring.into_param().abi())
                 }
-            }
-            impl ::std::cmp::PartialEq for PSTR {
-                fn eq(&self, other: &Self) -> bool {
-                    self.0 == other.0
+                pub unsafe fn SysAllocStringLen<'a>(
+                    strin: impl ::windows::IntoParam<'a, super::SystemServices::PWSTR>,
+                    ui: u32,
+                ) -> BSTR {
+                    #[link(name = "OLEAUT32")]
+                    extern "system" {
+                        pub fn SysAllocStringLen(
+                            strin: super::SystemServices::PWSTR,
+                            ui: u32,
+                        ) -> BSTR;
+                    }
+                    SysAllocStringLen(strin.into_param().abi(), ::std::mem::transmute(ui))
                 }
-            }
-            unsafe impl ::windows::Abi for PSTR {
-                type Abi = Self;
-                fn drop_param(param: &mut ::windows::Param<Self>) {
-                    if let ::windows::Param::Boxed(value) = param {
-                        if !value.0.is_null() {
+                pub unsafe fn SysStringLen<'a>(pbstr: impl ::windows::IntoParam<'a, BSTR>) -> u32 {
+                    #[link(name = "OLEAUT32")]
+                    extern "system" {
+                        pub fn SysStringLen(pbstr: BSTR_abi) -> u32;
+                    }
+                    SysStringLen(pbstr.into_param().abi())
+                }
+                #[repr(transparent)]
+                #[derive(:: std :: cmp :: Eq)]
+                pub struct BSTR(*mut u16);
+                impl BSTR {
+                    pub fn is_empty(&self) -> bool {
+                        self.0.is_null()
+                    }
+                    fn from_wide(value: &[u16]) -> Self {
+                        if value.len() == 0 {
+                            return Self(::std::ptr::null_mut());
+                        }
+                        unsafe {
+                            SysAllocStringLen(
+                                super::SystemServices::PWSTR(value.as_ptr() as _),
+                                value.len() as u32,
+                            )
+                        }
+                    }
+                    fn as_wide(&self) -> &[u16] {
+                        if self.0.is_null() {
+                            return &[];
+                        }
+                        unsafe {
+                            ::std::slice::from_raw_parts(
+                                self.0 as *const u16,
+                                SysStringLen(self) as usize,
+                            )
+                        }
+                    }
+                }
+                impl ::std::clone::Clone for BSTR {
+                    fn clone(&self) -> Self {
+                        Self::from_wide(self.as_wide())
+                    }
+                }
+                impl ::std::convert::From<&str> for BSTR {
+                    fn from(value: &str) -> Self {
+                        let value: ::std::vec::Vec<u16> = value.encode_utf16().collect();
+                        Self::from_wide(&value)
+                    }
+                }
+                impl ::std::convert::From<::std::string::String> for BSTR {
+                    fn from(value: ::std::string::String) -> Self {
+                        value.as_str().into()
+                    }
+                }
+                impl ::std::convert::From<&::std::string::String> for BSTR {
+                    fn from(value: &::std::string::String) -> Self {
+                        value.as_str().into()
+                    }
+                }
+                impl<'a> ::std::convert::TryFrom<&'a BSTR> for ::std::string::String {
+                    type Error = ::std::string::FromUtf16Error;
+                    fn try_from(value: &BSTR) -> ::std::result::Result<Self, Self::Error> {
+                        ::std::string::String::from_utf16(value.as_wide())
+                    }
+                }
+                impl ::std::convert::TryFrom<BSTR> for ::std::string::String {
+                    type Error = ::std::string::FromUtf16Error;
+                    fn try_from(value: BSTR) -> ::std::result::Result<Self, Self::Error> {
+                        ::std::string::String::try_from(&value)
+                    }
+                }
+                impl ::std::default::Default for BSTR {
+                    fn default() -> Self {
+                        Self(::std::ptr::null_mut())
+                    }
+                }
+                impl ::std::fmt::Display for BSTR {
+                    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                        use std::fmt::Write;
+                        for c in ::std::char::decode_utf16(self.as_wide().iter().cloned()) {
+                            f.write_char(c.map_err(|_| ::std::fmt::Error)?)?
+                        }
+                        Ok(())
+                    }
+                }
+                impl ::std::fmt::Debug for BSTR {
+                    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                        ::std::write!(f, "{}", self)
+                    }
+                }
+                impl ::std::cmp::PartialEq for BSTR {
+                    fn eq(&self, other: &Self) -> bool {
+                        self.as_wide() == other.as_wide()
+                    }
+                }
+                impl ::std::cmp::PartialEq<::std::string::String> for BSTR {
+                    fn eq(&self, other: &::std::string::String) -> bool {
+                        self == other.as_str()
+                    }
+                }
+                impl ::std::cmp::PartialEq<str> for BSTR {
+                    fn eq(&self, other: &str) -> bool {
+                        self == other
+                    }
+                }
+                impl ::std::cmp::PartialEq<&str> for BSTR {
+                    fn eq(&self, other: &&str) -> bool {
+                        self.as_wide().iter().copied().eq(other.encode_utf16())
+                    }
+                }
+                impl ::std::cmp::PartialEq<BSTR> for &str {
+                    fn eq(&self, other: &BSTR) -> bool {
+                        other == self
+                    }
+                }
+                impl ::std::ops::Drop for BSTR {
+                    fn drop(&mut self) {
+                        if !self.0.is_null() {
                             unsafe {
-                                ::std::boxed::Box::from_raw(value.0);
+                                SysFreeString(self as &Self);
                             }
                         }
                     }
                 }
-            }
-            impl<'a> ::windows::IntoParam<'a, PSTR> for &'a str {
-                fn into_param(self) -> ::windows::Param<'a, PSTR> {
-                    ::windows::Param::Boxed(PSTR(::std::boxed::Box::<[u8]>::into_raw(
-                        self.bytes()
-                            .chain(::std::iter::once(0))
-                            .collect::<std::vec::Vec<u8>>()
-                            .into_boxed_slice(),
-                    ) as _))
+                unsafe impl ::windows::Abi for BSTR {
+                    type Abi = *mut u16;
+                    fn set_abi(&mut self) -> *mut *mut u16 {
+                        debug_assert!(self.0.is_null());
+                        &mut self.0 as *mut _ as _
+                    }
                 }
-            }
-            impl<'a> ::windows::IntoParam<'a, PSTR> for String {
-                fn into_param(self) -> ::windows::Param<'a, PSTR> {
-                    ::windows::Param::Boxed(PSTR(::std::boxed::Box::<[u8]>::into_raw(
-                        self.bytes()
-                            .chain(::std::iter::once(0))
-                            .collect::<std::vec::Vec<u8>>()
-                            .into_boxed_slice(),
-                    ) as _))
+                pub type BSTR_abi = *mut u16;
+                #[repr(transparent)]
+                #[derive(
+                    :: std :: cmp :: PartialEq,
+                    :: std :: cmp :: Eq,
+                    :: std :: clone :: Clone,
+                    :: std :: fmt :: Debug,
+                )]
+                pub struct IErrorInfo(::windows::IUnknown);
+                impl IErrorInfo {
+                    pub unsafe fn GetGUID(
+                        &self,
+                        pguid: *mut ::windows::Guid,
+                    ) -> ::windows::HRESULT {
+                        (::windows::Interface::vtable(self).3)(
+                            ::windows::Abi::abi(self),
+                            ::std::mem::transmute(pguid),
+                        )
+                    }
+                    pub unsafe fn GetSource(&self, pbstrsource: *mut BSTR) -> ::windows::HRESULT {
+                        (::windows::Interface::vtable(self).4)(
+                            ::windows::Abi::abi(self),
+                            ::std::mem::transmute(pbstrsource),
+                        )
+                    }
+                    pub unsafe fn GetDescription(
+                        &self,
+                        pbstrdescription: *mut BSTR,
+                    ) -> ::windows::HRESULT {
+                        (::windows::Interface::vtable(self).5)(
+                            ::windows::Abi::abi(self),
+                            ::std::mem::transmute(pbstrdescription),
+                        )
+                    }
+                    pub unsafe fn GetHelpFile(
+                        &self,
+                        pbstrhelpfile: *mut BSTR,
+                    ) -> ::windows::HRESULT {
+                        (::windows::Interface::vtable(self).6)(
+                            ::windows::Abi::abi(self),
+                            ::std::mem::transmute(pbstrhelpfile),
+                        )
+                    }
+                    pub unsafe fn GetHelpContext(
+                        &self,
+                        pdwhelpcontext: *mut u32,
+                    ) -> ::windows::HRESULT {
+                        (::windows::Interface::vtable(self).7)(
+                            ::windows::Abi::abi(self),
+                            ::std::mem::transmute(pdwhelpcontext),
+                        )
+                    }
                 }
-            }
-            pub unsafe fn CreateEventA<'a>(
-                lpeventattributes: *mut SECURITY_ATTRIBUTES,
-                bmanualreset: impl ::windows::IntoParam<'a, BOOL>,
-                binitialstate: impl ::windows::IntoParam<'a, BOOL>,
-                lpname: impl ::windows::IntoParam<'a, PSTR>,
-            ) -> HANDLE {
-                #[link(name = "KERNEL32")]
-                extern "system" {
-                    pub fn CreateEventA(
-                        lpeventattributes: *mut SECURITY_ATTRIBUTES,
-                        bmanualreset: BOOL,
-                        binitialstate: BOOL,
-                        lpname: PSTR,
-                    ) -> HANDLE;
+                unsafe impl ::windows::Interface for IErrorInfo {
+                    type Vtable = IErrorInfo_abi;
+                    const IID: ::windows::Guid = ::windows::Guid::from_values(
+                        485667104,
+                        21629,
+                        4123,
+                        [142, 101, 8, 0, 43, 43, 209, 25],
+                    );
                 }
-                CreateEventA(
-                    ::std::mem::transmute(lpeventattributes),
-                    bmanualreset.into_param().abi(),
-                    binitialstate.into_param().abi(),
-                    lpname.into_param().abi(),
-                )
-            }
-            pub const E_POINTER: ::windows::HRESULT = ::windows::HRESULT(-2147467261i32 as _);
-            pub unsafe fn FreeLibrary(hlibmodule: isize) -> BOOL {
-                #[link(name = "KERNEL32")]
-                extern "system" {
-                    pub fn FreeLibrary(hlibmodule: isize) -> BOOL;
+                impl ::std::convert::From<IErrorInfo> for ::windows::IUnknown {
+                    fn from(value: IErrorInfo) -> Self {
+                        unsafe { ::std::mem::transmute(value) }
+                    }
                 }
-                FreeLibrary(::std::mem::transmute(hlibmodule))
-            }
-            pub type FARPROC = unsafe extern "system" fn() -> isize;
-            pub unsafe fn GetProcAddress<'a>(
-                hmodule: isize,
-                lpprocname: impl ::windows::IntoParam<'a, PSTR>,
-            ) -> ::std::option::Option<FARPROC> {
-                #[link(name = "KERNEL32")]
-                extern "system" {
-                    pub fn GetProcAddress(
-                        hmodule: isize,
-                        lpprocname: PSTR,
-                    ) -> ::std::option::Option<FARPROC>;
+                impl ::std::convert::From<&IErrorInfo> for ::windows::IUnknown {
+                    fn from(value: &IErrorInfo) -> Self {
+                        ::std::convert::From::from(::std::clone::Clone::clone(value))
+                    }
                 }
-                GetProcAddress(
-                    ::std::mem::transmute(hmodule),
-                    lpprocname.into_param().abi(),
-                )
-            }
-            #[repr(transparent)]
-            #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
-            pub struct HeapHandle(pub isize);
-            impl HeapHandle {}
-            impl ::std::default::Default for HeapHandle {
-                fn default() -> Self {
-                    Self(0)
+                impl<'a> ::windows::IntoParam<'a, ::windows::IUnknown> for IErrorInfo {
+                    fn into_param(self) -> ::windows::Param<'a, ::windows::IUnknown> {
+                        ::windows::Param::Owned(::std::convert::Into::<::windows::IUnknown>::into(
+                            self,
+                        ))
+                    }
                 }
-            }
-            impl HeapHandle {
-                pub const NULL: Self = Self(0);
-                pub fn is_null(&self) -> bool {
-                    self.0 == 0
-                }
-            }
-            impl ::std::fmt::Debug for HeapHandle {
-                fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                    fmt.debug_struct("HeapHandle")
-                        .field("Value", &format_args!("{:?}", self.0))
-                        .finish()
-                }
-            }
-            impl ::std::cmp::PartialEq for HeapHandle {
-                fn eq(&self, other: &Self) -> bool {
-                    self.0 == other.0
-                }
-            }
-            impl ::std::cmp::Eq for HeapHandle {}
-            unsafe impl ::windows::Abi for HeapHandle {
-                type Abi = Self;
-            }
-            #[repr(transparent)]
-            #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
-            pub struct ProcessHeapHandle(pub isize);
-            impl ProcessHeapHandle {}
-            impl ::std::default::Default for ProcessHeapHandle {
-                fn default() -> Self {
-                    Self(0)
-                }
-            }
-            impl ProcessHeapHandle {
-                pub const NULL: Self = Self(0);
-                pub fn is_null(&self) -> bool {
-                    self.0 == 0
-                }
-            }
-            impl ::std::fmt::Debug for ProcessHeapHandle {
-                fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                    fmt.debug_struct("ProcessHeapHandle")
-                        .field("Value", &format_args!("{:?}", self.0))
-                        .finish()
-                }
-            }
-            impl ::std::cmp::PartialEq for ProcessHeapHandle {
-                fn eq(&self, other: &Self) -> bool {
-                    self.0 == other.0
-                }
-            }
-            impl ::std::cmp::Eq for ProcessHeapHandle {}
-            unsafe impl ::windows::Abi for ProcessHeapHandle {
-                type Abi = Self;
-            }
-            impl<'a> ::windows::IntoParam<'a, HeapHandle> for ProcessHeapHandle {
-                fn into_param(self) -> ::windows::Param<'a, HeapHandle> {
-                    ::windows::Param::Owned(HeapHandle(self.0))
-                }
-            }
-            pub unsafe fn GetProcessHeap() -> ProcessHeapHandle {
-                #[link(name = "KERNEL32")]
-                extern "system" {
-                    pub fn GetProcessHeap() -> ProcessHeapHandle;
-                }
-                GetProcessHeap()
-            }
-            #[derive(
-                :: std :: cmp :: PartialEq,
-                :: std :: cmp :: Eq,
-                :: std :: marker :: Copy,
-                :: std :: clone :: Clone,
-                :: std :: default :: Default,
-                :: std :: fmt :: Debug,
-            )]
-            #[repr(transparent)]
-            pub struct HEAP_FLAGS(pub u32);
-            impl HEAP_FLAGS {
-                pub const HEAP_NONE: Self = Self(0u32);
-                pub const HEAP_NO_SERIALIZE: Self = Self(1u32);
-                pub const HEAP_GROWABLE: Self = Self(2u32);
-                pub const HEAP_GENERATE_EXCEPTIONS: Self = Self(4u32);
-                pub const HEAP_ZERO_MEMORY: Self = Self(8u32);
-                pub const HEAP_REALLOC_IN_PLACE_ONLY: Self = Self(16u32);
-                pub const HEAP_TAIL_CHECKING_ENABLED: Self = Self(32u32);
-                pub const HEAP_FREE_CHECKING_ENABLED: Self = Self(64u32);
-                pub const HEAP_DISABLE_COALESCE_ON_FREE: Self = Self(128u32);
-                pub const HEAP_CREATE_ALIGN_16: Self = Self(65536u32);
-                pub const HEAP_CREATE_ENABLE_TRACING: Self = Self(131072u32);
-                pub const HEAP_CREATE_ENABLE_EXECUTE: Self = Self(262144u32);
-                pub const HEAP_MAXIMUM_TAG: Self = Self(4095u32);
-                pub const HEAP_PSEUDO_TAG_FLAG: Self = Self(32768u32);
-                pub const HEAP_TAG_SHIFT: Self = Self(18u32);
-                pub const HEAP_CREATE_SEGMENT_HEAP: Self = Self(256u32);
-                pub const HEAP_CREATE_HARDENED: Self = Self(512u32);
-            }
-            impl ::std::convert::From<u32> for HEAP_FLAGS {
-                fn from(value: u32) -> Self {
-                    Self(value)
-                }
-            }
-            unsafe impl ::windows::Abi for HEAP_FLAGS {
-                type Abi = Self;
-            }
-            impl ::std::ops::BitOr for HEAP_FLAGS {
-                type Output = Self;
-                fn bitor(self, rhs: Self) -> Self {
-                    Self(self.0 | rhs.0)
-                }
-            }
-            impl ::std::ops::BitAnd for HEAP_FLAGS {
-                type Output = Self;
-                fn bitand(self, rhs: Self) -> Self {
-                    Self(self.0 & rhs.0)
-                }
-            }
-            impl ::std::ops::BitOrAssign for HEAP_FLAGS {
-                fn bitor_assign(&mut self, rhs: Self) {
-                    self.0.bitor_assign(rhs.0)
-                }
-            }
-            impl ::std::ops::BitAndAssign for HEAP_FLAGS {
-                fn bitand_assign(&mut self, rhs: Self) {
-                    self.0.bitand_assign(rhs.0)
-                }
-            }
-            pub unsafe fn HeapAlloc<'a>(
-                hheap: impl ::windows::IntoParam<'a, HeapHandle>,
-                dwflags: HEAP_FLAGS,
-                dwbytes: usize,
-            ) -> *mut ::std::ffi::c_void {
-                #[link(name = "KERNEL32")]
-                extern "system" {
-                    pub fn HeapAlloc(
-                        hheap: HeapHandle,
-                        dwflags: HEAP_FLAGS,
-                        dwbytes: usize,
-                    ) -> *mut ::std::ffi::c_void;
-                }
-                HeapAlloc(
-                    hheap.into_param().abi(),
-                    ::std::mem::transmute(dwflags),
-                    ::std::mem::transmute(dwbytes),
-                )
-            }
-            pub unsafe fn HeapFree<'a>(
-                hheap: impl ::windows::IntoParam<'a, HeapHandle>,
-                dwflags: HEAP_FLAGS,
-                lpmem: *mut ::std::ffi::c_void,
-            ) -> BOOL {
-                #[link(name = "KERNEL32")]
-                extern "system" {
-                    pub fn HeapFree(
-                        hheap: HeapHandle,
-                        dwflags: HEAP_FLAGS,
-                        lpmem: *mut ::std::ffi::c_void,
-                    ) -> BOOL;
-                }
-                HeapFree(
-                    hheap.into_param().abi(),
-                    ::std::mem::transmute(dwflags),
-                    ::std::mem::transmute(lpmem),
-                )
-            }
-            pub unsafe fn LoadLibraryA<'a>(
-                lplibfilename: impl ::windows::IntoParam<'a, PSTR>,
-            ) -> isize {
-                #[link(name = "KERNEL32")]
-                extern "system" {
-                    pub fn LoadLibraryA(lplibfilename: PSTR) -> isize;
-                }
-                LoadLibraryA(lplibfilename.into_param().abi())
-            }
-            pub unsafe fn SetEvent<'a>(hevent: impl ::windows::IntoParam<'a, HANDLE>) -> BOOL {
-                #[link(name = "KERNEL32")]
-                extern "system" {
-                    pub fn SetEvent(hevent: HANDLE) -> BOOL;
-                }
-                SetEvent(hevent.into_param().abi())
-            }
-            #[derive(
-                :: std :: cmp :: PartialEq,
-                :: std :: cmp :: Eq,
-                :: std :: marker :: Copy,
-                :: std :: clone :: Clone,
-                :: std :: default :: Default,
-                :: std :: fmt :: Debug,
-            )]
-            #[repr(transparent)]
-            pub struct WAIT_RETURN_CAUSE(pub u32);
-            impl WAIT_RETURN_CAUSE {
-                pub const WAIT_OBJECT_0: Self = Self(0u32);
-                pub const WAIT_ABANDONED: Self = Self(128u32);
-                pub const WAIT_ABANDONED_0: Self = Self(128u32);
-                pub const WAIT_IO_COMPLETION: Self = Self(192u32);
-                pub const WAIT_TIMEOUT: Self = Self(258u32);
-                pub const WAIT_FAILED: Self = Self(4294967295u32);
-            }
-            impl ::std::convert::From<u32> for WAIT_RETURN_CAUSE {
-                fn from(value: u32) -> Self {
-                    Self(value)
-                }
-            }
-            unsafe impl ::windows::Abi for WAIT_RETURN_CAUSE {
-                type Abi = Self;
-            }
-            impl ::std::ops::BitOr for WAIT_RETURN_CAUSE {
-                type Output = Self;
-                fn bitor(self, rhs: Self) -> Self {
-                    Self(self.0 | rhs.0)
-                }
-            }
-            impl ::std::ops::BitAnd for WAIT_RETURN_CAUSE {
-                type Output = Self;
-                fn bitand(self, rhs: Self) -> Self {
-                    Self(self.0 & rhs.0)
-                }
-            }
-            impl ::std::ops::BitOrAssign for WAIT_RETURN_CAUSE {
-                fn bitor_assign(&mut self, rhs: Self) {
-                    self.0.bitor_assign(rhs.0)
-                }
-            }
-            impl ::std::ops::BitAndAssign for WAIT_RETURN_CAUSE {
-                fn bitand_assign(&mut self, rhs: Self) {
-                    self.0.bitand_assign(rhs.0)
-                }
-            }
-            pub unsafe fn WaitForSingleObject<'a>(
-                hhandle: impl ::windows::IntoParam<'a, HANDLE>,
-                dwmilliseconds: u32,
-            ) -> WAIT_RETURN_CAUSE {
-                #[link(name = "KERNEL32")]
-                extern "system" {
-                    pub fn WaitForSingleObject(
-                        hhandle: HANDLE,
-                        dwmilliseconds: u32,
-                    ) -> WAIT_RETURN_CAUSE;
-                }
-                WaitForSingleObject(
-                    hhandle.into_param().abi(),
-                    ::std::mem::transmute(dwmilliseconds),
-                )
-            }
-        }
-        #[allow(
-            unused_variables,
-            non_upper_case_globals,
-            non_snake_case,
-            unused_unsafe,
-            non_camel_case_types,
-            dead_code,
-            clippy::all
-        )]
-        pub mod WinRT {
-            #[repr(transparent)]
-            #[derive(
-                :: std :: cmp :: PartialEq,
-                :: std :: cmp :: Eq,
-                :: std :: clone :: Clone,
-                :: std :: fmt :: Debug,
-            )]
-            pub struct ILanguageExceptionErrorInfo(::windows::IUnknown);
-            impl ILanguageExceptionErrorInfo {
-                pub unsafe fn GetLanguageException(
-                    &self,
-                    languageexception: *mut ::std::option::Option<::windows::IUnknown>,
-                ) -> ::windows::HRESULT {
-                    (::windows::Interface::vtable(self).3)(
-                        ::windows::Abi::abi(self),
-                        ::std::mem::transmute(languageexception),
-                    )
-                }
-            }
-            unsafe impl ::windows::Interface for ILanguageExceptionErrorInfo {
-                type Vtable = ILanguageExceptionErrorInfo_abi;
-                const IID: ::windows::Guid = ::windows::Guid::from_values(
-                    77782003,
-                    57219,
-                    4460,
-                    [9, 70, 8, 18, 171, 246, 224, 125],
-                );
-            }
-            impl ::std::convert::From<ILanguageExceptionErrorInfo> for ::windows::IUnknown {
-                fn from(value: ILanguageExceptionErrorInfo) -> Self {
-                    unsafe { ::std::mem::transmute(value) }
-                }
-            }
-            impl ::std::convert::From<&ILanguageExceptionErrorInfo> for ::windows::IUnknown {
-                fn from(value: &ILanguageExceptionErrorInfo) -> Self {
-                    ::std::convert::From::from(::std::clone::Clone::clone(value))
-                }
-            }
-            impl<'a> ::windows::IntoParam<'a, ::windows::IUnknown> for ILanguageExceptionErrorInfo {
-                fn into_param(self) -> ::windows::Param<'a, ::windows::IUnknown> {
-                    ::windows::Param::Owned(::std::convert::Into::<::windows::IUnknown>::into(self))
-                }
-            }
-            impl<'a> ::windows::IntoParam<'a, ::windows::IUnknown> for &'a ILanguageExceptionErrorInfo {
-                fn into_param(self) -> ::windows::Param<'a, ::windows::IUnknown> {
-                    ::windows::Param::Owned(::std::convert::Into::<::windows::IUnknown>::into(
-                        ::std::clone::Clone::clone(self),
-                    ))
-                }
-            }
-            #[repr(C)]
-            #[doc(hidden)]
-            pub struct ILanguageExceptionErrorInfo_abi(
-                pub  unsafe extern "system" fn(
-                    this: ::windows::RawPtr,
-                    iid: &::windows::Guid,
-                    interface: *mut ::windows::RawPtr,
-                ) -> ::windows::HRESULT,
-                pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
-                pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
-                pub  unsafe extern "system" fn(
-                    this: ::windows::RawPtr,
-                    languageexception: *mut ::windows::RawPtr,
-                ) -> ::windows::HRESULT,
-            );
-            #[repr(transparent)]
-            #[derive(
-                :: std :: cmp :: PartialEq,
-                :: std :: cmp :: Eq,
-                :: std :: clone :: Clone,
-                :: std :: fmt :: Debug,
-            )]
-            pub struct ILanguageExceptionErrorInfo2(::windows::IUnknown);
-            impl ILanguageExceptionErrorInfo2 {
-                pub unsafe fn GetLanguageException(
-                    &self,
-                    languageexception: *mut ::std::option::Option<::windows::IUnknown>,
-                ) -> ::windows::HRESULT {
-                    (::windows::Interface::vtable(self).3)(
-                        ::windows::Abi::abi(self),
-                        ::std::mem::transmute(languageexception),
-                    )
-                }
-                pub unsafe fn GetPreviousLanguageExceptionErrorInfo(
-                    &self,
-                    previouslanguageexceptionerrorinfo: *mut ::std::option::Option<
-                        ILanguageExceptionErrorInfo2,
-                    >,
-                ) -> ::windows::HRESULT {
-                    (::windows::Interface::vtable(self).4)(
-                        ::windows::Abi::abi(self),
-                        ::std::mem::transmute(previouslanguageexceptionerrorinfo),
-                    )
-                }
-                pub unsafe fn CapturePropagationContext<'a>(
-                    &self,
-                    languageexception: impl ::windows::IntoParam<'a, ::windows::IUnknown>,
-                ) -> ::windows::HRESULT {
-                    (::windows::Interface::vtable(self).5)(
-                        ::windows::Abi::abi(self),
-                        languageexception.into_param().abi(),
-                    )
-                }
-                pub unsafe fn GetPropagationContextHead(
-                    &self,
-                    propagatedlanguageexceptionerrorinfohead: *mut ::std::option::Option<
-                        ILanguageExceptionErrorInfo2,
-                    >,
-                ) -> ::windows::HRESULT {
-                    (::windows::Interface::vtable(self).6)(
-                        ::windows::Abi::abi(self),
-                        ::std::mem::transmute(propagatedlanguageexceptionerrorinfohead),
-                    )
-                }
-            }
-            unsafe impl ::windows::Interface for ILanguageExceptionErrorInfo2 {
-                type Vtable = ILanguageExceptionErrorInfo2_abi;
-                const IID: ::windows::Guid = ::windows::Guid::from_values(
-                    1464264132,
-                    23447,
-                    16972,
-                    [182, 32, 40, 34, 145, 87, 52, 221],
-                );
-            }
-            impl ::std::convert::From<ILanguageExceptionErrorInfo2> for ::windows::IUnknown {
-                fn from(value: ILanguageExceptionErrorInfo2) -> Self {
-                    unsafe { ::std::mem::transmute(value) }
-                }
-            }
-            impl ::std::convert::From<&ILanguageExceptionErrorInfo2> for ::windows::IUnknown {
-                fn from(value: &ILanguageExceptionErrorInfo2) -> Self {
-                    ::std::convert::From::from(::std::clone::Clone::clone(value))
-                }
-            }
-            impl<'a> ::windows::IntoParam<'a, ::windows::IUnknown> for ILanguageExceptionErrorInfo2 {
-                fn into_param(self) -> ::windows::Param<'a, ::windows::IUnknown> {
-                    ::windows::Param::Owned(::std::convert::Into::<::windows::IUnknown>::into(self))
-                }
-            }
-            impl<'a> ::windows::IntoParam<'a, ::windows::IUnknown> for &'a ILanguageExceptionErrorInfo2 {
-                fn into_param(self) -> ::windows::Param<'a, ::windows::IUnknown> {
-                    ::windows::Param::Owned(::std::convert::Into::<::windows::IUnknown>::into(
-                        ::std::clone::Clone::clone(self),
-                    ))
-                }
-            }
-            impl ::std::convert::From<ILanguageExceptionErrorInfo2> for ILanguageExceptionErrorInfo {
-                fn from(value: ILanguageExceptionErrorInfo2) -> Self {
-                    unsafe { ::std::mem::transmute(value) }
-                }
-            }
-            impl ::std::convert::From<&ILanguageExceptionErrorInfo2> for ILanguageExceptionErrorInfo {
-                fn from(value: &ILanguageExceptionErrorInfo2) -> Self {
-                    ::std::convert::From::from(::std::clone::Clone::clone(value))
-                }
-            }
-            impl<'a> ::windows::IntoParam<'a, ILanguageExceptionErrorInfo> for ILanguageExceptionErrorInfo2 {
-                fn into_param(self) -> ::windows::Param<'a, ILanguageExceptionErrorInfo> {
-                    ::windows::Param::Owned(
-                        ::std::convert::Into::<ILanguageExceptionErrorInfo>::into(self),
-                    )
-                }
-            }
-            impl<'a> ::windows::IntoParam<'a, ILanguageExceptionErrorInfo>
-                for &'a ILanguageExceptionErrorInfo2
-            {
-                fn into_param(self) -> ::windows::Param<'a, ILanguageExceptionErrorInfo> {
-                    ::windows::Param::Owned(
-                        ::std::convert::Into::<ILanguageExceptionErrorInfo>::into(
+                impl<'a> ::windows::IntoParam<'a, ::windows::IUnknown> for &'a IErrorInfo {
+                    fn into_param(self) -> ::windows::Param<'a, ::windows::IUnknown> {
+                        ::windows::Param::Owned(::std::convert::Into::<::windows::IUnknown>::into(
                             ::std::clone::Clone::clone(self),
-                        ),
+                        ))
+                    }
+                }
+                #[repr(C)]
+                #[doc(hidden)]
+                pub struct IErrorInfo_abi(
+                    pub  unsafe extern "system" fn(
+                        this: ::windows::RawPtr,
+                        iid: &::windows::Guid,
+                        interface: *mut ::windows::RawPtr,
+                    ) -> ::windows::HRESULT,
+                    pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
+                    pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
+                    pub  unsafe extern "system" fn(
+                        this: ::windows::RawPtr,
+                        pguid: *mut ::windows::Guid,
+                    ) -> ::windows::HRESULT,
+                    pub  unsafe extern "system" fn(
+                        this: ::windows::RawPtr,
+                        pbstrsource: *mut BSTR_abi,
+                    ) -> ::windows::HRESULT,
+                    pub  unsafe extern "system" fn(
+                        this: ::windows::RawPtr,
+                        pbstrdescription: *mut BSTR_abi,
+                    ) -> ::windows::HRESULT,
+                    pub  unsafe extern "system" fn(
+                        this: ::windows::RawPtr,
+                        pbstrhelpfile: *mut BSTR_abi,
+                    ) -> ::windows::HRESULT,
+                    pub  unsafe extern "system" fn(
+                        this: ::windows::RawPtr,
+                        pdwhelpcontext: *mut u32,
+                    ) -> ::windows::HRESULT,
+                );
+                pub unsafe fn GetErrorInfo(
+                    dwreserved: u32,
+                    pperrinfo: *mut ::std::option::Option<IErrorInfo>,
+                ) -> ::windows::HRESULT {
+                    #[link(name = "OLEAUT32")]
+                    extern "system" {
+                        pub fn GetErrorInfo(
+                            dwreserved: u32,
+                            pperrinfo: *mut ::windows::RawPtr,
+                        ) -> ::windows::HRESULT;
+                    }
+                    GetErrorInfo(
+                        ::std::mem::transmute(dwreserved),
+                        ::std::mem::transmute(pperrinfo),
+                    )
+                }
+                pub unsafe fn SetErrorInfo<'a>(
+                    dwreserved: u32,
+                    perrinfo: impl ::windows::IntoParam<'a, IErrorInfo>,
+                ) -> ::windows::HRESULT {
+                    #[link(name = "OLEAUT32")]
+                    extern "system" {
+                        pub fn SetErrorInfo(
+                            dwreserved: u32,
+                            perrinfo: ::windows::RawPtr,
+                        ) -> ::windows::HRESULT;
+                    }
+                    SetErrorInfo(
+                        ::std::mem::transmute(dwreserved),
+                        perrinfo.into_param().abi(),
                     )
                 }
             }
-            #[repr(C)]
-            #[doc(hidden)]
-            pub struct ILanguageExceptionErrorInfo2_abi(
-                pub  unsafe extern "system" fn(
-                    this: ::windows::RawPtr,
-                    iid: &::windows::Guid,
-                    interface: *mut ::windows::RawPtr,
-                ) -> ::windows::HRESULT,
-                pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
-                pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
-                pub  unsafe extern "system" fn(
-                    this: ::windows::RawPtr,
-                    languageexception: *mut ::windows::RawPtr,
-                ) -> ::windows::HRESULT,
-                pub  unsafe extern "system" fn(
-                    this: ::windows::RawPtr,
-                    previouslanguageexceptionerrorinfo: *mut ::windows::RawPtr,
-                ) -> ::windows::HRESULT,
-                pub  unsafe extern "system" fn(
-                    this: ::windows::RawPtr,
-                    languageexception: ::windows::RawPtr,
-                ) -> ::windows::HRESULT,
-                pub  unsafe extern "system" fn(
-                    this: ::windows::RawPtr,
-                    propagatedlanguageexceptionerrorinfohead: *mut ::windows::RawPtr,
-                ) -> ::windows::HRESULT,
-            );
-            #[repr(transparent)]
-            #[derive(
-                :: std :: cmp :: PartialEq,
-                :: std :: cmp :: Eq,
-                :: std :: clone :: Clone,
-                :: std :: fmt :: Debug,
+            #[allow(
+                unused_variables,
+                non_upper_case_globals,
+                non_snake_case,
+                unused_unsafe,
+                non_camel_case_types,
+                dead_code,
+                clippy::all
             )]
-            pub struct IRestrictedErrorInfo(::windows::IUnknown);
-            impl IRestrictedErrorInfo {
-                pub unsafe fn GetErrorDetails(
-                    &self,
-                    description: *mut super::Automation::BSTR,
-                    error: *mut ::windows::HRESULT,
-                    restricteddescription: *mut super::Automation::BSTR,
-                    capabilitysid: *mut super::Automation::BSTR,
-                ) -> ::windows::HRESULT {
-                    (::windows::Interface::vtable(self).3)(
-                        ::windows::Abi::abi(self),
-                        ::std::mem::transmute(description),
-                        ::std::mem::transmute(error),
-                        ::std::mem::transmute(restricteddescription),
-                        ::std::mem::transmute(capabilitysid),
+            pub mod SystemServices {
+                #[repr(transparent)]
+                #[derive(
+                    :: std :: clone :: Clone,
+                    :: std :: marker :: Copy,
+                    :: std :: cmp :: Eq,
+                    :: std :: fmt :: Debug,
+                )]
+                pub struct PWSTR(pub *mut u16);
+                impl PWSTR {
+                    pub const NULL: Self = Self(::std::ptr::null_mut());
+                    pub fn is_null(&self) -> bool {
+                        self.0.is_null()
+                    }
+                }
+                impl ::std::default::Default for PWSTR {
+                    fn default() -> Self {
+                        Self(::std::ptr::null_mut())
+                    }
+                }
+                impl ::std::cmp::PartialEq for PWSTR {
+                    fn eq(&self, other: &Self) -> bool {
+                        self.0 == other.0
+                    }
+                }
+                unsafe impl ::windows::Abi for PWSTR {
+                    type Abi = Self;
+                    fn drop_param(param: &mut ::windows::Param<Self>) {
+                        if let ::windows::Param::Boxed(value) = param {
+                            if !value.0.is_null() {
+                                unsafe {
+                                    ::std::boxed::Box::from_raw(value.0);
+                                }
+                            }
+                        }
+                    }
+                }
+                impl<'a> ::windows::IntoParam<'a, PWSTR> for &'a str {
+                    fn into_param(self) -> ::windows::Param<'a, PWSTR> {
+                        ::windows::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(
+                            self.encode_utf16()
+                                .chain(::std::iter::once(0))
+                                .collect::<std::vec::Vec<u16>>()
+                                .into_boxed_slice(),
+                        ) as _))
+                    }
+                }
+                impl<'a> ::windows::IntoParam<'a, PWSTR> for String {
+                    fn into_param(self) -> ::windows::Param<'a, PWSTR> {
+                        ::windows::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(
+                            self.encode_utf16()
+                                .chain(::std::iter::once(0))
+                                .collect::<std::vec::Vec<u16>>()
+                                .into_boxed_slice(),
+                        ) as _))
+                    }
+                }
+                #[repr(transparent)]
+                #[derive(
+                    :: std :: default :: Default,
+                    :: std :: clone :: Clone,
+                    :: std :: marker :: Copy,
+                    :: std :: cmp :: PartialEq,
+                    :: std :: cmp :: Eq,
+                    :: std :: fmt :: Debug,
+                )]
+                pub struct BOOL(pub i32);
+                unsafe impl ::windows::Abi for BOOL {
+                    type Abi = Self;
+                }
+                impl BOOL {
+                    #[inline]
+                    pub fn as_bool(self) -> bool {
+                        !(self.0 == 0)
+                    }
+                    #[inline]
+                    pub fn ok(self) -> ::windows::Result<()> {
+                        if self.as_bool() {
+                            Ok(())
+                        } else {
+                            Err(::windows::HRESULT::from_thread().into())
+                        }
+                    }
+                    #[inline]
+                    pub fn unwrap(self) {
+                        self.ok().unwrap();
+                    }
+                    #[inline]
+                    pub fn expect(self, msg: &str) {
+                        self.ok().expect(msg);
+                    }
+                }
+                impl ::std::convert::From<BOOL> for bool {
+                    fn from(value: BOOL) -> Self {
+                        value.as_bool()
+                    }
+                }
+                impl ::std::convert::From<&BOOL> for bool {
+                    fn from(value: &BOOL) -> Self {
+                        value.as_bool()
+                    }
+                }
+                impl ::std::convert::From<bool> for BOOL {
+                    fn from(value: bool) -> Self {
+                        if value {
+                            BOOL(1)
+                        } else {
+                            BOOL(0)
+                        }
+                    }
+                }
+                impl ::std::convert::From<&bool> for BOOL {
+                    fn from(value: &bool) -> Self {
+                        (*value).into()
+                    }
+                }
+                impl ::std::cmp::PartialEq<bool> for BOOL {
+                    fn eq(&self, other: &bool) -> bool {
+                        self.as_bool() == *other
+                    }
+                }
+                impl ::std::cmp::PartialEq<BOOL> for bool {
+                    fn eq(&self, other: &BOOL) -> bool {
+                        *self == other.as_bool()
+                    }
+                }
+                impl std::ops::Not for BOOL {
+                    type Output = Self;
+                    fn not(self) -> Self::Output {
+                        if self.as_bool() {
+                            BOOL(0)
+                        } else {
+                            BOOL(1)
+                        }
+                    }
+                }
+                impl<'a> ::windows::IntoParam<'a, BOOL> for bool {
+                    fn into_param(self) -> ::windows::Param<'a, BOOL> {
+                        ::windows::Param::Owned(self.into())
+                    }
+                }
+                pub const CO_E_NOTINITIALIZED: ::windows::HRESULT =
+                    ::windows::HRESULT(-2147221008i32 as _);
+                pub const E_POINTER: ::windows::HRESULT = ::windows::HRESULT(-2147467261i32 as _);
+                #[repr(transparent)]
+                #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
+                pub struct HINSTANCE(pub isize);
+                impl HINSTANCE {}
+                impl ::std::default::Default for HINSTANCE {
+                    fn default() -> Self {
+                        Self(0)
+                    }
+                }
+                impl HINSTANCE {
+                    pub const NULL: Self = Self(0);
+                    pub fn is_null(&self) -> bool {
+                        self.0 == 0
+                    }
+                }
+                impl ::std::fmt::Debug for HINSTANCE {
+                    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                        fmt.debug_struct("HINSTANCE")
+                            .field("Value", &format_args!("{:?}", self.0))
+                            .finish()
+                    }
+                }
+                impl ::std::cmp::PartialEq for HINSTANCE {
+                    fn eq(&self, other: &Self) -> bool {
+                        self.0 == other.0
+                    }
+                }
+                impl ::std::cmp::Eq for HINSTANCE {}
+                unsafe impl ::windows::Abi for HINSTANCE {
+                    type Abi = Self;
+                }
+                pub unsafe fn FreeLibrary<'a>(
+                    hlibmodule: impl ::windows::IntoParam<'a, HINSTANCE>,
+                ) -> BOOL {
+                    #[link(name = "KERNEL32")]
+                    extern "system" {
+                        pub fn FreeLibrary(hlibmodule: HINSTANCE) -> BOOL;
+                    }
+                    FreeLibrary(hlibmodule.into_param().abi())
+                }
+                pub type FARPROC = unsafe extern "system" fn() -> isize;
+                #[repr(transparent)]
+                #[derive(
+                    :: std :: clone :: Clone,
+                    :: std :: marker :: Copy,
+                    :: std :: cmp :: Eq,
+                    :: std :: fmt :: Debug,
+                )]
+                pub struct PSTR(pub *mut u8);
+                impl PSTR {
+                    pub const NULL: Self = Self(::std::ptr::null_mut());
+                    pub fn is_null(&self) -> bool {
+                        self.0.is_null()
+                    }
+                }
+                impl ::std::default::Default for PSTR {
+                    fn default() -> Self {
+                        Self(::std::ptr::null_mut())
+                    }
+                }
+                impl ::std::cmp::PartialEq for PSTR {
+                    fn eq(&self, other: &Self) -> bool {
+                        self.0 == other.0
+                    }
+                }
+                unsafe impl ::windows::Abi for PSTR {
+                    type Abi = Self;
+                    fn drop_param(param: &mut ::windows::Param<Self>) {
+                        if let ::windows::Param::Boxed(value) = param {
+                            if !value.0.is_null() {
+                                unsafe {
+                                    ::std::boxed::Box::from_raw(value.0);
+                                }
+                            }
+                        }
+                    }
+                }
+                impl<'a> ::windows::IntoParam<'a, PSTR> for &'a str {
+                    fn into_param(self) -> ::windows::Param<'a, PSTR> {
+                        ::windows::Param::Boxed(PSTR(::std::boxed::Box::<[u8]>::into_raw(
+                            self.bytes()
+                                .chain(::std::iter::once(0))
+                                .collect::<std::vec::Vec<u8>>()
+                                .into_boxed_slice(),
+                        ) as _))
+                    }
+                }
+                impl<'a> ::windows::IntoParam<'a, PSTR> for String {
+                    fn into_param(self) -> ::windows::Param<'a, PSTR> {
+                        ::windows::Param::Boxed(PSTR(::std::boxed::Box::<[u8]>::into_raw(
+                            self.bytes()
+                                .chain(::std::iter::once(0))
+                                .collect::<std::vec::Vec<u8>>()
+                                .into_boxed_slice(),
+                        ) as _))
+                    }
+                }
+                pub unsafe fn GetProcAddress<'a>(
+                    hmodule: impl ::windows::IntoParam<'a, HINSTANCE>,
+                    lpprocname: impl ::windows::IntoParam<'a, PSTR>,
+                ) -> ::std::option::Option<FARPROC> {
+                    #[link(name = "KERNEL32")]
+                    extern "system" {
+                        pub fn GetProcAddress(
+                            hmodule: HINSTANCE,
+                            lpprocname: PSTR,
+                        ) -> ::std::option::Option<FARPROC>;
+                    }
+                    GetProcAddress(hmodule.into_param().abi(), lpprocname.into_param().abi())
+                }
+                pub unsafe fn LoadLibraryA<'a>(
+                    lplibfilename: impl ::windows::IntoParam<'a, PSTR>,
+                ) -> HINSTANCE {
+                    #[link(name = "KERNEL32")]
+                    extern "system" {
+                        pub fn LoadLibraryA(lplibfilename: PSTR) -> HINSTANCE;
+                    }
+                    LoadLibraryA(lplibfilename.into_param().abi())
+                }
+                #[repr(transparent)]
+                #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
+                pub struct HANDLE(pub isize);
+                impl HANDLE {}
+                impl ::std::default::Default for HANDLE {
+                    fn default() -> Self {
+                        Self(0)
+                    }
+                }
+                impl HANDLE {
+                    pub const NULL: Self = Self(0);
+                    pub fn is_null(&self) -> bool {
+                        self.0 == 0
+                    }
+                }
+                impl ::std::fmt::Debug for HANDLE {
+                    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                        fmt.debug_struct("HANDLE")
+                            .field("Value", &format_args!("{:?}", self.0))
+                            .finish()
+                    }
+                }
+                impl ::std::cmp::PartialEq for HANDLE {
+                    fn eq(&self, other: &Self) -> bool {
+                        self.0 == other.0
+                    }
+                }
+                impl ::std::cmp::Eq for HANDLE {}
+                unsafe impl ::windows::Abi for HANDLE {
+                    type Abi = Self;
+                }
+                impl HANDLE {
+                    pub const INVALID: Self = Self(-1);
+                    pub fn is_invalid(&self) -> bool {
+                        self.0 == -1
+                    }
+                }
+                #[repr(C)]
+                #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
+                pub struct SECURITY_ATTRIBUTES {
+                    pub nLength: u32,
+                    pub lpSecurityDescriptor: *mut ::std::ffi::c_void,
+                    pub bInheritHandle: BOOL,
+                }
+                impl SECURITY_ATTRIBUTES {}
+                impl ::std::default::Default for SECURITY_ATTRIBUTES {
+                    fn default() -> Self {
+                        Self {
+                            nLength: 0,
+                            lpSecurityDescriptor: ::std::ptr::null_mut(),
+                            bInheritHandle: ::std::default::Default::default(),
+                        }
+                    }
+                }
+                impl ::std::fmt::Debug for SECURITY_ATTRIBUTES {
+                    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                        fmt.debug_struct("SECURITY_ATTRIBUTES")
+                            .field("nLength", &format_args!("{:?}", self.nLength))
+                            .field(
+                                "lpSecurityDescriptor",
+                                &format_args!("{:?}", self.lpSecurityDescriptor),
+                            )
+                            .field("bInheritHandle", &format_args!("{:?}", self.bInheritHandle))
+                            .finish()
+                    }
+                }
+                impl ::std::cmp::PartialEq for SECURITY_ATTRIBUTES {
+                    fn eq(&self, other: &Self) -> bool {
+                        self.nLength == other.nLength
+                            && self.lpSecurityDescriptor == other.lpSecurityDescriptor
+                            && self.bInheritHandle == other.bInheritHandle
+                    }
+                }
+                impl ::std::cmp::Eq for SECURITY_ATTRIBUTES {}
+                unsafe impl ::windows::Abi for SECURITY_ATTRIBUTES {
+                    type Abi = Self;
+                }
+            }
+            #[allow(
+                unused_variables,
+                non_upper_case_globals,
+                non_snake_case,
+                unused_unsafe,
+                non_camel_case_types,
+                dead_code,
+                clippy::all
+            )]
+            pub mod Threading {
+                pub unsafe fn CreateEventA<'a>(
+                    lpeventattributes: *mut super::SystemServices::SECURITY_ATTRIBUTES,
+                    bmanualreset: impl ::windows::IntoParam<'a, super::SystemServices::BOOL>,
+                    binitialstate: impl ::windows::IntoParam<'a, super::SystemServices::BOOL>,
+                    lpname: impl ::windows::IntoParam<'a, super::SystemServices::PSTR>,
+                ) -> super::SystemServices::HANDLE {
+                    #[link(name = "KERNEL32")]
+                    extern "system" {
+                        pub fn CreateEventA(
+                            lpeventattributes: *mut super::SystemServices::SECURITY_ATTRIBUTES,
+                            bmanualreset: super::SystemServices::BOOL,
+                            binitialstate: super::SystemServices::BOOL,
+                            lpname: super::SystemServices::PSTR,
+                        ) -> super::SystemServices::HANDLE;
+                    }
+                    CreateEventA(
+                        ::std::mem::transmute(lpeventattributes),
+                        bmanualreset.into_param().abi(),
+                        binitialstate.into_param().abi(),
+                        lpname.into_param().abi(),
                     )
                 }
-                pub unsafe fn GetReference(
-                    &self,
-                    reference: *mut super::Automation::BSTR,
-                ) -> ::windows::HRESULT {
-                    (::windows::Interface::vtable(self).4)(
-                        ::windows::Abi::abi(self),
-                        ::std::mem::transmute(reference),
+                pub unsafe fn SetEvent<'a>(
+                    hevent: impl ::windows::IntoParam<'a, super::SystemServices::HANDLE>,
+                ) -> super::SystemServices::BOOL {
+                    #[link(name = "KERNEL32")]
+                    extern "system" {
+                        pub fn SetEvent(
+                            hevent: super::SystemServices::HANDLE,
+                        ) -> super::SystemServices::BOOL;
+                    }
+                    SetEvent(hevent.into_param().abi())
+                }
+                #[derive(
+                    :: std :: cmp :: PartialEq,
+                    :: std :: cmp :: Eq,
+                    :: std :: marker :: Copy,
+                    :: std :: clone :: Clone,
+                    :: std :: default :: Default,
+                    :: std :: fmt :: Debug,
+                )]
+                #[repr(transparent)]
+                pub struct WAIT_RETURN_CAUSE(pub u32);
+                impl WAIT_RETURN_CAUSE {
+                    pub const WAIT_OBJECT_0: Self = Self(0u32);
+                    pub const WAIT_ABANDONED: Self = Self(128u32);
+                    pub const WAIT_ABANDONED_0: Self = Self(128u32);
+                    pub const WAIT_IO_COMPLETION: Self = Self(192u32);
+                    pub const WAIT_TIMEOUT: Self = Self(258u32);
+                    pub const WAIT_FAILED: Self = Self(4294967295u32);
+                }
+                impl ::std::convert::From<u32> for WAIT_RETURN_CAUSE {
+                    fn from(value: u32) -> Self {
+                        Self(value)
+                    }
+                }
+                unsafe impl ::windows::Abi for WAIT_RETURN_CAUSE {
+                    type Abi = Self;
+                }
+                impl ::std::ops::BitOr for WAIT_RETURN_CAUSE {
+                    type Output = Self;
+                    fn bitor(self, rhs: Self) -> Self {
+                        Self(self.0 | rhs.0)
+                    }
+                }
+                impl ::std::ops::BitAnd for WAIT_RETURN_CAUSE {
+                    type Output = Self;
+                    fn bitand(self, rhs: Self) -> Self {
+                        Self(self.0 & rhs.0)
+                    }
+                }
+                impl ::std::ops::BitOrAssign for WAIT_RETURN_CAUSE {
+                    fn bitor_assign(&mut self, rhs: Self) {
+                        self.0.bitor_assign(rhs.0)
+                    }
+                }
+                impl ::std::ops::BitAndAssign for WAIT_RETURN_CAUSE {
+                    fn bitand_assign(&mut self, rhs: Self) {
+                        self.0.bitand_assign(rhs.0)
+                    }
+                }
+                pub unsafe fn WaitForSingleObject<'a>(
+                    hhandle: impl ::windows::IntoParam<'a, super::SystemServices::HANDLE>,
+                    dwmilliseconds: u32,
+                ) -> WAIT_RETURN_CAUSE {
+                    #[link(name = "KERNEL32")]
+                    extern "system" {
+                        pub fn WaitForSingleObject(
+                            hhandle: super::SystemServices::HANDLE,
+                            dwmilliseconds: u32,
+                        ) -> WAIT_RETURN_CAUSE;
+                    }
+                    WaitForSingleObject(
+                        hhandle.into_param().abi(),
+                        ::std::mem::transmute(dwmilliseconds),
                     )
                 }
             }
-            unsafe impl ::windows::Interface for IRestrictedErrorInfo {
-                type Vtable = IRestrictedErrorInfo_abi;
-                const IID: ::windows::Guid = ::windows::Guid::from_values(
-                    2193256594,
-                    19592,
-                    17021,
-                    [167, 188, 22, 221, 147, 254, 182, 126],
+            #[allow(
+                unused_variables,
+                non_upper_case_globals,
+                non_snake_case,
+                unused_unsafe,
+                non_camel_case_types,
+                dead_code,
+                clippy::all
+            )]
+            pub mod WinRT {
+                #[repr(transparent)]
+                #[derive(
+                    :: std :: cmp :: PartialEq,
+                    :: std :: cmp :: Eq,
+                    :: std :: clone :: Clone,
+                    :: std :: fmt :: Debug,
+                )]
+                pub struct ILanguageExceptionErrorInfo(::windows::IUnknown);
+                impl ILanguageExceptionErrorInfo {
+                    pub unsafe fn GetLanguageException(
+                        &self,
+                        languageexception: *mut ::std::option::Option<::windows::IUnknown>,
+                    ) -> ::windows::HRESULT {
+                        (::windows::Interface::vtable(self).3)(
+                            ::windows::Abi::abi(self),
+                            ::std::mem::transmute(languageexception),
+                        )
+                    }
+                }
+                unsafe impl ::windows::Interface for ILanguageExceptionErrorInfo {
+                    type Vtable = ILanguageExceptionErrorInfo_abi;
+                    const IID: ::windows::Guid = ::windows::Guid::from_values(
+                        77782003,
+                        57219,
+                        4460,
+                        [9, 70, 8, 18, 171, 246, 224, 125],
+                    );
+                }
+                impl ::std::convert::From<ILanguageExceptionErrorInfo> for ::windows::IUnknown {
+                    fn from(value: ILanguageExceptionErrorInfo) -> Self {
+                        unsafe { ::std::mem::transmute(value) }
+                    }
+                }
+                impl ::std::convert::From<&ILanguageExceptionErrorInfo> for ::windows::IUnknown {
+                    fn from(value: &ILanguageExceptionErrorInfo) -> Self {
+                        ::std::convert::From::from(::std::clone::Clone::clone(value))
+                    }
+                }
+                impl<'a> ::windows::IntoParam<'a, ::windows::IUnknown> for ILanguageExceptionErrorInfo {
+                    fn into_param(self) -> ::windows::Param<'a, ::windows::IUnknown> {
+                        ::windows::Param::Owned(::std::convert::Into::<::windows::IUnknown>::into(
+                            self,
+                        ))
+                    }
+                }
+                impl<'a> ::windows::IntoParam<'a, ::windows::IUnknown> for &'a ILanguageExceptionErrorInfo {
+                    fn into_param(self) -> ::windows::Param<'a, ::windows::IUnknown> {
+                        ::windows::Param::Owned(::std::convert::Into::<::windows::IUnknown>::into(
+                            ::std::clone::Clone::clone(self),
+                        ))
+                    }
+                }
+                #[repr(C)]
+                #[doc(hidden)]
+                pub struct ILanguageExceptionErrorInfo_abi(
+                    pub  unsafe extern "system" fn(
+                        this: ::windows::RawPtr,
+                        iid: &::windows::Guid,
+                        interface: *mut ::windows::RawPtr,
+                    ) -> ::windows::HRESULT,
+                    pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
+                    pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
+                    pub  unsafe extern "system" fn(
+                        this: ::windows::RawPtr,
+                        languageexception: *mut ::windows::RawPtr,
+                    ) -> ::windows::HRESULT,
+                );
+                #[repr(transparent)]
+                #[derive(
+                    :: std :: cmp :: PartialEq,
+                    :: std :: cmp :: Eq,
+                    :: std :: clone :: Clone,
+                    :: std :: fmt :: Debug,
+                )]
+                pub struct ILanguageExceptionErrorInfo2(::windows::IUnknown);
+                impl ILanguageExceptionErrorInfo2 {
+                    pub unsafe fn GetLanguageException(
+                        &self,
+                        languageexception: *mut ::std::option::Option<::windows::IUnknown>,
+                    ) -> ::windows::HRESULT {
+                        (::windows::Interface::vtable(self).3)(
+                            ::windows::Abi::abi(self),
+                            ::std::mem::transmute(languageexception),
+                        )
+                    }
+                    pub unsafe fn GetPreviousLanguageExceptionErrorInfo(
+                        &self,
+                        previouslanguageexceptionerrorinfo: *mut ::std::option::Option<
+                            ILanguageExceptionErrorInfo2,
+                        >,
+                    ) -> ::windows::HRESULT {
+                        (::windows::Interface::vtable(self).4)(
+                            ::windows::Abi::abi(self),
+                            ::std::mem::transmute(previouslanguageexceptionerrorinfo),
+                        )
+                    }
+                    pub unsafe fn CapturePropagationContext<'a>(
+                        &self,
+                        languageexception: impl ::windows::IntoParam<'a, ::windows::IUnknown>,
+                    ) -> ::windows::HRESULT {
+                        (::windows::Interface::vtable(self).5)(
+                            ::windows::Abi::abi(self),
+                            languageexception.into_param().abi(),
+                        )
+                    }
+                    pub unsafe fn GetPropagationContextHead(
+                        &self,
+                        propagatedlanguageexceptionerrorinfohead: *mut ::std::option::Option<
+                            ILanguageExceptionErrorInfo2,
+                        >,
+                    ) -> ::windows::HRESULT {
+                        (::windows::Interface::vtable(self).6)(
+                            ::windows::Abi::abi(self),
+                            ::std::mem::transmute(propagatedlanguageexceptionerrorinfohead),
+                        )
+                    }
+                }
+                unsafe impl ::windows::Interface for ILanguageExceptionErrorInfo2 {
+                    type Vtable = ILanguageExceptionErrorInfo2_abi;
+                    const IID: ::windows::Guid = ::windows::Guid::from_values(
+                        1464264132,
+                        23447,
+                        16972,
+                        [182, 32, 40, 34, 145, 87, 52, 221],
+                    );
+                }
+                impl ::std::convert::From<ILanguageExceptionErrorInfo2> for ::windows::IUnknown {
+                    fn from(value: ILanguageExceptionErrorInfo2) -> Self {
+                        unsafe { ::std::mem::transmute(value) }
+                    }
+                }
+                impl ::std::convert::From<&ILanguageExceptionErrorInfo2> for ::windows::IUnknown {
+                    fn from(value: &ILanguageExceptionErrorInfo2) -> Self {
+                        ::std::convert::From::from(::std::clone::Clone::clone(value))
+                    }
+                }
+                impl<'a> ::windows::IntoParam<'a, ::windows::IUnknown> for ILanguageExceptionErrorInfo2 {
+                    fn into_param(self) -> ::windows::Param<'a, ::windows::IUnknown> {
+                        ::windows::Param::Owned(::std::convert::Into::<::windows::IUnknown>::into(
+                            self,
+                        ))
+                    }
+                }
+                impl<'a> ::windows::IntoParam<'a, ::windows::IUnknown> for &'a ILanguageExceptionErrorInfo2 {
+                    fn into_param(self) -> ::windows::Param<'a, ::windows::IUnknown> {
+                        ::windows::Param::Owned(::std::convert::Into::<::windows::IUnknown>::into(
+                            ::std::clone::Clone::clone(self),
+                        ))
+                    }
+                }
+                impl ::std::convert::From<ILanguageExceptionErrorInfo2> for ILanguageExceptionErrorInfo {
+                    fn from(value: ILanguageExceptionErrorInfo2) -> Self {
+                        unsafe { ::std::mem::transmute(value) }
+                    }
+                }
+                impl ::std::convert::From<&ILanguageExceptionErrorInfo2> for ILanguageExceptionErrorInfo {
+                    fn from(value: &ILanguageExceptionErrorInfo2) -> Self {
+                        ::std::convert::From::from(::std::clone::Clone::clone(value))
+                    }
+                }
+                impl<'a> ::windows::IntoParam<'a, ILanguageExceptionErrorInfo> for ILanguageExceptionErrorInfo2 {
+                    fn into_param(self) -> ::windows::Param<'a, ILanguageExceptionErrorInfo> {
+                        ::windows::Param::Owned(
+                            ::std::convert::Into::<ILanguageExceptionErrorInfo>::into(self),
+                        )
+                    }
+                }
+                impl<'a> ::windows::IntoParam<'a, ILanguageExceptionErrorInfo>
+                    for &'a ILanguageExceptionErrorInfo2
+                {
+                    fn into_param(self) -> ::windows::Param<'a, ILanguageExceptionErrorInfo> {
+                        ::windows::Param::Owned(
+                            ::std::convert::Into::<ILanguageExceptionErrorInfo>::into(
+                                ::std::clone::Clone::clone(self),
+                            ),
+                        )
+                    }
+                }
+                #[repr(C)]
+                #[doc(hidden)]
+                pub struct ILanguageExceptionErrorInfo2_abi(
+                    pub  unsafe extern "system" fn(
+                        this: ::windows::RawPtr,
+                        iid: &::windows::Guid,
+                        interface: *mut ::windows::RawPtr,
+                    ) -> ::windows::HRESULT,
+                    pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
+                    pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
+                    pub  unsafe extern "system" fn(
+                        this: ::windows::RawPtr,
+                        languageexception: *mut ::windows::RawPtr,
+                    ) -> ::windows::HRESULT,
+                    pub  unsafe extern "system" fn(
+                        this: ::windows::RawPtr,
+                        previouslanguageexceptionerrorinfo: *mut ::windows::RawPtr,
+                    ) -> ::windows::HRESULT,
+                    pub  unsafe extern "system" fn(
+                        this: ::windows::RawPtr,
+                        languageexception: ::windows::RawPtr,
+                    ) -> ::windows::HRESULT,
+                    pub  unsafe extern "system" fn(
+                        this: ::windows::RawPtr,
+                        propagatedlanguageexceptionerrorinfohead: *mut ::windows::RawPtr,
+                    ) -> ::windows::HRESULT,
+                );
+                #[repr(transparent)]
+                #[derive(
+                    :: std :: cmp :: PartialEq,
+                    :: std :: cmp :: Eq,
+                    :: std :: clone :: Clone,
+                    :: std :: fmt :: Debug,
+                )]
+                pub struct IRestrictedErrorInfo(::windows::IUnknown);
+                impl IRestrictedErrorInfo {
+                    pub unsafe fn GetErrorDetails(
+                        &self,
+                        description: *mut super::OleAutomation::BSTR,
+                        error: *mut ::windows::HRESULT,
+                        restricteddescription: *mut super::OleAutomation::BSTR,
+                        capabilitysid: *mut super::OleAutomation::BSTR,
+                    ) -> ::windows::HRESULT {
+                        (::windows::Interface::vtable(self).3)(
+                            ::windows::Abi::abi(self),
+                            ::std::mem::transmute(description),
+                            ::std::mem::transmute(error),
+                            ::std::mem::transmute(restricteddescription),
+                            ::std::mem::transmute(capabilitysid),
+                        )
+                    }
+                    pub unsafe fn GetReference(
+                        &self,
+                        reference: *mut super::OleAutomation::BSTR,
+                    ) -> ::windows::HRESULT {
+                        (::windows::Interface::vtable(self).4)(
+                            ::windows::Abi::abi(self),
+                            ::std::mem::transmute(reference),
+                        )
+                    }
+                }
+                unsafe impl ::windows::Interface for IRestrictedErrorInfo {
+                    type Vtable = IRestrictedErrorInfo_abi;
+                    const IID: ::windows::Guid = ::windows::Guid::from_values(
+                        2193256594,
+                        19592,
+                        17021,
+                        [167, 188, 22, 221, 147, 254, 182, 126],
+                    );
+                }
+                impl ::std::convert::From<IRestrictedErrorInfo> for ::windows::IUnknown {
+                    fn from(value: IRestrictedErrorInfo) -> Self {
+                        unsafe { ::std::mem::transmute(value) }
+                    }
+                }
+                impl ::std::convert::From<&IRestrictedErrorInfo> for ::windows::IUnknown {
+                    fn from(value: &IRestrictedErrorInfo) -> Self {
+                        ::std::convert::From::from(::std::clone::Clone::clone(value))
+                    }
+                }
+                impl<'a> ::windows::IntoParam<'a, ::windows::IUnknown> for IRestrictedErrorInfo {
+                    fn into_param(self) -> ::windows::Param<'a, ::windows::IUnknown> {
+                        ::windows::Param::Owned(::std::convert::Into::<::windows::IUnknown>::into(
+                            self,
+                        ))
+                    }
+                }
+                impl<'a> ::windows::IntoParam<'a, ::windows::IUnknown> for &'a IRestrictedErrorInfo {
+                    fn into_param(self) -> ::windows::Param<'a, ::windows::IUnknown> {
+                        ::windows::Param::Owned(::std::convert::Into::<::windows::IUnknown>::into(
+                            ::std::clone::Clone::clone(self),
+                        ))
+                    }
+                }
+                unsafe impl ::std::marker::Send for IRestrictedErrorInfo {}
+                unsafe impl ::std::marker::Sync for IRestrictedErrorInfo {}
+                #[repr(C)]
+                #[doc(hidden)]
+                pub struct IRestrictedErrorInfo_abi(
+                    pub  unsafe extern "system" fn(
+                        this: ::windows::RawPtr,
+                        iid: &::windows::Guid,
+                        interface: *mut ::windows::RawPtr,
+                    ) -> ::windows::HRESULT,
+                    pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
+                    pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
+                    pub  unsafe extern "system" fn(
+                        this: ::windows::RawPtr,
+                        description: *mut super::OleAutomation::BSTR_abi,
+                        error: *mut ::windows::HRESULT,
+                        restricteddescription: *mut super::OleAutomation::BSTR_abi,
+                        capabilitysid: *mut super::OleAutomation::BSTR_abi,
+                    ) -> ::windows::HRESULT,
+                    pub  unsafe extern "system" fn(
+                        this: ::windows::RawPtr,
+                        reference: *mut super::OleAutomation::BSTR_abi,
+                    ) -> ::windows::HRESULT,
+                );
+                #[repr(transparent)]
+                #[derive(
+                    :: std :: cmp :: PartialEq,
+                    :: std :: cmp :: Eq,
+                    :: std :: clone :: Clone,
+                    :: std :: fmt :: Debug,
+                )]
+                pub struct IWeakReference(::windows::IUnknown);
+                impl IWeakReference {
+                    pub unsafe fn Resolve<T: ::windows::Interface>(&self) -> ::windows::Result<T> {
+                        let mut result__ = ::std::option::Option::None;
+                        (::windows::Interface::vtable(self).3)(
+                            ::windows::Abi::abi(self),
+                            &<T as ::windows::Interface>::IID,
+                            ::windows::Abi::set_abi(&mut result__),
+                        )
+                        .and_some(result__)
+                    }
+                }
+                unsafe impl ::windows::Interface for IWeakReference {
+                    type Vtable = IWeakReference_abi;
+                    const IID: ::windows::Guid =
+                        ::windows::Guid::from_values(55, 0, 0, [192, 0, 0, 0, 0, 0, 0, 70]);
+                }
+                impl ::std::convert::From<IWeakReference> for ::windows::IUnknown {
+                    fn from(value: IWeakReference) -> Self {
+                        unsafe { ::std::mem::transmute(value) }
+                    }
+                }
+                impl ::std::convert::From<&IWeakReference> for ::windows::IUnknown {
+                    fn from(value: &IWeakReference) -> Self {
+                        ::std::convert::From::from(::std::clone::Clone::clone(value))
+                    }
+                }
+                impl<'a> ::windows::IntoParam<'a, ::windows::IUnknown> for IWeakReference {
+                    fn into_param(self) -> ::windows::Param<'a, ::windows::IUnknown> {
+                        ::windows::Param::Owned(::std::convert::Into::<::windows::IUnknown>::into(
+                            self,
+                        ))
+                    }
+                }
+                impl<'a> ::windows::IntoParam<'a, ::windows::IUnknown> for &'a IWeakReference {
+                    fn into_param(self) -> ::windows::Param<'a, ::windows::IUnknown> {
+                        ::windows::Param::Owned(::std::convert::Into::<::windows::IUnknown>::into(
+                            ::std::clone::Clone::clone(self),
+                        ))
+                    }
+                }
+                #[repr(C)]
+                #[doc(hidden)]
+                pub struct IWeakReference_abi(
+                    pub  unsafe extern "system" fn(
+                        this: ::windows::RawPtr,
+                        iid: &::windows::Guid,
+                        interface: *mut ::windows::RawPtr,
+                    ) -> ::windows::HRESULT,
+                    pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
+                    pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
+                    pub  unsafe extern "system" fn(
+                        this: ::windows::RawPtr,
+                        riid: *const ::windows::Guid,
+                        objectreference: *mut *mut ::std::ffi::c_void,
+                    ) -> ::windows::HRESULT,
+                );
+                #[repr(transparent)]
+                #[derive(
+                    :: std :: cmp :: PartialEq,
+                    :: std :: cmp :: Eq,
+                    :: std :: clone :: Clone,
+                    :: std :: fmt :: Debug,
+                )]
+                pub struct IWeakReferenceSource(::windows::IUnknown);
+                impl IWeakReferenceSource {
+                    pub unsafe fn GetWeakReference(
+                        &self,
+                        weakreference: *mut ::std::option::Option<IWeakReference>,
+                    ) -> ::windows::HRESULT {
+                        (::windows::Interface::vtable(self).3)(
+                            ::windows::Abi::abi(self),
+                            ::std::mem::transmute(weakreference),
+                        )
+                    }
+                }
+                unsafe impl ::windows::Interface for IWeakReferenceSource {
+                    type Vtable = IWeakReferenceSource_abi;
+                    const IID: ::windows::Guid =
+                        ::windows::Guid::from_values(56, 0, 0, [192, 0, 0, 0, 0, 0, 0, 70]);
+                }
+                impl ::std::convert::From<IWeakReferenceSource> for ::windows::IUnknown {
+                    fn from(value: IWeakReferenceSource) -> Self {
+                        unsafe { ::std::mem::transmute(value) }
+                    }
+                }
+                impl ::std::convert::From<&IWeakReferenceSource> for ::windows::IUnknown {
+                    fn from(value: &IWeakReferenceSource) -> Self {
+                        ::std::convert::From::from(::std::clone::Clone::clone(value))
+                    }
+                }
+                impl<'a> ::windows::IntoParam<'a, ::windows::IUnknown> for IWeakReferenceSource {
+                    fn into_param(self) -> ::windows::Param<'a, ::windows::IUnknown> {
+                        ::windows::Param::Owned(::std::convert::Into::<::windows::IUnknown>::into(
+                            self,
+                        ))
+                    }
+                }
+                impl<'a> ::windows::IntoParam<'a, ::windows::IUnknown> for &'a IWeakReferenceSource {
+                    fn into_param(self) -> ::windows::Param<'a, ::windows::IUnknown> {
+                        ::windows::Param::Owned(::std::convert::Into::<::windows::IUnknown>::into(
+                            ::std::clone::Clone::clone(self),
+                        ))
+                    }
+                }
+                #[repr(C)]
+                #[doc(hidden)]
+                pub struct IWeakReferenceSource_abi(
+                    pub  unsafe extern "system" fn(
+                        this: ::windows::RawPtr,
+                        iid: &::windows::Guid,
+                        interface: *mut ::windows::RawPtr,
+                    ) -> ::windows::HRESULT,
+                    pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
+                    pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
+                    pub  unsafe extern "system" fn(
+                        this: ::windows::RawPtr,
+                        weakreference: *mut ::windows::RawPtr,
+                    ) -> ::windows::HRESULT,
                 );
             }
-            impl ::std::convert::From<IRestrictedErrorInfo> for ::windows::IUnknown {
-                fn from(value: IRestrictedErrorInfo) -> Self {
-                    unsafe { ::std::mem::transmute(value) }
-                }
-            }
-            impl ::std::convert::From<&IRestrictedErrorInfo> for ::windows::IUnknown {
-                fn from(value: &IRestrictedErrorInfo) -> Self {
-                    ::std::convert::From::from(::std::clone::Clone::clone(value))
-                }
-            }
-            impl<'a> ::windows::IntoParam<'a, ::windows::IUnknown> for IRestrictedErrorInfo {
-                fn into_param(self) -> ::windows::Param<'a, ::windows::IUnknown> {
-                    ::windows::Param::Owned(::std::convert::Into::<::windows::IUnknown>::into(self))
-                }
-            }
-            impl<'a> ::windows::IntoParam<'a, ::windows::IUnknown> for &'a IRestrictedErrorInfo {
-                fn into_param(self) -> ::windows::Param<'a, ::windows::IUnknown> {
-                    ::windows::Param::Owned(::std::convert::Into::<::windows::IUnknown>::into(
-                        ::std::clone::Clone::clone(self),
-                    ))
-                }
-            }
-            unsafe impl ::std::marker::Send for IRestrictedErrorInfo {}
-            unsafe impl ::std::marker::Sync for IRestrictedErrorInfo {}
-            #[repr(C)]
-            #[doc(hidden)]
-            pub struct IRestrictedErrorInfo_abi(
-                pub  unsafe extern "system" fn(
-                    this: ::windows::RawPtr,
-                    iid: &::windows::Guid,
-                    interface: *mut ::windows::RawPtr,
-                ) -> ::windows::HRESULT,
-                pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
-                pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
-                pub  unsafe extern "system" fn(
-                    this: ::windows::RawPtr,
-                    description: *mut super::Automation::BSTR_abi,
-                    error: *mut ::windows::HRESULT,
-                    restricteddescription: *mut super::Automation::BSTR_abi,
-                    capabilitysid: *mut super::Automation::BSTR_abi,
-                ) -> ::windows::HRESULT,
-                pub  unsafe extern "system" fn(
-                    this: ::windows::RawPtr,
-                    reference: *mut super::Automation::BSTR_abi,
-                ) -> ::windows::HRESULT,
-            );
-            #[repr(transparent)]
-            #[derive(
-                :: std :: cmp :: PartialEq,
-                :: std :: cmp :: Eq,
-                :: std :: clone :: Clone,
-                :: std :: fmt :: Debug,
+            #[allow(
+                unused_variables,
+                non_upper_case_globals,
+                non_snake_case,
+                unused_unsafe,
+                non_camel_case_types,
+                dead_code,
+                clippy::all
             )]
-            pub struct IWeakReference(::windows::IUnknown);
-            impl IWeakReference {
-                pub unsafe fn Resolve(
-                    &self,
-                    riid: *const ::windows::Guid,
-                    objectreference: *mut ::std::option::Option<::windows::IInspectable>,
-                ) -> ::windows::HRESULT {
-                    (::windows::Interface::vtable(self).3)(
-                        ::windows::Abi::abi(self),
-                        ::std::mem::transmute(riid),
-                        ::std::mem::transmute(objectreference),
-                    )
+            pub mod WindowsProgramming {
+                pub unsafe fn CloseHandle<'a>(
+                    hobject: impl ::windows::IntoParam<'a, super::SystemServices::HANDLE>,
+                ) -> super::SystemServices::BOOL {
+                    #[link(name = "KERNEL32")]
+                    extern "system" {
+                        pub fn CloseHandle(
+                            hobject: super::SystemServices::HANDLE,
+                        ) -> super::SystemServices::BOOL;
+                    }
+                    CloseHandle(hobject.into_param().abi())
                 }
-            }
-            unsafe impl ::windows::Interface for IWeakReference {
-                type Vtable = IWeakReference_abi;
-                const IID: ::windows::Guid =
-                    ::windows::Guid::from_values(55, 0, 0, [192, 0, 0, 0, 0, 0, 0, 70]);
-            }
-            impl ::std::convert::From<IWeakReference> for ::windows::IUnknown {
-                fn from(value: IWeakReference) -> Self {
-                    unsafe { ::std::mem::transmute(value) }
-                }
-            }
-            impl ::std::convert::From<&IWeakReference> for ::windows::IUnknown {
-                fn from(value: &IWeakReference) -> Self {
-                    ::std::convert::From::from(::std::clone::Clone::clone(value))
-                }
-            }
-            impl<'a> ::windows::IntoParam<'a, ::windows::IUnknown> for IWeakReference {
-                fn into_param(self) -> ::windows::Param<'a, ::windows::IUnknown> {
-                    ::windows::Param::Owned(::std::convert::Into::<::windows::IUnknown>::into(self))
-                }
-            }
-            impl<'a> ::windows::IntoParam<'a, ::windows::IUnknown> for &'a IWeakReference {
-                fn into_param(self) -> ::windows::Param<'a, ::windows::IUnknown> {
-                    ::windows::Param::Owned(::std::convert::Into::<::windows::IUnknown>::into(
-                        ::std::clone::Clone::clone(self),
-                    ))
-                }
-            }
-            #[repr(C)]
-            #[doc(hidden)]
-            pub struct IWeakReference_abi(
-                pub  unsafe extern "system" fn(
-                    this: ::windows::RawPtr,
-                    iid: &::windows::Guid,
-                    interface: *mut ::windows::RawPtr,
-                ) -> ::windows::HRESULT,
-                pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
-                pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
-                pub  unsafe extern "system" fn(
-                    this: ::windows::RawPtr,
-                    riid: *const ::windows::Guid,
-                    objectreference: *mut ::windows::RawPtr,
-                ) -> ::windows::HRESULT,
-            );
-            #[repr(transparent)]
-            #[derive(
-                :: std :: cmp :: PartialEq,
-                :: std :: cmp :: Eq,
-                :: std :: clone :: Clone,
-                :: std :: fmt :: Debug,
-            )]
-            pub struct IWeakReferenceSource(::windows::IUnknown);
-            impl IWeakReferenceSource {
-                pub unsafe fn GetWeakReference(
-                    &self,
-                    weakreference: *mut ::std::option::Option<IWeakReference>,
-                ) -> ::windows::HRESULT {
-                    (::windows::Interface::vtable(self).3)(
-                        ::windows::Abi::abi(self),
-                        ::std::mem::transmute(weakreference),
-                    )
-                }
-            }
-            unsafe impl ::windows::Interface for IWeakReferenceSource {
-                type Vtable = IWeakReferenceSource_abi;
-                const IID: ::windows::Guid =
-                    ::windows::Guid::from_values(56, 0, 0, [192, 0, 0, 0, 0, 0, 0, 70]);
-            }
-            impl ::std::convert::From<IWeakReferenceSource> for ::windows::IUnknown {
-                fn from(value: IWeakReferenceSource) -> Self {
-                    unsafe { ::std::mem::transmute(value) }
-                }
-            }
-            impl ::std::convert::From<&IWeakReferenceSource> for ::windows::IUnknown {
-                fn from(value: &IWeakReferenceSource) -> Self {
-                    ::std::convert::From::from(::std::clone::Clone::clone(value))
-                }
-            }
-            impl<'a> ::windows::IntoParam<'a, ::windows::IUnknown> for IWeakReferenceSource {
-                fn into_param(self) -> ::windows::Param<'a, ::windows::IUnknown> {
-                    ::windows::Param::Owned(::std::convert::Into::<::windows::IUnknown>::into(self))
-                }
-            }
-            impl<'a> ::windows::IntoParam<'a, ::windows::IUnknown> for &'a IWeakReferenceSource {
-                fn into_param(self) -> ::windows::Param<'a, ::windows::IUnknown> {
-                    ::windows::Param::Owned(::std::convert::Into::<::windows::IUnknown>::into(
-                        ::std::clone::Clone::clone(self),
-                    ))
-                }
-            }
-            #[repr(C)]
-            #[doc(hidden)]
-            pub struct IWeakReferenceSource_abi(
-                pub  unsafe extern "system" fn(
-                    this: ::windows::RawPtr,
-                    iid: &::windows::Guid,
-                    interface: *mut ::windows::RawPtr,
-                ) -> ::windows::HRESULT,
-                pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
-                pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
-                pub  unsafe extern "system" fn(
-                    this: ::windows::RawPtr,
-                    weakreference: *mut ::windows::RawPtr,
-                ) -> ::windows::HRESULT,
-            );
-        }
-        #[allow(
-            unused_variables,
-            non_upper_case_globals,
-            non_snake_case,
-            unused_unsafe,
-            non_camel_case_types,
-            dead_code,
-            clippy::all
-        )]
-        pub mod WindowsProgramming {
-            pub unsafe fn CloseHandle<'a>(
-                hobject: impl ::windows::IntoParam<'a, super::SystemServices::HANDLE>,
-            ) -> super::SystemServices::BOOL {
-                #[link(name = "KERNEL32")]
-                extern "system" {
-                    pub fn CloseHandle(
-                        hobject: super::SystemServices::HANDLE,
-                    ) -> super::SystemServices::BOOL;
-                }
-                CloseHandle(hobject.into_param().abi())
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@ use interfaces::*;
 use runtime::*;
 
 #[doc(hidden)]
-pub use bindings::Windows::Win32::Com::IAgileObject;
+pub use bindings::Windows::Win32::System::Com::IAgileObject;
 
 #[doc(hidden)]
 pub use interfaces::IActivationFactory;

--- a/src/result/error.rs
+++ b/src/result/error.rs
@@ -2,8 +2,8 @@ use crate::*;
 use std::convert::TryInto;
 
 use bindings::{
-    Windows::Win32::Automation::{GetErrorInfo, SetErrorInfo, BSTR},
-    Windows::Win32::WinRT::{ILanguageExceptionErrorInfo2, IRestrictedErrorInfo},
+    Windows::Win32::System::OleAutomation::{GetErrorInfo, SetErrorInfo, BSTR},
+    Windows::Win32::System::WinRT::{ILanguageExceptionErrorInfo2, IRestrictedErrorInfo},
 };
 
 /// A WinRT error object consists of both an error code as well as detailed error information for debugging.

--- a/src/result/error_code.rs
+++ b/src/result/error_code.rs
@@ -1,8 +1,10 @@
 use crate::*;
 
 use bindings::{
-    Windows::Win32::Debug::{FormatMessageW, GetLastError, FORMAT_MESSAGE_OPTIONS},
-    Windows::Win32::SystemServices::{E_POINTER, PWSTR},
+    Windows::Win32::System::Diagnostics::Debug::{
+        FormatMessageW, GetLastError, FORMAT_MESSAGE_OPTIONS,
+    },
+    Windows::Win32::System::SystemServices::{E_POINTER, PWSTR},
 };
 
 /// A primitive error code value returned by most COM functions.

--- a/src/runtime/array.rs
+++ b/src/runtime/array.rs
@@ -1,6 +1,6 @@
 use crate::*;
 
-use bindings::Windows::Win32::Com::{CoTaskMemAlloc, CoTaskMemFree};
+use bindings::Windows::Win32::System::Com::{CoTaskMemAlloc, CoTaskMemFree};
 
 /// A WinRT array stores elements contiguously in a heap-allocated buffer.
 pub struct Array<T: RuntimeType> {

--- a/src/runtime/com.rs
+++ b/src/runtime/com.rs
@@ -1,6 +1,6 @@
 use crate::*;
 
-use bindings::Windows::Win32::Com::{CoCreateInstance, CoInitializeEx, CLSCTX, COINIT};
+use bindings::Windows::Win32::System::Com::{CoCreateInstance, CoInitializeEx, CLSCTX, COINIT};
 
 /// Initializes COM for use by the calling thread for the multi-threaded apartment (MTA).
 pub fn initialize_mta() -> Result<()> {

--- a/src/runtime/delay_load.rs
+++ b/src/runtime/delay_load.rs
@@ -1,12 +1,12 @@
 use crate::*;
 
-use bindings::Windows::Win32::SystemServices::{FreeLibrary, GetProcAddress, LoadLibraryA};
+use bindings::Windows::Win32::System::SystemServices::{FreeLibrary, GetProcAddress, LoadLibraryA};
 
 pub fn delay_load(library: &str, function: &str) -> std::result::Result<RawPtr, HRESULT> {
     unsafe {
         let library = LoadLibraryA(library);
 
-        if library == 0 {
+        if library.is_null() {
             return Err(HRESULT::from_thread());
         }
 

--- a/src/runtime/factory_cache.rs
+++ b/src/runtime/factory_cache.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use bindings::Windows::Win32::SystemServices::CO_E_NOTINITIALIZED;
+use bindings::Windows::Win32::System::SystemServices::CO_E_NOTINITIALIZED;
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicPtr, Ordering};
 

--- a/src/runtime/guid.rs
+++ b/src/runtime/guid.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::many_single_char_names)]
 
 use crate::*;
-use bindings::Windows::Win32::Com::{CLSIDFromProgID, CoCreateGuid};
+use bindings::Windows::Win32::System::Com::{CLSIDFromProgID, CoCreateGuid};
 
 /// A globally unique identifier [(GUID)](https://docs.microsoft.com/en-us/windows/win32/api/guiddef/ns-guiddef-guid)
 /// used to identify COM and WinRT interfaces.

--- a/src/runtime/heap.rs
+++ b/src/runtime/heap.rs
@@ -1,6 +1,6 @@
 use crate::*;
 
-use bindings::Windows::Win32::SystemServices::{GetProcessHeap, HeapAlloc, HeapFree, HEAP_FLAGS};
+use bindings::Windows::Win32::System::Memory::{GetProcessHeap, HeapAlloc, HeapFree, HEAP_FLAGS};
 
 pub fn heap_alloc(bytes: usize) -> RawPtr {
     unsafe { HeapAlloc(GetProcessHeap(), HEAP_FLAGS::HEAP_NONE, bytes) }

--- a/src/runtime/waiter.rs
+++ b/src/runtime/waiter.rs
@@ -1,8 +1,9 @@
 use crate::*;
 
 use bindings::{
-    Windows::Win32::SystemServices::{CreateEventA, SetEvent, WaitForSingleObject, HANDLE, PSTR},
-    Windows::Win32::WindowsProgramming::CloseHandle,
+    Windows::Win32::System::SystemServices::{HANDLE, PSTR},
+    Windows::Win32::System::Threading::{CreateEventA, SetEvent, WaitForSingleObject},
+    Windows::Win32::System::WindowsProgramming::CloseHandle,
 };
 
 /// A simple blocking waiter used by the generated bindings and should not be used directly.

--- a/src/runtime/weak.rs
+++ b/src/runtime/weak.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use bindings::Windows::Win32::WinRT::{IWeakReference, IWeakReferenceSource};
+use bindings::Windows::Win32::System::WinRT::{IWeakReference, IWeakReferenceSource};
 use std::marker::PhantomData;
 
 /// `Weak` holds a non-owning reference to an object.

--- a/src/runtime/weak_ref_count.rs
+++ b/src/runtime/weak_ref_count.rs
@@ -7,7 +7,7 @@
 )]
 
 use crate::*;
-use bindings::Windows::Win32::WinRT::{
+use bindings::Windows::Win32::System::WinRT::{
     IWeakReference, IWeakReferenceSource, IWeakReferenceSource_abi, IWeakReference_abi,
 };
 use std::sync::atomic::{AtomicIsize, Ordering};

--- a/src/traits/abi.rs
+++ b/src/traits/abi.rs
@@ -1,6 +1,6 @@
 use crate::*;
 
-use bindings::Windows::Win32::SystemServices::E_POINTER;
+use bindings::Windows::Win32::System::SystemServices::E_POINTER;
 
 /// Provides a generic way of referring to and converting between a Rust object
 /// and its ABI equivalent.

--- a/src/traits/interface.rs
+++ b/src/traits/interface.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use bindings::Windows::Win32::WinRT::IWeakReferenceSource;
+use bindings::Windows::Win32::System::WinRT::IWeakReferenceSource;
 
 /// Provides low-level access to a COM interface.
 ///

--- a/tests/bstr/build.rs
+++ b/tests/bstr/build.rs
@@ -2,6 +2,6 @@ fn main() {
     windows::build!(
         // The Windows crate manually injects various functions needed to implement BSTR.
         // This test validates these are included.
-        Windows::Win32::Automation::BSTR
+        Windows::Win32::System::OleAutomation::BSTR
     );
 }

--- a/tests/bstr/tests/bstr.rs
+++ b/tests/bstr/tests/bstr.rs
@@ -1,4 +1,4 @@
-use test_bstr::Windows::Win32::Automation::BSTR;
+use test_bstr::Windows::Win32::System::OleAutomation::BSTR;
 use windows::Abi;
 
 #[test]

--- a/tests/build_groups/build.rs
+++ b/tests/build_groups/build.rs
@@ -4,7 +4,7 @@ fn main() {
         Windows::Foundation::{IStringable, Collections::{IVector, IMap, IKeyValuePair}},
 
         // Test for https://github.com/microsoft/windows-rs/issues/699
-        Windows::Win32::{
+        Windows::Win32::System::Diagnostics::{
             Debug::GetLastError
         }
     );

--- a/tests/convertible/build.rs
+++ b/tests/convertible/build.rs
@@ -1,8 +1,8 @@
 fn main() {
     windows::build!(
-        // GetProcessHeap returns ProcessHeapHandle that is convertible to HeapHandle. So including ProcessHeapHandle
-        // (by virtue of GetProcessHeap) should also include HeapHandle.
-        Windows::Win32::SystemServices::GetProcessHeap,
+        // GetProcessHeap returns HeapHandle. So including GetProcessHeap
+        // should also include HeapHandle.
+        Windows::Win32::System::Memory::GetProcessHeap,
         // Note: don't add anything else to this build macro!
     );
 }

--- a/tests/convertible/tests/convertible.rs
+++ b/tests/convertible/tests/convertible.rs
@@ -1,11 +1,8 @@
-use test_convertible::Windows::Win32::SystemServices::{
-    GetProcessHeap, HeapHandle, ProcessHeapHandle,
-};
+use test_convertible::Windows::Win32::System::Memory::{GetProcessHeap, HeapHandle};
 
 #[test]
 fn test() {
     unsafe {
-        let _: ProcessHeapHandle = GetProcessHeap();
-        let _: HeapHandle = HeapHandle::default();
+        let _: HeapHandle = GetProcessHeap();
     }
 }

--- a/tests/handles/build.rs
+++ b/tests/handles/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     windows::build!(
-        Windows::Win32::SystemServices::{HANDLE, PSTR, PWSTR},
-        Windows::Win32::Gdi::HGDIOBJ,
+        Windows::Win32::System::SystemServices::{HANDLE, PSTR, PWSTR},
+        Windows::Win32::Graphics::Gdi::HGDIOBJ,
     );
 }

--- a/tests/handles/tests/null.rs
+++ b/tests/handles/tests/null.rs
@@ -1,6 +1,6 @@
 use test_handles::{
-    Windows::Win32::Gdi::HGDIOBJ,
-    Windows::Win32::SystemServices::{HANDLE, PSTR, PWSTR},
+    Windows::Win32::Graphics::Gdi::HGDIOBJ,
+    Windows::Win32::System::SystemServices::{HANDLE, PSTR, PWSTR},
 };
 
 #[test]

--- a/tests/interfaces/build.rs
+++ b/tests/interfaces/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     windows::build!(
         // Test for https://github.com/microsoft/win32metadata/issues/449
-        Windows::Win32::ComponentServices::ITransactionImport
+        Windows::Win32::System::ComponentServices::ITransactionImport
     );
 }

--- a/tests/interfaces/tests/transaction_import.rs
+++ b/tests/interfaces/tests/transaction_import.rs
@@ -1,4 +1,4 @@
-use test_interfaces::Windows::Win32::ComponentServices::ITransactionImport;
+use test_interfaces::Windows::Win32::System::ComponentServices::ITransactionImport;
 
 #[test]
 fn test() {

--- a/tests/interop/build.rs
+++ b/tests/interop/build.rs
@@ -1,7 +1,7 @@
 fn main() {
     windows::build!(
-        Windows::Win32::WinRT::RoActivateInstance,
+        Windows::Win32::System::WinRT::RoActivateInstance,
         Windows::Foundation::Collections::StringMap,
-        Windows::Win32::RadialInput::IRadialControllerInterop,
+        Windows::Win32::UI::RadialInput::IRadialControllerInterop,
     );
 }

--- a/tests/interop/tests/activate_instance.rs
+++ b/tests/interop/tests/activate_instance.rs
@@ -1,5 +1,5 @@
 use test_interop::{
-    Windows::Foundation::Collections::StringMap, Windows::Win32::WinRT::RoActivateInstance,
+    Windows::Foundation::Collections::StringMap, Windows::Win32::System::WinRT::RoActivateInstance,
 };
 
 use windows::{initialize_mta, Interface, Result};

--- a/tests/structs/build.rs
+++ b/tests/structs/build.rs
@@ -2,6 +2,6 @@ fn main() {
     windows::build!(
         // Test for https://github.com/microsoft/windows-rs/issues/738 as DebugPropertyInfo has a
         // BSTR field and needs to implement Clone.
-        Windows::Win32::Debug::DebugPropertyInfo
+        Windows::Win32::System::Diagnostics::Debug::DebugPropertyInfo
     );
 }

--- a/tests/structs/tests/bstr.rs
+++ b/tests/structs/tests/bstr.rs
@@ -1,4 +1,4 @@
-use test_structs::Windows::Win32::Debug::DebugPropertyInfo;
+use test_structs::Windows::Win32::System::Diagnostics::Debug::DebugPropertyInfo;
 use windows::Abi;
 
 #[test]

--- a/tests/unions/build.rs
+++ b/tests/unions/build.rs
@@ -1,7 +1,7 @@
 fn main() {
     windows::build!(
-        Windows::Win32::SystemServices::OVERLAPPED,
-        Windows::Win32::WindowsColorSystem::WhitePoint,
-        Windows::Win32::Direct3D12::D3D12_INDIRECT_ARGUMENT_DESC,
+        Windows::Win32::System::SystemServices::OVERLAPPED,
+        Windows::Win32::UI::ColorSystem::WhitePoint,
+        Windows::Win32::Graphics::Direct3D12::D3D12_INDIRECT_ARGUMENT_DESC,
     );
 }

--- a/tests/unions/tests/indirect_argument_desc.rs
+++ b/tests/unions/tests/indirect_argument_desc.rs
@@ -1,4 +1,4 @@
-use test_unions::Windows::Win32::Direct3D12::{
+use test_unions::Windows::Win32::Graphics::Direct3D12::{
     D3D12_INDIRECT_ARGUMENT_DESC, D3D12_INDIRECT_ARGUMENT_DESC_0, D3D12_INDIRECT_ARGUMENT_DESC_0_4,
     D3D12_INDIRECT_ARGUMENT_TYPE,
 };

--- a/tests/unions/tests/overlapped.rs
+++ b/tests/unions/tests/overlapped.rs
@@ -1,4 +1,4 @@
-use test_unions::Windows::Win32::SystemServices::{
+use test_unions::Windows::Win32::System::SystemServices::{
     HANDLE, OVERLAPPED, OVERLAPPED_0, OVERLAPPED_0_0,
 };
 

--- a/tests/unions/tests/white_point.rs
+++ b/tests/unions/tests/white_point.rs
@@ -1,4 +1,4 @@
-use test_unions::Windows::Win32::WindowsColorSystem::{WhitePoint, WhitePoint_0, XYYPoint};
+use test_unions::Windows::Win32::UI::ColorSystem::{WhitePoint, WhitePoint_0, XYYPoint};
 
 #[test]
 fn test() {

--- a/tests/weak/build.rs
+++ b/tests/weak/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     windows::build!(
         Windows::Foundation::Uri,
-        Windows::Win32::WinRT::{IWeakReference, IWeakReferenceSource},
+        Windows::Win32::System::WinRT::{IWeakReference, IWeakReferenceSource},
     );
 }

--- a/tests/weak/tests/implement.rs
+++ b/tests/weak/tests/implement.rs
@@ -1,7 +1,7 @@
 use test_weak::*;
 use windows::*;
 use Windows::Foundation::IStringable;
-use Windows::Win32::WinRT::{IWeakReference, IWeakReferenceSource};
+use Windows::Win32::System::WinRT::{IWeakReference, IWeakReferenceSource};
 
 #[test]
 fn test_implement() -> Result<()> {

--- a/tests/win32/build.rs
+++ b/tests/win32/build.rs
@@ -1,48 +1,48 @@
 fn main() {
     windows::build!(
-        Windows::Win32::Automation::BSTR,
+        Windows::Win32::System::OleAutomation::BSTR,
         Windows::Win32::Security::{
             ACCESS_MODE,
         },
-        Windows::Win32::WindowsAndMessaging::{
+        Windows::Win32::UI::WindowsAndMessaging::{
             CHOOSECOLORW,
             PROPENUMPROCA,
             PROPENUMPROCW,
             WM_KEYUP,
         },
-        Windows::Win32::Dxgi::{
+        Windows::Win32::Graphics::Dxgi::{
             DXGI_ADAPTER_FLAG, DXGI_FORMAT, DXGI_MODE_DESC, DXGI_MODE_SCALING,
             DXGI_MODE_SCANLINE_ORDER, DXGI_RATIONAL,IDXGIFactory7, CreateDXGIFactory1, DXGI_ERROR_INVALID_CALL,
         },
-        Windows::Win32::DisplayDevices::{
+        Windows::Win32::UI::DisplayDevices::{
             RECT,
         },
-        Windows::Win32::SystemServices::{
+        Windows::Win32::System::Threading::{
             CreateEventW,
             SetEvent,
             WaitForSingleObject,
         },
-        Windows::Win32::Direct2D::CLSID_D2D1Shadow,
-        Windows::Win32::Direct3D12::{
+        Windows::Win32::Graphics::Direct2D::CLSID_D2D1Shadow,
+        Windows::Win32::Graphics::Direct3D12::{
             D3D12_DEFAULT_BLEND_FACTOR_ALPHA
         },
-        Windows::Win32::WindowsAccessibility::{
+        Windows::Win32::UI::Accessibility::{
             UIA_ScrollPatternNoScroll
         },
-        Windows::Win32::Direct3DHlsl::{
+        Windows::Win32::Graphics::Hlsl::{
             D3DCOMPILER_DLL
         },
-        Windows::Win32::WindowsProgramming::{
+        Windows::Win32::System::WindowsProgramming::{
             CloseHandle
         },
-        Windows::Win32::Com::CreateUri,
-        Windows::Win32::StructuredStorage::{CreateStreamOnHGlobal, STREAM_SEEK},
-        Windows::Win32::UIAnimation::{UIAnimationManager, UIAnimationTransitionLibrary},
-        Windows::Win32::Ldap::ldapsearch,
-        Windows::Win32::GameMode::HasExpandedResources,
-        Windows::Win32::Debug::MiniDumpWriteDump,
-        Windows::Win32::Direct3D11::D3DDisassemble11Trace,
-        Windows::Win32::WindowsUpdateAgent::IAutomaticUpdates,
-        Windows::Win32::WindowsColorSystem::WhitePoint,
+        Windows::Win32::Gaming::HasExpandedResources,
+        Windows::Win32::Graphics::Direct3D11::D3DDisassemble11Trace,
+        Windows::Win32::Networking::Ldap::ldapsearch,
+        Windows::Win32::Storage::StructuredStorage::{CreateStreamOnHGlobal, STREAM_SEEK},
+        Windows::Win32::System::Com::CreateUri,
+        Windows::Win32::System::Diagnostics::Debug::MiniDumpWriteDump,
+        Windows::Win32::System::UpdateAgent::IAutomaticUpdates,
+        Windows::Win32::UI::Animation::{UIAnimationManager, UIAnimationTransitionLibrary},
+        Windows::Win32::UI::ColorSystem::WhitePoint,
     );
 }

--- a/tests/win32/tests/com.rs
+++ b/tests/win32/tests/com.rs
@@ -1,4 +1,4 @@
-use test_win32::Windows::Win32::WindowsUpdateAgent::IAutomaticUpdates;
+use test_win32::Windows::Win32::System::UpdateAgent::IAutomaticUpdates;
 use windows::{create_instance, initialize_mta, initialize_sta, Guid, Result};
 
 #[test]

--- a/tests/win32/tests/win32.rs
+++ b/tests/win32/tests/win32.rs
@@ -1,30 +1,31 @@
 use test_win32::{
-    Windows::Win32::Automation::BSTR,
-    Windows::Win32::Com::CreateUri,
-    Windows::Win32::Debug::{MiniDumpWriteDump, MINIDUMP_TYPE},
-    Windows::Win32::Direct2D::CLSID_D2D1Shadow,
-    Windows::Win32::Direct3D11::D3DDisassemble11Trace,
-    Windows::Win32::Direct3D12::D3D12_DEFAULT_BLEND_FACTOR_ALPHA,
-    Windows::Win32::Direct3DHlsl::D3DCOMPILER_DLL,
-    Windows::Win32::DisplayDevices::RECT,
-    Windows::Win32::Dxgi::{
+    Windows::Win32::Gaming::HasExpandedResources,
+    Windows::Win32::Graphics::Direct2D::CLSID_D2D1Shadow,
+    Windows::Win32::Graphics::Direct3D11::D3DDisassemble11Trace,
+    Windows::Win32::Graphics::Direct3D12::D3D12_DEFAULT_BLEND_FACTOR_ALPHA,
+    Windows::Win32::Graphics::Dxgi::{
         CreateDXGIFactory1, IDXGIFactory7, DXGI_ADAPTER_FLAG, DXGI_ERROR_INVALID_CALL, DXGI_FORMAT,
         DXGI_MODE_DESC, DXGI_MODE_SCALING, DXGI_MODE_SCANLINE_ORDER, DXGI_RATIONAL,
     },
-    Windows::Win32::GameMode::HasExpandedResources,
-    Windows::Win32::Ldap::ldapsearch,
+    Windows::Win32::Graphics::Hlsl::D3DCOMPILER_DLL,
+    Windows::Win32::Networking::Ldap::ldapsearch,
     Windows::Win32::Security::ACCESS_MODE,
-    Windows::Win32::StructuredStorage::{CreateStreamOnHGlobal, STREAM_SEEK},
-    Windows::Win32::SystemServices::{
-        CreateEventW, SetEvent, WaitForSingleObject, BOOL, HANDLE, PSTR, PWSTR, WAIT_RETURN_CAUSE,
+    Windows::Win32::Storage::StructuredStorage::{CreateStreamOnHGlobal, STREAM_SEEK},
+    Windows::Win32::System::Com::CreateUri,
+    Windows::Win32::System::Diagnostics::Debug::{MiniDumpWriteDump, MINIDUMP_TYPE},
+    Windows::Win32::System::OleAutomation::BSTR,
+    Windows::Win32::System::SystemServices::{BOOL, HANDLE, PSTR, PWSTR},
+    Windows::Win32::System::Threading::{
+        CreateEventW, SetEvent, WaitForSingleObject, WAIT_RETURN_CAUSE,
     },
-    Windows::Win32::UIAnimation::{UIAnimationManager, UIAnimationTransitionLibrary},
-    Windows::Win32::WindowsAccessibility::UIA_ScrollPatternNoScroll,
-    Windows::Win32::WindowsAndMessaging::{
+    Windows::Win32::System::WindowsProgramming::CloseHandle,
+    Windows::Win32::UI::Accessibility::UIA_ScrollPatternNoScroll,
+    Windows::Win32::UI::Animation::{UIAnimationManager, UIAnimationTransitionLibrary},
+    Windows::Win32::UI::ColorSystem::WhitePoint,
+    Windows::Win32::UI::DisplayDevices::RECT,
+    Windows::Win32::UI::WindowsAndMessaging::{
         CHOOSECOLORW, HWND, PROPENUMPROCA, PROPENUMPROCW, WM_KEYUP,
     },
-    Windows::Win32::WindowsColorSystem::WhitePoint,
-    Windows::Win32::WindowsProgramming::CloseHandle,
 };
 
 use windows::{Abi, Guid};

--- a/tests/win32_arrays/build.rs
+++ b/tests/win32_arrays/build.rs
@@ -1,8 +1,8 @@
 fn main() {
     windows::build!(
-        Windows::Win32::Dxgi::DXGI_ADAPTER_DESC1,
-        Windows::Win32::WindowsAndMessaging::NCCALCSIZE_PARAMS,
-        Windows::Win32::IpHelper::IPV6_ADDRESS_EX,
-        Windows::Win32::Debug::MINIDUMP_MEMORY_LIST,
+        Windows::Win32::Graphics::Dxgi::DXGI_ADAPTER_DESC1,
+        Windows::Win32::UI::WindowsAndMessaging::NCCALCSIZE_PARAMS,
+        Windows::Win32::NetworkManagement::IpHelper::IPV6_ADDRESS_EX,
+        Windows::Win32::System::Diagnostics::Debug::MINIDUMP_MEMORY_LIST,
     );
 }

--- a/tests/win32_arrays/tests/dxgi_adapter_desc1.rs
+++ b/tests/win32_arrays/tests/dxgi_adapter_desc1.rs
@@ -1,4 +1,4 @@
-use test_win32_arrays::Windows::Win32::Dxgi::DXGI_ADAPTER_DESC1;
+use test_win32_arrays::Windows::Win32::Graphics::Dxgi::DXGI_ADAPTER_DESC1;
 
 #[test]
 #[cfg(target_arch = "x86_64")]

--- a/tests/win32_arrays/tests/ipv6_address_ex.rs
+++ b/tests/win32_arrays/tests/ipv6_address_ex.rs
@@ -1,4 +1,4 @@
-use test_win32_arrays::Windows::Win32::IpHelper::IPV6_ADDRESS_EX;
+use test_win32_arrays::Windows::Win32::NetworkManagement::IpHelper::IPV6_ADDRESS_EX;
 
 #[test]
 fn test() {

--- a/tests/win32_arrays/tests/nccalcsize_params.rs
+++ b/tests/win32_arrays/tests/nccalcsize_params.rs
@@ -1,4 +1,4 @@
-use test_win32_arrays::Windows::Win32::WindowsAndMessaging::NCCALCSIZE_PARAMS;
+use test_win32_arrays::Windows::Win32::UI::WindowsAndMessaging::NCCALCSIZE_PARAMS;
 
 #[test]
 #[cfg(target_arch = "x86_64")]

--- a/tests/winrt/build.rs
+++ b/tests/winrt/build.rs
@@ -20,7 +20,7 @@ fn main() {
             ShareTargetActivatedEventArgs, FileOpenPickerActivatedEventArgs, FileSavePickerActivatedEventArgs,
             CachedFileUpdaterActivatedEventArgs, BackgroundActivatedEventArgs,
         },
-        Windows::Win32::SystemServices::{CreateDispatcherQueueController, E_POINTER, E_NOINTERFACE},
+        Windows::Win32::System::SystemServices::{CreateDispatcherQueueController, E_POINTER, E_NOINTERFACE},
         Windows::UI::Xaml::Interop::TypeName,
         Windows::UI::Xaml::Data::ICustomProperty,
 

--- a/tests/winrt/tests/collisions.rs
+++ b/tests/winrt/tests/collisions.rs
@@ -4,7 +4,7 @@ use test_winrt::{
         WiFiDirectConnectionParameters, WiFiDirectDevice, WiFiDirectDeviceSelectorType,
     },
     Windows::Storage::Streams::{InMemoryRandomAccessStream, RandomAccessStreamReference},
-    Windows::Win32::SystemServices::E_POINTER,
+    Windows::Win32::System::SystemServices::E_POINTER,
 };
 
 // WiFiDirectDevice has a pair of static factory interfaces with overloads. This test

--- a/tests/winrt/tests/composition.rs
+++ b/tests/winrt/tests/composition.rs
@@ -1,6 +1,6 @@
 use test_winrt::{
     Windows::System::DispatcherQueueController,
-    Windows::Win32::SystemServices::{
+    Windows::Win32::System::SystemServices::{
         CreateDispatcherQueueController, DispatcherQueueOptions,
         DISPATCHERQUEUE_THREAD_APARTMENTTYPE, DISPATCHERQUEUE_THREAD_TYPE,
     },

--- a/tests/winrt/tests/error.rs
+++ b/tests/winrt/tests/error.rs
@@ -1,4 +1,4 @@
-use test_winrt::{Windows::Foundation::Uri, Windows::Win32::SystemServices::E_NOINTERFACE};
+use test_winrt::{Windows::Foundation::Uri, Windows::Win32::System::SystemServices::E_NOINTERFACE};
 
 #[test]
 fn from_hresult() {


### PR DESCRIPTION
Following https://github.com/microsoft/win32metadata/commit/df833c5f4d51659aea57926f0947308a4a9c1fef

I wasn't planning on PR'ing this at all. Well, I took care of the few renames to get the types for `HRESULT` etc. proper again after using newer bindings... and why not PR those few lines in advance.... turns out that required much more effort than expected, and someone else has probably done the same work already. Here it is anyway, in case it is useful to someone when the next `Windows.Win32.winmd` is pushed :grimacing: 

Note that `bindings.rs` needs to be regenerated from Windows - I'm currently playing around with this crate on Linux :wink:.