### PR TITLE
Add `#[track_caller]` to unwrap()/expect() in HRESULT and BOOL

### DIFF
--- a/crates/gen/src/types/bool32.rs
+++ b/crates/gen/src/types/bool32.rs
@@ -25,11 +25,13 @@ pub fn gen_bool32() -> TokenStream {
             }
 
             #[inline]
+            #[track_caller]
             pub fn unwrap(self) {
                 self.ok().unwrap();
             }
 
             #[inline]
+            #[track_caller]
             pub fn expect(self, msg: &str) {
                 self.ok().expect(msg);
             }

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -1965,10 +1965,12 @@ pub mod Windows {
                     }
                 }
                 #[inline]
+                #[track_caller]
                 pub fn unwrap(self) {
                     self.ok().unwrap();
                 }
                 #[inline]
+                #[track_caller]
                 pub fn expect(self, msg: &str) {
                     self.ok().expect(msg);
                 }

--- a/src/result/error_code.rs
+++ b/src/result/error_code.rs
@@ -30,6 +30,7 @@ impl HRESULT {
     /// This will  invoke the `panic!` macro if `self` is a failure code and display
     /// the `HRESULT` value for diagnostics.
     #[inline]
+    #[track_caller]
     pub fn unwrap(self) {
         assert!(self.is_ok(), "HRESULT 0x{:X}", self.0);
     }


### PR DESCRIPTION
Annotating a function with `#[track_caller]`, introduced in [Rust 1.46](https://blog.rust-lang.org/2020/08/27/Rust-1.46.0.html#track_caller), causes it to use its caller as the location in its error message on panics. This seems like it would be useful for the unwrap() method on HRESULT, and the unwrap() and expect() methods on BOOL.

Fixes #355