### PR TITLE
Replace E_NOINTERFACE magic number with constant from metadata

### DIFF
--- a/crates/bindings/src/main.rs
+++ b/crates/bindings/src/main.rs
@@ -5,7 +5,7 @@ fn main() -> std::io::Result<()> {
         Windows::{
             Foundation::{IReference, IStringable, PropertyValue},
             Win32::{
-                Foundation::{CloseHandle, BSTR, CO_E_NOTINITIALIZED, E_POINTER},
+                Foundation::{CloseHandle, BSTR, CO_E_NOTINITIALIZED, E_NOINTERFACE, E_POINTER},
                 System::{
                     Com::{
                         CLSIDFromProgID, CoCreateGuid, CoCreateInstance, CoInitializeEx,

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -2073,6 +2073,7 @@ pub mod Windows {
                     unimplemented!("Unsupported target OS");
                 }
             }
+            pub const E_NOINTERFACE: ::windows::HRESULT = ::windows::HRESULT(-2147467262i32 as _);
             pub const E_POINTER: ::windows::HRESULT = ::windows::HRESULT(-2147467261i32 as _);
             #[repr(transparent)]
             #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]

--- a/src/result/error.rs
+++ b/src/result/error.rs
@@ -40,21 +40,22 @@ impl Error {
         Self { code, info }
     }
 
-    // Use internally to create an Error object without error info. Typically used with QueryInterface
-    // (E_NOINTERFACE) or the absense of an object to return (E_POINTER) to avoid the code gen overhead
-    // for casts that should be cheap (few instructions). Think of it as a way to create recoverable errors
-    // that don't need th overhead of debugging origination info.
-    pub fn fast_error(code: HRESULT) -> Self {
+    #[doc(hidden)]
+    /// Used internally to create an Error object without error info. Typically used with [`Interface::query`]
+    /// (`E_NOINTERFACE`) or the absence of an object to return (`E_POINTER`) to avoid the
+    /// code gen overhead for casts that should be cheap (few instructions). Think of it as a way to create
+    /// recoverable errors that don't need the overhead of debugging origination info.
+    pub const fn fast_error(code: HRESULT) -> Self {
         Self { code, info: None }
     }
 
     /// The error code describing the error.
-    pub fn code(&self) -> HRESULT {
+    pub const fn code(&self) -> HRESULT {
         self.code
     }
 
     /// The error information describing the error.
-    pub fn info(&self) -> &Option<IRestrictedErrorInfo> {
+    pub const fn info(&self) -> &Option<IRestrictedErrorInfo> {
         &self.info
     }
 

--- a/src/runtime/weak_ref_count.rs
+++ b/src/runtime/weak_ref_count.rs
@@ -7,8 +7,11 @@
 )]
 
 use crate::*;
-use bindings::Windows::Win32::System::WinRT::{
-    IWeakReference, IWeakReferenceSource, IWeakReferenceSource_abi, IWeakReference_abi,
+use bindings::Windows::Win32::{
+    Foundation::E_NOINTERFACE,
+    System::WinRT::{
+        IWeakReference, IWeakReferenceSource, IWeakReferenceSource_abi, IWeakReference_abi,
+    },
 };
 use std::sync::atomic::{AtomicIsize, Ordering};
 
@@ -225,7 +228,7 @@ impl TearOff {
         // TODO: implement IMarshal
 
         if (*interface).is_null() {
-            HRESULT(0x8000_4002) // E_NOINTERFACE
+            E_NOINTERFACE
         } else {
             this.weak_count.add_ref();
             HRESULT(0)

--- a/tests/weak/build.rs
+++ b/tests/weak/build.rs
@@ -1,6 +1,9 @@
 fn main() {
     windows::build! {
         Windows::Foundation::Uri,
-        Windows::Win32::System::WinRT::{IWeakReference, IWeakReferenceSource},
+        Windows::Win32::{
+            Foundation::E_NOINTERFACE,
+            System::WinRT::{IWeakReference, IWeakReferenceSource},
+        },
     };
 }

--- a/tests/weak/tests/uri.rs
+++ b/tests/weak/tests/uri.rs
@@ -1,5 +1,5 @@
-use test_weak::Windows::Foundation::Uri;
-use windows::{factory, IActivationFactory, Interface, Result, HRESULT};
+use test_weak::Windows::{Foundation::Uri, Win32::Foundation::E_NOINTERFACE};
+use windows::{factory, IActivationFactory, Interface, Result};
 
 // The Uri class supports weak references, so it is used to test a successful downgrade and upgrade.
 #[test]
@@ -23,7 +23,7 @@ fn test_failure() -> Result<()> {
     assert_eq!(result.is_err(), true);
 
     // E_NOINTERFACE is returned because IWeakReferenceSource is not implemented.
-    assert_eq!(result.unwrap_err().code(), HRESULT(0x8000_4002));
+    assert_eq!(result.unwrap_err().code(), E_NOINTERFACE);
 
     Ok(())
 }


### PR DESCRIPTION
Just like `E_POINTER` this constant can be generated and used from the bindings, instead of being hardcoded across the source.
