### PR TITLE
Add build macro format tool

### DIFF
--- a/crates/fmt/Cargo.toml
+++ b/crates/fmt/Cargo.toml
@@ -1,0 +1,7 @@
+[package]
+name = "fmt"
+version = "0.0.0"
+edition = "2018"
+
+[dependencies]
+windows_gen = { path = "../gen" }

--- a/crates/fmt/src/main.rs
+++ b/crates/fmt/src/main.rs
@@ -26,13 +26,18 @@ fn update_file(entry: &std::fs::DirEntry, set: bool) -> std::io::Result<()> {
             let mut file = std::fs::File::open(&path)?;
             let mut data = String::new();
             file.read_to_string(&mut data)?;
+            drop(file);
+
+            let macro_str = "windows::build! \x7b";
+            let use_str = "use \x7b // fmt";
 
             let data = if set { 
-                data.replace("windows::build!", "use")
+                data.replace(macro_str, use_str);
             } else {
-                data.replace("use", "windows::build!")
+                data.replace(use_str, macro_str)
             };
 
+            let mut file = std::fs::File::create(&path)?;
             file.write_all(data.as_bytes())?;
         }
     }
@@ -42,6 +47,8 @@ fn update_file(entry: &std::fs::DirEntry, set: bool) -> std::io::Result<()> {
 
 fn main() -> std::io::Result<()> {
     let workspace = windows_gen::workspace_dir();
-    update_dir(&workspace, true);
-    update_dir(&workspace, false);
+   // update_dir(&workspace, true)?;
+    update_dir(&workspace, false)?;
+
+    Ok(())
 }

--- a/crates/fmt/src/main.rs
+++ b/crates/fmt/src/main.rs
@@ -1,0 +1,47 @@
+use std::io::prelude::*;
+
+fn update_dir(dir: &std::path::Path, set: bool) -> std::io::Result<()> {
+    if dir.is_dir() {
+        for entry in std::fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+
+            if path.is_dir() {
+                update_dir(&path, set)?;
+            } else {
+                update_file(&entry, set)?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn update_file(entry: &std::fs::DirEntry, set: bool) -> std::io::Result<()> {
+    let path = entry.path();
+
+    if let Some(extension) = path.extension() {
+        if extension == "rs" {
+            println!("{:?}", path);
+            let mut file = std::fs::File::open(&path)?;
+            let mut data = String::new();
+            file.read_to_string(&mut data)?;
+
+            let data = if set { 
+                data.replace("windows::build!", "use")
+            } else {
+                data.replace("use", "windows::build!")
+            };
+
+            file.write_all(data.as_bytes())?;
+        }
+    }
+
+    Ok(())
+}
+
+fn main() -> std::io::Result<()> {
+    let workspace = windows_gen::workspace_dir();
+    update_dir(&workspace, true);
+    update_dir(&workspace, false);
+}

--- a/crates/fmt/src/main.rs
+++ b/crates/fmt/src/main.rs
@@ -1,15 +1,15 @@
 use std::io::prelude::*;
 
-fn update_dir(dir: &std::path::Path, set: bool) -> std::io::Result<()> {
+fn update_dir(dir: &std::path::Path) -> std::io::Result<()> {
     if dir.is_dir() {
         for entry in std::fs::read_dir(dir)? {
             let entry = entry?;
             let path = entry.path();
 
             if path.is_dir() {
-                update_dir(&path, set)?;
+                update_dir(&path)?;
             } else {
-                update_file(&entry, set)?;
+                update_file(&entry)?;
             }
         }
     }
@@ -17,28 +17,40 @@ fn update_dir(dir: &std::path::Path, set: bool) -> std::io::Result<()> {
     Ok(())
 }
 
-fn update_file(entry: &std::fs::DirEntry, set: bool) -> std::io::Result<()> {
+fn update_file(entry: &std::fs::DirEntry) -> std::io::Result<()> {
     let path = entry.path();
 
     if let Some(extension) = path.extension() {
         if extension == "rs" {
-            println!("{:?}", path);
             let mut file = std::fs::File::open(&path)?;
-            let mut data = String::new();
-            file.read_to_string(&mut data)?;
+            let mut before = String::new();
+            file.read_to_string(&mut before)?;
             drop(file);
 
             let macro_str = "windows::build! \x7b";
-            let use_str = "use \x7b // fmt";
+            let use_str = "use \x7b";
 
-            let data = if set { 
-                data.replace(macro_str, use_str);
-            } else {
-                data.replace(use_str, macro_str)
-            };
+            let after = before.replace(macro_str, use_str);
 
-            let mut file = std::fs::File::create(&path)?;
-            file.write_all(data.as_bytes())?;
+            if before != after {
+                println!("{:?}", path);
+                let mut file = std::fs::File::create(&path)?;
+                file.write_all(after.as_bytes())?;
+                drop(file);
+
+                let mut cmd = ::std::process::Command::new("rustfmt");
+                cmd.arg(&path);
+                cmd.output()?;
+
+                let mut file = std::fs::File::open(&path)?;
+                let mut before = String::new();
+                file.read_to_string(&mut before)?;
+                drop(file);
+
+                let after = before.replace(use_str, macro_str);
+                let mut file = std::fs::File::create(&path)?;
+                file.write_all(after.as_bytes())?;
+            }
         }
     }
 
@@ -46,9 +58,5 @@ fn update_file(entry: &std::fs::DirEntry, set: bool) -> std::io::Result<()> {
 }
 
 fn main() -> std::io::Result<()> {
-    let workspace = windows_gen::workspace_dir();
-   // update_dir(&workspace, true)?;
-    update_dir(&workspace, false)?;
-
-    Ok(())
+    update_dir(&windows_gen::workspace_dir())
 }

--- a/examples/ocr/bindings/build.rs
+++ b/examples/ocr/bindings/build.rs
@@ -1,9 +1,9 @@
 fn main() {
-    windows::build!(
-        Windows::Graphics::Imaging::{SoftwareBitmap, BitmapDecoder},
-        Windows::Media::Ocr::{OcrEngine, OcrResult},
-        Windows::Storage::{FileAccessMode, StorageFile},
+    use {
         Windows::Foundation::IAsyncOperation,
+        Windows::Graphics::Imaging::{BitmapDecoder, SoftwareBitmap},
+        Windows::Media::Ocr::{OcrEngine, OcrResult},
         Windows::Storage::Streams::IRandomAccessStream,
-    );
+        Windows::Storage::{FileAccessMode, StorageFile},
+    };
 }

--- a/examples/ocr/bindings/build.rs
+++ b/examples/ocr/bindings/build.rs
@@ -1,9 +1,9 @@
 fn main() {
-    use {
-        Windows::Foundation::IAsyncOperation,
-        Windows::Graphics::Imaging::{BitmapDecoder, SoftwareBitmap},
+    windows::build! {
+        Windows::Graphics::Imaging::{SoftwareBitmap, BitmapDecoder},
         Windows::Media::Ocr::{OcrEngine, OcrResult},
-        Windows::Storage::Streams::IRandomAccessStream,
         Windows::Storage::{FileAccessMode, StorageFile},
+        Windows::Foundation::IAsyncOperation,
+        Windows::Storage::Streams::IRandomAccessStream,
     };
 }


### PR DESCRIPTION
Adds a simple tool that can format build macros. I'll create a separate PR to update the build macros to use `{}` instead of `()` and perhaps we can use the yml trick from #828 to verify in CI builds. What do you think @MarijnS95?