### PR TITLE
Reduce churn when updating version

### DIFF
--- a/crates/bindings/Cargo.toml
+++ b/crates/bindings/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "windows_bindings"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Generates bindings for the Windows crate"
 
 [dependencies]
-windows_macros = { path = "../macros",  version = "0.9.1" }
-windows_gen = { path = "../gen",  version = "0.9.1" }
+windows_macros = { path = "../macros" }
+windows_gen = { path = "../gen" }

--- a/crates/crates/Cargo.toml
+++ b/crates/crates/Cargo.toml
@@ -1,10 +1,10 @@
 [package]
 name = "windows_crates"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Generates crates for the Windows APIs"
 
 [dependencies]
-gen = { package = "windows_gen", path = "../gen", version = "0.9.1" }
+gen = { package = "windows_gen", path = "../gen" }

--- a/examples/clock/Cargo.toml
+++ b/examples/clock/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clock"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/examples/clock/bindings/Cargo.toml
+++ b/examples/clock/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "clock_bindings"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/examples/com_uri/Cargo.toml
+++ b/examples/com_uri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "com_uri"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/examples/com_uri/bindings/Cargo.toml
+++ b/examples/com_uri/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "com_uri_bindings"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/examples/enum_windows/Cargo.toml
+++ b/examples/enum_windows/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enum_windows"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/examples/enum_windows/bindings/Cargo.toml
+++ b/examples/enum_windows/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "enum_windows_bindings"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/examples/event/Cargo.toml
+++ b/examples/event/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "event"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/examples/event/bindings/Cargo.toml
+++ b/examples/event/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "event_bindings"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/examples/message_box/Cargo.toml
+++ b/examples/message_box/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "message_box"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/examples/message_box/bindings/Cargo.toml
+++ b/examples/message_box/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "message_box_bindings"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/examples/ocr/Cargo.toml
+++ b/examples/ocr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocr"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/examples/ocr/bindings/Cargo.toml
+++ b/examples/ocr/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ocr_bindings"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/examples/overlapped/Cargo.toml
+++ b/examples/overlapped/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "overlapped"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/examples/overlapped/bindings/Cargo.toml
+++ b/examples/overlapped/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "overlapped_bindings"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/examples/rss/Cargo.toml
+++ b/examples/rss/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rss"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/examples/rss/bindings/Cargo.toml
+++ b/examples/rss/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rss_bindings"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/examples/simple/Cargo.toml
+++ b/examples/simple/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "simple"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/examples/spellchecker/Cargo.toml
+++ b/examples/spellchecker/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spellchecker"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/examples/spellchecker/bindings/Cargo.toml
+++ b/examples/spellchecker/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "spellchecker_bindings"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/examples/webview2/Cargo.toml
+++ b/examples/webview2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webview2"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/examples/webview2/bindings/Cargo.toml
+++ b/examples/webview2/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "webview2_bindings"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/examples/win2d/Cargo.toml
+++ b/examples/win2d/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "win2d"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/examples/win2d/bindings/Cargo.toml
+++ b/examples/win2d/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "win2d_bindings"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/examples/xml/Cargo.toml
+++ b/examples/xml/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xml"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/examples/xml/bindings/Cargo.toml
+++ b/examples/xml/bindings/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xml_bindings"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/tests/bstr/Cargo.toml
+++ b/tests/bstr/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_bstr"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/tests/convertible/Cargo.toml
+++ b/tests/convertible/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "test_convertible"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 
 [dependencies]
 windows = { path = "../.." }
-gen = { package = "windows_gen", path = "../../crates/gen",  version = "0.9.1" }
+gen = { package = "windows_gen", path = "../../crates/gen" }
 
 [build-dependencies]
 windows = { path = "../.." }

--- a/tests/deprecated/Cargo.toml
+++ b/tests/deprecated/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_deprecated"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/tests/handles/Cargo.toml
+++ b/tests/handles/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_handles"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/tests/interfaces/Cargo.toml
+++ b/tests/interfaces/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_interfaces"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/tests/interop/Cargo.toml
+++ b/tests/interop/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_interop"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/tests/matrix3x2/Cargo.toml
+++ b/tests/matrix3x2/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_matrix3x2"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/tests/structs/Cargo.toml
+++ b/tests/structs/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_structs"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/tests/unions/Cargo.toml
+++ b/tests/unions/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "test_unions"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 
 [dependencies]
 windows = { path = "../.." }
-gen = { package = "windows_gen", path = "../../crates/gen",  version = "0.9.1" }
+gen = { package = "windows_gen", path = "../../crates/gen" }
 
 [build-dependencies]
 windows = { path = "../.." }

--- a/tests/weak/Cargo.toml
+++ b/tests/weak/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "test_weak"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 

--- a/tests/wildcard/Cargo.toml
+++ b/tests/wildcard/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "test_wildcard"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 
 [dependencies]
 windows = { path = "../.." }
-gen = { package = "windows_gen", path = "../../crates/gen",  version = "0.9.1" }
+gen = { package = "windows_gen", path = "../../crates/gen" }
 
 [build-dependencies]
 windows = { path = "../.." }

--- a/tests/win32/Cargo.toml
+++ b/tests/win32/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "test_win32"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 
 [dependencies]
 windows = { path = "../.." }
-gen = { package = "windows_gen", path = "../../crates/gen",  version = "0.9.1" }
+gen = { package = "windows_gen", path = "../../crates/gen" }
 
 [build-dependencies]
 windows = { path = "../.." }

--- a/tests/win32_arrays/Cargo.toml
+++ b/tests/win32_arrays/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "test_win32_arrays"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 
 [dependencies]
 windows = { path = "../.." }
-gen = { package = "windows_gen", path = "../../crates/gen",  version = "0.9.1" }
+gen = { package = "windows_gen", path = "../../crates/gen" }
 
 [build-dependencies]
 windows = { path = "../.." }

--- a/tests/winrt/Cargo.toml
+++ b/tests/winrt/Cargo.toml
@@ -1,12 +1,12 @@
 [package]
 name = "test_winrt"
-version = "0.9.1"
+version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 
 [dependencies]
 windows = { path = "../.." }
-gen = { package = "windows_gen", path = "../../crates/gen",  version = "0.9.1" }
+gen = { package = "windows_gen", path = "../../crates/gen" }
 
 [dev-dependencies]
 futures = "0.3"


### PR DESCRIPTION
This update sets the version of all unpublished crates to `0.0.0` to avoid unnecessary churn when publishing a new version of the Windows crate.