### PR TITLE
Add MemoryBuffer example

### DIFF
--- a/examples/buffer/Cargo.toml
+++ b/examples/buffer/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name = "buffer"
+version = "0.0.0"
+authors = ["Microsoft"]
+edition = "2018"
+
+[dependencies]
+bindings = { package = "buffer_bindings", path = "bindings" }
+windows = { path = "../.." }

--- a/examples/buffer/bindings/Cargo.toml
+++ b/examples/buffer/bindings/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "buffer_bindings"
+version = "0.0.0"
+authors = ["Microsoft"]
+edition = "2018"
+
+[dependencies]
+windows = { path = "../../.." }
+
+[build-dependencies]
+windows = { path = "../../.." }

--- a/examples/buffer/bindings/build.rs
+++ b/examples/buffer/bindings/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    windows::build!(
+        Windows::Foundation::*,
+        Windows::Win32::WinRT::IMemoryBufferByteAccess,
+    );
+}

--- a/examples/buffer/bindings/src/lib.rs
+++ b/examples/buffer/bindings/src/lib.rs
@@ -1,0 +1,1 @@
+windows::include_bindings!();

--- a/examples/buffer/src/main.rs
+++ b/examples/buffer/src/main.rs
@@ -1,0 +1,33 @@
+use bindings::{Windows::Foundation::*, Windows::Win32::WinRT::IMemoryBufferByteAccess};
+use windows::*;
+
+fn as_slice(buffer: &IMemoryBufferReference) -> Result<&mut [u8]> {
+    let interop = buffer.cast::<IMemoryBufferByteAccess>()?;
+    let mut data = std::ptr::null_mut();
+    let mut len = 0;
+
+    unsafe {
+        interop.GetBuffer(&mut data, &mut len).ok()?;
+        Ok(std::slice::from_raw_parts_mut(data, len as _))
+    }
+}
+
+fn main() -> Result<()> {
+    let buffer = MemoryBuffer::Create(11)?;
+    let reference = buffer.CreateReference()?;
+    assert_eq!(reference.Capacity()?, 11);
+
+    // Write to buffer...
+    {
+        let slice = as_slice(&reference)?;
+        slice.copy_from_slice(b"hello world");
+    }
+
+    // Read from buffer...
+    {
+        let slice = as_slice(&reference)?;
+        assert_eq!(slice, b"hello world");
+    }
+
+    Ok(())
+}


### PR DESCRIPTION
This is a simple example illustrating how to use the WinRT `MemoryBuffer` class with the COM `IMemoryBufferByteAccess` interop interface.