### PR TITLE
Fix link in getting-started.md

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -41,7 +41,7 @@ The question now is: which APIs do we import? Knowing exactly which API you want
 
 Doing the search should lead you to find the following:
 
-![Search Results](/images/ISpellChecker.png)
+![Search Results](./images/ISpellChecker.png)
 
 Remember the module path that `ISpellChecker` is in underneath `bindings`: `Windows::Win32::Intl`. You'll want to use that exactly when specifying the types you need to generate.
 


### PR DESCRIPTION
  Fixed the getting-started.md link because the image was not displaying correctly in the browser.