### PR TITLE
Simplify type resolution

### DIFF
--- a/crates/gen/src/parser/codes.rs
+++ b/crates/gen/src/parser/codes.rs
@@ -329,9 +329,13 @@ impl TypeDefOrRef {
         }
     }
 
+                // Need to "re-resolve" the TypeDef as it may point to an arch-specific
+            // definition. This lets the TypeTree be built for a specific architecture
+            // without accidentally pulling in the wrong definition.
+
     pub fn resolve(&self) -> tables::TypeDef {
         match self {
-            Self::TypeDef(value) => value.clone(),
+            Self::TypeDef(value) => value.resolve(),
             Self::TypeRef(value) => value.resolve(),
             _ => unexpected!(),
         }

--- a/crates/gen/src/parser/codes.rs
+++ b/crates/gen/src/parser/codes.rs
@@ -329,9 +329,9 @@ impl TypeDefOrRef {
         }
     }
 
-                // Need to "re-resolve" the TypeDef as it may point to an arch-specific
-            // definition. This lets the TypeTree be built for a specific architecture
-            // without accidentally pulling in the wrong definition.
+    // Need to "re-resolve" the TypeDef as it may point to an arch-specific
+    // definition. This lets the TypeTree be built for a specific architecture
+    // without accidentally pulling in the wrong definition.
 
     pub fn resolve(&self) -> tables::TypeDef {
         match self {

--- a/crates/gen/src/parser/codes.rs
+++ b/crates/gen/src/parser/codes.rs
@@ -329,10 +329,6 @@ impl TypeDefOrRef {
         }
     }
 
-    // Need to "re-resolve" the TypeDef as it may point to an arch-specific
-    // definition. This lets the TypeTree be built for a specific architecture
-    // without accidentally pulling in the wrong definition.
-
     pub fn resolve(&self) -> tables::TypeDef {
         match self {
             Self::TypeDef(value) => value.resolve(),

--- a/crates/gen/src/parser/signature.rs
+++ b/crates/gen/src/parser/signature.rs
@@ -10,6 +10,7 @@ pub struct Signature {
 }
 
 impl Signature {
+    // TODO: move to TypeReader
     pub fn from_blob(blob: &mut Blob, generics: &[ElementType]) -> Option<Self> {
         let is_const = blob
             .read_modifiers()
@@ -30,7 +31,7 @@ impl Signature {
             pointers += 1;
         }
 
-        let kind = ElementType::from_blob(blob, generics);
+        let kind = TypeReader::get().type_from_blob(blob, generics);
 
         Some(Self {
             kind,

--- a/crates/gen/src/parser/signature.rs
+++ b/crates/gen/src/parser/signature.rs
@@ -10,38 +10,6 @@ pub struct Signature {
 }
 
 impl Signature {
-    // TODO: move to TypeReader
-    pub fn from_blob(blob: &mut Blob, generics: &[ElementType]) -> Option<Self> {
-        let is_const = blob
-            .read_modifiers()
-            .iter()
-            .any(|def| def.full_name() == ("System.Runtime.CompilerServices", "IsConst"));
-
-        let by_ref = blob.read_expected(0x10);
-
-        if blob.read_expected(0x01) {
-            return None;
-        }
-
-        let is_array = blob.read_expected(0x1D);
-
-        let mut pointers = 0;
-
-        while blob.read_expected(0x0f) {
-            pointers += 1;
-        }
-
-        let kind = TypeReader::get().type_from_blob(blob, generics);
-
-        Some(Self {
-            kind,
-            pointers,
-            by_ref,
-            is_const,
-            is_array,
-        })
-    }
-
     pub fn definition(&self) -> Vec<ElementType> {
         self.kind.definition()
     }

--- a/crates/gen/src/parser/type_reader.rs
+++ b/crates/gen/src/parser/type_reader.rs
@@ -117,7 +117,7 @@ impl TypeReader {
             }
         }
 
-        for (namespace, name, _) in WELL_KNOWN_TYPES {
+        for (namespace, name, _) in &WELL_KNOWN_TYPES {
             if let Some(value) = types.get_mut(namespace) {
                 value.remove(name);
             }
@@ -261,9 +261,9 @@ impl TypeReader {
 
         let full_name = code.full_name();
 
-        for (namespace, name, kind) in WELL_KNOWN_TYPES {
+        for (namespace, name, kind) in &WELL_KNOWN_TYPES {
             if full_name == (namespace, name) {
-                return kind;
+                return kind.clone();
             }
         }
 

--- a/crates/gen/src/parser/type_reader.rs
+++ b/crates/gen/src/parser/type_reader.rs
@@ -27,7 +27,6 @@ impl From<&TypeRow> for ElementType {
 }
 
 impl TypeReader {
-    // TODO: move almost all methods that require this get() to the TypeReader impl.
     pub fn get() -> &'static Self {
         use std::{mem::MaybeUninit, sync::Once};
         static ONCE: Once = Once::new();

--- a/crates/gen/src/parser/type_reader.rs
+++ b/crates/gen/src/parser/type_reader.rs
@@ -259,6 +259,7 @@ impl TypeReader {
 
     pub fn type_from_code(&'static self, code: &TypeDefOrRef, generics: &[ElementType]) -> ElementType {
         match code {
+            // TODO: store these in a const table shared with exclusions
             TypeDefOrRef::TypeRef(type_ref) => match type_ref.full_name() {
                 ("System", "Guid") => ElementType::Guid,
                 ("Windows.Win32.System.Com", "IUnknown") => ElementType::IUnknown,

--- a/crates/gen/src/parser/type_reader.rs
+++ b/crates/gen/src/parser/type_reader.rs
@@ -118,20 +118,9 @@ impl TypeReader {
             }
         }
 
-        let exclude = &[
-            ("Windows.Foundation", "HResult"),
-            ("Windows.Win32.System.Com", "HRESULT"),
-            ("Windows.Win32.System.Com", "IUnknown"),
-            ("Windows.Win32.System.WinRT", "HSTRING"),
-            ("Windows.Win32.System.WinRT", "IActivationFactory"),
-            ("Windows.Win32.Graphics.Direct2D", "D2D_MATRIX_3X2_F"),
-            ("Windows.Win32.System.SystemServices", "LARGE_INTEGER"),
-            ("Windows.Win32.System.SystemServices", "ULARGE_INTEGER"),
-        ];
-
-        for (namespace, name) in exclude {
-            if let Some(value) = types.get_mut(*namespace) {
-                value.remove(*name);
+        for (namespace, name, _) in WELL_KNOWN_TYPES {
+            if let Some(value) = types.get_mut(namespace) {
+                value.remove(name);
             }
         }
 
@@ -266,7 +255,6 @@ impl TypeReader {
         code: &TypeDefOrRef,
         generics: &[ElementType],
     ) -> ElementType {
-
         if let TypeDefOrRef::TypeSpec(def) = code {
             let mut blob = def.blob();
             return self.type_from_blob(&mut blob, generics);

--- a/crates/gen/src/tables/attribute.rs
+++ b/crates/gen/src/tables/attribute.rs
@@ -17,6 +17,8 @@ impl Attribute {
     }
 
     pub fn args(&self) -> Vec<(String, ConstantValue)> {
+        let reader = TypeReader::get();
+
         let (mut sig, mut values) = match self.constructor() {
             AttributeType::MethodDef(method) => (method.0.blob(4), self.0.blob(2)),
             AttributeType::MemberRef(method) => (method.0.blob(2), self.0.blob(2)),
@@ -32,7 +34,7 @@ impl Attribute {
         let mut args: Vec<(String, ConstantValue)> = Vec::with_capacity(fixed_arg_count as usize);
 
         for _ in 0..fixed_arg_count {
-            let arg = match ElementType::from_blob(&mut sig, &[]) {
+            let arg = match reader.type_from_blob(&mut sig, &[]) {
                 ElementType::I8 => ConstantValue::I8(values.read_i8()),
                 ElementType::U8 => ConstantValue::U8(values.read_u8()),
                 ElementType::I16 => ConstantValue::I16(values.read_i16()),
@@ -46,7 +48,7 @@ impl Attribute {
                     let name = values.read_str();
                     let index = name.rfind('.').unwrap();
                     ConstantValue::TypeDef(
-                        TypeReader::get()
+                        reader
                             .resolve_type_def(&name[0..index], &name[index + 1..])
                             .clone(),
                     )

--- a/crates/gen/src/tables/attribute.rs
+++ b/crates/gen/src/tables/attribute.rs
@@ -83,7 +83,7 @@ impl Attribute {
                     let name = values.read_str();
                     let index = name.rfind('.').unwrap();
                     ConstantValue::TypeDef(
-                        TypeReader::get()
+                        reader
                             .resolve_type_def(&name[0..index], &name[index + 1..])
                             .clone(),
                     )

--- a/crates/gen/src/tables/field.rs
+++ b/crates/gen/src/tables/field.rs
@@ -71,7 +71,7 @@ impl Field {
         let mut blob = self.blob();
         blob.read_unsigned();
         blob.read_modifiers();
-        Signature::from_blob(&mut blob, &[]).expect("Field")
+        TypeReader::get().signature_from_blob(&mut blob, &[]).expect("Field")
     }
 
     pub fn definition(&self) -> Vec<ElementType> {

--- a/crates/gen/src/tables/field.rs
+++ b/crates/gen/src/tables/field.rs
@@ -71,7 +71,9 @@ impl Field {
         let mut blob = self.blob();
         blob.read_unsigned();
         blob.read_modifiers();
-        TypeReader::get().signature_from_blob(&mut blob, &[]).expect("Field")
+        TypeReader::get()
+            .signature_from_blob(&mut blob, &[])
+            .expect("Field")
     }
 
     pub fn definition(&self) -> Vec<ElementType> {

--- a/crates/gen/src/tables/interface_impl.rs
+++ b/crates/gen/src/tables/interface_impl.rs
@@ -31,29 +31,9 @@ impl InterfaceImpl {
         self.has_attribute("OverridableAttribute")
     }
 
-    // TODO: return ElementType
-    pub fn generic_interface(&self, generics: &[ElementType]) -> Option<tables::TypeDef> {
-        let reader = TypeReader::get();
-
-        match self.interface() {
-            TypeDefOrRef::TypeDef(def) => Some(def),
-            TypeDefOrRef::TypeRef(def) => {
-                if def.full_name() == ("Windows.Win32.System.Com", "IUnknown") {
-                    None
-                } else {
-                    Some(def.resolve())
-                }
-            }
-            TypeDefOrRef::TypeSpec(def) => {
-                let mut blob = def.blob();
-
-                if let ElementType::TypeDef(def) = reader.type_from_blob(&mut blob, generics) {
-                    Some(def)
-                } else {
-                    None
-                }
-            }
-        }
+    // tODO: remove wrapper
+    pub fn generic_interface(&self, generics: &[ElementType]) -> ElementType {
+        TypeReader::get().type_from_code(&self.interface(), generics)
     }
 }
 

--- a/crates/gen/src/tables/interface_impl.rs
+++ b/crates/gen/src/tables/interface_impl.rs
@@ -31,7 +31,6 @@ impl InterfaceImpl {
         self.has_attribute("OverridableAttribute")
     }
 
-    // tODO: remove wrapper
     pub fn generic_interface(&self, generics: &[ElementType]) -> ElementType {
         TypeReader::get().type_from_code(&self.interface(), generics)
     }

--- a/crates/gen/src/tables/method_def.rs
+++ b/crates/gen/src/tables/method_def.rs
@@ -125,13 +125,14 @@ impl MethodDef {
     }
 
     pub fn signature(&self, generics: &[ElementType]) -> MethodSignature {
+        let reader = TypeReader::get();
         let params = self.params();
 
         let mut blob = self.0.blob(4);
         blob.read_unsigned();
         blob.read_unsigned(); // parameter count
 
-        let return_type = TypeReader::get().signature_from_blob(&mut blob, generics);
+        let return_type = reader.signature_from_blob(&mut blob, generics);
 
         let params = params
             .filter_map(|param| {
@@ -140,7 +141,7 @@ impl MethodDef {
                 } else {
                     Some(MethodParam {
                         param,
-                        signature: TypeReader::get()
+                        signature: reader
                             .signature_from_blob(&mut blob, generics)
                             .expect("MethodDef"),
                     })

--- a/crates/gen/src/tables/method_def.rs
+++ b/crates/gen/src/tables/method_def.rs
@@ -140,7 +140,9 @@ impl MethodDef {
                 } else {
                     Some(MethodParam {
                         param,
-                        signature: TypeReader::get().signature_from_blob(&mut blob, generics).expect("MethodDef"),
+                        signature: TypeReader::get()
+                            .signature_from_blob(&mut blob, generics)
+                            .expect("MethodDef"),
                     })
                 }
             })

--- a/crates/gen/src/tables/method_def.rs
+++ b/crates/gen/src/tables/method_def.rs
@@ -131,7 +131,7 @@ impl MethodDef {
         blob.read_unsigned();
         blob.read_unsigned(); // parameter count
 
-        let return_type = Signature::from_blob(&mut blob, generics);
+        let return_type = TypeReader::get().signature_from_blob(&mut blob, generics);
 
         let params = params
             .filter_map(|param| {
@@ -140,7 +140,7 @@ impl MethodDef {
                 } else {
                     Some(MethodParam {
                         param,
-                        signature: Signature::from_blob(&mut blob, generics).expect("MethodDef"),
+                        signature: TypeReader::get().signature_from_blob(&mut blob, generics).expect("MethodDef"),
                     })
                 }
             })

--- a/crates/gen/src/tables/type_def.rs
+++ b/crates/gen/src/tables/type_def.rs
@@ -17,13 +17,15 @@ impl From<Row> for TypeDef {
 
 impl TypeDef {
     pub fn from_blob(blob: &mut Blob, generics: &[ElementType]) -> Self {
+        let reader = TypeReader::get();
+
         blob.read_unsigned();
 
         let mut def = TypeDefOrRef::decode(blob.file, blob.read_unsigned()).resolve();
         let args = blob.read_unsigned();
 
         for _ in 0..args {
-            def.generics.push(ElementType::from_blob(blob, generics));
+            def.generics.push(reader.type_from_blob(blob, generics));
         }
 
         def
@@ -379,7 +381,7 @@ impl TypeDef {
                 blob.read_expected(0x1D);
                 blob.read_modifiers();
 
-                return ElementType::from_blob(blob, &[]);
+                return TypeReader::get().type_from_blob(blob, &[]);
             }
         }
 

--- a/crates/gen/src/tables/type_def.rs
+++ b/crates/gen/src/tables/type_def.rs
@@ -63,7 +63,6 @@ impl TypeDef {
         definition
     }
 
-    // TODO: return ElementType?
     pub fn default_interface(&self) -> Self {
         for interface in self.interface_impls() {
             if interface.is_default() {

--- a/crates/gen/src/tables/type_def.rs
+++ b/crates/gen/src/tables/type_def.rs
@@ -63,11 +63,12 @@ impl TypeDef {
         definition
     }
 
+    // TODO: return ElementType?
     pub fn default_interface(&self) -> Self {
         for interface in self.interface_impls() {
             if interface.is_default() {
-                if let Some(result) = interface.generic_interface(&self.generics) {
-                    return result;
+                if let ElementType::TypeDef(def) = interface.generic_interface(&self.generics) {
+                    return def;
                 }
             }
         }
@@ -81,7 +82,13 @@ impl TypeDef {
 
     pub fn interfaces(&self) -> impl Iterator<Item = Self> + '_ {
         self.interface_impls()
-            .filter_map(move |i| i.generic_interface(&self.generics))
+            .filter_map(move |i| {
+                if let ElementType::TypeDef(def) = i.generic_interface(&self.generics) {
+                    Some(def)
+                } else {
+                    None
+                }
+            })
     }
 
     pub fn gen_name(&self, gen: &Gen) -> TokenStream {

--- a/crates/gen/src/tables/type_def.rs
+++ b/crates/gen/src/tables/type_def.rs
@@ -680,6 +680,9 @@ impl TypeDef {
             .collect()
     }
 
+    // May need to "re-resolve" the TypeDef as it may point to an arch-specific
+    // definition. This lets the TypeTree be built for a specific architecture
+    // without accidentally pulling in the wrong definition.
     pub fn resolve(&self) -> Self {
         TypeReader::get().resolve_type_def(self.namespace(), self.name())
     }

--- a/crates/gen/src/tables/type_def.rs
+++ b/crates/gen/src/tables/type_def.rs
@@ -16,21 +16,6 @@ impl From<Row> for TypeDef {
 }
 
 impl TypeDef {
-    pub fn from_blob(blob: &mut Blob, generics: &[ElementType]) -> Self {
-        let reader = TypeReader::get();
-
-        blob.read_unsigned();
-
-        let mut def = TypeDefOrRef::decode(blob.file, blob.read_unsigned()).resolve();
-        let args = blob.read_unsigned();
-
-        for _ in 0..args {
-            def.generics.push(reader.type_from_blob(blob, generics));
-        }
-
-        def
-    }
-
     pub fn with_generics(mut self) -> Self {
         self.generics = self
             .generic_params()

--- a/crates/gen/src/tables/type_def.rs
+++ b/crates/gen/src/tables/type_def.rs
@@ -81,14 +81,13 @@ impl TypeDef {
     }
 
     pub fn interfaces(&self) -> impl Iterator<Item = Self> + '_ {
-        self.interface_impls()
-            .filter_map(move |i| {
-                if let ElementType::TypeDef(def) = i.generic_interface(&self.generics) {
-                    Some(def)
-                } else {
-                    None
-                }
-            })
+        self.interface_impls().filter_map(move |i| {
+            if let ElementType::TypeDef(def) = i.generic_interface(&self.generics) {
+                Some(def)
+            } else {
+                None
+            }
+        })
     }
 
     pub fn gen_name(&self, gen: &Gen) -> TokenStream {
@@ -679,6 +678,10 @@ impl TypeDef {
             .iter()
             .flat_map(|interface| interface.methods().map(|method| method.name()))
             .collect()
+    }
+
+    pub fn resolve(&self) -> Self {
+        TypeReader::get().resolve_type_def(self.namespace(), self.name())
     }
 }
 

--- a/crates/gen/src/tables/type_ref.rs
+++ b/crates/gen/src/tables/type_ref.rs
@@ -20,7 +20,6 @@ impl TypeRef {
         (self.namespace(), self.name())
     }
 
-    // TODO: consider removing and making cache hits explicit
     pub fn resolve(&self) -> TypeDef {
         TypeReader::get().resolve_type_ref(self)
     }

--- a/crates/gen/src/types/class.rs
+++ b/crates/gen/src/types/class.rs
@@ -11,7 +11,7 @@ impl Class {
             is_base: bool,
         ) {
             for child in parent.interface_impls() {
-                if let Some(def) = child.generic_interface(&parent.generics) {
+                if let ElementType::TypeDef(def) = child.generic_interface(&parent.generics) {
                     let kind = if !is_base && child.is_default() {
                         InterfaceKind::Default
                     } else if child.is_overridable() {

--- a/crates/gen/src/types/com_interface.rs
+++ b/crates/gen/src/types/com_interface.rs
@@ -11,8 +11,14 @@ impl ComInterface {
         loop {
             let base = if let Some(next) = next
                 .interface_impls()
+                .filter_map(move |i| {
+                    if let ElementType::TypeDef(def) = i.generic_interface(&[]) {
+                        Some(def)
+                    } else {
+                        None
+                    }
+                })
                 .next()
-                .and_then(|i| i.generic_interface(&[]))
             {
                 next
             } else {

--- a/crates/gen/src/types/interface.rs
+++ b/crates/gen/src/types/interface.rs
@@ -11,7 +11,7 @@ impl Interface {
             is_base: bool,
         ) {
             for child in parent.interface_impls() {
-                if let Some(def) = child.generic_interface(&parent.generics) {
+                if let ElementType::TypeDef(def) = child.generic_interface(&parent.generics) {
                     if !result.iter().any(|info| info.def == def) {
                         add_interfaces(result, &def, is_base);
                         let version = def.version();


### PR DESCRIPTION
This update simplifies and consolidates type resolution. Types are now re-resolved to ensure arch-specific TypeDefs are used (future support). There are now also `WELL_KNOWN_TYPES` that should help manage the ripple effect from upstream changes. Well-known types can now freely move between TypeDef or TypeRef without breaking the parser. 