### PR TITLE
Add dll example

### DIFF
--- a/examples/dll/Cargo.toml
+++ b/examples/dll/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "dll"
+version = "0.0.0"
+authors = ["Microsoft"]
+edition = "2018"
+
+[dependencies]
+bindings = { package = "dll_bindings", path = "bindings" }
+
+[lib]
+crate-type = ["cdylib"]

--- a/examples/dll/bindings/Cargo.toml
+++ b/examples/dll/bindings/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "dll_bindings"
+version = "0.0.0"
+authors = ["Microsoft"]
+edition = "2018"
+
+[dependencies]
+windows = { path = "../../.." }
+
+[build-dependencies]
+windows = { path = "../../.." }

--- a/examples/dll/bindings/build.rs
+++ b/examples/dll/bindings/build.rs
@@ -1,6 +1,5 @@
 fn main() {
     windows::build!(
-        Windows::Win32::System::SystemServices::{HINSTANCE, DLL_PROCESS_ATTACH, DLL_THREAD_ATTACH, DLL_THREAD_DETACH, DLL_PROCESS_DETACH},
-        Windows::Win32::UI::WindowsAndMessaging::{MessageBoxA, MB_OK},
+        Windows::Win32::System::SystemServices::{BOOL, DLL_PROCESS_ATTACH, DLL_PROCESS_DETACH, DLL_THREAD_ATTACH, DLL_THREAD_DETACH, HINSTANCE},
     );
 }

--- a/examples/dll/bindings/build.rs
+++ b/examples/dll/bindings/build.rs
@@ -1,0 +1,6 @@
+fn main() {
+    windows::build!(
+        Windows::Win32::System::SystemServices::{HINSTANCE, DLL_PROCESS_ATTACH, DLL_THREAD_ATTACH, DLL_THREAD_DETACH, DLL_PROCESS_DETACH},
+        Windows::Win32::UI::WindowsAndMessaging::{MessageBoxA, MB_OK},
+    );
+}

--- a/examples/dll/bindings/src/lib.rs
+++ b/examples/dll/bindings/src/lib.rs
@@ -1,0 +1,1 @@
+windows::include_bindings!();

--- a/examples/dll/src/lib.rs
+++ b/examples/dll/src/lib.rs
@@ -1,22 +1,18 @@
 use bindings::Windows::Win32::System::SystemServices::{
-    DLL_PROCESS_ATTACH, DLL_PROCESS_DETACH, DLL_THREAD_ATTACH, DLL_THREAD_DETACH, HINSTANCE,
+    BOOL, DLL_PROCESS_ATTACH, DLL_PROCESS_DETACH, DLL_THREAD_ATTACH, DLL_THREAD_DETACH, HINSTANCE,
 };
-use bindings::Windows::Win32::UI::WindowsAndMessaging::{MessageBoxA, MB_OK};
 use std::ffi::c_void;
 
 #[no_mangle]
-#[allow(non_snake_case)]
 #[allow(unused_variables)]
-pub extern "stdcall" fn DllMain(module: HINSTANCE, reason: u32, reserved: *mut c_void) -> bool {
+pub extern "stdcall" fn DllMain(module: HINSTANCE, reason: u32, reserved: *mut c_void) -> BOOL {
     match reason {
-        DLL_PROCESS_ATTACH => unsafe {
-            MessageBoxA(None, "Hello from the DLL!", "Hello World", MB_OK);
-        },
+        DLL_PROCESS_ATTACH => println!("Hello from the dll!"),
         DLL_THREAD_ATTACH => (),
         DLL_THREAD_DETACH => (),
-        DLL_PROCESS_DETACH => (),
+        DLL_PROCESS_DETACH => println!("Goodbye from the dll!"),
         _ => (),
     }
 
-    true
+    BOOL::from(true)
 }

--- a/examples/dll/src/lib.rs
+++ b/examples/dll/src/lib.rs
@@ -1,0 +1,22 @@
+use bindings::Windows::Win32::System::SystemServices::{
+    DLL_PROCESS_ATTACH, DLL_PROCESS_DETACH, DLL_THREAD_ATTACH, DLL_THREAD_DETACH, HINSTANCE,
+};
+use bindings::Windows::Win32::UI::WindowsAndMessaging::{MessageBoxA, MB_OK};
+use std::ffi::c_void;
+
+#[no_mangle]
+#[allow(non_snake_case)]
+#[allow(unused_variables)]
+pub extern "stdcall" fn DllMain(module: HINSTANCE, reason: u32, reserved: *mut c_void) -> bool {
+    match reason {
+        DLL_PROCESS_ATTACH => unsafe {
+            MessageBoxA(None, "Hello from the DLL!", "Hello World", MB_OK);
+        },
+        DLL_THREAD_ATTACH => (),
+        DLL_THREAD_DETACH => (),
+        DLL_PROCESS_DETACH => (),
+        _ => (),
+    }
+
+    true
+}

--- a/examples/dll_loader/Cargo.toml
+++ b/examples/dll_loader/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "dll_loader"
+version = "0.0.0"
+authors = ["Microsoft"]
+edition = "2018"
+
+[dependencies]
+bindings = { package = "dll_loader_bindings", path = "bindings" }

--- a/examples/dll_loader/bindings/Cargo.toml
+++ b/examples/dll_loader/bindings/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "dll_loader_bindings"
+version = "0.0.0"
+authors = ["Microsoft"]
+edition = "2018"
+
+[dependencies]
+windows = { path = "../../.." }
+
+[build-dependencies]
+windows = { path = "../../.." }

--- a/examples/dll_loader/bindings/build.rs
+++ b/examples/dll_loader/bindings/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    windows::build!(Windows::Win32::System::SystemServices::LoadLibraryA);
+}

--- a/examples/dll_loader/bindings/src/lib.rs
+++ b/examples/dll_loader/bindings/src/lib.rs
@@ -1,0 +1,1 @@
+windows::include_bindings!();

--- a/examples/dll_loader/src/main.rs
+++ b/examples/dll_loader/src/main.rs
@@ -1,0 +1,13 @@
+use bindings::Windows::Win32::System::SystemServices::LoadLibraryA;
+
+fn main() {
+    let file_name = std::env::args()
+        .nth(1)
+        .expect("expected a dll filename as program argument");
+
+    let library = unsafe { LoadLibraryA(file_name.as_str()) };
+
+    if library.is_null() {
+        println!("Library with filename {} does not exist", file_name)
+    }
+}


### PR DESCRIPTION
Hello,

I have created an example for a Windows DLL that displays a messagebox upon being loaded.

Extra notes:
Looking into the window-rs documentation I was not able to locate _DWORD_ nor _LPVOID_ for _DllMain_ so I opted to check the [winapi](https://docs.rs/winapi/0.3.9/winapi/) crate, and found:

1. [DWORD](https://tyleo.github.io/sharedlib/doc/winapi/minwindef/type.DWORD.html) is equivalent to [c_ulong](https://tyleo.github.io/sharedlib/doc/winapi/type.c_ulong.html) which is equivalent to `u32`
2. [LPVOID](https://tyleo.github.io/sharedlib/doc/winapi/minwindef/type.LPVOID.html) is equivalent to `*mut c_void`