### PR TITLE
Remove dead code

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,6 @@ gen = { package = "windows_gen", path = "crates/gen",  version = "0.9.1", option
 const-sha1 = "0.2"
 
 [dev-dependencies]
-doc-comment = "0.3"
 gen = { package = "windows_gen", path = "crates/gen" }
 
 [workspace]

--- a/crates/gen/src/parser/element_type.rs
+++ b/crates/gen/src/parser/element_type.rs
@@ -126,7 +126,7 @@ impl ElementType {
 
                 match code {
                     TypeDefOrRef::TypeRef(type_ref) => match type_ref.full_name() {
-                        ("System", "Guid") | ("Windows.Win32.System.Com", "Guid") => Self::Guid,
+                        ("System", "Guid") => Self::Guid,
                         ("Windows.Win32.System.Com", "IUnknown") => Self::IUnknown,
                         ("Windows.Foundation", "HResult") => Self::HRESULT,
                         ("Windows.Win32.System.Com", "HRESULT") => Self::HRESULT,


### PR DESCRIPTION
`Guid` is no longer defined in Win32 metadata and the `doc-comment` dependency is unused.