### PR TITLE
Fixes memory leaks

### DIFF
--- a/examples/spellchecker/bindings/build.rs
+++ b/examples/spellchecker/bindings/build.rs
@@ -5,6 +5,6 @@ fn main() {
             IEnumSpellingError, ISpellChecker, ISpellCheckerFactory, ISpellingError,
             SpellCheckerFactory, CORRECTIVE_ACTION,
         },
-        Windows::Win32::System::Com::IEnumString,
+        Windows::Win32::System::Com::{CoTaskMemFree, IEnumString},
     };
 }

--- a/examples/spellchecker/src/main.rs
+++ b/examples/spellchecker/src/main.rs
@@ -22,18 +22,13 @@ fn main() -> windows::Result<()> {
 
     // Create a ISpellChecker
     let mut checker = None;
-    unsafe { factory.CreateSpellChecker(locale, &mut checker).ok()? };
-    let checker = checker.unwrap();
+    let checker = unsafe { factory.CreateSpellChecker(locale, &mut checker) }.and_some(checker)?;
 
     // Get errors enumerator for the supplied string
+    println!("Checking the text: '{}'", input);
     let mut errors = None;
-    unsafe {
-        println!("Checking the text: '{}'", input);
-        checker
-            .ComprehensiveCheck(input.clone(), &mut errors)
-            .ok()?
-    };
-    let errors = errors.unwrap();
+    let errors =
+        unsafe { checker.ComprehensiveCheck(input.clone(), &mut errors) }.and_some(errors)?;
 
     // Loop through all the errors
     loop {
@@ -43,8 +38,7 @@ fn main() -> windows::Result<()> {
         if result == S_FALSE {
             break;
         }
-        result.ok()?;
-        let error = error.unwrap();
+        let error = result.and_some(error)?;
 
         // Get the start index and length of the error
         let mut start_index = 0u32;
@@ -80,8 +74,8 @@ fn main() -> windows::Result<()> {
             Globalization::CORRECTIVE_ACTION_GET_SUGGESTIONS => {
                 // Get an enumerator for all the suggestions for a substring
                 let mut suggestions = None;
-                unsafe { checker.Suggest(substring, &mut suggestions).ok()? };
-                let suggestions = suggestions.unwrap();
+                let suggestions = unsafe { checker.Suggest(substring, &mut suggestions) }
+                    .and_some(suggestions)?;
 
                 // Loop through the suggestions
                 loop {

--- a/examples/spellchecker/src/main.rs
+++ b/examples/spellchecker/src/main.rs
@@ -1,6 +1,7 @@
 use bindings::Windows::Win32;
 use Win32::Foundation::{BOOL, PWSTR, S_FALSE};
 use Win32::Globalization;
+use Win32::System::Com::CoTaskMemFree;
 
 fn main() -> windows::Result<()> {
     let input = std::env::args()
@@ -73,6 +74,8 @@ fn main() -> windows::Result<()> {
                 println!("Replace: {} with {}", substring, unsafe {
                     read_to_string(replacement)
                 });
+
+                unsafe { CoTaskMemFree(replacement.0 as *mut _) };
             }
             Globalization::CORRECTIVE_ACTION_GET_SUGGESTIONS => {
                 // Get an enumerator for all the suggestions for a substring
@@ -94,6 +97,8 @@ fn main() -> windows::Result<()> {
                     println!("Maybe replace: {} with {}", substring, unsafe {
                         read_to_string(suggestion)
                     });
+
+                    unsafe { CoTaskMemFree(suggestion.0 as *mut _) };
                 }
             }
             _ => {}


### PR DESCRIPTION
Fixes #865

This PR adds calls to `CoTaskMemFree` to clean up memory allocated on behalf of the caller. I'm not aware of a convenient way to turn `PWSTR`'s into `*mut c_void`'s, so the calls are a bit clunky: `CoTaskMemFree(suggestion.0 as *mut _)`. If there is a better, more conventional way to go about it, feel free to apply changes.

There's another issue with the code that I'd like to address: The calls to `unwrap()`. After I had discovered the [and_some](https://docs.rs/windows/0.11.0/windows/struct.HRESULT.html#method.and_some) associated function for `HRESULT`, my code changed for the better:

```rust
let mut suggestions = None;
unsafe { checker.Suggest(substring, &mut suggestions).ok()? };
let suggestions = suggestions.unwrap();
```

became

```rust
let mut suggestions = None;
let suggestions = unsafe { checker.Suggest(substring, &mut suggestions) }
    .and_some(suggestions)?;
```

I can apply similar changes, either in this PR or in a separate PR. Or not at all, if there is a reason not to. I'm fine either way, just let me know.

Thanks