### PR TITLE
ci: Make sure bindings.rs is up-to-date

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,6 @@
 name: Build and Test
 
-on: 
+on:
   pull_request:
   push:
     branches:
@@ -12,7 +12,7 @@ env:
 jobs:
   test:
     runs-on: ${{ matrix.os }}
-    strategy: 
+    strategy:
       matrix:
         include:
         - os: windows-latest
@@ -49,4 +49,11 @@ jobs:
 
     - name: fmt
       run: cargo fmt --all -- --check
+      if: matrix.os == 'windows-latest' && matrix.rust == 'stable'
+
+    - name: generate bindings
+      run: |
+        cargo run -p windows_bindings --target ${{ matrix.other }}
+        git diff --exit-code || (echo '::error::Generated bindings are out-of-date. Make sure to update them by running `cargo run -p windows_bindings`'; exit 1)
+      shell: bash
       if: matrix.os == 'windows-latest' && matrix.rust == 'stable'

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1712,7 +1712,7 @@ pub mod Windows {
                     .from_abi::<::windows::IInspectable>(result__)
                 })
             }
-            fn IPropertyValueStatics<
+            pub fn IPropertyValueStatics<
                 R,
                 F: FnOnce(&IPropertyValueStatics) -> ::windows::Result<R>,
             >(
@@ -2284,10 +2284,25 @@ pub mod Windows {
                 #[derive(:: std :: cmp :: Eq)]
                 pub struct BSTR(*mut u16);
                 impl BSTR {
+                    #[doc = r" Create an empty `BSTR`."]
+                    #[doc = r""]
+                    #[doc = r" This function does not allocate memory."]
+                    pub fn new() -> Self {
+                        Self(std::ptr::null_mut())
+                    }
+                    #[doc = r" Returns `true` if the string is empty."]
                     pub fn is_empty(&self) -> bool {
                         self.0.is_null()
                     }
-                    fn from_wide(value: &[u16]) -> Self {
+                    #[doc = r" Returns the length of the string."]
+                    pub fn len(&self) -> usize {
+                        if self.is_empty() {
+                            return 0;
+                        }
+                        unsafe { SysStringLen(self) as usize }
+                    }
+                    #[doc = r" Create a `BSTR` from a slice of 16-bit characters."]
+                    pub fn from_wide(value: &[u16]) -> Self {
                         if value.len() == 0 {
                             return Self(::std::ptr::null_mut());
                         }
@@ -2298,7 +2313,8 @@ pub mod Windows {
                             )
                         }
                     }
-                    fn as_wide(&self) -> &[u16] {
+                    #[doc = r" Get the string as 16-bit characters."]
+                    pub fn as_wide(&self) -> &[u16] {
                         if self.0.is_null() {
                             return &[];
                         }


### PR DESCRIPTION
Recent PRs show that this file is sometimes not updated after generator changes. Make the CI fail to ensure it's always representing the same version of `gen` in-tree.

I hope extraneous whitespace removal is okay - there's no rusftmt run the CI script itself :grimacing: 