### PR TITLE
crates/fmt: Reformat `build!` macro calls with a single top-level import

### DIFF
--- a/crates/fmt/src/main.rs
+++ b/crates/fmt/src/main.rs
@@ -36,11 +36,22 @@ fn format_file(file: &Path, pattern: &str) -> Result<()> {
         // If curly braces have been removed, find the `use` statement and terminating semicolon
         let usetree_start = macro_start + SHIM.len();
         let semi = contents[usetree_start..].find(';').expect("Semi");
+
+        let indent = contents[..macro_start]
+            .chars()
+            .rev()
+            .take_while(|&c| c == ' ')
+            .count();
+
+        let indent = std::iter::repeat(' ').take(indent).collect::<String>();
+
         // Replace `use` with macro call and insert curly braces around the UseTree
         let macro_ = format!(
-            "{}{{{}}}",
+            "{}{{\n    {}{},\n{}}}",
             pattern,
-            &contents[usetree_start..usetree_start + semi]
+            indent,
+            contents[usetree_start..usetree_start + semi].replace('\n', "\n    "),
+            indent,
         );
         let mut contents = contents;
         contents.replace_range(macro_start..usetree_start + semi, &macro_);

--- a/examples/enum_windows/bindings/build.rs
+++ b/examples/enum_windows/bindings/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    windows::build! {
-        Windows::Win32::UI::WindowsAndMessaging::{EnumWindows, GetWindowTextW}
-    };
+    windows::build! {Windows::Win32::UI::WindowsAndMessaging::{
+        EnumWindows, GetWindowTextW,
+    }};
 }

--- a/examples/enum_windows/bindings/build.rs
+++ b/examples/enum_windows/bindings/build.rs
@@ -1,5 +1,7 @@
 fn main() {
-    windows::build! {Windows::Win32::UI::WindowsAndMessaging::{
-        EnumWindows, GetWindowTextW,
-    }};
+    windows::build! {
+        Windows::Win32::UI::WindowsAndMessaging::{
+            EnumWindows, GetWindowTextW,
+        },
+    };
 }

--- a/examples/message_box/bindings/build.rs
+++ b/examples/message_box/bindings/build.rs
@@ -1,5 +1,3 @@
 fn main() {
-    windows::build! {
-        Windows::Win32::UI::WindowsAndMessaging::{MessageBoxA}
-    };
+    windows::build! {Windows::Win32::UI::WindowsAndMessaging::MessageBoxA};
 }

--- a/examples/message_box/bindings/build.rs
+++ b/examples/message_box/bindings/build.rs
@@ -1,3 +1,5 @@
 fn main() {
-    windows::build! {Windows::Win32::UI::WindowsAndMessaging::MessageBoxA};
+    windows::build! {
+        Windows::Win32::UI::WindowsAndMessaging::MessageBoxA,
+    };
 }

--- a/examples/win2d/bindings/build.rs
+++ b/examples/win2d/bindings/build.rs
@@ -1,3 +1,5 @@
 fn main() {
-    windows::build! {Microsoft::Graphics::Canvas::CanvasDevice};
+    windows::build! {
+        Microsoft::Graphics::Canvas::CanvasDevice,
+    };
 }

--- a/tests/bstr/build.rs
+++ b/tests/bstr/build.rs
@@ -1,7 +1,5 @@
 fn main() {
-    windows::build! {
-        // The Windows crate manually injects various functions needed to implement BSTR.
-        // This test validates these are included.
-        Windows::Win32::System::OleAutomation::BSTR
-    };
+    // The Windows crate manually injects various functions needed to implement BSTR.
+    // This test validates these are included.
+    windows::build! {Windows::Win32::System::OleAutomation::BSTR};
 }

--- a/tests/bstr/build.rs
+++ b/tests/bstr/build.rs
@@ -1,5 +1,7 @@
 fn main() {
     // The Windows crate manually injects various functions needed to implement BSTR.
     // This test validates these are included.
-    windows::build! {Windows::Win32::System::OleAutomation::BSTR};
+    windows::build! {
+        Windows::Win32::System::OleAutomation::BSTR,
+    };
 }

--- a/tests/build_wildcard/build.rs
+++ b/tests/build_wildcard/build.rs
@@ -1,5 +1,3 @@
 fn main() {
-    windows::build! {
-        Windows::Foundation::*,
-    };
+    windows::build! {Windows::Foundation::*};
 }

--- a/tests/build_wildcard/build.rs
+++ b/tests/build_wildcard/build.rs
@@ -1,3 +1,5 @@
 fn main() {
-    windows::build! {Windows::Foundation::*};
+    windows::build! {
+        Windows::Foundation::*,
+    };
 }

--- a/tests/convertible/build.rs
+++ b/tests/convertible/build.rs
@@ -1,8 +1,6 @@
 fn main() {
-    windows::build! {
-        // GetProcessHeap returns HeapHandle. So including GetProcessHeap
-        // should also include HeapHandle.
-        Windows::Win32::System::Memory::GetProcessHeap,
-        // Note: don't add anything else to this build macro!
-    };
+    // GetProcessHeap returns HeapHandle. So including GetProcessHeap
+    // should also include HeapHandle.
+    windows::build! {Windows::Win32::System::Memory::GetProcessHeap};
+    // Note: don't add anything else to this build macro!
 }

--- a/tests/convertible/build.rs
+++ b/tests/convertible/build.rs
@@ -1,6 +1,8 @@
 fn main() {
     // GetProcessHeap returns HeapHandle. So including GetProcessHeap
     // should also include HeapHandle.
-    windows::build! {Windows::Win32::System::Memory::GetProcessHeap};
+    windows::build! {
+        Windows::Win32::System::Memory::GetProcessHeap,
+    };
     // Note: don't add anything else to this build macro!
 }

--- a/tests/deprecated/build.rs
+++ b/tests/deprecated/build.rs
@@ -1,3 +1,5 @@
 fn main() {
-    windows::build! {Windows::ApplicationModel::Contacts::KnownContactField};
+    windows::build! {
+        Windows::ApplicationModel::Contacts::KnownContactField,
+    };
 }

--- a/tests/interfaces/build.rs
+++ b/tests/interfaces/build.rs
@@ -1,6 +1,4 @@
 fn main() {
-    windows::build! {
-        // Test for https://github.com/microsoft/win32metadata/issues/449
-        Windows::Win32::System::ComponentServices::ITransactionImport
-    };
+    // Test for https://github.com/microsoft/win32metadata/issues/449
+    windows::build! {Windows::Win32::System::ComponentServices::ITransactionImport};
 }

--- a/tests/interfaces/build.rs
+++ b/tests/interfaces/build.rs
@@ -1,4 +1,6 @@
 fn main() {
     // Test for https://github.com/microsoft/win32metadata/issues/449
-    windows::build! {Windows::Win32::System::ComponentServices::ITransactionImport};
+    windows::build! {
+        Windows::Win32::System::ComponentServices::ITransactionImport,
+    };
 }

--- a/tests/matrix3x2/build.rs
+++ b/tests/matrix3x2/build.rs
@@ -1,5 +1,7 @@
 fn main() {
     // The Windows crate manually injects a functions needed to implement Matrix3x2.
     // This test validates this is included.
-    windows::build! {Windows::Foundation::Numerics::Matrix3x2};
+    windows::build! {
+        Windows::Foundation::Numerics::Matrix3x2,
+    };
 }

--- a/tests/matrix3x2/build.rs
+++ b/tests/matrix3x2/build.rs
@@ -1,7 +1,5 @@
 fn main() {
-    windows::build! {
-        // The Windows crate manually injects a functions needed to implement Matrix3x2.
-        // This test validates this is included.
-        Windows::Foundation::Numerics::Matrix3x2
-    };
+    // The Windows crate manually injects a functions needed to implement Matrix3x2.
+    // This test validates this is included.
+    windows::build! {Windows::Foundation::Numerics::Matrix3x2};
 }

--- a/tests/structs/build.rs
+++ b/tests/structs/build.rs
@@ -1,7 +1,5 @@
 fn main() {
-    windows::build! {
-        // Test for https://github.com/microsoft/windows-rs/issues/738 as DebugPropertyInfo has a
-        // BSTR field and needs to implement Clone.
-        Windows::Win32::System::Diagnostics::Debug::DebugPropertyInfo
-    };
+    // Test for https://github.com/microsoft/windows-rs/issues/738 as DebugPropertyInfo has a
+    // BSTR field and needs to implement Clone.
+    windows::build! {Windows::Win32::System::Diagnostics::Debug::DebugPropertyInfo};
 }

--- a/tests/structs/build.rs
+++ b/tests/structs/build.rs
@@ -1,5 +1,7 @@
 fn main() {
     // Test for https://github.com/microsoft/windows-rs/issues/738 as DebugPropertyInfo has a
     // BSTR field and needs to implement Clone.
-    windows::build! {Windows::Win32::System::Diagnostics::Debug::DebugPropertyInfo};
+    windows::build! {
+        Windows::Win32::System::Diagnostics::Debug::DebugPropertyInfo,
+    };
 }


### PR DESCRIPTION
`build!` macro calls containing a single top-level import will have their curly braces removed, making it a little more complicated to substitute the `use` (used to trick `rustfmt` into formatting our macro-call) back with a macro call and surrounding it in curly braces again.

---

CC @tim-weis for https://github.com/microsoft/windows-rs/pull/843#discussion_r647174799
