### PR TITLE
Make HRESULT derive Eq as well as PartialEq

### DIFF
--- a/src/result/error_code.rs
+++ b/src/result/error_code.rs
@@ -7,7 +7,7 @@ use bindings::{
 
 /// A primitive error code value returned by most COM functions.
 #[repr(transparent)]
-#[derive(Copy, Clone, Default, Debug, PartialEq)]
+#[derive(Copy, Clone, Default, Debug, Eq, PartialEq)]
 #[must_use]
 #[allow(non_camel_case_types)]
 pub struct HRESULT(pub u32);


### PR DESCRIPTION
This allows HRESULTs to be used as constants in match expressions.

Resolves #872 
