### PR TITLE
update winmd

### DIFF
--- a/crates/bindings/src/main.rs
+++ b/crates/bindings/src/main.rs
@@ -3,6 +3,7 @@ use std::io::prelude::*;
 fn main() -> std::io::Result<()> {
     let tokens = windows_macros::generate!(
         Windows::Foundation::{IReference, IStringable, PropertyValue},
+        Windows::Win32::Foundation::{CloseHandle, BSTR, CO_E_NOTINITIALIZED, E_POINTER},
         Windows::Win32::System::Com::{
             CoCreateGuid, CoTaskMemAlloc, CoTaskMemFree, CLSIDFromProgID, CoInitializeEx, CoCreateInstance,
             IAgileObject, COINIT_MULTITHREADED, COINIT_APARTMENTTHREADED, CLSCTX_ALL,
@@ -14,14 +15,13 @@ fn main() -> std::io::Result<()> {
         Windows::Win32::System::Memory::{
             GetProcessHeap, HeapAlloc, HeapFree, HEAP_NONE,
         },
-        Windows::Win32::System::OleAutomation::{BSTR, GetErrorInfo, IErrorInfo, SetErrorInfo},
-        Windows::Win32::System::SystemServices::{
-            GetProcAddress, LoadLibraryA, FreeLibrary, CO_E_NOTINITIALIZED, E_POINTER,
+        Windows::Win32::System::LibraryLoader::{
+            GetProcAddress, LoadLibraryA, FreeLibrary,
         },
+        Windows::Win32::System::OleAutomation::{GetErrorInfo, IErrorInfo, SetErrorInfo},
         Windows::Win32::System::Threading::{
             CreateEventA, SetEvent, WaitForSingleObject,
         },
-        Windows::Win32::System::WindowsProgramming::CloseHandle,
         Windows::Win32::System::WinRT::{
             IRestrictedErrorInfo, ILanguageExceptionErrorInfo2, IWeakReference, IWeakReferenceSource,
         },

--- a/crates/gen/src/parser/element_type.rs
+++ b/crates/gen/src/parser/element_type.rs
@@ -129,7 +129,7 @@ impl ElementType {
                         ("System", "Guid") => Self::Guid,
                         ("Windows.Win32.System.Com", "IUnknown") => Self::IUnknown,
                         ("Windows.Foundation", "HResult") => Self::HRESULT,
-                        ("Windows.Win32.System.Com", "HRESULT") => Self::HRESULT,
+                        ("Windows.Win32.Foundation", "HRESULT") => Self::HRESULT,
                         ("Windows.Win32.System.WinRT", "HSTRING") => Self::String,
                         ("Windows.Win32.System.WinRT", "IInspectable") => Self::IInspectable,
                         ("Windows.Win32.System.SystemServices", "LARGE_INTEGER") => Self::I64,

--- a/crates/gen/src/parser/type_reader.rs
+++ b/crates/gen/src/parser/type_reader.rs
@@ -122,7 +122,7 @@ impl TypeReader {
 
         let exclude = &[
             ("Windows.Foundation", "HResult"),
-            ("Windows.Win32.System.Com", "HRESULT"),
+            ("Windows.Win32.Foundation", "HRESULT"),
             ("Windows.Win32.System.Com", "IUnknown"),
             ("Windows.Win32.System.WinRT", "HSTRING"),
             ("Windows.Win32.System.WinRT", "IActivationFactory"),

--- a/crates/gen/src/types/bstr.rs
+++ b/crates/gen/src/types/bstr.rs
@@ -24,7 +24,7 @@ pub fn gen_bstr() -> TokenStream {
                     return 0;
                 }
 
-                unsafe { SysStringLen(self) as usize }
+                unsafe { super::System::OleAutomation::SysStringLen(self) as usize }
             }
 
             /// Create a `BSTR` from a slice of 16-bit characters.
@@ -33,7 +33,7 @@ pub fn gen_bstr() -> TokenStream {
                     return Self(::std::ptr::null_mut());
                 }
 
-                unsafe { SysAllocStringLen(super::SystemServices::PWSTR(value.as_ptr() as _), value.len() as u32) }
+                unsafe { super::System::OleAutomation::SysAllocStringLen(super::Foundation::PWSTR(value.as_ptr() as _), value.len() as u32) }
             }
 
             /// Get the string as 16-bit characters.
@@ -42,7 +42,7 @@ pub fn gen_bstr() -> TokenStream {
                     return &[];
                 }
 
-                unsafe { ::std::slice::from_raw_parts(self.0 as *const u16, SysStringLen(self) as usize) }
+                unsafe { ::std::slice::from_raw_parts(self.0 as *const u16, super::System::OleAutomation::SysStringLen(self) as usize) }
             }
         }
         impl ::std::clone::Clone for BSTR {
@@ -131,7 +131,7 @@ pub fn gen_bstr() -> TokenStream {
         impl ::std::ops::Drop for BSTR {
             fn drop(&mut self) {
                 if !self.0.is_null() {
-                    unsafe { SysFreeString(self as &Self); }
+                    unsafe { super::System::OleAutomation::SysFreeString(self as &Self); }
                 }
             }
         }

--- a/crates/gen/src/types/struct.rs
+++ b/crates/gen/src/types/struct.rs
@@ -24,7 +24,7 @@ impl Struct {
         let mut dependencies = vec![];
 
         match self.0.full_name() {
-            ("Windows.Win32.System.OleAutomation", "BSTR") => {
+            ("Windows.Win32.Foundation", "BSTR") => {
                 dependencies.push(
                     reader.resolve_type("Windows.Win32.System.OleAutomation", "SysFreeString"),
                 );
@@ -58,7 +58,7 @@ impl Struct {
 
     pub fn is_blittable(&self) -> bool {
         // TODO: should be "if self.can_drop().is_some() {" once win32metadata bugs are fixed (423, 422, 421, 389)
-        if self.0.full_name() == ("Windows.Win32.System.OleAutomation", "BSTR") {
+        if self.0.full_name() == ("Windows.Win32.Foundation", "BSTR") {
             false
         } else {
             self.0.fields().all(|f| f.is_blittable())
@@ -461,10 +461,10 @@ impl Struct {
 
     fn gen_replacement(&self) -> Option<TokenStream> {
         match self.0.full_name() {
-            ("Windows.Win32.System.SystemServices", "BOOL") => Some(gen_bool32()),
-            ("Windows.Win32.System.SystemServices", "PWSTR") => Some(gen_pwstr()),
-            ("Windows.Win32.System.SystemServices", "PSTR") => Some(gen_pstr()),
-            ("Windows.Win32.System.OleAutomation", "BSTR") => Some(gen_bstr()),
+            ("Windows.Win32.Foundation", "BOOL") => Some(gen_bool32()),
+            ("Windows.Win32.Foundation", "BSTR") => Some(gen_bstr()),
+            ("Windows.Win32.Foundation", "PSTR") => Some(gen_pstr()),
+            ("Windows.Win32.Foundation", "PWSTR") => Some(gen_pwstr()),
             _ => None,
         }
     }
@@ -477,7 +477,7 @@ impl Struct {
             ("Windows.Foundation.Numerics", "Vector4") => gen_vector4(),
             ("Windows.Foundation.Numerics", "Matrix3x2") => gen_matrix3x2(),
             ("Windows.Foundation.Numerics", "Matrix4x4") => gen_matrix4x4(),
-            ("Windows.Win32.System.SystemServices", "HANDLE") => gen_handle(),
+            ("Windows.Win32.Foundation", "HANDLE") => gen_handle(),
             _ => TokenStream::new(),
         }
     }

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -55,8 +55,8 @@ fn main() {
     windows::build!(
         // Note that we're using the `Intl` namespace which is nested inside the `Win32` namespace
         // which itself is inside the `Windows` namespace.
+        Windows::Win32::Foundation::{BOOL, PWSTR, S_FALSE},
         Windows::Win32::Globalization::{ISpellChecker, SpellCheckerFactory, ISpellCheckerFactory, CORRECTIVE_ACTION, IEnumSpellingError, ISpellingError},
-        Windows::Win32::System::SystemServices::{BOOL, PWSTR, S_FALSE},
         Windows::Win32::System::Com::IEnumString
     )
 }
@@ -95,8 +95,8 @@ fn main() -> windows::Result<()> {
 Next, we'll initialize the `ISpellCheckerFactory` which is what gives us access to spellcheckers. We'll first make sure the `intl` namespace and two types we'll need `PWSTR` and `BOOL` are in scope at the top of the main.rs file:
 
 ```rust
+use bindings::Windows::Win32::Foundation::{BOOL, PWSTR};
 use bindings::Windows::Win32::Globalization;
-use bindings::Windows::Win32::System::SystemServices::{BOOL, PWSTR};
 ```
 
 Then we can do the initialization by calling `windows::create_instance` which calls [CoCreateInstance](https://docs.microsoft.com/en-us/windows/win32/api/combaseapi/nf-combaseapi-cocreateinstance) under the hood:

--- a/examples/clock/bindings/build.rs
+++ b/examples/clock/bindings/build.rs
@@ -25,11 +25,11 @@ fn main() {
             DXGI_USAGE_RENDER_TARGET_OUTPUT,
         },
         Windows::Win32::Graphics::Gdi::{BeginPaint, EndPaint, PAINTSTRUCT},
-        Windows::Win32::System::SystemServices::{
-            GetModuleHandleA, DXGI_STATUS_OCCLUDED, HINSTANCE, LRESULT, PSTR,
-        },
+        Windows::Win32::Foundation::{DXGI_STATUS_OCCLUDED, HINSTANCE, HWND, LPARAM, LRESULT, PSTR, WPARAM},
+        Windows::Win32::System::LibraryLoader::GetModuleHandleA,
+        Windows::Win32::System::SystemInformation::GetLocalTime,
         Windows::Win32::System::WindowsProgramming::{
-            GetLocalTime, QueryPerformanceCounter, QueryPerformanceFrequency,
+            QueryPerformanceCounter, QueryPerformanceFrequency,
         },
         Windows::Win32::UI::Animation::{
             IUIAnimationManager, IUIAnimationTransition, IUIAnimationTransitionLibrary,
@@ -40,9 +40,9 @@ fn main() {
             CreateWindowExA, DefWindowProcA, DispatchMessageA, GetMessageA, GetWindowLongPtrA,
             LoadCursorW, PeekMessageA, PostQuitMessage, RegisterClassA, SetWindowLongPtrA,
             SetWindowLongA, GetWindowLongA,
-            CREATESTRUCTA, CS_HREDRAW, CS_VREDRAW, CW_USEDEFAULT, GWLP_USERDATA, HWND, IDC_HAND,
-            LPARAM, MSG, PM_REMOVE, SIZE_MINIMIZED, WINDOW_LONG_PTR_INDEX, WM_ACTIVATE, WM_DESTROY,
-            WM_DISPLAYCHANGE, WM_NCCREATE, WM_PAINT, WM_QUIT, WM_SIZE, WM_USER, WNDCLASSA, WPARAM,
+            CREATESTRUCTA, CS_HREDRAW, CS_VREDRAW, CW_USEDEFAULT, GWLP_USERDATA, IDC_HAND,
+            MSG, PM_REMOVE, SIZE_MINIMIZED, WINDOW_LONG_PTR_INDEX, WM_ACTIVATE, WM_DESTROY,
+            WM_DISPLAYCHANGE, WM_NCCREATE, WM_PAINT, WM_QUIT, WM_SIZE, WM_USER, WNDCLASSA,
             WS_OVERLAPPEDWINDOW, WS_VISIBLE,
         },
     );

--- a/examples/com_uri/bindings/build.rs
+++ b/examples/com_uri/bindings/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     windows::build!(
-        Windows::Win32::System::OleAutomation::BSTR,
+        Windows::Win32::Foundation::BSTR,
         Windows::Win32::System::Com::CreateUri,
     );
 }

--- a/examples/com_uri/src/main.rs
+++ b/examples/com_uri/src/main.rs
@@ -1,5 +1,5 @@
 use bindings::{
-    Windows::Win32::System::Com::CreateUri, Windows::Win32::System::OleAutomation::BSTR,
+    Windows::Win32::System::Com::CreateUri, Windows::Win32::Foundation::BSTR,
 };
 
 fn main() -> windows::Result<()> {

--- a/examples/d3d12/bindings/build.rs
+++ b/examples/d3d12/bindings/build.rs
@@ -1,5 +1,6 @@
 fn main() {
     windows::build!(
+        Windows::Win32::Foundation::{HINSTANCE, PSTR, RECT},
         Windows::Win32::Graphics::Direct3D12::*,
         Windows::Win32::Graphics::Dxgi::*,
         Windows::Win32::Graphics::Direct3D11::{
@@ -41,20 +42,13 @@ fn main() {
             WNDCLASSEXA,
             WS_OVERLAPPEDWINDOW,
         },
-        Windows::Win32::System::SystemServices::{
-            GetModuleHandleA,
-            HINSTANCE,
-            PSTR,
-        },
+        Windows::Win32::System::LibraryLoader::GetModuleHandleA,
         Windows::Win32::System::Threading::{
             CreateEventA,
             WaitForSingleObject
         },
         Windows::Win32::System::WindowsProgramming::{
             INFINITE
-        },
-        Windows::Win32::UI::DisplayDevices::{
-            RECT
         },
     );
 }

--- a/examples/enum_windows/src/main.rs
+++ b/examples/enum_windows/src/main.rs
@@ -1,6 +1,6 @@
 use bindings::{
-    Windows::Win32::System::SystemServices::{BOOL, PWSTR},
-    Windows::Win32::UI::WindowsAndMessaging::{EnumWindows, GetWindowTextW, HWND, LPARAM},
+    Windows::Win32::Foundation::{BOOL, HWND, LPARAM, PWSTR},
+    Windows::Win32::UI::WindowsAndMessaging::{EnumWindows, GetWindowTextW},
 };
 
 fn main() -> windows::Result<()> {

--- a/examples/event/bindings/build.rs
+++ b/examples/event/bindings/build.rs
@@ -3,6 +3,6 @@ fn main() {
         Windows::Win32::System::Threading::{
             CreateEventW, SetEvent, WaitForSingleObject, WAIT_OBJECT_0,
         },
-        Windows::Win32::System::WindowsProgramming::CloseHandle
+        Windows::Win32::Foundation::CloseHandle
     );
 }

--- a/examples/event/src/main.rs
+++ b/examples/event/src/main.rs
@@ -1,8 +1,8 @@
 use bindings::{
+    Windows::Win32::Foundation::CloseHandle,
     Windows::Win32::System::Threading::{
         CreateEventW, SetEvent, WaitForSingleObject, WAIT_OBJECT_0,
     },
-    Windows::Win32::System::WindowsProgramming::CloseHandle,
 };
 
 fn main() -> windows::Result<()> {

--- a/examples/overlapped/bindings/build.rs
+++ b/examples/overlapped/bindings/build.rs
@@ -1,5 +1,6 @@
 fn main() {
     windows::build!(
+      Windows::Win32::Foundation::CloseHandle,
       Windows::Win32::Storage::FileSystem::{
         CreateFileA, ReadFile, FILE_GENERIC_READ, FILE_SHARE_READ, OPEN_EXISTING,
         FILE_FLAG_OVERLAPPED,
@@ -9,6 +10,5 @@ fn main() {
           CreateEventA, WaitForSingleObject, WAIT_OBJECT_0,
       },
       Windows::Win32::System::Diagnostics::Debug::{GetLastError, ERROR_IO_PENDING},
-      Windows::Win32::System::WindowsProgramming::CloseHandle,
     );
 }

--- a/examples/spellchecker/bindings/build.rs
+++ b/examples/spellchecker/bindings/build.rs
@@ -1,11 +1,11 @@
 fn main() {
     windows::build!(
+        Windows::Win32::Foundation::{BOOL, PWSTR, S_FALSE},
         Windows::Win32::Globalization::{
             ISpellChecker, SpellCheckerFactory, ISpellCheckerFactory, IEnumSpellingError,
             ISpellingError, CORRECTIVE_ACTION_NONE, CORRECTIVE_ACTION_DELETE,
             CORRECTIVE_ACTION_REPLACE, CORRECTIVE_ACTION_GET_SUGGESTIONS,
         },
-        Windows::Win32::System::SystemServices::{BOOL, PWSTR, S_FALSE},
         Windows::Win32::System::Com::IEnumString
     )
 }

--- a/examples/spellchecker/src/main.rs
+++ b/examples/spellchecker/src/main.rs
@@ -1,6 +1,6 @@
 use bindings::Windows::Win32;
+use Win32::Foundation::{BOOL, PWSTR, S_FALSE};
 use Win32::Globalization;
-use Win32::System::SystemServices::{BOOL, PWSTR, S_FALSE};
 
 fn main() -> windows::Result<()> {
     let input = std::env::args()

--- a/examples/webview2/bindings/build.rs
+++ b/examples/webview2/bindings/build.rs
@@ -3,14 +3,13 @@ fn main() {
         Microsoft::Web::WebView2::Core::*,
         Windows::Foundation::*,
         Windows::Win32::Graphics::Gdi::UpdateWindow,
-        Windows::Win32::System::SystemServices::{GetModuleHandleA, HINSTANCE, LRESULT, PWSTR},
+        Windows::Win32::Foundation::{HINSTANCE, LRESULT, POINT, PWSTR, RECT, SIZE},
+        Windows::Win32::System::LibraryLoader::GetModuleHandleA,
         Windows::Win32::System::Threading::GetCurrentThreadId,
-        Windows::Win32::UI::DisplayDevices::{POINT, RECT, SIZE},
         Windows::Win32::UI::HiDpi::{
             PROCESS_DPI_AWARENESS, SetProcessDpiAwareness, PROCESS_PER_MONITOR_DPI_AWARE
         },
         Windows::Win32::UI::KeyboardAndMouseInput::SetFocus,
-        Windows::Win32::UI::MenusAndResources::HMENU,
         Windows::Win32::UI::WindowsAndMessaging::*
     )
 }

--- a/examples/webview2/src/main.rs
+++ b/examples/webview2/src/main.rs
@@ -13,10 +13,10 @@ use bindings::{
     Microsoft::Web::WebView2::Core::*,
     Windows::Foundation::*,
     Windows::Win32::{
+        Foundation::*,
         Graphics::Gdi::*,
-        System::SystemServices::*,
-        System::Threading::*,
-        UI::{DisplayDevices::*, HiDpi::*, KeyboardAndMouseInput::*, WindowsAndMessaging::*},
+        System::{LibraryLoader::*,Threading::*},
+        UI::{HiDpi::*, KeyboardAndMouseInput::*, WindowsAndMessaging::*},
     },
 };
 

--- a/readme.md
+++ b/readme.md
@@ -30,8 +30,8 @@ This will allow Cargo to download, build, and cache Windows support as a package
 fn main() {
     windows::build!(
         Windows::Data::Xml::Dom::*,
+        Windows::Win32::Foundation::CloseHandle,
         Windows::Win32::System::Threading::{CreateEventW, SetEvent, WaitForSingleObject},
-        Windows::Win32::System::WindowsProgramming::CloseHandle,
         Windows::Win32::UI::WindowsAndMessaging::{MessageBoxA, MB_OK},
     );
 }
@@ -46,8 +46,8 @@ mod bindings {
 
 use bindings::{
     Windows::Data::Xml::Dom::*,
+    Windows::Win32::Foundation::CloseHandle,
     Windows::Win32::System::Threading::{CreateEventW, SetEvent, WaitForSingleObject},
-    Windows::Win32::System::WindowsProgramming::CloseHandle,
     Windows::Win32::UI::WindowsAndMessaging::{MessageBoxA, MB_OK},
 };
 

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1712,7 +1712,7 @@ pub mod Windows {
                     .from_abi::<::windows::IInspectable>(result__)
                 })
             }
-            fn IPropertyValueStatics<
+            pub fn IPropertyValueStatics<
                 R,
                 F: FnOnce(&IPropertyValueStatics) -> ::windows::Result<R>,
             >(
@@ -1737,6 +1737,482 @@ pub mod Windows {
         clippy::all
     )]
     pub mod Win32 {
+        #[allow(
+            unused_variables,
+            non_upper_case_globals,
+            non_snake_case,
+            unused_unsafe,
+            non_camel_case_types,
+            dead_code,
+            clippy::all
+        )]
+        pub mod Foundation {
+            #[repr(transparent)]
+            #[derive(
+                :: std :: clone :: Clone,
+                :: std :: marker :: Copy,
+                :: std :: cmp :: Eq,
+                :: std :: fmt :: Debug,
+            )]
+            pub struct PWSTR(pub *mut u16);
+            impl PWSTR {
+                pub const NULL: Self = Self(::std::ptr::null_mut());
+                pub fn is_null(&self) -> bool {
+                    self.0.is_null()
+                }
+            }
+            impl ::std::default::Default for PWSTR {
+                fn default() -> Self {
+                    Self(::std::ptr::null_mut())
+                }
+            }
+            impl ::std::cmp::PartialEq for PWSTR {
+                fn eq(&self, other: &Self) -> bool {
+                    self.0 == other.0
+                }
+            }
+            unsafe impl ::windows::Abi for PWSTR {
+                type Abi = Self;
+                fn drop_param(param: &mut ::windows::Param<Self>) {
+                    if let ::windows::Param::Boxed(value) = param {
+                        if !value.0.is_null() {
+                            unsafe {
+                                ::std::boxed::Box::from_raw(value.0);
+                            }
+                        }
+                    }
+                }
+            }
+            impl<'a> ::windows::IntoParam<'a, PWSTR> for &'a str {
+                fn into_param(self) -> ::windows::Param<'a, PWSTR> {
+                    ::windows::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(
+                        self.encode_utf16()
+                            .chain(::std::iter::once(0))
+                            .collect::<std::vec::Vec<u16>>()
+                            .into_boxed_slice(),
+                    ) as _))
+                }
+            }
+            impl<'a> ::windows::IntoParam<'a, PWSTR> for String {
+                fn into_param(self) -> ::windows::Param<'a, PWSTR> {
+                    ::windows::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(
+                        self.encode_utf16()
+                            .chain(::std::iter::once(0))
+                            .collect::<std::vec::Vec<u16>>()
+                            .into_boxed_slice(),
+                    ) as _))
+                }
+            }
+            #[repr(transparent)]
+            #[derive(:: std :: cmp :: Eq)]
+            pub struct BSTR(*mut u16);
+            impl BSTR {
+                #[doc = r" Create an empty `BSTR`."]
+                #[doc = r""]
+                #[doc = r" This function does not allocate memory."]
+                pub fn new() -> Self {
+                    Self(std::ptr::null_mut())
+                }
+                #[doc = r" Returns `true` if the string is empty."]
+                pub fn is_empty(&self) -> bool {
+                    self.0.is_null()
+                }
+                #[doc = r" Returns the length of the string."]
+                pub fn len(&self) -> usize {
+                    if self.is_empty() {
+                        return 0;
+                    }
+                    unsafe { super::System::OleAutomation::SysStringLen(self) as usize }
+                }
+                #[doc = r" Create a `BSTR` from a slice of 16-bit characters."]
+                pub fn from_wide(value: &[u16]) -> Self {
+                    if value.len() == 0 {
+                        return Self(::std::ptr::null_mut());
+                    }
+                    unsafe {
+                        super::System::OleAutomation::SysAllocStringLen(
+                            super::Foundation::PWSTR(value.as_ptr() as _),
+                            value.len() as u32,
+                        )
+                    }
+                }
+                #[doc = r" Get the string as 16-bit characters."]
+                pub fn as_wide(&self) -> &[u16] {
+                    if self.0.is_null() {
+                        return &[];
+                    }
+                    unsafe {
+                        ::std::slice::from_raw_parts(
+                            self.0 as *const u16,
+                            super::System::OleAutomation::SysStringLen(self) as usize,
+                        )
+                    }
+                }
+            }
+            impl ::std::clone::Clone for BSTR {
+                fn clone(&self) -> Self {
+                    Self::from_wide(self.as_wide())
+                }
+            }
+            impl ::std::convert::From<&str> for BSTR {
+                fn from(value: &str) -> Self {
+                    let value: ::std::vec::Vec<u16> = value.encode_utf16().collect();
+                    Self::from_wide(&value)
+                }
+            }
+            impl ::std::convert::From<::std::string::String> for BSTR {
+                fn from(value: ::std::string::String) -> Self {
+                    value.as_str().into()
+                }
+            }
+            impl ::std::convert::From<&::std::string::String> for BSTR {
+                fn from(value: &::std::string::String) -> Self {
+                    value.as_str().into()
+                }
+            }
+            impl<'a> ::std::convert::TryFrom<&'a BSTR> for ::std::string::String {
+                type Error = ::std::string::FromUtf16Error;
+                fn try_from(value: &BSTR) -> ::std::result::Result<Self, Self::Error> {
+                    ::std::string::String::from_utf16(value.as_wide())
+                }
+            }
+            impl ::std::convert::TryFrom<BSTR> for ::std::string::String {
+                type Error = ::std::string::FromUtf16Error;
+                fn try_from(value: BSTR) -> ::std::result::Result<Self, Self::Error> {
+                    ::std::string::String::try_from(&value)
+                }
+            }
+            impl ::std::default::Default for BSTR {
+                fn default() -> Self {
+                    Self(::std::ptr::null_mut())
+                }
+            }
+            impl ::std::fmt::Display for BSTR {
+                fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                    use std::fmt::Write;
+                    for c in ::std::char::decode_utf16(self.as_wide().iter().cloned()) {
+                        f.write_char(c.map_err(|_| ::std::fmt::Error)?)?
+                    }
+                    Ok(())
+                }
+            }
+            impl ::std::fmt::Debug for BSTR {
+                fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                    ::std::write!(f, "{}", self)
+                }
+            }
+            impl ::std::cmp::PartialEq for BSTR {
+                fn eq(&self, other: &Self) -> bool {
+                    self.as_wide() == other.as_wide()
+                }
+            }
+            impl ::std::cmp::PartialEq<::std::string::String> for BSTR {
+                fn eq(&self, other: &::std::string::String) -> bool {
+                    self == other.as_str()
+                }
+            }
+            impl ::std::cmp::PartialEq<str> for BSTR {
+                fn eq(&self, other: &str) -> bool {
+                    self == other
+                }
+            }
+            impl ::std::cmp::PartialEq<&str> for BSTR {
+                fn eq(&self, other: &&str) -> bool {
+                    self.as_wide().iter().copied().eq(other.encode_utf16())
+                }
+            }
+            impl ::std::cmp::PartialEq<BSTR> for &str {
+                fn eq(&self, other: &BSTR) -> bool {
+                    other == self
+                }
+            }
+            impl ::std::ops::Drop for BSTR {
+                fn drop(&mut self) {
+                    if !self.0.is_null() {
+                        unsafe {
+                            super::System::OleAutomation::SysFreeString(self as &Self);
+                        }
+                    }
+                }
+            }
+            unsafe impl ::windows::Abi for BSTR {
+                type Abi = *mut u16;
+                fn set_abi(&mut self) -> *mut *mut u16 {
+                    debug_assert!(self.0.is_null());
+                    &mut self.0 as *mut _ as _
+                }
+            }
+            pub type BSTR_abi = *mut u16;
+            pub const CO_E_NOTINITIALIZED: ::windows::HRESULT =
+                ::windows::HRESULT(-2147221008i32 as _);
+            #[repr(transparent)]
+            #[derive(
+                :: std :: default :: Default,
+                :: std :: clone :: Clone,
+                :: std :: marker :: Copy,
+                :: std :: cmp :: PartialEq,
+                :: std :: cmp :: Eq,
+                :: std :: fmt :: Debug,
+            )]
+            pub struct BOOL(pub i32);
+            unsafe impl ::windows::Abi for BOOL {
+                type Abi = Self;
+            }
+            impl BOOL {
+                #[inline]
+                pub fn as_bool(self) -> bool {
+                    !(self.0 == 0)
+                }
+                #[inline]
+                pub fn ok(self) -> ::windows::Result<()> {
+                    if self.as_bool() {
+                        Ok(())
+                    } else {
+                        Err(::windows::HRESULT::from_thread().into())
+                    }
+                }
+                #[inline]
+                pub fn unwrap(self) {
+                    self.ok().unwrap();
+                }
+                #[inline]
+                pub fn expect(self, msg: &str) {
+                    self.ok().expect(msg);
+                }
+            }
+            impl ::std::convert::From<BOOL> for bool {
+                fn from(value: BOOL) -> Self {
+                    value.as_bool()
+                }
+            }
+            impl ::std::convert::From<&BOOL> for bool {
+                fn from(value: &BOOL) -> Self {
+                    value.as_bool()
+                }
+            }
+            impl ::std::convert::From<bool> for BOOL {
+                fn from(value: bool) -> Self {
+                    if value {
+                        BOOL(1)
+                    } else {
+                        BOOL(0)
+                    }
+                }
+            }
+            impl ::std::convert::From<&bool> for BOOL {
+                fn from(value: &bool) -> Self {
+                    (*value).into()
+                }
+            }
+            impl ::std::cmp::PartialEq<bool> for BOOL {
+                fn eq(&self, other: &bool) -> bool {
+                    self.as_bool() == *other
+                }
+            }
+            impl ::std::cmp::PartialEq<BOOL> for bool {
+                fn eq(&self, other: &BOOL) -> bool {
+                    *self == other.as_bool()
+                }
+            }
+            impl std::ops::Not for BOOL {
+                type Output = Self;
+                fn not(self) -> Self::Output {
+                    if self.as_bool() {
+                        BOOL(0)
+                    } else {
+                        BOOL(1)
+                    }
+                }
+            }
+            impl<'a> ::windows::IntoParam<'a, BOOL> for bool {
+                fn into_param(self) -> ::windows::Param<'a, BOOL> {
+                    ::windows::Param::Owned(self.into())
+                }
+            }
+            #[repr(transparent)]
+            #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
+            pub struct HANDLE(pub isize);
+            impl HANDLE {}
+            impl ::std::default::Default for HANDLE {
+                fn default() -> Self {
+                    Self(0)
+                }
+            }
+            impl HANDLE {
+                pub const NULL: Self = Self(0);
+                pub fn is_null(&self) -> bool {
+                    self.0 == 0
+                }
+            }
+            impl ::std::fmt::Debug for HANDLE {
+                fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                    fmt.debug_struct("HANDLE")
+                        .field("Value", &format_args!("{:?}", self.0))
+                        .finish()
+                }
+            }
+            impl ::std::cmp::PartialEq for HANDLE {
+                fn eq(&self, other: &Self) -> bool {
+                    self.0 == other.0
+                }
+            }
+            impl ::std::cmp::Eq for HANDLE {}
+            unsafe impl ::windows::Abi for HANDLE {
+                type Abi = Self;
+            }
+            impl HANDLE {
+                pub const INVALID: Self = Self(-1);
+                pub fn is_invalid(&self) -> bool {
+                    self.0 == -1
+                }
+            }
+            pub unsafe fn CloseHandle<'a>(hobject: impl ::windows::IntoParam<'a, HANDLE>) -> BOOL {
+                #[link(name = "KERNEL32")]
+                extern "system" {
+                    fn CloseHandle(hobject: HANDLE) -> BOOL;
+                }
+                CloseHandle(hobject.into_param().abi())
+            }
+            pub const E_POINTER: ::windows::HRESULT = ::windows::HRESULT(-2147467261i32 as _);
+            #[repr(transparent)]
+            #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
+            pub struct HINSTANCE(pub isize);
+            impl HINSTANCE {}
+            impl ::std::default::Default for HINSTANCE {
+                fn default() -> Self {
+                    Self(0)
+                }
+            }
+            impl HINSTANCE {
+                pub const NULL: Self = Self(0);
+                pub fn is_null(&self) -> bool {
+                    self.0 == 0
+                }
+            }
+            impl ::std::fmt::Debug for HINSTANCE {
+                fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                    fmt.debug_struct("HINSTANCE")
+                        .field("Value", &format_args!("{:?}", self.0))
+                        .finish()
+                }
+            }
+            impl ::std::cmp::PartialEq for HINSTANCE {
+                fn eq(&self, other: &Self) -> bool {
+                    self.0 == other.0
+                }
+            }
+            impl ::std::cmp::Eq for HINSTANCE {}
+            unsafe impl ::windows::Abi for HINSTANCE {
+                type Abi = Self;
+            }
+            #[repr(transparent)]
+            #[derive(
+                :: std :: clone :: Clone,
+                :: std :: marker :: Copy,
+                :: std :: cmp :: Eq,
+                :: std :: fmt :: Debug,
+            )]
+            pub struct PSTR(pub *mut u8);
+            impl PSTR {
+                pub const NULL: Self = Self(::std::ptr::null_mut());
+                pub fn is_null(&self) -> bool {
+                    self.0.is_null()
+                }
+            }
+            impl ::std::default::Default for PSTR {
+                fn default() -> Self {
+                    Self(::std::ptr::null_mut())
+                }
+            }
+            impl ::std::cmp::PartialEq for PSTR {
+                fn eq(&self, other: &Self) -> bool {
+                    self.0 == other.0
+                }
+            }
+            unsafe impl ::windows::Abi for PSTR {
+                type Abi = Self;
+                fn drop_param(param: &mut ::windows::Param<Self>) {
+                    if let ::windows::Param::Boxed(value) = param {
+                        if !value.0.is_null() {
+                            unsafe {
+                                ::std::boxed::Box::from_raw(value.0);
+                            }
+                        }
+                    }
+                }
+            }
+            impl<'a> ::windows::IntoParam<'a, PSTR> for &'a str {
+                fn into_param(self) -> ::windows::Param<'a, PSTR> {
+                    ::windows::Param::Boxed(PSTR(::std::boxed::Box::<[u8]>::into_raw(
+                        self.bytes()
+                            .chain(::std::iter::once(0))
+                            .collect::<std::vec::Vec<u8>>()
+                            .into_boxed_slice(),
+                    ) as _))
+                }
+            }
+            impl<'a> ::windows::IntoParam<'a, PSTR> for String {
+                fn into_param(self) -> ::windows::Param<'a, PSTR> {
+                    ::windows::Param::Boxed(PSTR(::std::boxed::Box::<[u8]>::into_raw(
+                        self.bytes()
+                            .chain(::std::iter::once(0))
+                            .collect::<std::vec::Vec<u8>>()
+                            .into_boxed_slice(),
+                    ) as _))
+                }
+            }
+        }
+        #[allow(
+            unused_variables,
+            non_upper_case_globals,
+            non_snake_case,
+            unused_unsafe,
+            non_camel_case_types,
+            dead_code,
+            clippy::all
+        )]
+        pub mod Security {
+            #[repr(C)]
+            #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
+            pub struct SECURITY_ATTRIBUTES {
+                pub nLength: u32,
+                pub lpSecurityDescriptor: *mut ::std::ffi::c_void,
+                pub bInheritHandle: super::Foundation::BOOL,
+            }
+            impl SECURITY_ATTRIBUTES {}
+            impl ::std::default::Default for SECURITY_ATTRIBUTES {
+                fn default() -> Self {
+                    Self {
+                        nLength: 0,
+                        lpSecurityDescriptor: ::std::ptr::null_mut(),
+                        bInheritHandle: ::std::default::Default::default(),
+                    }
+                }
+            }
+            impl ::std::fmt::Debug for SECURITY_ATTRIBUTES {
+                fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                    fmt.debug_struct("SECURITY_ATTRIBUTES")
+                        .field("nLength", &format_args!("{:?}", self.nLength))
+                        .field(
+                            "lpSecurityDescriptor",
+                            &format_args!("{:?}", self.lpSecurityDescriptor),
+                        )
+                        .field("bInheritHandle", &format_args!("{:?}", self.bInheritHandle))
+                        .finish()
+                }
+            }
+            impl ::std::cmp::PartialEq for SECURITY_ATTRIBUTES {
+                fn eq(&self, other: &Self) -> bool {
+                    self.nLength == other.nLength
+                        && self.lpSecurityDescriptor == other.lpSecurityDescriptor
+                        && self.bInheritHandle == other.bInheritHandle
+                }
+            }
+            impl ::std::cmp::Eq for SECURITY_ATTRIBUTES {}
+            unsafe impl ::windows::Abi for SECURITY_ATTRIBUTES {
+                type Abi = Self;
+            }
+        }
         #[allow(
             unused_variables,
             non_upper_case_globals,
@@ -1799,13 +2275,13 @@ pub mod Windows {
                 }
                 pub const CLSCTX_ALL: CLSCTX = CLSCTX(23u32 as _);
                 pub unsafe fn CLSIDFromProgID<'a>(
-                    lpszprogid: impl ::windows::IntoParam<'a, super::SystemServices::PWSTR>,
+                    lpszprogid: impl ::windows::IntoParam<'a, super::super::Foundation::PWSTR>,
                     lpclsid: *mut ::windows::Guid,
                 ) -> ::windows::HRESULT {
                     #[link(name = "OLE32")]
                     extern "system" {
                         fn CLSIDFromProgID(
-                            lpszprogid: super::SystemServices::PWSTR,
+                            lpszprogid: super::super::Foundation::PWSTR,
                             lpclsid: *mut ::windows::Guid,
                         ) -> ::windows::HRESULT;
                     }
@@ -2043,7 +2519,7 @@ pub mod Windows {
                         lpsource: *const ::std::ffi::c_void,
                         dwmessageid: u32,
                         dwlanguageid: u32,
-                        lpbuffer: super::super::SystemServices::PWSTR,
+                        lpbuffer: super::super::super::Foundation::PWSTR,
                         nsize: u32,
                         arguments: *mut *mut i8,
                     ) -> u32 {
@@ -2054,7 +2530,7 @@ pub mod Windows {
                                 lpsource: *const ::std::ffi::c_void,
                                 dwmessageid: u32,
                                 dwlanguageid: u32,
-                                lpbuffer: super::super::SystemServices::PWSTR,
+                                lpbuffer: super::super::super::Foundation::PWSTR,
                                 nsize: u32,
                                 arguments: *mut *mut i8,
                             ) -> u32;
@@ -2116,6 +2592,52 @@ pub mod Windows {
                         }
                         GetLastError()
                     }
+                }
+            }
+            #[allow(
+                unused_variables,
+                non_upper_case_globals,
+                non_snake_case,
+                unused_unsafe,
+                non_camel_case_types,
+                dead_code,
+                clippy::all
+            )]
+            pub mod LibraryLoader {
+                pub unsafe fn FreeLibrary<'a>(
+                    hlibmodule: impl ::windows::IntoParam<'a, super::super::Foundation::HINSTANCE>,
+                ) -> super::super::Foundation::BOOL {
+                    #[link(name = "KERNEL32")]
+                    extern "system" {
+                        fn FreeLibrary(
+                            hlibmodule: super::super::Foundation::HINSTANCE,
+                        ) -> super::super::Foundation::BOOL;
+                    }
+                    FreeLibrary(hlibmodule.into_param().abi())
+                }
+                pub unsafe fn GetProcAddress<'a>(
+                    hmodule: impl ::windows::IntoParam<'a, super::super::Foundation::HINSTANCE>,
+                    lpprocname: impl ::windows::IntoParam<'a, super::super::Foundation::PSTR>,
+                ) -> ::std::option::Option<super::SystemServices::FARPROC> {
+                    #[link(name = "KERNEL32")]
+                    extern "system" {
+                        fn GetProcAddress(
+                            hmodule: super::super::Foundation::HINSTANCE,
+                            lpprocname: super::super::Foundation::PSTR,
+                        ) -> ::std::option::Option<super::SystemServices::FARPROC>;
+                    }
+                    GetProcAddress(hmodule.into_param().abi(), lpprocname.into_param().abi())
+                }
+                pub unsafe fn LoadLibraryA<'a>(
+                    lplibfilename: impl ::windows::IntoParam<'a, super::super::Foundation::PSTR>,
+                ) -> super::super::Foundation::HINSTANCE {
+                    #[link(name = "KERNEL32")]
+                    extern "system" {
+                        fn LoadLibraryA(
+                            lplibfilename: super::super::Foundation::PSTR,
+                        ) -> super::super::Foundation::HINSTANCE;
+                    }
+                    LoadLibraryA(lplibfilename.into_param().abi())
                 }
             }
             #[allow(
@@ -2230,14 +2752,14 @@ pub mod Windows {
                     hheap: impl ::windows::IntoParam<'a, HeapHandle>,
                     dwflags: HEAP_FLAGS,
                     lpmem: *mut ::std::ffi::c_void,
-                ) -> super::SystemServices::BOOL {
+                ) -> super::super::Foundation::BOOL {
                     #[link(name = "KERNEL32")]
                     extern "system" {
                         fn HeapFree(
                             hheap: HeapHandle,
                             dwflags: HEAP_FLAGS,
                             lpmem: *mut ::std::ffi::c_void,
-                        ) -> super::SystemServices::BOOL;
+                        ) -> super::super::Foundation::BOOL;
                     }
                     HeapFree(
                         hheap.into_param().abi(),
@@ -2256,154 +2778,37 @@ pub mod Windows {
                 clippy::all
             )]
             pub mod OleAutomation {
-                pub unsafe fn SysFreeString<'a>(bstrstring: impl ::windows::IntoParam<'a, BSTR>) {
+                pub unsafe fn SysFreeString<'a>(
+                    bstrstring: impl ::windows::IntoParam<'a, super::super::Foundation::BSTR>,
+                ) {
                     #[link(name = "OLEAUT32")]
                     extern "system" {
-                        fn SysFreeString(bstrstring: BSTR_abi);
+                        fn SysFreeString(bstrstring: super::super::Foundation::BSTR_abi);
                     }
                     SysFreeString(bstrstring.into_param().abi())
                 }
                 pub unsafe fn SysAllocStringLen<'a>(
-                    strin: impl ::windows::IntoParam<'a, super::SystemServices::PWSTR>,
+                    strin: impl ::windows::IntoParam<'a, super::super::Foundation::PWSTR>,
                     ui: u32,
-                ) -> BSTR {
+                ) -> super::super::Foundation::BSTR {
                     #[link(name = "OLEAUT32")]
                     extern "system" {
-                        fn SysAllocStringLen(strin: super::SystemServices::PWSTR, ui: u32) -> BSTR;
+                        fn SysAllocStringLen(
+                            strin: super::super::Foundation::PWSTR,
+                            ui: u32,
+                        ) -> super::super::Foundation::BSTR;
                     }
                     SysAllocStringLen(strin.into_param().abi(), ::std::mem::transmute(ui))
                 }
-                pub unsafe fn SysStringLen<'a>(pbstr: impl ::windows::IntoParam<'a, BSTR>) -> u32 {
+                pub unsafe fn SysStringLen<'a>(
+                    pbstr: impl ::windows::IntoParam<'a, super::super::Foundation::BSTR>,
+                ) -> u32 {
                     #[link(name = "OLEAUT32")]
                     extern "system" {
-                        fn SysStringLen(pbstr: BSTR_abi) -> u32;
+                        fn SysStringLen(pbstr: super::super::Foundation::BSTR_abi) -> u32;
                     }
                     SysStringLen(pbstr.into_param().abi())
                 }
-                #[repr(transparent)]
-                #[derive(:: std :: cmp :: Eq)]
-                pub struct BSTR(*mut u16);
-                impl BSTR {
-                    pub fn is_empty(&self) -> bool {
-                        self.0.is_null()
-                    }
-                    fn from_wide(value: &[u16]) -> Self {
-                        if value.len() == 0 {
-                            return Self(::std::ptr::null_mut());
-                        }
-                        unsafe {
-                            SysAllocStringLen(
-                                super::SystemServices::PWSTR(value.as_ptr() as _),
-                                value.len() as u32,
-                            )
-                        }
-                    }
-                    fn as_wide(&self) -> &[u16] {
-                        if self.0.is_null() {
-                            return &[];
-                        }
-                        unsafe {
-                            ::std::slice::from_raw_parts(
-                                self.0 as *const u16,
-                                SysStringLen(self) as usize,
-                            )
-                        }
-                    }
-                }
-                impl ::std::clone::Clone for BSTR {
-                    fn clone(&self) -> Self {
-                        Self::from_wide(self.as_wide())
-                    }
-                }
-                impl ::std::convert::From<&str> for BSTR {
-                    fn from(value: &str) -> Self {
-                        let value: ::std::vec::Vec<u16> = value.encode_utf16().collect();
-                        Self::from_wide(&value)
-                    }
-                }
-                impl ::std::convert::From<::std::string::String> for BSTR {
-                    fn from(value: ::std::string::String) -> Self {
-                        value.as_str().into()
-                    }
-                }
-                impl ::std::convert::From<&::std::string::String> for BSTR {
-                    fn from(value: &::std::string::String) -> Self {
-                        value.as_str().into()
-                    }
-                }
-                impl<'a> ::std::convert::TryFrom<&'a BSTR> for ::std::string::String {
-                    type Error = ::std::string::FromUtf16Error;
-                    fn try_from(value: &BSTR) -> ::std::result::Result<Self, Self::Error> {
-                        ::std::string::String::from_utf16(value.as_wide())
-                    }
-                }
-                impl ::std::convert::TryFrom<BSTR> for ::std::string::String {
-                    type Error = ::std::string::FromUtf16Error;
-                    fn try_from(value: BSTR) -> ::std::result::Result<Self, Self::Error> {
-                        ::std::string::String::try_from(&value)
-                    }
-                }
-                impl ::std::default::Default for BSTR {
-                    fn default() -> Self {
-                        Self(::std::ptr::null_mut())
-                    }
-                }
-                impl ::std::fmt::Display for BSTR {
-                    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                        use std::fmt::Write;
-                        for c in ::std::char::decode_utf16(self.as_wide().iter().cloned()) {
-                            f.write_char(c.map_err(|_| ::std::fmt::Error)?)?
-                        }
-                        Ok(())
-                    }
-                }
-                impl ::std::fmt::Debug for BSTR {
-                    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                        ::std::write!(f, "{}", self)
-                    }
-                }
-                impl ::std::cmp::PartialEq for BSTR {
-                    fn eq(&self, other: &Self) -> bool {
-                        self.as_wide() == other.as_wide()
-                    }
-                }
-                impl ::std::cmp::PartialEq<::std::string::String> for BSTR {
-                    fn eq(&self, other: &::std::string::String) -> bool {
-                        self == other.as_str()
-                    }
-                }
-                impl ::std::cmp::PartialEq<str> for BSTR {
-                    fn eq(&self, other: &str) -> bool {
-                        self == other
-                    }
-                }
-                impl ::std::cmp::PartialEq<&str> for BSTR {
-                    fn eq(&self, other: &&str) -> bool {
-                        self.as_wide().iter().copied().eq(other.encode_utf16())
-                    }
-                }
-                impl ::std::cmp::PartialEq<BSTR> for &str {
-                    fn eq(&self, other: &BSTR) -> bool {
-                        other == self
-                    }
-                }
-                impl ::std::ops::Drop for BSTR {
-                    fn drop(&mut self) {
-                        if !self.0.is_null() {
-                            unsafe {
-                                SysFreeString(self as &Self);
-                            }
-                        }
-                    }
-                }
-                unsafe impl ::windows::Abi for BSTR {
-                    type Abi = *mut u16;
-                    fn set_abi(&mut self) -> *mut *mut u16 {
-                        debug_assert!(self.0.is_null());
-                        &mut self.0 as *mut _ as _
-                    }
-                }
-                pub type BSTR_abi = *mut u16;
                 #[repr(transparent)]
                 #[derive(
                     :: std :: cmp :: PartialEq,
@@ -2422,7 +2827,10 @@ pub mod Windows {
                             ::std::mem::transmute(pguid),
                         )
                     }
-                    pub unsafe fn GetSource(&self, pbstrsource: *mut BSTR) -> ::windows::HRESULT {
+                    pub unsafe fn GetSource(
+                        &self,
+                        pbstrsource: *mut super::super::Foundation::BSTR,
+                    ) -> ::windows::HRESULT {
                         (::windows::Interface::vtable(self).4)(
                             ::windows::Abi::abi(self),
                             ::std::mem::transmute(pbstrsource),
@@ -2430,7 +2838,7 @@ pub mod Windows {
                     }
                     pub unsafe fn GetDescription(
                         &self,
-                        pbstrdescription: *mut BSTR,
+                        pbstrdescription: *mut super::super::Foundation::BSTR,
                     ) -> ::windows::HRESULT {
                         (::windows::Interface::vtable(self).5)(
                             ::windows::Abi::abi(self),
@@ -2439,7 +2847,7 @@ pub mod Windows {
                     }
                     pub unsafe fn GetHelpFile(
                         &self,
-                        pbstrhelpfile: *mut BSTR,
+                        pbstrhelpfile: *mut super::super::Foundation::BSTR,
                     ) -> ::windows::HRESULT {
                         (::windows::Interface::vtable(self).6)(
                             ::windows::Abi::abi(self),
@@ -2505,15 +2913,15 @@ pub mod Windows {
                     ) -> ::windows::HRESULT,
                     pub  unsafe extern "system" fn(
                         this: ::windows::RawPtr,
-                        pbstrsource: *mut BSTR_abi,
+                        pbstrsource: *mut super::super::Foundation::BSTR_abi,
                     ) -> ::windows::HRESULT,
                     pub  unsafe extern "system" fn(
                         this: ::windows::RawPtr,
-                        pbstrdescription: *mut BSTR_abi,
+                        pbstrdescription: *mut super::super::Foundation::BSTR_abi,
                     ) -> ::windows::HRESULT,
                     pub  unsafe extern "system" fn(
                         this: ::windows::RawPtr,
-                        pbstrhelpfile: *mut BSTR_abi,
+                        pbstrhelpfile: *mut super::super::Foundation::BSTR_abi,
                     ) -> ::windows::HRESULT,
                     pub  unsafe extern "system" fn(
                         this: ::windows::RawPtr,
@@ -2563,345 +2971,7 @@ pub mod Windows {
                 clippy::all
             )]
             pub mod SystemServices {
-                #[repr(transparent)]
-                #[derive(
-                    :: std :: clone :: Clone,
-                    :: std :: marker :: Copy,
-                    :: std :: cmp :: Eq,
-                    :: std :: fmt :: Debug,
-                )]
-                pub struct PWSTR(pub *mut u16);
-                impl PWSTR {
-                    pub const NULL: Self = Self(::std::ptr::null_mut());
-                    pub fn is_null(&self) -> bool {
-                        self.0.is_null()
-                    }
-                }
-                impl ::std::default::Default for PWSTR {
-                    fn default() -> Self {
-                        Self(::std::ptr::null_mut())
-                    }
-                }
-                impl ::std::cmp::PartialEq for PWSTR {
-                    fn eq(&self, other: &Self) -> bool {
-                        self.0 == other.0
-                    }
-                }
-                unsafe impl ::windows::Abi for PWSTR {
-                    type Abi = Self;
-                    fn drop_param(param: &mut ::windows::Param<Self>) {
-                        if let ::windows::Param::Boxed(value) = param {
-                            if !value.0.is_null() {
-                                unsafe {
-                                    ::std::boxed::Box::from_raw(value.0);
-                                }
-                            }
-                        }
-                    }
-                }
-                impl<'a> ::windows::IntoParam<'a, PWSTR> for &'a str {
-                    fn into_param(self) -> ::windows::Param<'a, PWSTR> {
-                        ::windows::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(
-                            self.encode_utf16()
-                                .chain(::std::iter::once(0))
-                                .collect::<std::vec::Vec<u16>>()
-                                .into_boxed_slice(),
-                        ) as _))
-                    }
-                }
-                impl<'a> ::windows::IntoParam<'a, PWSTR> for String {
-                    fn into_param(self) -> ::windows::Param<'a, PWSTR> {
-                        ::windows::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(
-                            self.encode_utf16()
-                                .chain(::std::iter::once(0))
-                                .collect::<std::vec::Vec<u16>>()
-                                .into_boxed_slice(),
-                        ) as _))
-                    }
-                }
-                #[repr(transparent)]
-                #[derive(
-                    :: std :: default :: Default,
-                    :: std :: clone :: Clone,
-                    :: std :: marker :: Copy,
-                    :: std :: cmp :: PartialEq,
-                    :: std :: cmp :: Eq,
-                    :: std :: fmt :: Debug,
-                )]
-                pub struct BOOL(pub i32);
-                unsafe impl ::windows::Abi for BOOL {
-                    type Abi = Self;
-                }
-                impl BOOL {
-                    #[inline]
-                    pub fn as_bool(self) -> bool {
-                        !(self.0 == 0)
-                    }
-                    #[inline]
-                    pub fn ok(self) -> ::windows::Result<()> {
-                        if self.as_bool() {
-                            Ok(())
-                        } else {
-                            Err(::windows::HRESULT::from_thread().into())
-                        }
-                    }
-                    #[inline]
-                    pub fn unwrap(self) {
-                        self.ok().unwrap();
-                    }
-                    #[inline]
-                    pub fn expect(self, msg: &str) {
-                        self.ok().expect(msg);
-                    }
-                }
-                impl ::std::convert::From<BOOL> for bool {
-                    fn from(value: BOOL) -> Self {
-                        value.as_bool()
-                    }
-                }
-                impl ::std::convert::From<&BOOL> for bool {
-                    fn from(value: &BOOL) -> Self {
-                        value.as_bool()
-                    }
-                }
-                impl ::std::convert::From<bool> for BOOL {
-                    fn from(value: bool) -> Self {
-                        if value {
-                            BOOL(1)
-                        } else {
-                            BOOL(0)
-                        }
-                    }
-                }
-                impl ::std::convert::From<&bool> for BOOL {
-                    fn from(value: &bool) -> Self {
-                        (*value).into()
-                    }
-                }
-                impl ::std::cmp::PartialEq<bool> for BOOL {
-                    fn eq(&self, other: &bool) -> bool {
-                        self.as_bool() == *other
-                    }
-                }
-                impl ::std::cmp::PartialEq<BOOL> for bool {
-                    fn eq(&self, other: &BOOL) -> bool {
-                        *self == other.as_bool()
-                    }
-                }
-                impl std::ops::Not for BOOL {
-                    type Output = Self;
-                    fn not(self) -> Self::Output {
-                        if self.as_bool() {
-                            BOOL(0)
-                        } else {
-                            BOOL(1)
-                        }
-                    }
-                }
-                impl<'a> ::windows::IntoParam<'a, BOOL> for bool {
-                    fn into_param(self) -> ::windows::Param<'a, BOOL> {
-                        ::windows::Param::Owned(self.into())
-                    }
-                }
-                pub const CO_E_NOTINITIALIZED: ::windows::HRESULT =
-                    ::windows::HRESULT(-2147221008i32 as _);
-                pub const E_POINTER: ::windows::HRESULT = ::windows::HRESULT(-2147467261i32 as _);
-                #[repr(transparent)]
-                #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
-                pub struct HINSTANCE(pub isize);
-                impl HINSTANCE {}
-                impl ::std::default::Default for HINSTANCE {
-                    fn default() -> Self {
-                        Self(0)
-                    }
-                }
-                impl HINSTANCE {
-                    pub const NULL: Self = Self(0);
-                    pub fn is_null(&self) -> bool {
-                        self.0 == 0
-                    }
-                }
-                impl ::std::fmt::Debug for HINSTANCE {
-                    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                        fmt.debug_struct("HINSTANCE")
-                            .field("Value", &format_args!("{:?}", self.0))
-                            .finish()
-                    }
-                }
-                impl ::std::cmp::PartialEq for HINSTANCE {
-                    fn eq(&self, other: &Self) -> bool {
-                        self.0 == other.0
-                    }
-                }
-                impl ::std::cmp::Eq for HINSTANCE {}
-                unsafe impl ::windows::Abi for HINSTANCE {
-                    type Abi = Self;
-                }
-                pub unsafe fn FreeLibrary<'a>(
-                    hlibmodule: impl ::windows::IntoParam<'a, HINSTANCE>,
-                ) -> BOOL {
-                    #[link(name = "KERNEL32")]
-                    extern "system" {
-                        fn FreeLibrary(hlibmodule: HINSTANCE) -> BOOL;
-                    }
-                    FreeLibrary(hlibmodule.into_param().abi())
-                }
                 pub type FARPROC = unsafe extern "system" fn() -> isize;
-                #[repr(transparent)]
-                #[derive(
-                    :: std :: clone :: Clone,
-                    :: std :: marker :: Copy,
-                    :: std :: cmp :: Eq,
-                    :: std :: fmt :: Debug,
-                )]
-                pub struct PSTR(pub *mut u8);
-                impl PSTR {
-                    pub const NULL: Self = Self(::std::ptr::null_mut());
-                    pub fn is_null(&self) -> bool {
-                        self.0.is_null()
-                    }
-                }
-                impl ::std::default::Default for PSTR {
-                    fn default() -> Self {
-                        Self(::std::ptr::null_mut())
-                    }
-                }
-                impl ::std::cmp::PartialEq for PSTR {
-                    fn eq(&self, other: &Self) -> bool {
-                        self.0 == other.0
-                    }
-                }
-                unsafe impl ::windows::Abi for PSTR {
-                    type Abi = Self;
-                    fn drop_param(param: &mut ::windows::Param<Self>) {
-                        if let ::windows::Param::Boxed(value) = param {
-                            if !value.0.is_null() {
-                                unsafe {
-                                    ::std::boxed::Box::from_raw(value.0);
-                                }
-                            }
-                        }
-                    }
-                }
-                impl<'a> ::windows::IntoParam<'a, PSTR> for &'a str {
-                    fn into_param(self) -> ::windows::Param<'a, PSTR> {
-                        ::windows::Param::Boxed(PSTR(::std::boxed::Box::<[u8]>::into_raw(
-                            self.bytes()
-                                .chain(::std::iter::once(0))
-                                .collect::<std::vec::Vec<u8>>()
-                                .into_boxed_slice(),
-                        ) as _))
-                    }
-                }
-                impl<'a> ::windows::IntoParam<'a, PSTR> for String {
-                    fn into_param(self) -> ::windows::Param<'a, PSTR> {
-                        ::windows::Param::Boxed(PSTR(::std::boxed::Box::<[u8]>::into_raw(
-                            self.bytes()
-                                .chain(::std::iter::once(0))
-                                .collect::<std::vec::Vec<u8>>()
-                                .into_boxed_slice(),
-                        ) as _))
-                    }
-                }
-                pub unsafe fn GetProcAddress<'a>(
-                    hmodule: impl ::windows::IntoParam<'a, HINSTANCE>,
-                    lpprocname: impl ::windows::IntoParam<'a, PSTR>,
-                ) -> ::std::option::Option<FARPROC> {
-                    #[link(name = "KERNEL32")]
-                    extern "system" {
-                        fn GetProcAddress(
-                            hmodule: HINSTANCE,
-                            lpprocname: PSTR,
-                        ) -> ::std::option::Option<FARPROC>;
-                    }
-                    GetProcAddress(hmodule.into_param().abi(), lpprocname.into_param().abi())
-                }
-                pub unsafe fn LoadLibraryA<'a>(
-                    lplibfilename: impl ::windows::IntoParam<'a, PSTR>,
-                ) -> HINSTANCE {
-                    #[link(name = "KERNEL32")]
-                    extern "system" {
-                        fn LoadLibraryA(lplibfilename: PSTR) -> HINSTANCE;
-                    }
-                    LoadLibraryA(lplibfilename.into_param().abi())
-                }
-                #[repr(transparent)]
-                #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
-                pub struct HANDLE(pub isize);
-                impl HANDLE {}
-                impl ::std::default::Default for HANDLE {
-                    fn default() -> Self {
-                        Self(0)
-                    }
-                }
-                impl HANDLE {
-                    pub const NULL: Self = Self(0);
-                    pub fn is_null(&self) -> bool {
-                        self.0 == 0
-                    }
-                }
-                impl ::std::fmt::Debug for HANDLE {
-                    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                        fmt.debug_struct("HANDLE")
-                            .field("Value", &format_args!("{:?}", self.0))
-                            .finish()
-                    }
-                }
-                impl ::std::cmp::PartialEq for HANDLE {
-                    fn eq(&self, other: &Self) -> bool {
-                        self.0 == other.0
-                    }
-                }
-                impl ::std::cmp::Eq for HANDLE {}
-                unsafe impl ::windows::Abi for HANDLE {
-                    type Abi = Self;
-                }
-                impl HANDLE {
-                    pub const INVALID: Self = Self(-1);
-                    pub fn is_invalid(&self) -> bool {
-                        self.0 == -1
-                    }
-                }
-                #[repr(C)]
-                #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
-                pub struct SECURITY_ATTRIBUTES {
-                    pub nLength: u32,
-                    pub lpSecurityDescriptor: *mut ::std::ffi::c_void,
-                    pub bInheritHandle: BOOL,
-                }
-                impl SECURITY_ATTRIBUTES {}
-                impl ::std::default::Default for SECURITY_ATTRIBUTES {
-                    fn default() -> Self {
-                        Self {
-                            nLength: 0,
-                            lpSecurityDescriptor: ::std::ptr::null_mut(),
-                            bInheritHandle: ::std::default::Default::default(),
-                        }
-                    }
-                }
-                impl ::std::fmt::Debug for SECURITY_ATTRIBUTES {
-                    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                        fmt.debug_struct("SECURITY_ATTRIBUTES")
-                            .field("nLength", &format_args!("{:?}", self.nLength))
-                            .field(
-                                "lpSecurityDescriptor",
-                                &format_args!("{:?}", self.lpSecurityDescriptor),
-                            )
-                            .field("bInheritHandle", &format_args!("{:?}", self.bInheritHandle))
-                            .finish()
-                    }
-                }
-                impl ::std::cmp::PartialEq for SECURITY_ATTRIBUTES {
-                    fn eq(&self, other: &Self) -> bool {
-                        self.nLength == other.nLength
-                            && self.lpSecurityDescriptor == other.lpSecurityDescriptor
-                            && self.bInheritHandle == other.bInheritHandle
-                    }
-                }
-                impl ::std::cmp::Eq for SECURITY_ATTRIBUTES {}
-                unsafe impl ::windows::Abi for SECURITY_ATTRIBUTES {
-                    type Abi = Self;
-                }
             }
             #[allow(
                 unused_variables,
@@ -2914,19 +2984,19 @@ pub mod Windows {
             )]
             pub mod Threading {
                 pub unsafe fn CreateEventA<'a>(
-                    lpeventattributes: *mut super::SystemServices::SECURITY_ATTRIBUTES,
-                    bmanualreset: impl ::windows::IntoParam<'a, super::SystemServices::BOOL>,
-                    binitialstate: impl ::windows::IntoParam<'a, super::SystemServices::BOOL>,
-                    lpname: impl ::windows::IntoParam<'a, super::SystemServices::PSTR>,
-                ) -> super::SystemServices::HANDLE {
+                    lpeventattributes: *mut super::super::Security::SECURITY_ATTRIBUTES,
+                    bmanualreset: impl ::windows::IntoParam<'a, super::super::Foundation::BOOL>,
+                    binitialstate: impl ::windows::IntoParam<'a, super::super::Foundation::BOOL>,
+                    lpname: impl ::windows::IntoParam<'a, super::super::Foundation::PSTR>,
+                ) -> super::super::Foundation::HANDLE {
                     #[link(name = "KERNEL32")]
                     extern "system" {
                         fn CreateEventA(
-                            lpeventattributes: *mut super::SystemServices::SECURITY_ATTRIBUTES,
-                            bmanualreset: super::SystemServices::BOOL,
-                            binitialstate: super::SystemServices::BOOL,
-                            lpname: super::SystemServices::PSTR,
-                        ) -> super::SystemServices::HANDLE;
+                            lpeventattributes: *mut super::super::Security::SECURITY_ATTRIBUTES,
+                            bmanualreset: super::super::Foundation::BOOL,
+                            binitialstate: super::super::Foundation::BOOL,
+                            lpname: super::super::Foundation::PSTR,
+                        ) -> super::super::Foundation::HANDLE;
                     }
                     CreateEventA(
                         ::std::mem::transmute(lpeventattributes),
@@ -2936,13 +3006,13 @@ pub mod Windows {
                     )
                 }
                 pub unsafe fn SetEvent<'a>(
-                    hevent: impl ::windows::IntoParam<'a, super::SystemServices::HANDLE>,
-                ) -> super::SystemServices::BOOL {
+                    hevent: impl ::windows::IntoParam<'a, super::super::Foundation::HANDLE>,
+                ) -> super::super::Foundation::BOOL {
                     #[link(name = "KERNEL32")]
                     extern "system" {
                         fn SetEvent(
-                            hevent: super::SystemServices::HANDLE,
-                        ) -> super::SystemServices::BOOL;
+                            hevent: super::super::Foundation::HANDLE,
+                        ) -> super::super::Foundation::BOOL;
                     }
                     SetEvent(hevent.into_param().abi())
                 }
@@ -2987,13 +3057,13 @@ pub mod Windows {
                     }
                 }
                 pub unsafe fn WaitForSingleObject<'a>(
-                    hhandle: impl ::windows::IntoParam<'a, super::SystemServices::HANDLE>,
+                    hhandle: impl ::windows::IntoParam<'a, super::super::Foundation::HANDLE>,
                     dwmilliseconds: u32,
                 ) -> WAIT_RETURN_CAUSE {
                     #[link(name = "KERNEL32")]
                     extern "system" {
                         fn WaitForSingleObject(
-                            hhandle: super::SystemServices::HANDLE,
+                            hhandle: super::super::Foundation::HANDLE,
                             dwmilliseconds: u32,
                         ) -> WAIT_RETURN_CAUSE;
                     }
@@ -3229,10 +3299,10 @@ pub mod Windows {
                 impl IRestrictedErrorInfo {
                     pub unsafe fn GetErrorDetails(
                         &self,
-                        description: *mut super::OleAutomation::BSTR,
+                        description: *mut super::super::Foundation::BSTR,
                         error: *mut ::windows::HRESULT,
-                        restricteddescription: *mut super::OleAutomation::BSTR,
-                        capabilitysid: *mut super::OleAutomation::BSTR,
+                        restricteddescription: *mut super::super::Foundation::BSTR,
+                        capabilitysid: *mut super::super::Foundation::BSTR,
                     ) -> ::windows::HRESULT {
                         (::windows::Interface::vtable(self).3)(
                             ::windows::Abi::abi(self),
@@ -3244,7 +3314,7 @@ pub mod Windows {
                     }
                     pub unsafe fn GetReference(
                         &self,
-                        reference: *mut super::OleAutomation::BSTR,
+                        reference: *mut super::super::Foundation::BSTR,
                     ) -> ::windows::HRESULT {
                         (::windows::Interface::vtable(self).4)(
                             ::windows::Abi::abi(self),
@@ -3299,14 +3369,14 @@ pub mod Windows {
                     pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
                     pub  unsafe extern "system" fn(
                         this: ::windows::RawPtr,
-                        description: *mut super::OleAutomation::BSTR_abi,
+                        description: *mut super::super::Foundation::BSTR_abi,
                         error: *mut ::windows::HRESULT,
-                        restricteddescription: *mut super::OleAutomation::BSTR_abi,
-                        capabilitysid: *mut super::OleAutomation::BSTR_abi,
+                        restricteddescription: *mut super::super::Foundation::BSTR_abi,
+                        capabilitysid: *mut super::super::Foundation::BSTR_abi,
                     ) -> ::windows::HRESULT,
                     pub  unsafe extern "system" fn(
                         this: ::windows::RawPtr,
-                        reference: *mut super::OleAutomation::BSTR_abi,
+                        reference: *mut super::super::Foundation::BSTR_abi,
                     ) -> ::windows::HRESULT,
                 );
                 #[repr(transparent)]
@@ -3436,28 +3506,6 @@ pub mod Windows {
                         weakreference: *mut ::windows::RawPtr,
                     ) -> ::windows::HRESULT,
                 );
-            }
-            #[allow(
-                unused_variables,
-                non_upper_case_globals,
-                non_snake_case,
-                unused_unsafe,
-                non_camel_case_types,
-                dead_code,
-                clippy::all
-            )]
-            pub mod WindowsProgramming {
-                pub unsafe fn CloseHandle<'a>(
-                    hobject: impl ::windows::IntoParam<'a, super::SystemServices::HANDLE>,
-                ) -> super::SystemServices::BOOL {
-                    #[link(name = "KERNEL32")]
-                    extern "system" {
-                        fn CloseHandle(
-                            hobject: super::SystemServices::HANDLE,
-                        ) -> super::SystemServices::BOOL;
-                    }
-                    CloseHandle(hobject.into_param().abi())
-                }
             }
         }
     }

--- a/src/result/error.rs
+++ b/src/result/error.rs
@@ -2,7 +2,8 @@ use crate::*;
 use std::convert::TryInto;
 
 use bindings::{
-    Windows::Win32::System::OleAutomation::{GetErrorInfo, SetErrorInfo, BSTR},
+    Windows::Win32::Foundation::BSTR,
+    Windows::Win32::System::OleAutomation::{GetErrorInfo, SetErrorInfo},
     Windows::Win32::System::WinRT::{ILanguageExceptionErrorInfo2, IRestrictedErrorInfo},
 };
 

--- a/src/result/error_code.rs
+++ b/src/result/error_code.rs
@@ -1,8 +1,8 @@
 use crate::*;
 
 use bindings::{
+    Windows::Win32::Foundation::{E_POINTER, PWSTR},
     Windows::Win32::System::Diagnostics::Debug::*,
-    Windows::Win32::System::SystemServices::{E_POINTER, PWSTR},
 };
 
 /// A primitive error code value returned by most COM functions.

--- a/src/runtime/delay_load.rs
+++ b/src/runtime/delay_load.rs
@@ -1,6 +1,6 @@
 use crate::*;
 
-use bindings::Windows::Win32::System::SystemServices::{FreeLibrary, GetProcAddress, LoadLibraryA};
+use bindings::Windows::Win32::System::LibraryLoader::{FreeLibrary, GetProcAddress, LoadLibraryA};
 
 pub fn delay_load(library: &str, function: &str) -> std::result::Result<RawPtr, HRESULT> {
     unsafe {

--- a/src/runtime/factory_cache.rs
+++ b/src/runtime/factory_cache.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use bindings::Windows::Win32::System::SystemServices::CO_E_NOTINITIALIZED;
+use bindings::Windows::Win32::Foundation::CO_E_NOTINITIALIZED;
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicPtr, Ordering};
 

--- a/src/runtime/waiter.rs
+++ b/src/runtime/waiter.rs
@@ -1,9 +1,8 @@
 use crate::*;
 
 use bindings::{
-    Windows::Win32::System::SystemServices::{HANDLE, PSTR},
+    Windows::Win32::Foundation::{CloseHandle, HANDLE, PSTR},
     Windows::Win32::System::Threading::{CreateEventA, SetEvent, WaitForSingleObject},
-    Windows::Win32::System::WindowsProgramming::CloseHandle,
 };
 
 /// A simple blocking waiter used by the generated bindings and should not be used directly.

--- a/src/traits/abi.rs
+++ b/src/traits/abi.rs
@@ -1,6 +1,6 @@
 use crate::*;
 
-use bindings::Windows::Win32::System::SystemServices::E_POINTER;
+use bindings::Windows::Win32::Foundation::E_POINTER;
 
 /// Provides a generic way of referring to and converting between a Rust object
 /// and its ABI equivalent.

--- a/tests/bstr/build.rs
+++ b/tests/bstr/build.rs
@@ -2,6 +2,6 @@ fn main() {
     windows::build!(
         // The Windows crate manually injects various functions needed to implement BSTR.
         // This test validates these are included.
-        Windows::Win32::System::OleAutomation::BSTR
+        Windows::Win32::Foundation::BSTR
     );
 }

--- a/tests/bstr/tests/bstr.rs
+++ b/tests/bstr/tests/bstr.rs
@@ -1,4 +1,4 @@
-use test_bstr::Windows::Win32::System::OleAutomation::BSTR;
+use test_bstr::Windows::Win32::Foundation::BSTR;
 use windows::Abi;
 
 #[test]

--- a/tests/handles/build.rs
+++ b/tests/handles/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     windows::build!(
-        Windows::Win32::System::SystemServices::{HANDLE, PSTR, PWSTR},
+        Windows::Win32::Foundation::{HANDLE, PSTR, PWSTR},
         Windows::Win32::Graphics::Gdi::HGDIOBJ,
     );
 }

--- a/tests/handles/tests/null.rs
+++ b/tests/handles/tests/null.rs
@@ -1,6 +1,6 @@
 use test_handles::{
+    Windows::Win32::Foundation::{HANDLE, PSTR, PWSTR},
     Windows::Win32::Graphics::Gdi::HGDIOBJ,
-    Windows::Win32::System::SystemServices::{HANDLE, PSTR, PWSTR},
 };
 
 #[test]

--- a/tests/interop/build.rs
+++ b/tests/interop/build.rs
@@ -1,7 +1,7 @@
 fn main() {
     windows::build!(
-        Windows::Win32::System::WinRT::RoActivateInstance,
         Windows::Foundation::Collections::StringMap,
+        Windows::Win32::System::WinRT::RoActivateInstance,
         Windows::Win32::UI::RadialInput::IRadialControllerInterop,
     );
 }

--- a/tests/win32/build.rs
+++ b/tests/win32/build.rs
@@ -1,7 +1,7 @@
 fn main() {
     windows::build!(
-        Windows::Win32::System::OleAutomation::BSTR,
-        Windows::Win32::Security::{
+        Windows::Win32::Foundation::{CloseHandle, BSTR, RECT},
+        Windows::Win32::Security::Authorization::{
             REVOKE_ACCESS,
         },
         Windows::Win32::UI::WindowsAndMessaging::{
@@ -17,9 +17,6 @@ fn main() {
             DXGI_FORMAT_R32_TYPELESS, DXGI_MODE_SCANLINE_ORDER_PROGRESSIVE,
             DXGI_MODE_SCALING_CENTERED,
         },
-        Windows::Win32::UI::DisplayDevices::{
-            RECT,
-        },
         Windows::Win32::System::Threading::{
             CreateEventW, SetEvent, WaitForSingleObject, WAIT_OBJECT_0,
         },
@@ -32,9 +29,6 @@ fn main() {
         },
         Windows::Win32::Graphics::Hlsl::{
             D3DCOMPILER_DLL
-        },
-        Windows::Win32::System::WindowsProgramming::{
-            CloseHandle
         },
         Windows::Win32::Gaming::HasExpandedResources,
         Windows::Win32::Graphics::Direct3D11::D3DDisassemble11Trace,

--- a/tests/win32/tests/win32.rs
+++ b/tests/win32/tests/win32.rs
@@ -1,4 +1,5 @@
 use test_win32::{
+    Windows::Win32::Foundation::{CloseHandle, BOOL, BSTR, HANDLE, PSTR, PWSTR, RECT},
     Windows::Win32::Gaming::HasExpandedResources,
     Windows::Win32::Graphics::Direct2D::CLSID_D2D1Shadow,
     Windows::Win32::Graphics::Direct3D11::D3DDisassemble11Trace,
@@ -10,14 +11,10 @@ use test_win32::{
     Windows::Win32::Storage::StructuredStorage::*,
     Windows::Win32::System::Com::CreateUri,
     Windows::Win32::System::Diagnostics::Debug::*,
-    Windows::Win32::System::OleAutomation::BSTR,
-    Windows::Win32::System::SystemServices::{BOOL, HANDLE, PSTR, PWSTR},
     Windows::Win32::System::Threading::*,
-    Windows::Win32::System::WindowsProgramming::CloseHandle,
     Windows::Win32::UI::Accessibility::UIA_ScrollPatternNoScroll,
     Windows::Win32::UI::Animation::{UIAnimationManager, UIAnimationTransitionLibrary},
     Windows::Win32::UI::ColorSystem::WhitePoint,
-    Windows::Win32::UI::DisplayDevices::RECT,
     Windows::Win32::UI::WindowsAndMessaging::{
         CHOOSECOLORW, HWND, PROPENUMPROCA, PROPENUMPROCW, WM_KEYUP,
     },

--- a/tests/winrt/build.rs
+++ b/tests/winrt/build.rs
@@ -20,9 +20,9 @@ fn main() {
             ShareTargetActivatedEventArgs, FileOpenPickerActivatedEventArgs, FileSavePickerActivatedEventArgs,
             CachedFileUpdaterActivatedEventArgs, BackgroundActivatedEventArgs,
         },
-        Windows::Win32::System::SystemServices::{
-            CreateDispatcherQueueController, E_POINTER, E_NOINTERFACE, DQTAT_COM_NONE,
-            DQTYPE_THREAD_CURRENT
+        Windows::Win32::Foundation::{E_POINTER, E_NOINTERFACE},
+        Windows::Win32::System::WinRT::{
+            CreateDispatcherQueueController, DQTAT_COM_NONE, DQTYPE_THREAD_CURRENT
         },
         Windows::UI::Xaml::Interop::TypeName,
         Windows::UI::Xaml::Data::ICustomProperty,

--- a/tests/winrt/tests/collisions.rs
+++ b/tests/winrt/tests/collisions.rs
@@ -4,7 +4,7 @@ use test_winrt::{
         WiFiDirectConnectionParameters, WiFiDirectDevice, WiFiDirectDeviceSelectorType,
     },
     Windows::Storage::Streams::{InMemoryRandomAccessStream, RandomAccessStreamReference},
-    Windows::Win32::System::SystemServices::E_POINTER,
+    Windows::Win32::Foundation::E_POINTER,
 };
 
 // WiFiDirectDevice has a pair of static factory interfaces with overloads. This test

--- a/tests/winrt/tests/composition.rs
+++ b/tests/winrt/tests/composition.rs
@@ -1,6 +1,6 @@
 use test_winrt::{
     Windows::System::DispatcherQueueController,
-    Windows::Win32::System::SystemServices::{
+    Windows::Win32::System::WinRT::{
         CreateDispatcherQueueController, DispatcherQueueOptions, DQTAT_COM_NONE,
         DQTYPE_THREAD_CURRENT,
     },

--- a/tests/winrt/tests/error.rs
+++ b/tests/winrt/tests/error.rs
@@ -1,4 +1,4 @@
-use test_winrt::{Windows::Foundation::Uri, Windows::Win32::System::SystemServices::E_NOINTERFACE};
+use test_winrt::{Windows::Foundation::Uri, Windows::Win32::Foundation::E_NOINTERFACE};
 
 #[test]
 fn from_hresult() {


### PR DESCRIPTION
Windows.Win32.winmd comes from: https://github.com/microsoft/win32metadata/blob/3895e772aa70fc8f0f5f81d003d0651d7f251065/scripts/BaselineWinmd/Windows.Win32.winmd

Examples that don't work:
- clock
- d3d12
- overlapped

Tests that don't work:
- interop
- matrix3x2
- unions
- win32
- winrt

The errors are:
- Could not find type def `Windows.Win32.Graphics.Direct2D.D2D_MATRIX_3X2_F`
- Could not find type def `Windows.Win32.Graphics.Direct3D12._Anonymous_e__Union`
- Could not find type def `Windows.Win32.System.Diagnostics.Debug._Anonymous_e__Union`
- Could not find type def `Windows.Win32.System.SystemServices._Anonymous_e__Union`
- Could not find type def `Windows.Win32.System.WinRT.HSTRING`

Looking in dnSpy at OVERLAPPED for both winmd's
new:
![image](https://user-images.githubusercontent.com/22673928/119998378-fad35e80-c013-11eb-95c1-faae5e24731e.png)
old:
![image](https://user-images.githubusercontent.com/22673928/119998427-0888e400-c014-11eb-94ae-18bfc01d935d.png)

Similar situation case for D2D_MATRIX_3X2_F,
new:
![image](https://user-images.githubusercontent.com/22673928/119999140-c3b17d00-c014-11eb-846d-9f29e8689294.png)
old:
![image](https://user-images.githubusercontent.com/22673928/119999163-c7dd9a80-c014-11eb-8b2c-1ea065bbc081.png)

fix maybe by replacing the namespace with the type if field name contains Anonymous, including Anoynmous1