### PR TITLE
README: Update to new namespaces

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -30,14 +30,11 @@ This will allow Cargo to download, build, and cache Windows support as a package
 fn main() {
     windows::build!(
         Windows::Data::Xml::Dom::*,
+        Windows::Win32::System::Threading::{
+            CreateEventW, SetEvent, WaitForSingleObject
+        },
         Windows::Win32::System::WindowsProgramming::CloseHandle,
         Windows::Win32::UI::WindowsAndMessaging::MessageBoxA,
-        Windows::Win32::Threading::{
-            CreateEventW, SetEvent,
-        }
-        Windows::Win32::System::SystemServices::{
-            WaitForSingleObject
-        },
     );
 }
 ```
@@ -51,10 +48,9 @@ mod bindings {
 
 use bindings::{
     Windows::Data::Xml::Dom::*,
-    Windows::Win32::System::Threading::{CreateEventW, SetEvent},
-    Windows::Win32::System::SystemServices::{WaitForSingleObject},
-    Windows::Win32::UI::WindowsAndMessaging::{MessageBoxA, MESSAGEBOX_STYLE},
+    Windows::Win32::System::Threading::{CreateEventW, SetEvent, WaitForSingleObject},
     Windows::Win32::System::WindowsProgramming::CloseHandle,
+    Windows::Win32::UI::WindowsAndMessaging::{MessageBoxA, MESSAGEBOX_STYLE},
 };
 
 fn main() -> windows::Result<()> {


### PR DESCRIPTION
`WaitForSingleObject` resides under `System::Threading`, and that block
was missing a comma.  The `build!` macro is sorted based on `rustfmt` on
the `use` group in `main.rs`.

Fixes: e5e9d31 ("Update metadata (#749)")