### PR TITLE
Add basic string functions to `BSTR`

### DIFF
--- a/crates/gen/src/types/bstr.rs
+++ b/crates/gen/src/types/bstr.rs
@@ -27,7 +27,7 @@ pub fn gen_bstr() -> TokenStream {
                 unsafe { SysStringLen(self) as usize }
             }
 
-            /// Create a `impl` from a slice of 16-bit characters.
+            /// Create a `BSTR` from a slice of 16-bit characters.
             pub fn from_wide(value: &[u16]) -> Self {
                 if value.len() == 0 {
                     return Self(::std::ptr::null_mut());

--- a/crates/gen/src/types/bstr.rs
+++ b/crates/gen/src/types/bstr.rs
@@ -6,17 +6,38 @@ pub fn gen_bstr() -> TokenStream {
         #[derive(::std::cmp::Eq)]
         pub struct BSTR(*mut u16);
         impl BSTR {
+            /// Create an empty `BSTR`.
+            ///
+            /// This function does not allocate memory.
+            pub fn new() -> Self {
+                Self(std::ptr::null_mut())
+            }
+
+            /// Returns `true` if the string is empty.
             pub fn is_empty(&self) -> bool {
                 self.0.is_null()
             }
-            fn from_wide(value: &[u16]) -> Self {
+
+            /// Returns the length of the string.
+            pub fn len(&self) -> usize {
+                if self.is_empty() {
+                    return 0;
+                }
+
+                unsafe { SysStringLen(self) as usize }
+            }
+
+            /// Create a `impl` from a slice of 16-bit characters.
+            pub fn from_wide(value: &[u16]) -> Self {
                 if value.len() == 0 {
                     return Self(::std::ptr::null_mut());
                 }
 
                 unsafe { SysAllocStringLen(super::SystemServices::PWSTR(value.as_ptr() as _), value.len() as u32) }
             }
-            fn as_wide(&self) -> &[u16] {
+
+            /// Get the string as 16-bit characters.
+            pub fn as_wide(&self) -> &[u16] {
                 if self.0.is_null() {
                     return &[];
                 }

--- a/src/runtime/hstring.rs
+++ b/src/runtime/hstring.rs
@@ -12,7 +12,7 @@ pub struct HSTRING(*mut Header);
 impl HSTRING {
     /// Create an empty `HSTRING`.
     ///
-    /// This function does no allocation.
+    /// This function does not allocate memory.
     pub fn new() -> Self {
         Self(std::ptr::null_mut())
     }
@@ -23,7 +23,7 @@ impl HSTRING {
         self.0.is_null()
     }
 
-    /// Returns the length of `self`.
+    /// Returns the length of the string.
     pub fn len(&self) -> usize {
         if self.is_empty() {
             return 0;

--- a/tests/bstr/tests/bstr.rs
+++ b/tests/bstr/tests/bstr.rs
@@ -20,4 +20,17 @@ fn clone() {
     assert_eq!(a, "");
     assert_eq!(b, "");
     assert_eq!(a.abi(), b.abi());
+
+    let a = BSTR::new();
+    assert_eq!(a.is_empty(), true);
+    assert_eq!(a.len(), 0);
+    assert_eq!(a.as_wide().len(), 0);
+
+    let wide = &[0x68, 0x65, 0x6c, 0x6c, 0x6f];
+    let a = BSTR::from_wide(wide);
+    assert_eq!(a.is_empty(), false);
+    assert_eq!(a.len(), 5);
+    assert_eq!(a.as_wide().len(), 5);
+    assert_eq!(a.as_wide(), wide);
+    assert_eq!(a, "hello");
 }


### PR DESCRIPTION
A larger effort is coming to provide more comprehensive and uniform string support for the various historical string types in the Windows API. For now, this just makes using `BSTR` a little easier to use. 