### PR TITLE
Annotate lifetime for `::windows::Param`

### DIFF
--- a/crates/gen/src/types/pstr.rs
+++ b/crates/gen/src/types/pstr.rs
@@ -26,7 +26,7 @@ pub fn gen_pstr() -> TokenStream {
         unsafe impl ::windows::Abi for PSTR {
             type Abi = Self;
 
-            fn drop_param(param: &mut ::windows::Param<Self>) {
+            fn drop_param(param: &mut ::windows::Param<'_, Self>) {
                 if let ::windows::Param::Boxed(value) = param {
                     if !value.0.is_null() {
                         unsafe { ::std::boxed::Box::from_raw(value.0); }

--- a/crates/gen/src/types/pwstr.rs
+++ b/crates/gen/src/types/pwstr.rs
@@ -26,7 +26,7 @@ pub fn gen_pwstr() -> TokenStream {
         unsafe impl ::windows::Abi for PWSTR {
             type Abi = Self;
 
-            fn drop_param(param: &mut ::windows::Param<Self>) {
+            fn drop_param(param: &mut ::windows::Param<'_, Self>) {
                 if let ::windows::Param::Boxed(value) = param {
                     if !value.0.is_null() {
                         unsafe { ::std::boxed::Box::from_raw(value.0); }

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1773,7 +1773,7 @@ pub mod Windows {
             }
             unsafe impl ::windows::Abi for PWSTR {
                 type Abi = Self;
-                fn drop_param(param: &mut ::windows::Param<Self>) {
+                fn drop_param(param: &mut ::windows::Param<'_, Self>) {
                     if let ::windows::Param::Boxed(value) = param {
                         if !value.0.is_null() {
                             unsafe {
@@ -2125,7 +2125,7 @@ pub mod Windows {
             }
             unsafe impl ::windows::Abi for PSTR {
                 type Abi = Self;
-                fn drop_param(param: &mut ::windows::Param<Self>) {
+                fn drop_param(param: &mut ::windows::Param<'_, Self>) {
                     if let ::windows::Param::Boxed(value) = param {
                         if !value.0.is_null() {
                             unsafe {


### PR DESCRIPTION
Brings `::windows::Param<Self>` usage in line with `rust_2018_idioms`.