### PR TITLE
Implement `BSTR` and `PWSTR` using platform-agnostic `widestring` crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ exclude = [".github", ".windows", "docs", "examples"]
 [dependencies]
 windows_macros = { path = "crates/macros",  version = "0.10.0", optional = true }
 gen = { package = "windows_gen", path = "crates/gen",  version = "0.10.0", optional = true }
+
 const-sha1 = "0.2"
+widestring = "0.4"
 
 [dev-dependencies]
 gen = { package = "windows_gen", path = "crates/gen" }

--- a/crates/gen/src/types/bstr.rs
+++ b/crates/gen/src/types/bstr.rs
@@ -13,16 +13,61 @@ pub fn gen_bstr() -> TokenStream {
                 self.0.is_null()
             }
             pub fn len(&self) -> usize {
+                // TODO: Override directly in bindings.rs generation
+                #[cfg(not(windows))]
+                unsafe fn SysStringLen(s: &BSTR) -> u32 {
+                    unsafe fn SysStringByteLen(s: &BSTR) -> u32 {
+                        if s.0.is_null() {
+                            0
+                        } else {
+                            s.0.cast::<u32>().offset(-1).read()
+                        }
+                    }
+                    SysStringByteLen(s)
+                        / std::mem::size_of::<::windows::widestring::WideChar>()
+                        as u32
+                }
                 unsafe { SysStringLen(self) as usize }
             }
             fn from_wide(value: &::windows::widestring::WideStr) -> Self {
                 if value.is_empty() {
                     return Self(::std::ptr::null_mut());
                 }
+                #[cfg(windows)]
                 unsafe {
                     SysAllocStringLen(
                         super::SystemServices::PWSTR(value.as_ptr() as _),
                         value.len() as u32,
+                    )
+                }
+                // TODO: Implement this inside `SysAllocStringLen`
+                #[cfg(not(windows))]
+                {
+                    const LENGTH_PREFIX_IN_CHARS: usize = std::mem::size_of::<u32>()
+                        / std::mem::size_of::<::windows::widestring::WideChar>();
+                    let mut vec: Vec<::windows::widestring::WideChar> =
+                        // Includes trailing null character
+                        vec![0; LENGTH_PREFIX_IN_CHARS + value.len() + 1];
+                    vec[LENGTH_PREFIX_IN_CHARS..LENGTH_PREFIX_IN_CHARS + value.len()]
+                        .copy_from_slice(value.as_slice());
+                    assert_eq!(vec[LENGTH_PREFIX_IN_CHARS + value.len()], 0);
+
+                    // Cast to u32 for easy access to length prefix and
+                    // pointer beyond that
+                    let vec_ptr = vec.as_mut_ptr().cast::<u32>();
+                    std::mem::forget(vec);
+
+                    // Store length-prefix without NULL, in bytes
+                    unsafe {
+                        *vec_ptr = (value.len()
+                            * std::mem::size_of::<::windows::widestring::WideChar>())
+                            as u32
+                    };
+
+                    BSTR(
+                        // Pointer points to first character byte, not to length-prefix
+                        unsafe { vec_ptr.offset(1) }
+                            .cast::<::windows::widestring::WideChar>(),
                     )
                 }
             }
@@ -122,6 +167,11 @@ pub fn gen_bstr() -> TokenStream {
 
         impl ::std::ops::Drop for BSTR {
             fn drop(&mut self) {
+                #[cfg(not(windows))]
+                unsafe fn SysFreeString(s: &BSTR) {
+                    ::std::boxed::Box::from_raw(s.0.cast::<u32>().offset(-1));
+                }
+
                 if !self.0.is_null() {
                     unsafe { SysFreeString(self as &Self) };
                 }

--- a/crates/gen/src/types/pwstr.rs
+++ b/crates/gen/src/types/pwstr.rs
@@ -3,46 +3,92 @@ use super::*;
 pub fn gen_pwstr() -> TokenStream {
     quote! {
         #[repr(transparent)]
-        #[derive(::std::clone::Clone, ::std::marker::Copy, ::std::cmp::Eq, ::std::fmt::Debug)]
-        pub struct PWSTR(pub *mut u16);
+        #[derive(::std::clone::Clone, ::std::marker::Copy, ::std::cmp::Eq)]
+        /// Uses [`::windows::widestring::UCStr`] for null-terminated, checked strings.
+        pub struct PWSTR(pub *mut ::windows::widestring::WideChar);
         impl PWSTR {
             pub const NULL: Self = Self(::std::ptr::null_mut());
             pub fn is_null(&self) -> bool {
                 self.0.is_null()
             }
+            pub fn is_empty(&self) -> bool {
+                // TODO: Should possibly also check length!
+                self.is_null()
+            }
+            pub fn len(&self) -> usize {
+                self.as_wide().len()
+            }
+            fn as_wide(&self) -> &::windows::widestring::WideCStr {
+                if self.is_null() {
+                    Default::default()
+                } else {
+                    unsafe { ::windows::widestring::WideCStr::from_ptr_str(self.0) }
+                }
+            }
         }
+
         impl ::std::default::Default for PWSTR {
             fn default() -> Self {
                 Self(::std::ptr::null_mut())
             }
         }
-        // TODO: impl Debug and Display to display value and PartialEq etc
-        impl ::std::cmp::PartialEq for PWSTR {
-            fn eq(&self, other: &Self) -> bool {
-                // TODO: do value compare
-                self.0 == other.0
+
+        impl ::std::fmt::Display for PWSTR {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                f.write_str(&self.as_wide().to_string().unwrap())
             }
         }
+        impl ::std::fmt::Debug for PWSTR {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                ::std::write!(f, "{}", self)
+            }
+        }
+
+        impl ::std::cmp::PartialEq for PWSTR {
+            fn eq(&self, other: &Self) -> bool {
+                self.as_wide().eq(other.as_wide())
+            }
+        }
+        impl ::std::cmp::PartialEq<&str> for PWSTR {
+            fn eq(&self, other: &&str) -> bool {
+                let other = unsafe { ::windows::widestring::WideCString::from_str_unchecked(other) };
+                self.as_wide().eq(&other)
+            }
+        }
+        impl ::std::cmp::PartialEq<PWSTR> for &str {
+            fn eq(&self, other: &PWSTR) -> bool {
+                other.eq(self)
+            }
+        }
+
         unsafe impl ::windows::Abi for PWSTR {
             type Abi = Self;
 
             fn drop_param(param: &mut ::windows::Param<Self>) {
                 if let ::windows::Param::Boxed(value) = param {
-                    if !value.0.is_null() {
-                        unsafe { ::std::boxed::Box::from_raw(value.0); }
+                    if !value.is_null() {
+                        unsafe { ::windows::widestring::WideCString::from_raw(value.0) };
                     }
                 }
             }
         }
         impl<'a> ::windows::IntoParam<'a, PWSTR> for &'a str {
             fn into_param(self) -> ::windows::Param<'a, PWSTR> {
-                ::windows::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(self.encode_utf16().chain(::std::iter::once(0)).collect::<std::vec::Vec<u16>>().into_boxed_slice()) as _))
+                ::windows::Param::Boxed(PWSTR(
+                    ::windows::widestring::WideCString::from_str(self)
+                        .unwrap()
+                        .into_raw(),
+                ))
             }
         }
         impl<'a> ::windows::IntoParam<'a, PWSTR> for String {
             fn into_param(self) -> ::windows::Param<'a, PWSTR> {
                 // TODO: call variant above
-                ::windows::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(self.encode_utf16().chain(::std::iter::once(0)).collect::<std::vec::Vec<u16>>().into_boxed_slice()) as _))
+                ::windows::Param::Boxed(PWSTR(
+                    ::windows::widestring::WideCString::from_str(self)
+                        .unwrap()
+                        .into_raw(),
+                ))
             }
         }
     }

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -2565,16 +2565,27 @@ pub mod Windows {
             pub mod SystemServices {
                 #[repr(transparent)]
                 #[derive(
-                    :: std :: clone :: Clone,
-                    :: std :: marker :: Copy,
-                    :: std :: cmp :: Eq,
-                    :: std :: fmt :: Debug,
+                    :: std :: clone :: Clone, :: std :: marker :: Copy, :: std :: cmp :: Eq,
                 )]
-                pub struct PWSTR(pub *mut u16);
+                #[doc = r" Uses [`::windows::widestring::UCStr`] for null-terminated, checked strings."]
+                pub struct PWSTR(pub *mut ::windows::widestring::WideChar);
                 impl PWSTR {
                     pub const NULL: Self = Self(::std::ptr::null_mut());
                     pub fn is_null(&self) -> bool {
                         self.0.is_null()
+                    }
+                    pub fn is_empty(&self) -> bool {
+                        self.is_null()
+                    }
+                    pub fn len(&self) -> usize {
+                        self.as_wide().len()
+                    }
+                    fn as_wide(&self) -> &::windows::widestring::WideCStr {
+                        if self.is_null() {
+                            Default::default()
+                        } else {
+                            unsafe { ::windows::widestring::WideCStr::from_ptr_str(self.0) }
+                        }
                     }
                 }
                 impl ::std::default::Default for PWSTR {
@@ -2582,41 +2593,60 @@ pub mod Windows {
                         Self(::std::ptr::null_mut())
                     }
                 }
+                impl ::std::fmt::Display for PWSTR {
+                    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                        f.write_str(&self.as_wide().to_string().unwrap())
+                    }
+                }
+                impl ::std::fmt::Debug for PWSTR {
+                    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                        ::std::write!(f, "{}", self)
+                    }
+                }
                 impl ::std::cmp::PartialEq for PWSTR {
                     fn eq(&self, other: &Self) -> bool {
-                        self.0 == other.0
+                        self.as_wide().eq(other.as_wide())
+                    }
+                }
+                impl ::std::cmp::PartialEq<&str> for PWSTR {
+                    fn eq(&self, other: &&str) -> bool {
+                        let other = unsafe {
+                            ::windows::widestring::WideCString::from_str_unchecked(other)
+                        };
+                        self.as_wide().eq(&other)
+                    }
+                }
+                impl ::std::cmp::PartialEq<PWSTR> for &str {
+                    fn eq(&self, other: &PWSTR) -> bool {
+                        other.eq(self)
                     }
                 }
                 unsafe impl ::windows::Abi for PWSTR {
                     type Abi = Self;
                     fn drop_param(param: &mut ::windows::Param<Self>) {
                         if let ::windows::Param::Boxed(value) = param {
-                            if !value.0.is_null() {
-                                unsafe {
-                                    ::std::boxed::Box::from_raw(value.0);
-                                }
+                            if !value.is_null() {
+                                unsafe { ::windows::widestring::WideCString::from_raw(value.0) };
                             }
                         }
                     }
                 }
                 impl<'a> ::windows::IntoParam<'a, PWSTR> for &'a str {
                     fn into_param(self) -> ::windows::Param<'a, PWSTR> {
-                        ::windows::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(
-                            self.encode_utf16()
-                                .chain(::std::iter::once(0))
-                                .collect::<std::vec::Vec<u16>>()
-                                .into_boxed_slice(),
-                        ) as _))
+                        ::windows::Param::Boxed(PWSTR(
+                            ::windows::widestring::WideCString::from_str(self)
+                                .unwrap()
+                                .into_raw(),
+                        ))
                     }
                 }
                 impl<'a> ::windows::IntoParam<'a, PWSTR> for String {
                     fn into_param(self) -> ::windows::Param<'a, PWSTR> {
-                        ::windows::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(
-                            self.encode_utf16()
-                                .chain(::std::iter::once(0))
-                                .collect::<std::vec::Vec<u16>>()
-                                .into_boxed_slice(),
-                        ) as _))
+                        ::windows::Param::Boxed(PWSTR(
+                            ::windows::widestring::WideCString::from_str(self)
+                                .unwrap()
+                                .into_raw(),
+                        ))
                     }
                 }
                 #[repr(transparent)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,3 +45,6 @@ pub type RawPtr = *mut std::ffi::c_void;
 
 #[doc(hidden)]
 pub use const_sha1::ConstBuffer;
+
+#[doc(hidden)]
+pub use widestring;


### PR DESCRIPTION
Widestrings are UTF-16 on Windows but UTF-32 on other platforms. The `widestring` crate abstracts this detail away behind its `WideString`, `WideCString`, `WideStr` and `WideCStr` type aliases for convenience. Aside that it provides useful helpers and makes a clear distinction between null-terminated strings and "binary strings" with an explicit length and interior NULLs.

The only downside of `widestring` is that it includes `winapi` under `dev-dependencies` for an example in the documentation.

This change adds some missing value comparison, debugging and printing functionality.

### TODO

Shims for non-Windows platforms are not ready. They're in a separate commit and best reviewed (and PR'd) separately, but it'd be nice if we can discuss how to override the `Sys*` functions themselves. see also #770.

### `crates/gen/src/types` ergonomics

Editing these massive generated `quote!` blocks is really cumbersome without autoformatting and `rust-analyzer`. Are there plans to promote these types to the `windows` crate (like `HRESULT` and `IUnknown`)? That makes editing easier **and** slims down all autogenerated files by a fair bit.