### PR TITLE
Explicitly document MSRV

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,9 @@ jobs:
           rust: stable
           other: x86_64-pc-windows-msvc
         - os: windows-latest
+          rust: 1.51.0
+          other: x86_64-pc-windows-msvc
+        - os: windows-latest
           rust: nightly
           other: x86_64-pc-windows-msvc
         - os: windows-latest

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -1,5 +1,9 @@
 # Frequently Asked Questions
 
+## What is the minimum version of Rust (MSRV) that that this crate can be used with?
+
+This crate can be used on Rust 1.51.0 and above.
+
 ## How do I read the signatures of generated functions and methods? What's with `IntoParam`?
 
 Let's take a look at the method signature of `ISpellCheckerFactor::IsSupported`:


### PR DESCRIPTION
Somewhere along the way, we stopped tracking the minimum supported Rust version (MSRV). This adds it back to CI and adds a note about it in the FAQ. 

New CI tests run in parallel and the new pass for the MSRV is faster than other tests we're doing so this does not slow down CI builds. 