### PR TITLE
Add DirectXShaderCompiler example

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,9 @@ exclude = [".github", ".windows", "docs", "examples"]
 [dependencies]
 windows_macros = { path = "crates/macros",  version = "0.10.0", optional = true }
 gen = { package = "windows_gen", path = "crates/gen",  version = "0.10.0", optional = true }
+
 const-sha1 = "0.2"
+widestring = "0.4"
 
 [dev-dependencies]
 gen = { package = "windows_gen", path = "crates/gen" }

--- a/crates/gen/src/types/pwstr.rs
+++ b/crates/gen/src/types/pwstr.rs
@@ -3,46 +3,92 @@ use super::*;
 pub fn gen_pwstr() -> TokenStream {
     quote! {
         #[repr(transparent)]
-        #[derive(::std::clone::Clone, ::std::marker::Copy, ::std::cmp::Eq, ::std::fmt::Debug)]
-        pub struct PWSTR(pub *mut u16);
+        #[derive(::std::clone::Clone, ::std::marker::Copy, ::std::cmp::Eq)]
+        /// Uses [`::windows::widestring::UCStr`] for null-terminated, checked strings.
+        pub struct PWSTR(pub *mut ::windows::widestring::WideChar);
         impl PWSTR {
             pub const NULL: Self = Self(::std::ptr::null_mut());
             pub fn is_null(&self) -> bool {
                 self.0.is_null()
             }
+            pub fn is_empty(&self) -> bool {
+                // TODO: Should possibly also check length!
+                self.is_null()
+            }
+            pub fn len(&self) -> usize {
+                self.as_wide().len()
+            }
+            fn as_wide(&self) -> &::windows::widestring::WideCStr {
+                if self.is_null() {
+                    Default::default()
+                } else {
+                    unsafe { ::windows::widestring::WideCStr::from_ptr_str(self.0) }
+                }
+            }
         }
+
         impl ::std::default::Default for PWSTR {
             fn default() -> Self {
                 Self(::std::ptr::null_mut())
             }
         }
-        // TODO: impl Debug and Display to display value and PartialEq etc
-        impl ::std::cmp::PartialEq for PWSTR {
-            fn eq(&self, other: &Self) -> bool {
-                // TODO: do value compare
-                self.0 == other.0
+
+        impl ::std::fmt::Display for PWSTR {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                f.write_str(&self.as_wide().to_string().unwrap())
             }
         }
+        impl ::std::fmt::Debug for PWSTR {
+            fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                ::std::write!(f, "{}", self)
+            }
+        }
+
+        impl ::std::cmp::PartialEq for PWSTR {
+            fn eq(&self, other: &Self) -> bool {
+                self.as_wide().eq(other.as_wide())
+            }
+        }
+        impl ::std::cmp::PartialEq<&str> for PWSTR {
+            fn eq(&self, other: &&str) -> bool {
+                let other = unsafe { ::windows::widestring::WideCString::from_str_unchecked(other) };
+                self.as_wide().eq(&other)
+            }
+        }
+        impl ::std::cmp::PartialEq<PWSTR> for &str {
+            fn eq(&self, other: &PWSTR) -> bool {
+                other.eq(self)
+            }
+        }
+
         unsafe impl ::windows::Abi for PWSTR {
             type Abi = Self;
 
             fn drop_param(param: &mut ::windows::Param<Self>) {
                 if let ::windows::Param::Boxed(value) = param {
-                    if !value.0.is_null() {
-                        unsafe { ::std::boxed::Box::from_raw(value.0); }
+                    if !value.is_null() {
+                        unsafe { ::windows::widestring::WideCString::from_raw(value.0) };
                     }
                 }
             }
         }
         impl<'a> ::windows::IntoParam<'a, PWSTR> for &'a str {
             fn into_param(self) -> ::windows::Param<'a, PWSTR> {
-                ::windows::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(self.encode_utf16().chain(::std::iter::once(0)).collect::<std::vec::Vec<u16>>().into_boxed_slice()) as _))
+                ::windows::Param::Boxed(PWSTR(
+                    ::windows::widestring::WideCString::from_str(self)
+                        .unwrap()
+                        .into_raw(),
+                ))
             }
         }
         impl<'a> ::windows::IntoParam<'a, PWSTR> for String {
             fn into_param(self) -> ::windows::Param<'a, PWSTR> {
                 // TODO: call variant above
-                ::windows::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(self.encode_utf16().chain(::std::iter::once(0)).collect::<std::vec::Vec<u16>>().into_boxed_slice()) as _))
+                ::windows::Param::Boxed(PWSTR(
+                    ::windows::widestring::WideCString::from_str(self)
+                        .unwrap()
+                        .into_raw(),
+                ))
             }
         }
     }

--- a/examples/dxc/Cargo.toml
+++ b/examples/dxc/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "dxc"
+version = "0.0.0"
+authors = ["Microsoft"]
+edition = "2018"
+
+[dependencies]
+bindings = { package = "dxc_bindings", path = "bindings" }
+libloading = "0.7"
+windows = { path = "../.." }

--- a/examples/dxc/bindings/Cargo.toml
+++ b/examples/dxc/bindings/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "dxc_bindings"
+version = "0.0.0"
+authors = ["Microsoft"]
+edition = "2018"
+
+[dependencies]
+windows = { path = "../../.." }
+
+[build-dependencies]
+windows = { path = "../../.." }

--- a/examples/dxc/bindings/build.rs
+++ b/examples/dxc/bindings/build.rs
@@ -2,5 +2,6 @@ fn main() {
     windows::build!(
         Windows::Win32::Globalization::CP_UTF8,
         Windows::Win32::Graphics::Hlsl::*,
+        Windows::Win32::System::Diagnostics::Debug::ERROR_FILE_NOT_FOUND,
     );
 }

--- a/examples/dxc/bindings/build.rs
+++ b/examples/dxc/bindings/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    windows::build!(
+        Windows::Win32::Globalization::CP_UTF8,
+        Windows::Win32::Graphics::Hlsl::*,
+    );
+}

--- a/examples/dxc/bindings/src/lib.rs
+++ b/examples/dxc/bindings/src/lib.rs
@@ -1,0 +1,1 @@
+windows::include_bindings!();

--- a/examples/dxc/src/copy.hlsl
+++ b/examples/dxc/src/copy.hlsl
@@ -1,0 +1,8 @@
+Texture2D<float4> g_input    : register(t0, space0);
+RWTexture2D<float4> g_output : register(u0, space0);
+
+[numthreads(8, 8, 1)]
+void copyCs(uint3 dispatchThreadId : SV_DispatchThreadID)
+{
+	g_output[dispatchThreadId.xy] = g_input[dispatchThreadId.xy];
+}

--- a/examples/dxc/src/main.rs
+++ b/examples/dxc/src/main.rs
@@ -1,8 +1,14 @@
 use bindings::Windows::Win32::{
-    Globalization::CP_UTF8, Graphics::Hlsl::*, System::SystemServices::BOOL,
+    Globalization::CP_UTF8,
+    Graphics::Hlsl::*,
+    System::{
+        Diagnostics::Debug::ERROR_FILE_NOT_FOUND,
+        SystemServices::{BOOL, PWSTR},
+    },
 };
 use libloading::{Library, Symbol};
 use std::path::Path;
+use std::rc::Rc;
 use windows::*;
 
 // Only exists in newer DXC headers
@@ -38,6 +44,20 @@ fn blob_encoding_as_str(blob: &IDxcBlobEncoding) -> &str {
     }
 }
 
+fn create_blob(library: &IDxcLibrary, data: &str) -> windows::Result<IDxcBlobEncoding> {
+    let mut blob = None;
+    unsafe {
+        library.CreateBlobWithEncodingFromPinned(
+            data.as_ptr() as *const _,
+            data.len() as u32,
+            DXC_CP_UTF8,
+            &mut blob,
+        )
+    }
+    .and_some(blob)
+}
+
+#[allow(non_snake_case)]
 fn main() -> windows::Result<()> {
     let lib = unsafe { Library::new(dxcompiler_lib_name()) }.unwrap();
     let create: Symbol<DxcCreateInstanceProc> = unsafe { lib.get(b"DxcCreateInstance\0") }.unwrap();
@@ -48,35 +68,133 @@ fn main() -> windows::Result<()> {
 
     dbg!(&compiler, &library);
 
-    let main_shader = include_str!("copy.hlsl");
+    let main_shader = "#include \"copy.hlsl\"";
+    let shader_blob = create_blob(&library, main_shader)?;
 
-    let mut blob = None;
-    let shader_blob = unsafe {
-        library.CreateBlobWithEncodingFromPinned(
-            main_shader.as_ptr() as *const _,
-            main_shader.len() as u32,
-            DXC_CP_UTF8,
-            &mut blob,
-        )
+    unsafe extern "system" fn LoadSource(
+        this: RawPtr,
+        pfilename: PWSTR,
+        ppincludesource: *mut RawPtr,
+    ) -> HRESULT {
+        let this = &mut *(this as *mut IncludeHandlerData);
+        dbg!(&this, pfilename, ppincludesource);
+
+        if pfilename != "./foo/bar/copy.hlsl" {
+            return HRESULT::from_win32(ERROR_FILE_NOT_FOUND.0);
+        }
+        let copy_shader = include_str!("copy.hlsl");
+        let shader_blob = create_blob(&this.library, copy_shader).unwrap();
+        *ppincludesource = shader_blob.abi();
+        this.alive_shaders.push(shader_blob);
+        HRESULT(0)
     }
-    .and_some(blob)?;
-    dbg!(&shader_blob);
+
+    unsafe extern "system" fn QueryInterface(
+        _ptr: RawPtr,
+        _iid: &Guid,
+        _interface: *mut RawPtr,
+    ) -> HRESULT {
+        todo!()
+    }
+
+    unsafe extern "system" fn AddRef(this: ::windows::RawPtr) -> u32 {
+        let this = &mut *(this as *mut IncludeHandlerData);
+        dbg!(this.refs.add_ref())
+    }
+
+    unsafe extern "system" fn Release(this: ::windows::RawPtr) -> u32 {
+        let this = &mut *(this as *mut IncludeHandlerData);
+        dbg!(this.refs.release())
+    }
+
+    #[cfg(not(windows))]
+    unsafe extern "system" fn dtor(_ptr: ::windows::RawPtr) {
+        todo!()
+    }
+
+    let include_handler = IDxcIncludeHandler_abi(
+        // IUnknown
+        QueryInterface,
+        AddRef,
+        Release,
+        // Virtual destructors breaking the vtable, hack for !windows DXC
+        #[cfg(not(windows))]
+        dtor,
+        #[cfg(not(windows))]
+        dtor,
+        LoadSource,
+    );
+
+    #[derive(Debug)]
+    struct IncludeHandlerData {
+        vtable: *const IDxcIncludeHandler_abi,
+        refs: RefCount,
+        library: Rc<IDxcLibrary>,
+        alive_shaders: Vec<IDxcBlobEncoding>,
+    }
+
+    #[derive(Debug)]
+    struct IncludeHandler(std::ptr::NonNull<IncludeHandlerData>);
+
+    let library = Rc::new(library);
+
+    let handler_data = Box::new(IncludeHandlerData {
+        vtable: &include_handler,
+        refs: RefCount::new(1),
+        library,
+        alive_shaders: vec![],
+    });
+
+    let handler =
+        IncludeHandler(unsafe { std::ptr::NonNull::new_unchecked(Box::into_raw(handler_data)) });
+
+    unsafe impl ::windows::Interface for IncludeHandler {
+        type Vtable = IDxcIncludeHandler_abi;
+        const IID: ::windows::Guid = ::windows::Guid::from_values(
+            2137128061,
+            38157,
+            18047,
+            [179, 227, 60, 2, 251, 73, 24, 124],
+        );
+    }
+    impl ::std::convert::From<IncludeHandler> for IDxcIncludeHandler {
+        fn from(value: IncludeHandler) -> Self {
+            unsafe { ::std::mem::transmute(value) }
+        }
+    }
+    impl ::std::convert::From<&IncludeHandler> for &IDxcIncludeHandler {
+        fn from(value: &IncludeHandler) -> Self {
+            unsafe { ::std::mem::transmute(value) }
+        }
+    }
+    impl<'a> IntoParam<'a, IDxcIncludeHandler> for IncludeHandler {
+        fn into_param(self) -> Param<'a, IDxcIncludeHandler> {
+            Param::Owned(::std::convert::Into::<IDxcIncludeHandler>::into(self))
+        }
+    }
+    impl<'a> IntoParam<'a, IDxcIncludeHandler> for &'a IncludeHandler {
+        fn into_param(self) -> Param<'a, IDxcIncludeHandler> {
+            Param::Borrowed(::std::convert::Into::<&IDxcIncludeHandler>::into(self))
+        }
+    }
+
+    dbg!(&handler);
 
     let mut args = vec![];
     let defines = vec![];
-
     let mut result = None;
     let result = unsafe {
         compiler.Compile(
             shader_blob,
-            "copy.hlsl",
+            "foo/bar/baz.hlsl",
             "copyCs",
             "cs_6_5",
             args.as_mut_ptr(), // Should not be mut?
             args.len() as u32,
             defines.as_ptr(),
             defines.len() as u32,
-            None,
+            // TODO: This also accepts a borrow which does not decrease our refcount to 0
+            handler,
             &mut result,
         )
     }

--- a/examples/dxc/src/main.rs
+++ b/examples/dxc/src/main.rs
@@ -1,0 +1,104 @@
+use bindings::Windows::Win32::{
+    Globalization::CP_UTF8, Graphics::Hlsl::*, System::SystemServices::BOOL,
+};
+use libloading::{Library, Symbol};
+use std::path::Path;
+use windows::*;
+
+// Only exists in newer DXC headers
+const DXC_CP_UTF8: u32 = CP_UTF8;
+
+#[cfg(target_os = "windows")]
+fn dxcompiler_lib_name() -> &'static Path {
+    Path::new("dxcompiler.dll")
+}
+
+#[cfg(target_os = "linux")]
+fn dxcompiler_lib_name() -> &'static Path {
+    Path::new("./libdxcompiler.so")
+}
+
+#[cfg(target_os = "macos")]
+fn dxcompiler_lib_name() -> &'static Path {
+    Path::new("./libdxcompiler.dynlib")
+}
+
+fn blob_encoding_as_str(blob: &IDxcBlobEncoding) -> &str {
+    let mut known: BOOL = false.into();
+    let mut cp = 0;
+    unsafe { blob.GetEncoding(known.set_abi(), cp.set_abi()) }.unwrap();
+    assert!(bool::from(known));
+    assert_eq!(cp, DXC_CP_UTF8);
+    unsafe {
+        let slice = std::slice::from_raw_parts(
+            blob.GetBufferPointer() as *const u8,
+            blob.GetBufferSize() - 1,
+        );
+        std::str::from_utf8_unchecked(slice)
+    }
+}
+
+fn main() -> windows::Result<()> {
+    let lib = unsafe { Library::new(dxcompiler_lib_name()) }.unwrap();
+    let create: Symbol<DxcCreateInstanceProc> = unsafe { lib.get(b"DxcCreateInstance\0") }.unwrap();
+    dbg!(&create);
+
+    let compiler: IDxcCompiler2 = unsafe { DxcCreateInstanceProc(&create, &CLSID_DxcCompiler) }?;
+    let library: IDxcLibrary = unsafe { DxcCreateInstanceProc(&create, &CLSID_DxcLibrary) }?;
+
+    dbg!(&compiler, &library);
+
+    let main_shader = include_str!("copy.hlsl");
+
+    let mut blob = None;
+    let shader_blob = unsafe {
+        library.CreateBlobWithEncodingFromPinned(
+            main_shader.as_ptr() as *const _,
+            main_shader.len() as u32,
+            DXC_CP_UTF8,
+            &mut blob,
+        )
+    }
+    .and_some(blob)?;
+    dbg!(&shader_blob);
+
+    let mut args = vec![];
+    let defines = vec![];
+
+    let mut result = None;
+    let result = unsafe {
+        compiler.Compile(
+            shader_blob,
+            "copy.hlsl",
+            "copyCs",
+            "cs_6_5",
+            args.as_mut_ptr(), // Should not be mut?
+            args.len() as u32,
+            defines.as_ptr(),
+            defines.len() as u32,
+            None,
+            &mut result,
+        )
+    }
+    .and_some(result)?;
+
+    let mut status = HRESULT::default();
+    unsafe { result.GetStatus(&mut status) }.ok()?;
+    if status.is_err() {
+        let mut errors = None;
+        let errors = unsafe { result.GetErrorBuffer(&mut errors) }.and_some(errors)?;
+        let errors = blob_encoding_as_str(&errors);
+        eprintln!("Compilation failed with {:?}: `{}`", status, errors);
+        status.ok()
+    } else {
+        let mut blob = None;
+        let blob = unsafe { result.GetResult(&mut blob) }.and_some(blob)?;
+        let shader = unsafe {
+            std::slice::from_raw_parts(blob.GetBufferPointer().cast::<u8>(), blob.GetBufferSize())
+        };
+        for c in shader.chunks(16) {
+            println!("{:02x?}", c);
+        }
+        Ok(())
+    }
+}

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -2565,16 +2565,27 @@ pub mod Windows {
             pub mod SystemServices {
                 #[repr(transparent)]
                 #[derive(
-                    :: std :: clone :: Clone,
-                    :: std :: marker :: Copy,
-                    :: std :: cmp :: Eq,
-                    :: std :: fmt :: Debug,
+                    :: std :: clone :: Clone, :: std :: marker :: Copy, :: std :: cmp :: Eq,
                 )]
-                pub struct PWSTR(pub *mut u16);
+                #[doc = r" Uses [`::windows::widestring::UCStr`] for null-terminated, checked strings."]
+                pub struct PWSTR(pub *mut ::windows::widestring::WideChar);
                 impl PWSTR {
                     pub const NULL: Self = Self(::std::ptr::null_mut());
                     pub fn is_null(&self) -> bool {
                         self.0.is_null()
+                    }
+                    pub fn is_empty(&self) -> bool {
+                        self.is_null()
+                    }
+                    pub fn len(&self) -> usize {
+                        self.as_wide().len()
+                    }
+                    fn as_wide(&self) -> &::windows::widestring::WideCStr {
+                        if self.is_null() {
+                            Default::default()
+                        } else {
+                            unsafe { ::windows::widestring::WideCStr::from_ptr_str(self.0) }
+                        }
                     }
                 }
                 impl ::std::default::Default for PWSTR {
@@ -2582,41 +2593,60 @@ pub mod Windows {
                         Self(::std::ptr::null_mut())
                     }
                 }
+                impl ::std::fmt::Display for PWSTR {
+                    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                        f.write_str(&self.as_wide().to_string().unwrap())
+                    }
+                }
+                impl ::std::fmt::Debug for PWSTR {
+                    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                        ::std::write!(f, "{}", self)
+                    }
+                }
                 impl ::std::cmp::PartialEq for PWSTR {
                     fn eq(&self, other: &Self) -> bool {
-                        self.0 == other.0
+                        self.as_wide().eq(other.as_wide())
+                    }
+                }
+                impl ::std::cmp::PartialEq<&str> for PWSTR {
+                    fn eq(&self, other: &&str) -> bool {
+                        let other = unsafe {
+                            ::windows::widestring::WideCString::from_str_unchecked(other)
+                        };
+                        self.as_wide().eq(&other)
+                    }
+                }
+                impl ::std::cmp::PartialEq<PWSTR> for &str {
+                    fn eq(&self, other: &PWSTR) -> bool {
+                        other.eq(self)
                     }
                 }
                 unsafe impl ::windows::Abi for PWSTR {
                     type Abi = Self;
                     fn drop_param(param: &mut ::windows::Param<Self>) {
                         if let ::windows::Param::Boxed(value) = param {
-                            if !value.0.is_null() {
-                                unsafe {
-                                    ::std::boxed::Box::from_raw(value.0);
-                                }
+                            if !value.is_null() {
+                                unsafe { ::windows::widestring::WideCString::from_raw(value.0) };
                             }
                         }
                     }
                 }
                 impl<'a> ::windows::IntoParam<'a, PWSTR> for &'a str {
                     fn into_param(self) -> ::windows::Param<'a, PWSTR> {
-                        ::windows::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(
-                            self.encode_utf16()
-                                .chain(::std::iter::once(0))
-                                .collect::<std::vec::Vec<u16>>()
-                                .into_boxed_slice(),
-                        ) as _))
+                        ::windows::Param::Boxed(PWSTR(
+                            ::windows::widestring::WideCString::from_str(self)
+                                .unwrap()
+                                .into_raw(),
+                        ))
                     }
                 }
                 impl<'a> ::windows::IntoParam<'a, PWSTR> for String {
                     fn into_param(self) -> ::windows::Param<'a, PWSTR> {
-                        ::windows::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(
-                            self.encode_utf16()
-                                .chain(::std::iter::once(0))
-                                .collect::<std::vec::Vec<u16>>()
-                                .into_boxed_slice(),
-                        ) as _))
+                        ::windows::Param::Boxed(PWSTR(
+                            ::windows::widestring::WideCString::from_str(self)
+                                .unwrap()
+                                .into_raw(),
+                        ))
                     }
                 }
                 #[repr(transparent)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,3 +45,6 @@ pub type RawPtr = *mut std::ffi::c_void;
 
 #[doc(hidden)]
 pub use const_sha1::ConstBuffer;
+
+#[doc(hidden)]
+pub use widestring;

--- a/src/runtime/ref_count.rs
+++ b/src/runtime/ref_count.rs
@@ -2,11 +2,11 @@ use std::sync::atomic::{fence, AtomicI32, Ordering};
 
 /// A thread-safe reference count for use with COM/HSTRING implementations.
 #[repr(transparent)]
-#[derive(Default)]
+#[derive(Default, Debug)]
 pub struct RefCount(pub(crate) AtomicI32);
 
 impl RefCount {
-    /// Creates a new `RefCount` with an initial value of `1`.
+    /// Creates a new `RefCount` with an initial value of `count`.
     pub fn new(count: u32) -> Self {
         Self(AtomicI32::new(count as _))
     }


### PR DESCRIPTION
Depends on #747, #800

Following the discussion in https://github.com/microsoft/windows-rs/discussions/566#discussioncomment-467792 and the acknowledgement to have something in the tree that could possibly run on the Linux CI (more requirements in https://github.com/microsoft/windows-rs/discussions/566#discussioncomment-701806). Now there's a use for #747 too :)

### TODO
- Should I put `dxcompiler.dll` (and later `libdxcompiler.so`) in `.windows/<arch>`?
- Should I remove the include handler (last commit) until proper `COM` overriding/implementing is finished? It's a complete hack anyway.