### PR TITLE
Update metadata to 10.2.84-preview and regroup UseTrees

### DIFF
--- a/crates/bindings/src/main.rs
+++ b/crates/bindings/src/main.rs
@@ -2,23 +2,27 @@ use std::io::prelude::*;
 
 fn main() -> std::io::Result<()> {
     let tokens = windows_macros::generate! {
-        Windows::Foundation::{IReference, IStringable, PropertyValue},
-        Windows::Win32::System::Com::{
-            CLSIDFromProgID, CoCreateGuid, CoCreateInstance, CoInitializeEx, CoTaskMemAlloc,
-            CoTaskMemFree, IAgileObject,
+        Windows::{
+            Foundation::{IReference, IStringable, PropertyValue},
+            Win32::{
+                Foundation::{CloseHandle, BSTR, CO_E_NOTINITIALIZED, E_POINTER},
+                System::{
+                    Com::{
+                        CLSIDFromProgID, CoCreateGuid, CoCreateInstance, CoInitializeEx,
+                        CoTaskMemAlloc, CoTaskMemFree, IAgileObject,
+                    },
+                    Diagnostics::Debug::{FormatMessageW, GetLastError},
+                    LibraryLoader::{FreeLibrary, GetProcAddress, LoadLibraryA},
+                    Memory::{GetProcessHeap, HeapAlloc, HeapFree},
+                    OleAutomation::{GetErrorInfo, IErrorInfo, SetErrorInfo},
+                    Threading::{CreateEventA, SetEvent, WaitForSingleObject},
+                    WinRT::{
+                        ILanguageExceptionErrorInfo2, IRestrictedErrorInfo, IWeakReference,
+                        IWeakReferenceSource,
+                    },
+                },
+            },
         },
-        Windows::Win32::System::Diagnostics::Debug::{FormatMessageW, GetLastError},
-        Windows::Win32::System::Memory::{GetProcessHeap, HeapAlloc, HeapFree},
-        Windows::Win32::System::OleAutomation::{GetErrorInfo, IErrorInfo, SetErrorInfo, BSTR},
-        Windows::Win32::System::SystemServices::{
-            FreeLibrary, GetProcAddress, LoadLibraryA, CO_E_NOTINITIALIZED, E_POINTER,
-        },
-        Windows::Win32::System::Threading::{CreateEventA, SetEvent, WaitForSingleObject},
-        Windows::Win32::System::WinRT::{
-            ILanguageExceptionErrorInfo2, IRestrictedErrorInfo, IWeakReference,
-            IWeakReferenceSource,
-        },
-        Windows::Win32::System::WindowsProgramming::CloseHandle,
     };
 
     let mut path = windows_gen::workspace_dir();

--- a/crates/gen/default/readme.md
+++ b/crates/gen/default/readme.md
@@ -4,7 +4,7 @@ dependent crate or workspace has an empty or non-existent `.windows/winmd` direc
 
 ## Windows.Win32.winmd
 - Source: https://www.nuget.org/packages/Microsoft.Windows.SDK.Win32Metadata/
-- Version: 10.0.19041.202-preview
+- Version: 10.2.84-preview
 
 ## Windows.WinRT.winmd
 - Source: https://www.nuget.org/packages/Microsoft.Windows.SDK.Contracts

--- a/crates/gen/src/parser/type_reader.rs
+++ b/crates/gen/src/parser/type_reader.rs
@@ -322,7 +322,7 @@ const WELL_KNOWN_TYPES: [(&'static str, &'static str, ElementType); 10] = [
         ElementType::IUnknown,
     ),
     ("Windows.Foundation", "HResult", ElementType::HRESULT),
-    ("Windows.Win32.System.Com", "HRESULT", ElementType::HRESULT),
+    ("Windows.Win32.Foundation", "HRESULT", ElementType::HRESULT),
     ("Windows.Win32.System.WinRT", "HSTRING", ElementType::String),
     (
         "Windows.Win32.System.WinRT",

--- a/crates/gen/src/tables/type_def.rs
+++ b/crates/gen/src/tables/type_def.rs
@@ -258,7 +258,7 @@ impl TypeDef {
                 let mut dependencies = vec![];
 
                 match self.full_name() {
-                    ("Windows.Win32.System.OleAutomation", "BSTR") => {
+                    ("Windows.Win32.Foundation", "BSTR") => {
                         dependencies.push(
                             reader.resolve_type(
                                 "Windows.Win32.System.OleAutomation",
@@ -575,7 +575,7 @@ impl TypeDef {
         match self.kind() {
             TypeKind::Struct => {
                 // TODO: should be "if self.can_drop().is_some() {" once win32metadata bugs are fixed (423, 422, 421, 389)
-                if self.full_name() == ("Windows.Win32.System.OleAutomation", "BSTR") {
+                if self.full_name() == ("Windows.Win32.Foundation", "BSTR") {
                     false
                 } else {
                     self.fields().all(|f| f.is_blittable())

--- a/crates/gen/src/types/bstr.rs
+++ b/crates/gen/src/types/bstr.rs
@@ -24,7 +24,7 @@ pub fn gen_bstr() -> TokenStream {
                     return 0;
                 }
 
-                unsafe { SysStringLen(self) as usize }
+                unsafe { super::System::OleAutomation::SysStringLen(self) as usize }
             }
 
             /// Create a `BSTR` from a slice of 16-bit characters.
@@ -33,7 +33,12 @@ pub fn gen_bstr() -> TokenStream {
                     return Self(::std::ptr::null_mut());
                 }
 
-                unsafe { SysAllocStringLen(super::SystemServices::PWSTR(value.as_ptr() as _), value.len() as u32) }
+                unsafe {
+                    super::System::OleAutomation::SysAllocStringLen(
+                        PWSTR(value.as_ptr() as _),
+                        value.len() as u32,
+                    )
+                }
             }
 
             /// Get the string as 16-bit characters.
@@ -42,7 +47,7 @@ pub fn gen_bstr() -> TokenStream {
                     return &[];
                 }
 
-                unsafe { ::std::slice::from_raw_parts(self.0 as *const u16, SysStringLen(self) as usize) }
+                unsafe { ::std::slice::from_raw_parts(self.0 as *const u16, self.len()) }
             }
         }
         impl ::std::clone::Clone for BSTR {
@@ -131,7 +136,7 @@ pub fn gen_bstr() -> TokenStream {
         impl ::std::ops::Drop for BSTR {
             fn drop(&mut self) {
                 if !self.0.is_null() {
-                    unsafe { SysFreeString(self as &Self); }
+                    unsafe { super::System::OleAutomation::SysFreeString(self as &Self) }
                 }
             }
         }

--- a/crates/gen/src/types/struct.rs
+++ b/crates/gen/src/types/struct.rs
@@ -385,10 +385,10 @@ impl Struct {
 
     fn gen_replacement(&self) -> Option<TokenStream> {
         match self.0.full_name() {
-            ("Windows.Win32.System.SystemServices", "BOOL") => Some(gen_bool32()),
-            ("Windows.Win32.System.SystemServices", "PWSTR") => Some(gen_pwstr()),
-            ("Windows.Win32.System.SystemServices", "PSTR") => Some(gen_pstr()),
-            ("Windows.Win32.System.OleAutomation", "BSTR") => Some(gen_bstr()),
+            ("Windows.Win32.Foundation", "BOOL") => Some(gen_bool32()),
+            ("Windows.Win32.Foundation", "PWSTR") => Some(gen_pwstr()),
+            ("Windows.Win32.Foundation", "PSTR") => Some(gen_pstr()),
+            ("Windows.Win32.Foundation", "BSTR") => Some(gen_bstr()),
             _ => None,
         }
     }
@@ -401,7 +401,7 @@ impl Struct {
             ("Windows.Foundation.Numerics", "Vector4") => gen_vector4(),
             ("Windows.Foundation.Numerics", "Matrix3x2") => gen_matrix3x2(),
             ("Windows.Foundation.Numerics", "Matrix4x4") => gen_matrix4x4(),
-            ("Windows.Win32.System.SystemServices", "HANDLE") => gen_handle(),
+            ("Windows.Win32.Foundation", "HANDLE") => gen_handle(),
             _ => TokenStream::new(),
         }
     }

--- a/examples/clock/bindings/build.rs
+++ b/examples/clock/bindings/build.rs
@@ -1,41 +1,48 @@
 fn main() {
     windows::build! {
-        Windows::Foundation::Numerics::Matrix3x2,
-        Windows::Win32::Graphics::Direct2D::{
-            CLSID_D2D1Shadow, D2D1CreateFactory, ID2D1Bitmap1, ID2D1Device, ID2D1DeviceContext,
-            ID2D1Effect, ID2D1Factory1, ID2D1SolidColorBrush, ID2D1StrokeStyle,
-            D2D1_BITMAP_PROPERTIES1, D2D1_BRUSH_PROPERTIES, D2D1_COLOR_F, D2D1_COMPOSITE_MODE,
-            D2D1_DEVICE_CONTEXT_OPTIONS, D2D1_ELLIPSE, D2D1_FACTORY_OPTIONS,
-            D2D1_INTERPOLATION_MODE, D2D1_PIXEL_FORMAT, D2D1_STROKE_STYLE_PROPERTIES,
-            D2D1_UNIT_MODE, D2D_POINT_2F, D2D_RECT_F, D2D_SIZE_F, D2D_SIZE_U,
-        },
-        Windows::Win32::Graphics::Direct3D11::{
-            D3D11CreateDevice, ID3D11Device, D3D11_SDK_VERSION, D3D_DRIVER_TYPE,
-        },
-        Windows::Win32::Graphics::Dxgi::{
-            CreateDXGIFactory1, IDXGIDevice, IDXGIFactory2, IDXGIFactory7, IDXGIOutput,
-            IDXGISurface, IDXGISwapChain1, DXGI_ERROR_UNSUPPORTED, DXGI_PRESENT_TEST,
-            DXGI_SAMPLE_DESC, DXGI_SWAP_CHAIN_DESC1, DXGI_SWAP_CHAIN_FULLSCREEN_DESC,
-            DXGI_USAGE_RENDER_TARGET_OUTPUT,
-        },
-        Windows::Win32::Graphics::Gdi::{BeginPaint, EndPaint, PAINTSTRUCT},
-        Windows::Win32::System::SystemServices::{
-            GetModuleHandleA, DXGI_STATUS_OCCLUDED, HINSTANCE, LRESULT, PSTR,
-        },
-        Windows::Win32::System::WindowsProgramming::{
-            GetLocalTime, QueryPerformanceCounter, QueryPerformanceFrequency,
-        },
-        Windows::Win32::UI::Animation::{
-            IUIAnimationManager, IUIAnimationTransition, IUIAnimationTransitionLibrary,
-            IUIAnimationVariable, UIAnimationManager, UIAnimationTransitionLibrary,
-            UI_ANIMATION_UPDATE_RESULT,
-        },
-        Windows::Win32::UI::WindowsAndMessaging::{
-            CreateWindowExA, DefWindowProcA, DispatchMessageA, GetMessageA, GetWindowLongA,
-            GetWindowLongPtrA, LoadCursorW, PeekMessageA, PostQuitMessage, RegisterClassA,
-            SetWindowLongA, SetWindowLongPtrA, CREATESTRUCTA, CW_USEDEFAULT, HWND, IDC_HAND,
-            LPARAM, MSG, SIZE_MINIMIZED, WINDOW_LONG_PTR_INDEX, WM_ACTIVATE, WM_DESTROY,
-            WM_DISPLAYCHANGE, WM_NCCREATE, WM_PAINT, WM_QUIT, WM_SIZE, WM_USER, WNDCLASSA, WPARAM,
+        Windows::{
+            Foundation::Numerics::Matrix3x2,
+            Win32::{
+                Foundation::{DXGI_STATUS_OCCLUDED, HINSTANCE, HWND, LPARAM, LRESULT, PSTR, WPARAM},
+                Graphics::{
+                    Direct2D::{
+                        CLSID_D2D1Shadow, D2D1CreateFactory, ID2D1Bitmap1, ID2D1Device,
+                        ID2D1DeviceContext, ID2D1Effect, ID2D1Factory1, ID2D1SolidColorBrush,
+                        ID2D1StrokeStyle, D2D1_BITMAP_PROPERTIES1, D2D1_BRUSH_PROPERTIES, D2D1_COLOR_F,
+                        D2D1_COMPOSITE_MODE, D2D1_DEVICE_CONTEXT_OPTIONS, D2D1_ELLIPSE,
+                        D2D1_FACTORY_OPTIONS, D2D1_INTERPOLATION_MODE, D2D1_PIXEL_FORMAT,
+                        D2D1_STROKE_STYLE_PROPERTIES, D2D1_UNIT_MODE, D2D_POINT_2F, D2D_RECT_F,
+                        D2D_SIZE_F, D2D_SIZE_U,
+                    },
+                    Direct3D11::{D3D11CreateDevice, ID3D11Device, D3D11_SDK_VERSION, D3D_DRIVER_TYPE},
+                    Dxgi::{
+                        CreateDXGIFactory1, IDXGIDevice, IDXGIFactory2, IDXGIFactory7, IDXGIOutput,
+                        IDXGISurface, IDXGISwapChain1, DXGI_ERROR_UNSUPPORTED, DXGI_PRESENT_TEST,
+                        DXGI_SAMPLE_DESC, DXGI_SWAP_CHAIN_DESC1, DXGI_SWAP_CHAIN_FULLSCREEN_DESC,
+                        DXGI_USAGE_RENDER_TARGET_OUTPUT,
+                    },
+                    Gdi::{BeginPaint, EndPaint, PAINTSTRUCT},
+                },
+                System::{
+                    LibraryLoader::GetModuleHandleA,
+                    Performance::{QueryPerformanceCounter, QueryPerformanceFrequency},
+                    SystemInformation::GetLocalTime,
+                },
+                UI::{
+                    Animation::{
+                        IUIAnimationManager, IUIAnimationTransition, IUIAnimationTransitionLibrary,
+                        IUIAnimationVariable, UIAnimationManager, UIAnimationTransitionLibrary,
+                        UI_ANIMATION_UPDATE_RESULT,
+                    },
+                    WindowsAndMessaging::{
+                        CreateWindowExA, DefWindowProcA, DispatchMessageA, GetMessageA, GetWindowLongA,
+                        GetWindowLongPtrA, LoadCursorW, PeekMessageA, PostQuitMessage, RegisterClassA,
+                        SetWindowLongA, SetWindowLongPtrA, CREATESTRUCTA, CW_USEDEFAULT, IDC_HAND, MSG,
+                        SIZE_MINIMIZED, WINDOW_LONG_PTR_INDEX, WM_ACTIVATE, WM_DESTROY,
+                        WM_DISPLAYCHANGE, WM_NCCREATE, WM_PAINT, WM_QUIT, WM_SIZE, WM_USER, WNDCLASSA,
+                    },
+                },
+            },
         },
     };
 }

--- a/examples/clock/src/main.rs
+++ b/examples/clock/src/main.rs
@@ -1,9 +1,12 @@
 use bindings::{
-    Windows::Foundation::Numerics::*, Windows::Win32::Graphics::Direct2D::*,
-    Windows::Win32::Graphics::Direct3D11::*, Windows::Win32::Graphics::Dxgi::*,
-    Windows::Win32::Graphics::Gdi::*, Windows::Win32::System::SystemServices::*,
-    Windows::Win32::System::WindowsProgramming::*, Windows::Win32::UI::Animation::*,
-    Windows::Win32::UI::WindowsAndMessaging::*,
+    Windows::Foundation::Numerics::*,
+    Windows::Win32::{
+        Foundation::*,
+        Graphics::{Direct2D::*, Direct3D11::*, Dxgi::*, Gdi::*},
+        System::{LibraryLoader::*, Performance::*, SystemInformation::GetLocalTime},
+        UI::Animation::*,
+        UI::WindowsAndMessaging::*,
+    },
 };
 
 use windows::*;

--- a/examples/com_uri/bindings/build.rs
+++ b/examples/com_uri/bindings/build.rs
@@ -1,5 +1,5 @@
 fn main() {
     windows::build! {
-        Windows::Win32::System::Com::CreateUri, Windows::Win32::System::OleAutomation::BSTR,
+        Windows::Win32::Foundation::BSTR, Windows::Win32::System::Com::CreateUri,
     };
 }

--- a/examples/com_uri/src/main.rs
+++ b/examples/com_uri/src/main.rs
@@ -1,6 +1,4 @@
-use bindings::{
-    Windows::Win32::System::Com::CreateUri, Windows::Win32::System::OleAutomation::BSTR,
-};
+use bindings::Windows::Win32::{Foundation::BSTR, System::Com::CreateUri};
 
 fn main() -> windows::Result<()> {
     unsafe {

--- a/examples/d3d12/bindings/build.rs
+++ b/examples/d3d12/bindings/build.rs
@@ -1,12 +1,12 @@
 fn main() {
     windows::build! {
+        Windows::Win32::Foundation::{HINSTANCE, PSTR, RECT},
         Windows::Win32::Graphics::Direct3D12::*,
         Windows::Win32::Graphics::Dxgi::*,
         Windows::Win32::Graphics::Hlsl::*,
-        Windows::Win32::System::SystemServices::{GetModuleHandleA, HINSTANCE, PSTR},
+        Windows::Win32::System::LibraryLoader::GetModuleHandleA,
         Windows::Win32::System::Threading::{CreateEventA, WaitForSingleObject},
         Windows::Win32::System::WindowsProgramming::INFINITE,
-        Windows::Win32::UI::DisplayDevices::RECT,
         Windows::Win32::UI::WindowsAndMessaging::{
             AdjustWindowRect, CreateWindowExA, DefWindowProcA, DispatchMessageA, GetWindowLongA,
             GetWindowLongPtrA, LoadCursorW, PeekMessageA, PostQuitMessage, RegisterClassExA,

--- a/examples/d3d12/src/main.rs
+++ b/examples/d3d12/src/main.rs
@@ -1,7 +1,8 @@
 use bindings::Windows::Win32::{
+    Foundation::*,
     Graphics::{Direct3D11::*, Direct3D12::*, Dxgi::*, Hlsl::*},
-    System::{SystemServices::*, Threading::*, WindowsProgramming::*},
-    UI::{DisplayDevices::*, WindowsAndMessaging::*},
+    System::{LibraryLoader::*, Threading::*, WindowsProgramming::*},
+    UI::WindowsAndMessaging::*,
 };
 use std::mem::transmute;
 use windows::*;

--- a/examples/enum_windows/src/main.rs
+++ b/examples/enum_windows/src/main.rs
@@ -1,6 +1,6 @@
-use bindings::{
-    Windows::Win32::System::SystemServices::{BOOL, PWSTR},
-    Windows::Win32::UI::WindowsAndMessaging::{EnumWindows, GetWindowTextW, HWND, LPARAM},
+use bindings::Windows::Win32::{
+    Foundation::{BOOL, HWND, LPARAM, PWSTR},
+    UI::WindowsAndMessaging::{EnumWindows, GetWindowTextW},
 };
 
 fn main() -> windows::Result<()> {

--- a/examples/event/bindings/build.rs
+++ b/examples/event/bindings/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     windows::build! {
+        Windows::Win32::Foundation::CloseHandle,
         Windows::Win32::System::Threading::{CreateEventW, SetEvent, WaitForSingleObject},
-        Windows::Win32::System::WindowsProgramming::CloseHandle,
     };
 }

--- a/examples/event/src/main.rs
+++ b/examples/event/src/main.rs
@@ -1,8 +1,6 @@
-use bindings::{
-    Windows::Win32::System::Threading::{
-        CreateEventW, SetEvent, WaitForSingleObject, WAIT_OBJECT_0,
-    },
-    Windows::Win32::System::WindowsProgramming::CloseHandle,
+use bindings::Windows::Win32::{
+    Foundation::CloseHandle,
+    System::Threading::{CreateEventW, SetEvent, WaitForSingleObject, WAIT_OBJECT_0},
 };
 
 fn main() -> windows::Result<()> {

--- a/examples/overlapped/bindings/build.rs
+++ b/examples/overlapped/bindings/build.rs
@@ -1,9 +1,9 @@
 fn main() {
     windows::build! {
+        Windows::Win32::Foundation::CloseHandle,
         Windows::Win32::Storage::FileSystem::{CreateFileA, ReadFile},
         Windows::Win32::System::Diagnostics::Debug::GetLastError,
         Windows::Win32::System::SystemServices::GetOverlappedResult,
         Windows::Win32::System::Threading::{CreateEventA, WaitForSingleObject},
-        Windows::Win32::System::WindowsProgramming::CloseHandle,
     };
 }

--- a/examples/overlapped/src/main.rs
+++ b/examples/overlapped/src/main.rs
@@ -1,7 +1,7 @@
-use bindings::{
-    Windows::Win32::Storage::FileSystem::*, Windows::Win32::System::Diagnostics::Debug::*,
-    Windows::Win32::System::SystemServices::*, Windows::Win32::System::Threading::*,
-    Windows::Win32::System::WindowsProgramming::*,
+use bindings::Windows::Win32::{
+    Foundation::*,
+    Storage::FileSystem::*,
+    System::{Diagnostics::Debug::*, SystemServices::*, Threading::*},
 };
 
 fn main() -> windows::Result<()> {

--- a/examples/spellchecker/bindings/build.rs
+++ b/examples/spellchecker/bindings/build.rs
@@ -1,10 +1,10 @@
 fn main() {
     windows::build! {
+        Windows::Win32::Foundation::{BOOL, PWSTR, S_FALSE},
         Windows::Win32::Globalization::{
             IEnumSpellingError, ISpellChecker, ISpellCheckerFactory, ISpellingError,
             SpellCheckerFactory, CORRECTIVE_ACTION,
         },
         Windows::Win32::System::Com::IEnumString,
-        Windows::Win32::System::SystemServices::{BOOL, PWSTR, S_FALSE},
     };
 }

--- a/examples/spellchecker/src/main.rs
+++ b/examples/spellchecker/src/main.rs
@@ -1,6 +1,6 @@
 use bindings::Windows::Win32;
+use Win32::Foundation::{BOOL, PWSTR, S_FALSE};
 use Win32::Globalization;
-use Win32::System::SystemServices::{BOOL, PWSTR, S_FALSE};
 
 fn main() -> windows::Result<()> {
     let input = std::env::args()

--- a/examples/webview2/bindings/build.rs
+++ b/examples/webview2/bindings/build.rs
@@ -2,13 +2,12 @@ fn main() {
     windows::build! {
         Microsoft::Web::WebView2::Core::*,
         Windows::Foundation::*,
+        Windows::Win32::Foundation::{HINSTANCE, LRESULT, POINT, PWSTR, RECT, SIZE},
         Windows::Win32::Graphics::Gdi::UpdateWindow,
-        Windows::Win32::System::SystemServices::{GetModuleHandleA, HINSTANCE, LRESULT, PWSTR},
+        Windows::Win32::System::LibraryLoader::GetModuleHandleA,
         Windows::Win32::System::Threading::GetCurrentThreadId,
-        Windows::Win32::UI::DisplayDevices::{POINT, RECT, SIZE},
-        Windows::Win32::UI::HiDpi::{SetProcessDpiAwareness, PROCESS_DPI_AWARENESS},
+        Windows::Win32::UI::HiDpi::SetProcessDpiAwareness,
         Windows::Win32::UI::KeyboardAndMouseInput::SetFocus,
-        Windows::Win32::UI::MenusAndResources::HMENU,
         Windows::Win32::UI::WindowsAndMessaging::*,
     };
 }

--- a/examples/webview2/src/main.rs
+++ b/examples/webview2/src/main.rs
@@ -13,10 +13,10 @@ use bindings::{
     Microsoft::Web::WebView2::Core::*,
     Windows::Foundation::*,
     Windows::Win32::{
+        Foundation::*,
         Graphics::Gdi::*,
-        System::SystemServices::*,
-        System::Threading::*,
-        UI::{DisplayDevices::*, HiDpi::*, KeyboardAndMouseInput::*, WindowsAndMessaging::*},
+        System::{LibraryLoader::*, Threading::*},
+        UI::{HiDpi::*, KeyboardAndMouseInput::*, WindowsAndMessaging::*},
     },
 };
 

--- a/readme.md
+++ b/readme.md
@@ -31,7 +31,7 @@ fn main() {
     windows::build! {
         Windows::Data::Xml::Dom::*,
         Windows::Win32::System::Threading::{CreateEventW, SetEvent, WaitForSingleObject},
-        Windows::Win32::System::WindowsProgramming::CloseHandle,
+        Windows::Win32::Foundation::CloseHandle,
         Windows::Win32::UI::WindowsAndMessaging::{MessageBoxA, MB_OK},
     };
 }
@@ -47,7 +47,7 @@ mod bindings {
 use bindings::{
     Windows::Data::Xml::Dom::*,
     Windows::Win32::System::Threading::{CreateEventW, SetEvent, WaitForSingleObject},
-    Windows::Win32::System::WindowsProgramming::CloseHandle,
+    Windows::Win32::Foundation::CloseHandle,
     Windows::Win32::UI::WindowsAndMessaging::{MessageBoxA, MB_OK},
 };
 

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1746,6 +1746,476 @@ pub mod Windows {
             dead_code,
             clippy::all
         )]
+        pub mod Foundation {
+            #[repr(transparent)]
+            #[derive(
+                :: std :: clone :: Clone,
+                :: std :: marker :: Copy,
+                :: std :: cmp :: Eq,
+                :: std :: fmt :: Debug,
+            )]
+            pub struct PWSTR(pub *mut u16);
+            impl PWSTR {
+                pub const NULL: Self = Self(::std::ptr::null_mut());
+                pub fn is_null(&self) -> bool {
+                    self.0.is_null()
+                }
+            }
+            impl ::std::default::Default for PWSTR {
+                fn default() -> Self {
+                    Self(::std::ptr::null_mut())
+                }
+            }
+            impl ::std::cmp::PartialEq for PWSTR {
+                fn eq(&self, other: &Self) -> bool {
+                    self.0 == other.0
+                }
+            }
+            unsafe impl ::windows::Abi for PWSTR {
+                type Abi = Self;
+                fn drop_param(param: &mut ::windows::Param<Self>) {
+                    if let ::windows::Param::Boxed(value) = param {
+                        if !value.0.is_null() {
+                            unsafe {
+                                ::std::boxed::Box::from_raw(value.0);
+                            }
+                        }
+                    }
+                }
+            }
+            impl<'a> ::windows::IntoParam<'a, PWSTR> for &'a str {
+                fn into_param(self) -> ::windows::Param<'a, PWSTR> {
+                    ::windows::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(
+                        self.encode_utf16()
+                            .chain(::std::iter::once(0))
+                            .collect::<std::vec::Vec<u16>>()
+                            .into_boxed_slice(),
+                    ) as _))
+                }
+            }
+            impl<'a> ::windows::IntoParam<'a, PWSTR> for String {
+                fn into_param(self) -> ::windows::Param<'a, PWSTR> {
+                    ::windows::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(
+                        self.encode_utf16()
+                            .chain(::std::iter::once(0))
+                            .collect::<std::vec::Vec<u16>>()
+                            .into_boxed_slice(),
+                    ) as _))
+                }
+            }
+            #[repr(transparent)]
+            #[derive(:: std :: cmp :: Eq)]
+            pub struct BSTR(*mut u16);
+            impl BSTR {
+                #[doc = r" Create an empty `BSTR`."]
+                #[doc = r""]
+                #[doc = r" This function does not allocate memory."]
+                pub fn new() -> Self {
+                    Self(std::ptr::null_mut())
+                }
+                #[doc = r" Returns `true` if the string is empty."]
+                pub fn is_empty(&self) -> bool {
+                    self.0.is_null()
+                }
+                #[doc = r" Returns the length of the string."]
+                pub fn len(&self) -> usize {
+                    if self.is_empty() {
+                        return 0;
+                    }
+                    unsafe { super::System::OleAutomation::SysStringLen(self) as usize }
+                }
+                #[doc = r" Create a `BSTR` from a slice of 16-bit characters."]
+                pub fn from_wide(value: &[u16]) -> Self {
+                    if value.len() == 0 {
+                        return Self(::std::ptr::null_mut());
+                    }
+                    unsafe {
+                        super::System::OleAutomation::SysAllocStringLen(
+                            PWSTR(value.as_ptr() as _),
+                            value.len() as u32,
+                        )
+                    }
+                }
+                #[doc = r" Get the string as 16-bit characters."]
+                pub fn as_wide(&self) -> &[u16] {
+                    if self.0.is_null() {
+                        return &[];
+                    }
+                    unsafe { ::std::slice::from_raw_parts(self.0 as *const u16, self.len()) }
+                }
+            }
+            impl ::std::clone::Clone for BSTR {
+                fn clone(&self) -> Self {
+                    Self::from_wide(self.as_wide())
+                }
+            }
+            impl ::std::convert::From<&str> for BSTR {
+                fn from(value: &str) -> Self {
+                    let value: ::std::vec::Vec<u16> = value.encode_utf16().collect();
+                    Self::from_wide(&value)
+                }
+            }
+            impl ::std::convert::From<::std::string::String> for BSTR {
+                fn from(value: ::std::string::String) -> Self {
+                    value.as_str().into()
+                }
+            }
+            impl ::std::convert::From<&::std::string::String> for BSTR {
+                fn from(value: &::std::string::String) -> Self {
+                    value.as_str().into()
+                }
+            }
+            impl<'a> ::std::convert::TryFrom<&'a BSTR> for ::std::string::String {
+                type Error = ::std::string::FromUtf16Error;
+                fn try_from(value: &BSTR) -> ::std::result::Result<Self, Self::Error> {
+                    ::std::string::String::from_utf16(value.as_wide())
+                }
+            }
+            impl ::std::convert::TryFrom<BSTR> for ::std::string::String {
+                type Error = ::std::string::FromUtf16Error;
+                fn try_from(value: BSTR) -> ::std::result::Result<Self, Self::Error> {
+                    ::std::string::String::try_from(&value)
+                }
+            }
+            impl ::std::default::Default for BSTR {
+                fn default() -> Self {
+                    Self(::std::ptr::null_mut())
+                }
+            }
+            impl ::std::fmt::Display for BSTR {
+                fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                    use std::fmt::Write;
+                    for c in ::std::char::decode_utf16(self.as_wide().iter().cloned()) {
+                        f.write_char(c.map_err(|_| ::std::fmt::Error)?)?
+                    }
+                    Ok(())
+                }
+            }
+            impl ::std::fmt::Debug for BSTR {
+                fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                    ::std::write!(f, "{}", self)
+                }
+            }
+            impl ::std::cmp::PartialEq for BSTR {
+                fn eq(&self, other: &Self) -> bool {
+                    self.as_wide() == other.as_wide()
+                }
+            }
+            impl ::std::cmp::PartialEq<::std::string::String> for BSTR {
+                fn eq(&self, other: &::std::string::String) -> bool {
+                    self == other.as_str()
+                }
+            }
+            impl ::std::cmp::PartialEq<str> for BSTR {
+                fn eq(&self, other: &str) -> bool {
+                    self == other
+                }
+            }
+            impl ::std::cmp::PartialEq<&str> for BSTR {
+                fn eq(&self, other: &&str) -> bool {
+                    self.as_wide().iter().copied().eq(other.encode_utf16())
+                }
+            }
+            impl ::std::cmp::PartialEq<BSTR> for &str {
+                fn eq(&self, other: &BSTR) -> bool {
+                    other == self
+                }
+            }
+            impl ::std::ops::Drop for BSTR {
+                fn drop(&mut self) {
+                    if !self.0.is_null() {
+                        unsafe { super::System::OleAutomation::SysFreeString(self as &Self) }
+                    }
+                }
+            }
+            unsafe impl ::windows::Abi for BSTR {
+                type Abi = *mut u16;
+                fn set_abi(&mut self) -> *mut *mut u16 {
+                    debug_assert!(self.0.is_null());
+                    &mut self.0 as *mut _ as _
+                }
+            }
+            pub type BSTR_abi = *mut u16;
+            pub const CO_E_NOTINITIALIZED: ::windows::HRESULT =
+                ::windows::HRESULT(-2147221008i32 as _);
+            #[repr(transparent)]
+            #[derive(
+                :: std :: default :: Default,
+                :: std :: clone :: Clone,
+                :: std :: marker :: Copy,
+                :: std :: cmp :: PartialEq,
+                :: std :: cmp :: Eq,
+                :: std :: fmt :: Debug,
+            )]
+            pub struct BOOL(pub i32);
+            unsafe impl ::windows::Abi for BOOL {
+                type Abi = Self;
+            }
+            impl BOOL {
+                #[inline]
+                pub fn as_bool(self) -> bool {
+                    !(self.0 == 0)
+                }
+                #[inline]
+                pub fn ok(self) -> ::windows::Result<()> {
+                    if self.as_bool() {
+                        Ok(())
+                    } else {
+                        Err(::windows::HRESULT::from_thread().into())
+                    }
+                }
+                #[inline]
+                pub fn unwrap(self) {
+                    self.ok().unwrap();
+                }
+                #[inline]
+                pub fn expect(self, msg: &str) {
+                    self.ok().expect(msg);
+                }
+            }
+            impl ::std::convert::From<BOOL> for bool {
+                fn from(value: BOOL) -> Self {
+                    value.as_bool()
+                }
+            }
+            impl ::std::convert::From<&BOOL> for bool {
+                fn from(value: &BOOL) -> Self {
+                    value.as_bool()
+                }
+            }
+            impl ::std::convert::From<bool> for BOOL {
+                fn from(value: bool) -> Self {
+                    if value {
+                        BOOL(1)
+                    } else {
+                        BOOL(0)
+                    }
+                }
+            }
+            impl ::std::convert::From<&bool> for BOOL {
+                fn from(value: &bool) -> Self {
+                    (*value).into()
+                }
+            }
+            impl ::std::cmp::PartialEq<bool> for BOOL {
+                fn eq(&self, other: &bool) -> bool {
+                    self.as_bool() == *other
+                }
+            }
+            impl ::std::cmp::PartialEq<BOOL> for bool {
+                fn eq(&self, other: &BOOL) -> bool {
+                    *self == other.as_bool()
+                }
+            }
+            impl std::ops::Not for BOOL {
+                type Output = Self;
+                fn not(self) -> Self::Output {
+                    if self.as_bool() {
+                        BOOL(0)
+                    } else {
+                        BOOL(1)
+                    }
+                }
+            }
+            impl<'a> ::windows::IntoParam<'a, BOOL> for bool {
+                fn into_param(self) -> ::windows::Param<'a, BOOL> {
+                    ::windows::Param::Owned(self.into())
+                }
+            }
+            #[repr(transparent)]
+            #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
+            pub struct HANDLE(pub isize);
+            impl HANDLE {}
+            impl ::std::default::Default for HANDLE {
+                fn default() -> Self {
+                    Self(0)
+                }
+            }
+            impl HANDLE {
+                pub const NULL: Self = Self(0);
+                pub fn is_null(&self) -> bool {
+                    self.0 == 0
+                }
+            }
+            impl ::std::fmt::Debug for HANDLE {
+                fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                    fmt.debug_struct("HANDLE")
+                        .field("Value", &format_args!("{:?}", self.0))
+                        .finish()
+                }
+            }
+            impl ::std::cmp::PartialEq for HANDLE {
+                fn eq(&self, other: &Self) -> bool {
+                    self.0 == other.0
+                }
+            }
+            impl ::std::cmp::Eq for HANDLE {}
+            unsafe impl ::windows::Abi for HANDLE {
+                type Abi = Self;
+            }
+            impl HANDLE {
+                pub const INVALID: Self = Self(-1);
+                pub fn is_invalid(&self) -> bool {
+                    self.0 == -1
+                }
+            }
+            pub unsafe fn CloseHandle<'a>(hobject: impl ::windows::IntoParam<'a, HANDLE>) -> BOOL {
+                #[link(name = "KERNEL32")]
+                extern "system" {
+                    fn CloseHandle(hobject: HANDLE) -> BOOL;
+                }
+                CloseHandle(hobject.into_param().abi())
+            }
+            pub const E_POINTER: ::windows::HRESULT = ::windows::HRESULT(-2147467261i32 as _);
+            #[repr(transparent)]
+            #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
+            pub struct HINSTANCE(pub isize);
+            impl HINSTANCE {}
+            impl ::std::default::Default for HINSTANCE {
+                fn default() -> Self {
+                    Self(0)
+                }
+            }
+            impl HINSTANCE {
+                pub const NULL: Self = Self(0);
+                pub fn is_null(&self) -> bool {
+                    self.0 == 0
+                }
+            }
+            impl ::std::fmt::Debug for HINSTANCE {
+                fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                    fmt.debug_struct("HINSTANCE")
+                        .field("Value", &format_args!("{:?}", self.0))
+                        .finish()
+                }
+            }
+            impl ::std::cmp::PartialEq for HINSTANCE {
+                fn eq(&self, other: &Self) -> bool {
+                    self.0 == other.0
+                }
+            }
+            impl ::std::cmp::Eq for HINSTANCE {}
+            unsafe impl ::windows::Abi for HINSTANCE {
+                type Abi = Self;
+            }
+            pub type FARPROC = unsafe extern "system" fn() -> isize;
+            #[repr(transparent)]
+            #[derive(
+                :: std :: clone :: Clone,
+                :: std :: marker :: Copy,
+                :: std :: cmp :: Eq,
+                :: std :: fmt :: Debug,
+            )]
+            pub struct PSTR(pub *mut u8);
+            impl PSTR {
+                pub const NULL: Self = Self(::std::ptr::null_mut());
+                pub fn is_null(&self) -> bool {
+                    self.0.is_null()
+                }
+            }
+            impl ::std::default::Default for PSTR {
+                fn default() -> Self {
+                    Self(::std::ptr::null_mut())
+                }
+            }
+            impl ::std::cmp::PartialEq for PSTR {
+                fn eq(&self, other: &Self) -> bool {
+                    self.0 == other.0
+                }
+            }
+            unsafe impl ::windows::Abi for PSTR {
+                type Abi = Self;
+                fn drop_param(param: &mut ::windows::Param<Self>) {
+                    if let ::windows::Param::Boxed(value) = param {
+                        if !value.0.is_null() {
+                            unsafe {
+                                ::std::boxed::Box::from_raw(value.0);
+                            }
+                        }
+                    }
+                }
+            }
+            impl<'a> ::windows::IntoParam<'a, PSTR> for &'a str {
+                fn into_param(self) -> ::windows::Param<'a, PSTR> {
+                    ::windows::Param::Boxed(PSTR(::std::boxed::Box::<[u8]>::into_raw(
+                        self.bytes()
+                            .chain(::std::iter::once(0))
+                            .collect::<std::vec::Vec<u8>>()
+                            .into_boxed_slice(),
+                    ) as _))
+                }
+            }
+            impl<'a> ::windows::IntoParam<'a, PSTR> for String {
+                fn into_param(self) -> ::windows::Param<'a, PSTR> {
+                    ::windows::Param::Boxed(PSTR(::std::boxed::Box::<[u8]>::into_raw(
+                        self.bytes()
+                            .chain(::std::iter::once(0))
+                            .collect::<std::vec::Vec<u8>>()
+                            .into_boxed_slice(),
+                    ) as _))
+                }
+            }
+        }
+        #[allow(
+            unused_variables,
+            non_upper_case_globals,
+            non_snake_case,
+            unused_unsafe,
+            non_camel_case_types,
+            dead_code,
+            clippy::all
+        )]
+        pub mod Security {
+            #[repr(C)]
+            #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
+            pub struct SECURITY_ATTRIBUTES {
+                pub nLength: u32,
+                pub lpSecurityDescriptor: *mut ::std::ffi::c_void,
+                pub bInheritHandle: super::Foundation::BOOL,
+            }
+            impl SECURITY_ATTRIBUTES {}
+            impl ::std::default::Default for SECURITY_ATTRIBUTES {
+                fn default() -> Self {
+                    Self {
+                        nLength: 0,
+                        lpSecurityDescriptor: ::std::ptr::null_mut(),
+                        bInheritHandle: ::std::default::Default::default(),
+                    }
+                }
+            }
+            impl ::std::fmt::Debug for SECURITY_ATTRIBUTES {
+                fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
+                    fmt.debug_struct("SECURITY_ATTRIBUTES")
+                        .field("nLength", &format_args!("{:?}", self.nLength))
+                        .field(
+                            "lpSecurityDescriptor",
+                            &format_args!("{:?}", self.lpSecurityDescriptor),
+                        )
+                        .field("bInheritHandle", &format_args!("{:?}", self.bInheritHandle))
+                        .finish()
+                }
+            }
+            impl ::std::cmp::PartialEq for SECURITY_ATTRIBUTES {
+                fn eq(&self, other: &Self) -> bool {
+                    self.nLength == other.nLength
+                        && self.lpSecurityDescriptor == other.lpSecurityDescriptor
+                        && self.bInheritHandle == other.bInheritHandle
+                }
+            }
+            impl ::std::cmp::Eq for SECURITY_ATTRIBUTES {}
+            unsafe impl ::windows::Abi for SECURITY_ATTRIBUTES {
+                type Abi = Self;
+            }
+        }
+        #[allow(
+            unused_variables,
+            non_upper_case_globals,
+            non_snake_case,
+            unused_unsafe,
+            non_camel_case_types,
+            dead_code,
+            clippy::all
+        )]
         pub mod System {
             #[allow(
                 unused_variables,
@@ -1758,13 +2228,13 @@ pub mod Windows {
             )]
             pub mod Com {
                 pub unsafe fn CLSIDFromProgID<'a>(
-                    lpszprogid: impl ::windows::IntoParam<'a, super::SystemServices::PWSTR>,
+                    lpszprogid: impl ::windows::IntoParam<'a, super::super::Foundation::PWSTR>,
                     lpclsid: *mut ::windows::Guid,
                 ) -> ::windows::HRESULT {
                     #[link(name = "OLE32")]
                     extern "system" {
                         fn CLSIDFromProgID(
-                            lpszprogid: super::SystemServices::PWSTR,
+                            lpszprogid: super::super::Foundation::PWSTR,
                             lpclsid: *mut ::windows::Guid,
                         ) -> ::windows::HRESULT;
                     }
@@ -2079,7 +2549,7 @@ pub mod Windows {
                         lpsource: *const ::std::ffi::c_void,
                         dwmessageid: u32,
                         dwlanguageid: u32,
-                        lpbuffer: super::super::SystemServices::PWSTR,
+                        lpbuffer: super::super::super::Foundation::PWSTR,
                         nsize: u32,
                         arguments: *mut *mut i8,
                     ) -> u32 {
@@ -2090,7 +2560,7 @@ pub mod Windows {
                                 lpsource: *const ::std::ffi::c_void,
                                 dwmessageid: u32,
                                 dwlanguageid: u32,
-                                lpbuffer: super::super::SystemServices::PWSTR,
+                                lpbuffer: super::super::super::Foundation::PWSTR,
                                 nsize: u32,
                                 arguments: *mut *mut i8,
                             ) -> u32;
@@ -6135,6 +6605,52 @@ pub mod Windows {
                 dead_code,
                 clippy::all
             )]
+            pub mod LibraryLoader {
+                pub unsafe fn FreeLibrary<'a>(
+                    hlibmodule: impl ::windows::IntoParam<'a, super::super::Foundation::HINSTANCE>,
+                ) -> super::super::Foundation::BOOL {
+                    #[link(name = "KERNEL32")]
+                    extern "system" {
+                        fn FreeLibrary(
+                            hlibmodule: super::super::Foundation::HINSTANCE,
+                        ) -> super::super::Foundation::BOOL;
+                    }
+                    FreeLibrary(hlibmodule.into_param().abi())
+                }
+                pub unsafe fn GetProcAddress<'a>(
+                    hmodule: impl ::windows::IntoParam<'a, super::super::Foundation::HINSTANCE>,
+                    lpprocname: impl ::windows::IntoParam<'a, super::super::Foundation::PSTR>,
+                ) -> ::std::option::Option<super::super::Foundation::FARPROC> {
+                    #[link(name = "KERNEL32")]
+                    extern "system" {
+                        fn GetProcAddress(
+                            hmodule: super::super::Foundation::HINSTANCE,
+                            lpprocname: super::super::Foundation::PSTR,
+                        ) -> ::std::option::Option<super::super::Foundation::FARPROC>;
+                    }
+                    GetProcAddress(hmodule.into_param().abi(), lpprocname.into_param().abi())
+                }
+                pub unsafe fn LoadLibraryA<'a>(
+                    lplibfilename: impl ::windows::IntoParam<'a, super::super::Foundation::PSTR>,
+                ) -> super::super::Foundation::HINSTANCE {
+                    #[link(name = "KERNEL32")]
+                    extern "system" {
+                        fn LoadLibraryA(
+                            lplibfilename: super::super::Foundation::PSTR,
+                        ) -> super::super::Foundation::HINSTANCE;
+                    }
+                    LoadLibraryA(lplibfilename.into_param().abi())
+                }
+            }
+            #[allow(
+                unused_variables,
+                non_upper_case_globals,
+                non_snake_case,
+                unused_unsafe,
+                non_camel_case_types,
+                dead_code,
+                clippy::all
+            )]
             pub mod Memory {
                 #[repr(transparent)]
                 #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
@@ -6254,14 +6770,14 @@ pub mod Windows {
                     hheap: impl ::windows::IntoParam<'a, HeapHandle>,
                     dwflags: HEAP_FLAGS,
                     lpmem: *mut ::std::ffi::c_void,
-                ) -> super::SystemServices::BOOL {
+                ) -> super::super::Foundation::BOOL {
                     #[link(name = "KERNEL32")]
                     extern "system" {
                         fn HeapFree(
                             hheap: HeapHandle,
                             dwflags: HEAP_FLAGS,
                             lpmem: *mut ::std::ffi::c_void,
-                        ) -> super::SystemServices::BOOL;
+                        ) -> super::super::Foundation::BOOL;
                     }
                     HeapFree(
                         hheap.into_param().abi(),
@@ -6280,170 +6796,37 @@ pub mod Windows {
                 clippy::all
             )]
             pub mod OleAutomation {
-                pub unsafe fn SysFreeString<'a>(bstrstring: impl ::windows::IntoParam<'a, BSTR>) {
+                pub unsafe fn SysFreeString<'a>(
+                    bstrstring: impl ::windows::IntoParam<'a, super::super::Foundation::BSTR>,
+                ) {
                     #[link(name = "OLEAUT32")]
                     extern "system" {
-                        fn SysFreeString(bstrstring: BSTR_abi);
+                        fn SysFreeString(bstrstring: super::super::Foundation::BSTR_abi);
                     }
                     SysFreeString(bstrstring.into_param().abi())
                 }
                 pub unsafe fn SysAllocStringLen<'a>(
-                    strin: impl ::windows::IntoParam<'a, super::SystemServices::PWSTR>,
+                    strin: impl ::windows::IntoParam<'a, super::super::Foundation::PWSTR>,
                     ui: u32,
-                ) -> BSTR {
+                ) -> super::super::Foundation::BSTR {
                     #[link(name = "OLEAUT32")]
                     extern "system" {
-                        fn SysAllocStringLen(strin: super::SystemServices::PWSTR, ui: u32) -> BSTR;
+                        fn SysAllocStringLen(
+                            strin: super::super::Foundation::PWSTR,
+                            ui: u32,
+                        ) -> super::super::Foundation::BSTR;
                     }
                     SysAllocStringLen(strin.into_param().abi(), ::std::mem::transmute(ui))
                 }
-                pub unsafe fn SysStringLen<'a>(pbstr: impl ::windows::IntoParam<'a, BSTR>) -> u32 {
+                pub unsafe fn SysStringLen<'a>(
+                    pbstr: impl ::windows::IntoParam<'a, super::super::Foundation::BSTR>,
+                ) -> u32 {
                     #[link(name = "OLEAUT32")]
                     extern "system" {
-                        fn SysStringLen(pbstr: BSTR_abi) -> u32;
+                        fn SysStringLen(pbstr: super::super::Foundation::BSTR_abi) -> u32;
                     }
                     SysStringLen(pbstr.into_param().abi())
                 }
-                #[repr(transparent)]
-                #[derive(:: std :: cmp :: Eq)]
-                pub struct BSTR(*mut u16);
-                impl BSTR {
-                    #[doc = r" Create an empty `BSTR`."]
-                    #[doc = r""]
-                    #[doc = r" This function does not allocate memory."]
-                    pub fn new() -> Self {
-                        Self(std::ptr::null_mut())
-                    }
-                    #[doc = r" Returns `true` if the string is empty."]
-                    pub fn is_empty(&self) -> bool {
-                        self.0.is_null()
-                    }
-                    #[doc = r" Returns the length of the string."]
-                    pub fn len(&self) -> usize {
-                        if self.is_empty() {
-                            return 0;
-                        }
-                        unsafe { SysStringLen(self) as usize }
-                    }
-                    #[doc = r" Create a `BSTR` from a slice of 16-bit characters."]
-                    pub fn from_wide(value: &[u16]) -> Self {
-                        if value.len() == 0 {
-                            return Self(::std::ptr::null_mut());
-                        }
-                        unsafe {
-                            SysAllocStringLen(
-                                super::SystemServices::PWSTR(value.as_ptr() as _),
-                                value.len() as u32,
-                            )
-                        }
-                    }
-                    #[doc = r" Get the string as 16-bit characters."]
-                    pub fn as_wide(&self) -> &[u16] {
-                        if self.0.is_null() {
-                            return &[];
-                        }
-                        unsafe {
-                            ::std::slice::from_raw_parts(
-                                self.0 as *const u16,
-                                SysStringLen(self) as usize,
-                            )
-                        }
-                    }
-                }
-                impl ::std::clone::Clone for BSTR {
-                    fn clone(&self) -> Self {
-                        Self::from_wide(self.as_wide())
-                    }
-                }
-                impl ::std::convert::From<&str> for BSTR {
-                    fn from(value: &str) -> Self {
-                        let value: ::std::vec::Vec<u16> = value.encode_utf16().collect();
-                        Self::from_wide(&value)
-                    }
-                }
-                impl ::std::convert::From<::std::string::String> for BSTR {
-                    fn from(value: ::std::string::String) -> Self {
-                        value.as_str().into()
-                    }
-                }
-                impl ::std::convert::From<&::std::string::String> for BSTR {
-                    fn from(value: &::std::string::String) -> Self {
-                        value.as_str().into()
-                    }
-                }
-                impl<'a> ::std::convert::TryFrom<&'a BSTR> for ::std::string::String {
-                    type Error = ::std::string::FromUtf16Error;
-                    fn try_from(value: &BSTR) -> ::std::result::Result<Self, Self::Error> {
-                        ::std::string::String::from_utf16(value.as_wide())
-                    }
-                }
-                impl ::std::convert::TryFrom<BSTR> for ::std::string::String {
-                    type Error = ::std::string::FromUtf16Error;
-                    fn try_from(value: BSTR) -> ::std::result::Result<Self, Self::Error> {
-                        ::std::string::String::try_from(&value)
-                    }
-                }
-                impl ::std::default::Default for BSTR {
-                    fn default() -> Self {
-                        Self(::std::ptr::null_mut())
-                    }
-                }
-                impl ::std::fmt::Display for BSTR {
-                    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                        use std::fmt::Write;
-                        for c in ::std::char::decode_utf16(self.as_wide().iter().cloned()) {
-                            f.write_char(c.map_err(|_| ::std::fmt::Error)?)?
-                        }
-                        Ok(())
-                    }
-                }
-                impl ::std::fmt::Debug for BSTR {
-                    fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                        ::std::write!(f, "{}", self)
-                    }
-                }
-                impl ::std::cmp::PartialEq for BSTR {
-                    fn eq(&self, other: &Self) -> bool {
-                        self.as_wide() == other.as_wide()
-                    }
-                }
-                impl ::std::cmp::PartialEq<::std::string::String> for BSTR {
-                    fn eq(&self, other: &::std::string::String) -> bool {
-                        self == other.as_str()
-                    }
-                }
-                impl ::std::cmp::PartialEq<str> for BSTR {
-                    fn eq(&self, other: &str) -> bool {
-                        self == other
-                    }
-                }
-                impl ::std::cmp::PartialEq<&str> for BSTR {
-                    fn eq(&self, other: &&str) -> bool {
-                        self.as_wide().iter().copied().eq(other.encode_utf16())
-                    }
-                }
-                impl ::std::cmp::PartialEq<BSTR> for &str {
-                    fn eq(&self, other: &BSTR) -> bool {
-                        other == self
-                    }
-                }
-                impl ::std::ops::Drop for BSTR {
-                    fn drop(&mut self) {
-                        if !self.0.is_null() {
-                            unsafe {
-                                SysFreeString(self as &Self);
-                            }
-                        }
-                    }
-                }
-                unsafe impl ::windows::Abi for BSTR {
-                    type Abi = *mut u16;
-                    fn set_abi(&mut self) -> *mut *mut u16 {
-                        debug_assert!(self.0.is_null());
-                        &mut self.0 as *mut _ as _
-                    }
-                }
-                pub type BSTR_abi = *mut u16;
                 #[repr(transparent)]
                 #[derive(
                     :: std :: cmp :: PartialEq,
@@ -6462,7 +6845,10 @@ pub mod Windows {
                             ::std::mem::transmute(pguid),
                         )
                     }
-                    pub unsafe fn GetSource(&self, pbstrsource: *mut BSTR) -> ::windows::HRESULT {
+                    pub unsafe fn GetSource(
+                        &self,
+                        pbstrsource: *mut super::super::Foundation::BSTR,
+                    ) -> ::windows::HRESULT {
                         (::windows::Interface::vtable(self).4)(
                             ::windows::Abi::abi(self),
                             ::std::mem::transmute(pbstrsource),
@@ -6470,7 +6856,7 @@ pub mod Windows {
                     }
                     pub unsafe fn GetDescription(
                         &self,
-                        pbstrdescription: *mut BSTR,
+                        pbstrdescription: *mut super::super::Foundation::BSTR,
                     ) -> ::windows::HRESULT {
                         (::windows::Interface::vtable(self).5)(
                             ::windows::Abi::abi(self),
@@ -6479,7 +6865,7 @@ pub mod Windows {
                     }
                     pub unsafe fn GetHelpFile(
                         &self,
-                        pbstrhelpfile: *mut BSTR,
+                        pbstrhelpfile: *mut super::super::Foundation::BSTR,
                     ) -> ::windows::HRESULT {
                         (::windows::Interface::vtable(self).6)(
                             ::windows::Abi::abi(self),
@@ -6545,15 +6931,15 @@ pub mod Windows {
                     ) -> ::windows::HRESULT,
                     pub  unsafe extern "system" fn(
                         this: ::windows::RawPtr,
-                        pbstrsource: *mut BSTR_abi,
+                        pbstrsource: *mut super::super::Foundation::BSTR_abi,
                     ) -> ::windows::HRESULT,
                     pub  unsafe extern "system" fn(
                         this: ::windows::RawPtr,
-                        pbstrdescription: *mut BSTR_abi,
+                        pbstrdescription: *mut super::super::Foundation::BSTR_abi,
                     ) -> ::windows::HRESULT,
                     pub  unsafe extern "system" fn(
                         this: ::windows::RawPtr,
-                        pbstrhelpfile: *mut BSTR_abi,
+                        pbstrhelpfile: *mut super::super::Foundation::BSTR_abi,
                     ) -> ::windows::HRESULT,
                     pub  unsafe extern "system" fn(
                         this: ::windows::RawPtr,
@@ -6602,371 +6988,21 @@ pub mod Windows {
                 dead_code,
                 clippy::all
             )]
-            pub mod SystemServices {
-                #[repr(transparent)]
-                #[derive(
-                    :: std :: clone :: Clone,
-                    :: std :: marker :: Copy,
-                    :: std :: cmp :: Eq,
-                    :: std :: fmt :: Debug,
-                )]
-                pub struct PWSTR(pub *mut u16);
-                impl PWSTR {
-                    pub const NULL: Self = Self(::std::ptr::null_mut());
-                    pub fn is_null(&self) -> bool {
-                        self.0.is_null()
-                    }
-                }
-                impl ::std::default::Default for PWSTR {
-                    fn default() -> Self {
-                        Self(::std::ptr::null_mut())
-                    }
-                }
-                impl ::std::cmp::PartialEq for PWSTR {
-                    fn eq(&self, other: &Self) -> bool {
-                        self.0 == other.0
-                    }
-                }
-                unsafe impl ::windows::Abi for PWSTR {
-                    type Abi = Self;
-                    fn drop_param(param: &mut ::windows::Param<Self>) {
-                        if let ::windows::Param::Boxed(value) = param {
-                            if !value.0.is_null() {
-                                unsafe {
-                                    ::std::boxed::Box::from_raw(value.0);
-                                }
-                            }
-                        }
-                    }
-                }
-                impl<'a> ::windows::IntoParam<'a, PWSTR> for &'a str {
-                    fn into_param(self) -> ::windows::Param<'a, PWSTR> {
-                        ::windows::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(
-                            self.encode_utf16()
-                                .chain(::std::iter::once(0))
-                                .collect::<std::vec::Vec<u16>>()
-                                .into_boxed_slice(),
-                        ) as _))
-                    }
-                }
-                impl<'a> ::windows::IntoParam<'a, PWSTR> for String {
-                    fn into_param(self) -> ::windows::Param<'a, PWSTR> {
-                        ::windows::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(
-                            self.encode_utf16()
-                                .chain(::std::iter::once(0))
-                                .collect::<std::vec::Vec<u16>>()
-                                .into_boxed_slice(),
-                        ) as _))
-                    }
-                }
-                #[repr(transparent)]
-                #[derive(
-                    :: std :: default :: Default,
-                    :: std :: clone :: Clone,
-                    :: std :: marker :: Copy,
-                    :: std :: cmp :: PartialEq,
-                    :: std :: cmp :: Eq,
-                    :: std :: fmt :: Debug,
-                )]
-                pub struct BOOL(pub i32);
-                unsafe impl ::windows::Abi for BOOL {
-                    type Abi = Self;
-                }
-                impl BOOL {
-                    #[inline]
-                    pub fn as_bool(self) -> bool {
-                        !(self.0 == 0)
-                    }
-                    #[inline]
-                    pub fn ok(self) -> ::windows::Result<()> {
-                        if self.as_bool() {
-                            Ok(())
-                        } else {
-                            Err(::windows::HRESULT::from_thread().into())
-                        }
-                    }
-                    #[inline]
-                    pub fn unwrap(self) {
-                        self.ok().unwrap();
-                    }
-                    #[inline]
-                    pub fn expect(self, msg: &str) {
-                        self.ok().expect(msg);
-                    }
-                }
-                impl ::std::convert::From<BOOL> for bool {
-                    fn from(value: BOOL) -> Self {
-                        value.as_bool()
-                    }
-                }
-                impl ::std::convert::From<&BOOL> for bool {
-                    fn from(value: &BOOL) -> Self {
-                        value.as_bool()
-                    }
-                }
-                impl ::std::convert::From<bool> for BOOL {
-                    fn from(value: bool) -> Self {
-                        if value {
-                            BOOL(1)
-                        } else {
-                            BOOL(0)
-                        }
-                    }
-                }
-                impl ::std::convert::From<&bool> for BOOL {
-                    fn from(value: &bool) -> Self {
-                        (*value).into()
-                    }
-                }
-                impl ::std::cmp::PartialEq<bool> for BOOL {
-                    fn eq(&self, other: &bool) -> bool {
-                        self.as_bool() == *other
-                    }
-                }
-                impl ::std::cmp::PartialEq<BOOL> for bool {
-                    fn eq(&self, other: &BOOL) -> bool {
-                        *self == other.as_bool()
-                    }
-                }
-                impl std::ops::Not for BOOL {
-                    type Output = Self;
-                    fn not(self) -> Self::Output {
-                        if self.as_bool() {
-                            BOOL(0)
-                        } else {
-                            BOOL(1)
-                        }
-                    }
-                }
-                impl<'a> ::windows::IntoParam<'a, BOOL> for bool {
-                    fn into_param(self) -> ::windows::Param<'a, BOOL> {
-                        ::windows::Param::Owned(self.into())
-                    }
-                }
-                pub const CO_E_NOTINITIALIZED: ::windows::HRESULT =
-                    ::windows::HRESULT(-2147221008i32 as _);
-                pub const E_POINTER: ::windows::HRESULT = ::windows::HRESULT(-2147467261i32 as _);
-                #[repr(transparent)]
-                #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
-                pub struct HINSTANCE(pub isize);
-                impl HINSTANCE {}
-                impl ::std::default::Default for HINSTANCE {
-                    fn default() -> Self {
-                        Self(0)
-                    }
-                }
-                impl HINSTANCE {
-                    pub const NULL: Self = Self(0);
-                    pub fn is_null(&self) -> bool {
-                        self.0 == 0
-                    }
-                }
-                impl ::std::fmt::Debug for HINSTANCE {
-                    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                        fmt.debug_struct("HINSTANCE")
-                            .field("Value", &format_args!("{:?}", self.0))
-                            .finish()
-                    }
-                }
-                impl ::std::cmp::PartialEq for HINSTANCE {
-                    fn eq(&self, other: &Self) -> bool {
-                        self.0 == other.0
-                    }
-                }
-                impl ::std::cmp::Eq for HINSTANCE {}
-                unsafe impl ::windows::Abi for HINSTANCE {
-                    type Abi = Self;
-                }
-                pub unsafe fn FreeLibrary<'a>(
-                    hlibmodule: impl ::windows::IntoParam<'a, HINSTANCE>,
-                ) -> BOOL {
-                    #[link(name = "KERNEL32")]
-                    extern "system" {
-                        fn FreeLibrary(hlibmodule: HINSTANCE) -> BOOL;
-                    }
-                    FreeLibrary(hlibmodule.into_param().abi())
-                }
-                pub type FARPROC = unsafe extern "system" fn() -> isize;
-                #[repr(transparent)]
-                #[derive(
-                    :: std :: clone :: Clone,
-                    :: std :: marker :: Copy,
-                    :: std :: cmp :: Eq,
-                    :: std :: fmt :: Debug,
-                )]
-                pub struct PSTR(pub *mut u8);
-                impl PSTR {
-                    pub const NULL: Self = Self(::std::ptr::null_mut());
-                    pub fn is_null(&self) -> bool {
-                        self.0.is_null()
-                    }
-                }
-                impl ::std::default::Default for PSTR {
-                    fn default() -> Self {
-                        Self(::std::ptr::null_mut())
-                    }
-                }
-                impl ::std::cmp::PartialEq for PSTR {
-                    fn eq(&self, other: &Self) -> bool {
-                        self.0 == other.0
-                    }
-                }
-                unsafe impl ::windows::Abi for PSTR {
-                    type Abi = Self;
-                    fn drop_param(param: &mut ::windows::Param<Self>) {
-                        if let ::windows::Param::Boxed(value) = param {
-                            if !value.0.is_null() {
-                                unsafe {
-                                    ::std::boxed::Box::from_raw(value.0);
-                                }
-                            }
-                        }
-                    }
-                }
-                impl<'a> ::windows::IntoParam<'a, PSTR> for &'a str {
-                    fn into_param(self) -> ::windows::Param<'a, PSTR> {
-                        ::windows::Param::Boxed(PSTR(::std::boxed::Box::<[u8]>::into_raw(
-                            self.bytes()
-                                .chain(::std::iter::once(0))
-                                .collect::<std::vec::Vec<u8>>()
-                                .into_boxed_slice(),
-                        ) as _))
-                    }
-                }
-                impl<'a> ::windows::IntoParam<'a, PSTR> for String {
-                    fn into_param(self) -> ::windows::Param<'a, PSTR> {
-                        ::windows::Param::Boxed(PSTR(::std::boxed::Box::<[u8]>::into_raw(
-                            self.bytes()
-                                .chain(::std::iter::once(0))
-                                .collect::<std::vec::Vec<u8>>()
-                                .into_boxed_slice(),
-                        ) as _))
-                    }
-                }
-                pub unsafe fn GetProcAddress<'a>(
-                    hmodule: impl ::windows::IntoParam<'a, HINSTANCE>,
-                    lpprocname: impl ::windows::IntoParam<'a, PSTR>,
-                ) -> ::std::option::Option<FARPROC> {
-                    #[link(name = "KERNEL32")]
-                    extern "system" {
-                        fn GetProcAddress(
-                            hmodule: HINSTANCE,
-                            lpprocname: PSTR,
-                        ) -> ::std::option::Option<FARPROC>;
-                    }
-                    GetProcAddress(hmodule.into_param().abi(), lpprocname.into_param().abi())
-                }
-                pub unsafe fn LoadLibraryA<'a>(
-                    lplibfilename: impl ::windows::IntoParam<'a, PSTR>,
-                ) -> HINSTANCE {
-                    #[link(name = "KERNEL32")]
-                    extern "system" {
-                        fn LoadLibraryA(lplibfilename: PSTR) -> HINSTANCE;
-                    }
-                    LoadLibraryA(lplibfilename.into_param().abi())
-                }
-                #[repr(transparent)]
-                #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
-                pub struct HANDLE(pub isize);
-                impl HANDLE {}
-                impl ::std::default::Default for HANDLE {
-                    fn default() -> Self {
-                        Self(0)
-                    }
-                }
-                impl HANDLE {
-                    pub const NULL: Self = Self(0);
-                    pub fn is_null(&self) -> bool {
-                        self.0 == 0
-                    }
-                }
-                impl ::std::fmt::Debug for HANDLE {
-                    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                        fmt.debug_struct("HANDLE")
-                            .field("Value", &format_args!("{:?}", self.0))
-                            .finish()
-                    }
-                }
-                impl ::std::cmp::PartialEq for HANDLE {
-                    fn eq(&self, other: &Self) -> bool {
-                        self.0 == other.0
-                    }
-                }
-                impl ::std::cmp::Eq for HANDLE {}
-                unsafe impl ::windows::Abi for HANDLE {
-                    type Abi = Self;
-                }
-                impl HANDLE {
-                    pub const INVALID: Self = Self(-1);
-                    pub fn is_invalid(&self) -> bool {
-                        self.0 == -1
-                    }
-                }
-                #[repr(C)]
-                #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
-                pub struct SECURITY_ATTRIBUTES {
-                    pub nLength: u32,
-                    pub lpSecurityDescriptor: *mut ::std::ffi::c_void,
-                    pub bInheritHandle: BOOL,
-                }
-                impl SECURITY_ATTRIBUTES {}
-                impl ::std::default::Default for SECURITY_ATTRIBUTES {
-                    fn default() -> Self {
-                        Self {
-                            nLength: 0,
-                            lpSecurityDescriptor: ::std::ptr::null_mut(),
-                            bInheritHandle: ::std::default::Default::default(),
-                        }
-                    }
-                }
-                impl ::std::fmt::Debug for SECURITY_ATTRIBUTES {
-                    fn fmt(&self, fmt: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
-                        fmt.debug_struct("SECURITY_ATTRIBUTES")
-                            .field("nLength", &format_args!("{:?}", self.nLength))
-                            .field(
-                                "lpSecurityDescriptor",
-                                &format_args!("{:?}", self.lpSecurityDescriptor),
-                            )
-                            .field("bInheritHandle", &format_args!("{:?}", self.bInheritHandle))
-                            .finish()
-                    }
-                }
-                impl ::std::cmp::PartialEq for SECURITY_ATTRIBUTES {
-                    fn eq(&self, other: &Self) -> bool {
-                        self.nLength == other.nLength
-                            && self.lpSecurityDescriptor == other.lpSecurityDescriptor
-                            && self.bInheritHandle == other.bInheritHandle
-                    }
-                }
-                impl ::std::cmp::Eq for SECURITY_ATTRIBUTES {}
-                unsafe impl ::windows::Abi for SECURITY_ATTRIBUTES {
-                    type Abi = Self;
-                }
-            }
-            #[allow(
-                unused_variables,
-                non_upper_case_globals,
-                non_snake_case,
-                unused_unsafe,
-                non_camel_case_types,
-                dead_code,
-                clippy::all
-            )]
             pub mod Threading {
                 pub unsafe fn CreateEventA<'a>(
-                    lpeventattributes: *mut super::SystemServices::SECURITY_ATTRIBUTES,
-                    bmanualreset: impl ::windows::IntoParam<'a, super::SystemServices::BOOL>,
-                    binitialstate: impl ::windows::IntoParam<'a, super::SystemServices::BOOL>,
-                    lpname: impl ::windows::IntoParam<'a, super::SystemServices::PSTR>,
-                ) -> super::SystemServices::HANDLE {
+                    lpeventattributes: *mut super::super::Security::SECURITY_ATTRIBUTES,
+                    bmanualreset: impl ::windows::IntoParam<'a, super::super::Foundation::BOOL>,
+                    binitialstate: impl ::windows::IntoParam<'a, super::super::Foundation::BOOL>,
+                    lpname: impl ::windows::IntoParam<'a, super::super::Foundation::PSTR>,
+                ) -> super::super::Foundation::HANDLE {
                     #[link(name = "KERNEL32")]
                     extern "system" {
                         fn CreateEventA(
-                            lpeventattributes: *mut super::SystemServices::SECURITY_ATTRIBUTES,
-                            bmanualreset: super::SystemServices::BOOL,
-                            binitialstate: super::SystemServices::BOOL,
-                            lpname: super::SystemServices::PSTR,
-                        ) -> super::SystemServices::HANDLE;
+                            lpeventattributes: *mut super::super::Security::SECURITY_ATTRIBUTES,
+                            bmanualreset: super::super::Foundation::BOOL,
+                            binitialstate: super::super::Foundation::BOOL,
+                            lpname: super::super::Foundation::PSTR,
+                        ) -> super::super::Foundation::HANDLE;
                     }
                     CreateEventA(
                         ::std::mem::transmute(lpeventattributes),
@@ -6976,13 +7012,13 @@ pub mod Windows {
                     )
                 }
                 pub unsafe fn SetEvent<'a>(
-                    hevent: impl ::windows::IntoParam<'a, super::SystemServices::HANDLE>,
-                ) -> super::SystemServices::BOOL {
+                    hevent: impl ::windows::IntoParam<'a, super::super::Foundation::HANDLE>,
+                ) -> super::super::Foundation::BOOL {
                     #[link(name = "KERNEL32")]
                     extern "system" {
                         fn SetEvent(
-                            hevent: super::SystemServices::HANDLE,
-                        ) -> super::SystemServices::BOOL;
+                            hevent: super::super::Foundation::HANDLE,
+                        ) -> super::super::Foundation::BOOL;
                     }
                     SetEvent(hevent.into_param().abi())
                 }
@@ -7033,13 +7069,13 @@ pub mod Windows {
                     }
                 }
                 pub unsafe fn WaitForSingleObject<'a>(
-                    hhandle: impl ::windows::IntoParam<'a, super::SystemServices::HANDLE>,
+                    hhandle: impl ::windows::IntoParam<'a, super::super::Foundation::HANDLE>,
                     dwmilliseconds: u32,
                 ) -> WAIT_RETURN_CAUSE {
                     #[link(name = "KERNEL32")]
                     extern "system" {
                         fn WaitForSingleObject(
-                            hhandle: super::SystemServices::HANDLE,
+                            hhandle: super::super::Foundation::HANDLE,
                             dwmilliseconds: u32,
                         ) -> WAIT_RETURN_CAUSE;
                     }
@@ -7275,10 +7311,10 @@ pub mod Windows {
                 impl IRestrictedErrorInfo {
                     pub unsafe fn GetErrorDetails(
                         &self,
-                        description: *mut super::OleAutomation::BSTR,
+                        description: *mut super::super::Foundation::BSTR,
                         error: *mut ::windows::HRESULT,
-                        restricteddescription: *mut super::OleAutomation::BSTR,
-                        capabilitysid: *mut super::OleAutomation::BSTR,
+                        restricteddescription: *mut super::super::Foundation::BSTR,
+                        capabilitysid: *mut super::super::Foundation::BSTR,
                     ) -> ::windows::HRESULT {
                         (::windows::Interface::vtable(self).3)(
                             ::windows::Abi::abi(self),
@@ -7290,7 +7326,7 @@ pub mod Windows {
                     }
                     pub unsafe fn GetReference(
                         &self,
-                        reference: *mut super::OleAutomation::BSTR,
+                        reference: *mut super::super::Foundation::BSTR,
                     ) -> ::windows::HRESULT {
                         (::windows::Interface::vtable(self).4)(
                             ::windows::Abi::abi(self),
@@ -7345,14 +7381,14 @@ pub mod Windows {
                     pub unsafe extern "system" fn(this: ::windows::RawPtr) -> u32,
                     pub  unsafe extern "system" fn(
                         this: ::windows::RawPtr,
-                        description: *mut super::OleAutomation::BSTR_abi,
+                        description: *mut super::super::Foundation::BSTR_abi,
                         error: *mut ::windows::HRESULT,
-                        restricteddescription: *mut super::OleAutomation::BSTR_abi,
-                        capabilitysid: *mut super::OleAutomation::BSTR_abi,
+                        restricteddescription: *mut super::super::Foundation::BSTR_abi,
+                        capabilitysid: *mut super::super::Foundation::BSTR_abi,
                     ) -> ::windows::HRESULT,
                     pub  unsafe extern "system" fn(
                         this: ::windows::RawPtr,
-                        reference: *mut super::OleAutomation::BSTR_abi,
+                        reference: *mut super::super::Foundation::BSTR_abi,
                     ) -> ::windows::HRESULT,
                 );
                 #[repr(transparent)]
@@ -7482,28 +7518,6 @@ pub mod Windows {
                         weakreference: *mut ::windows::RawPtr,
                     ) -> ::windows::HRESULT,
                 );
-            }
-            #[allow(
-                unused_variables,
-                non_upper_case_globals,
-                non_snake_case,
-                unused_unsafe,
-                non_camel_case_types,
-                dead_code,
-                clippy::all
-            )]
-            pub mod WindowsProgramming {
-                pub unsafe fn CloseHandle<'a>(
-                    hobject: impl ::windows::IntoParam<'a, super::SystemServices::HANDLE>,
-                ) -> super::SystemServices::BOOL {
-                    #[link(name = "KERNEL32")]
-                    extern "system" {
-                        fn CloseHandle(
-                            hobject: super::SystemServices::HANDLE,
-                        ) -> super::SystemServices::BOOL;
-                    }
-                    CloseHandle(hobject.into_param().abi())
-                }
             }
         }
     }

--- a/src/result/error.rs
+++ b/src/result/error.rs
@@ -2,7 +2,8 @@ use crate::*;
 use std::convert::TryInto;
 
 use bindings::{
-    Windows::Win32::System::OleAutomation::{GetErrorInfo, SetErrorInfo, BSTR},
+    Windows::Win32::Foundation::BSTR,
+    Windows::Win32::System::OleAutomation::{GetErrorInfo, SetErrorInfo},
     Windows::Win32::System::WinRT::{ILanguageExceptionErrorInfo2, IRestrictedErrorInfo},
 };
 

--- a/src/result/error_code.rs
+++ b/src/result/error_code.rs
@@ -1,8 +1,8 @@
 use crate::*;
 
 use bindings::{
+    Windows::Win32::Foundation::{E_POINTER, PWSTR},
     Windows::Win32::System::Diagnostics::Debug::*,
-    Windows::Win32::System::SystemServices::{E_POINTER, PWSTR},
 };
 
 /// A primitive error code value returned by most COM functions.

--- a/src/runtime/delay_load.rs
+++ b/src/runtime/delay_load.rs
@@ -1,6 +1,6 @@
 use crate::*;
 
-use bindings::Windows::Win32::System::SystemServices::{FreeLibrary, GetProcAddress, LoadLibraryA};
+use bindings::Windows::Win32::System::LibraryLoader::{FreeLibrary, GetProcAddress, LoadLibraryA};
 
 pub fn delay_load(library: &str, function: &str) -> std::result::Result<RawPtr, HRESULT> {
     unsafe {

--- a/src/runtime/factory_cache.rs
+++ b/src/runtime/factory_cache.rs
@@ -1,5 +1,5 @@
 use crate::*;
-use bindings::Windows::Win32::System::SystemServices::CO_E_NOTINITIALIZED;
+use bindings::Windows::Win32::Foundation::CO_E_NOTINITIALIZED;
 use std::marker::PhantomData;
 use std::sync::atomic::{AtomicPtr, Ordering};
 

--- a/src/runtime/waiter.rs
+++ b/src/runtime/waiter.rs
@@ -1,9 +1,8 @@
 use crate::*;
 
 use bindings::{
-    Windows::Win32::System::SystemServices::{HANDLE, PSTR},
+    Windows::Win32::Foundation::{CloseHandle, HANDLE, PSTR},
     Windows::Win32::System::Threading::{CreateEventA, SetEvent, WaitForSingleObject},
-    Windows::Win32::System::WindowsProgramming::CloseHandle,
 };
 
 /// A simple blocking waiter used by the generated bindings and should not be used directly.

--- a/src/traits/abi.rs
+++ b/src/traits/abi.rs
@@ -1,6 +1,6 @@
 use crate::*;
 
-use bindings::Windows::Win32::System::SystemServices::E_POINTER;
+use bindings::Windows::Win32::Foundation::E_POINTER;
 
 /// Provides a generic way of referring to and converting between a Rust object
 /// and its ABI equivalent.

--- a/tests/bstr/build.rs
+++ b/tests/bstr/build.rs
@@ -2,6 +2,6 @@ fn main() {
     // The Windows crate manually injects various functions needed to implement BSTR.
     // This test validates these are included.
     windows::build! {
-        Windows::Win32::System::OleAutomation::BSTR,
+        Windows::Win32::Foundation::BSTR,
     };
 }

--- a/tests/bstr/tests/bstr.rs
+++ b/tests/bstr/tests/bstr.rs
@@ -1,4 +1,4 @@
-use test_bstr::Windows::Win32::System::OleAutomation::BSTR;
+use test_bstr::Windows::Win32::Foundation::BSTR;
 use windows::Abi;
 
 #[test]

--- a/tests/handles/build.rs
+++ b/tests/handles/build.rs
@@ -1,6 +1,6 @@
 fn main() {
     windows::build! {
+        Windows::Win32::Foundation::{HANDLE, PSTR, PWSTR},
         Windows::Win32::Graphics::Gdi::HGDIOBJ,
-        Windows::Win32::System::SystemServices::{HANDLE, PSTR, PWSTR},
     };
 }

--- a/tests/handles/tests/null.rs
+++ b/tests/handles/tests/null.rs
@@ -1,6 +1,6 @@
 use test_handles::{
+    Windows::Win32::Foundation::{HANDLE, PSTR, PWSTR},
     Windows::Win32::Graphics::Gdi::HGDIOBJ,
-    Windows::Win32::System::SystemServices::{HANDLE, PSTR, PWSTR},
 };
 
 #[test]

--- a/tests/unions/tests/overlapped.rs
+++ b/tests/unions/tests/overlapped.rs
@@ -1,5 +1,6 @@
-use test_unions::Windows::Win32::System::SystemServices::{
-    HANDLE, OVERLAPPED, OVERLAPPED_0, OVERLAPPED_0_0,
+use test_unions::Windows::Win32::{
+    Foundation::HANDLE,
+    System::SystemServices::{OVERLAPPED, OVERLAPPED_0, OVERLAPPED_0_0},
 };
 
 #[test]

--- a/tests/win32/build.rs
+++ b/tests/win32/build.rs
@@ -1,5 +1,6 @@
 fn main() {
     windows::build! {
+        Windows::Win32::Foundation::{CloseHandle, BSTR, RECT},
         Windows::Win32::Gaming::HasExpandedResources,
         Windows::Win32::Graphics::Direct2D::CLSID_D2D1Shadow,
         Windows::Win32::Graphics::Direct3D11::D3DDisassemble11Trace,
@@ -10,18 +11,15 @@ fn main() {
         },
         Windows::Win32::Graphics::Hlsl::D3DCOMPILER_DLL,
         Windows::Win32::Networking::Ldap::ldapsearch,
-        Windows::Win32::Security::ACCESS_MODE,
+        Windows::Win32::Security::Authorization::ACCESS_MODE,
         Windows::Win32::Storage::StructuredStorage::{CreateStreamOnHGlobal, STREAM_SEEK},
         Windows::Win32::System::Com::CreateUri,
-        Windows::Win32::System::Diagnostics::Debug::MiniDumpWriteDump,
-        Windows::Win32::System::OleAutomation::BSTR,
+        Windows::Win32::System::Diagnostics::Debug::{MiniDumpWriteDump, MINIDUMP_TYPE},
         Windows::Win32::System::Threading::{CreateEventW, SetEvent, WaitForSingleObject},
         Windows::Win32::System::UpdateAgent::IAutomaticUpdates,
-        Windows::Win32::System::WindowsProgramming::CloseHandle,
         Windows::Win32::UI::Accessibility::UIA_ScrollPatternNoScroll,
         Windows::Win32::UI::Animation::{UIAnimationManager, UIAnimationTransitionLibrary},
         Windows::Win32::UI::ColorSystem::WhitePoint,
-        Windows::Win32::UI::DisplayDevices::RECT,
         Windows::Win32::UI::WindowsAndMessaging::{
             CHOOSECOLORW, PROPENUMPROCA, PROPENUMPROCW, WM_KEYUP,
         },

--- a/tests/win32/tests/win32.rs
+++ b/tests/win32/tests/win32.rs
@@ -1,25 +1,19 @@
-use test_win32::{
-    Windows::Win32::Gaming::HasExpandedResources,
-    Windows::Win32::Graphics::Direct2D::CLSID_D2D1Shadow,
-    Windows::Win32::Graphics::Direct3D11::D3DDisassemble11Trace,
-    Windows::Win32::Graphics::Direct3D12::D3D12_DEFAULT_BLEND_FACTOR_ALPHA,
-    Windows::Win32::Graphics::Dxgi::*,
-    Windows::Win32::Graphics::Hlsl::D3DCOMPILER_DLL,
-    Windows::Win32::Networking::Ldap::ldapsearch,
-    Windows::Win32::Security::*,
-    Windows::Win32::Storage::StructuredStorage::*,
-    Windows::Win32::System::Com::CreateUri,
-    Windows::Win32::System::Diagnostics::Debug::*,
-    Windows::Win32::System::OleAutomation::BSTR,
-    Windows::Win32::System::SystemServices::{BOOL, HANDLE, PSTR, PWSTR},
-    Windows::Win32::System::Threading::*,
-    Windows::Win32::System::WindowsProgramming::CloseHandle,
-    Windows::Win32::UI::Accessibility::UIA_ScrollPatternNoScroll,
-    Windows::Win32::UI::Animation::{UIAnimationManager, UIAnimationTransitionLibrary},
-    Windows::Win32::UI::ColorSystem::WhitePoint,
-    Windows::Win32::UI::DisplayDevices::RECT,
-    Windows::Win32::UI::WindowsAndMessaging::{
-        CHOOSECOLORW, HWND, PROPENUMPROCA, PROPENUMPROCW, WM_KEYUP,
+use test_win32::Windows::Win32::{
+    Foundation::{CloseHandle, BOOL, BSTR, HANDLE, HWND, PSTR, PWSTR, RECT},
+    Gaming::HasExpandedResources,
+    Graphics::{
+        Direct2D::CLSID_D2D1Shadow, Direct3D11::D3DDisassemble11Trace,
+        Direct3D12::D3D12_DEFAULT_BLEND_FACTOR_ALPHA, Dxgi::*, Hlsl::D3DCOMPILER_DLL,
+    },
+    Networking::Ldap::ldapsearch,
+    Security::Authorization::*,
+    Storage::StructuredStorage::*,
+    System::{Com::CreateUri, Diagnostics::Debug::*, Threading::*},
+    UI::{
+        Accessibility::UIA_ScrollPatternNoScroll,
+        Animation::{UIAnimationManager, UIAnimationTransitionLibrary},
+        ColorSystem::WhitePoint,
+        WindowsAndMessaging::{CHOOSECOLORW, PROPENUMPROCA, PROPENUMPROCW, WM_KEYUP},
     },
 };
 

--- a/tests/winrt/build.rs
+++ b/tests/winrt/build.rs
@@ -26,13 +26,12 @@ fn main() {
 
         Windows::Storage::Streams::{
             DataReader, DataReaderLoadOperation, DataWriter, DataWriterStoreOperation,
-            InMemoryRandomAccessStream,
+            InMemoryRandomAccessStream, RandomAccessStreamReference,
         },
-        Windows::Storage::Streams::{InMemoryRandomAccessStream, RandomAccessStreamReference},
 
-        Windows::Win32::System::SystemServices::{
-            CreateDispatcherQueueController, E_NOINTERFACE, E_POINTER,
-        },
+        Windows::Win32::Foundation::{E_NOINTERFACE, E_POINTER},
+
+        Windows::Win32::System::WinRT::CreateDispatcherQueueController,
         Windows::AI::MachineLearning::*,
         Windows::UI::Composition::{
             CompositionColorBrush, Compositor, SpriteVisual, Visual, VisualCollection,

--- a/tests/winrt/tests/collisions.rs
+++ b/tests/winrt/tests/collisions.rs
@@ -4,7 +4,7 @@ use test_winrt::{
         WiFiDirectConnectionParameters, WiFiDirectDevice, WiFiDirectDeviceSelectorType,
     },
     Windows::Storage::Streams::{InMemoryRandomAccessStream, RandomAccessStreamReference},
-    Windows::Win32::System::SystemServices::E_POINTER,
+    Windows::Win32::Foundation::E_POINTER,
 };
 
 // WiFiDirectDevice has a pair of static factory interfaces with overloads. This test

--- a/tests/winrt/tests/composition.rs
+++ b/tests/winrt/tests/composition.rs
@@ -1,6 +1,6 @@
 use test_winrt::{
     Windows::System::DispatcherQueueController,
-    Windows::Win32::System::SystemServices::{
+    Windows::Win32::System::WinRT::{
         CreateDispatcherQueueController, DispatcherQueueOptions, DQTAT_COM_NONE,
         DQTYPE_THREAD_CURRENT,
     },

--- a/tests/winrt/tests/error.rs
+++ b/tests/winrt/tests/error.rs
@@ -1,4 +1,4 @@
-use test_winrt::{Windows::Foundation::Uri, Windows::Win32::System::SystemServices::E_NOINTERFACE};
+use test_winrt::Windows::{Foundation::Uri, Win32::Foundation::E_NOINTERFACE};
 
 #[test]
 fn from_hresult() {


### PR DESCRIPTION
The [10.2.84-preview](https://www.nuget.org/packages/Microsoft.Windows.SDK.Win32Metadata/10.2.84-preview) `win32metadata` just dropped and only required few extra modifications since starting on this a few weeks ago, to regroup and clean up `UseTree`s. Not all are done yet, but it should look a lot better already (also keeping in mind #827/#828).

~Note that this uses the file from https://github.com/microsoft/win32metadata/tree/v10.2.84-preview/scripts/BaselineWinmd because the nuget package appears to miss some types from the foundation namespace :thinking: - still investigating.~ The broken types switched from `TypeRef` to `TypeDef`.