### PR TITLE
Fix identity for minimally defined types

### DIFF
--- a/crates/gen/src/tables/type_def.rs
+++ b/crates/gen/src/tables/type_def.rs
@@ -238,8 +238,17 @@ impl TypeDef {
                 dependencies
             }
             TypeKind::Class => {
+                let class = types::Class(self.clone());
                 if include == TypeInclude::Minimal {
-                    return Vec::new();
+                    if let Some(default_interface) = class
+                        .interfaces()
+                        .iter()
+                        .find(|i| i.kind == InterfaceKind::Default)
+                    {
+                        return default_interface.def.definition(TypeInclude::Minimal);
+                    } else {
+                        return Vec::new();
+                    }
                 }
 
                 let generics = self

--- a/crates/gen/src/types/class.rs
+++ b/crates/gen/src/types/class.rs
@@ -208,15 +208,22 @@ impl Class {
                 }
             }
         } else {
+            let default_interface = interfaces
+                .iter()
+                .find(|i| i.kind == InterfaceKind::Default)
+                .unwrap();
+
+            let guid = default_interface.def.gen_guid(gen);
             let type_signature = Literal::byte_string(self.0.type_signature().as_bytes());
 
             quote! {
                 #[repr(transparent)]
                 #[derive(::std::cmp::PartialEq, ::std::cmp::Eq, ::std::clone::Clone, ::std::fmt::Debug)]
+                #[doc(hidden)]
                 pub struct #name(::windows::IInspectable);
                 unsafe impl ::windows::Interface for #name {
                     type Vtable = <::windows::IUnknown as ::windows::Interface>::Vtable;
-                    const IID: ::windows::Guid = ::windows::Guid::zeroed();
+                    const IID: ::windows::Guid = #guid;
                 }
                 unsafe impl ::windows::RuntimeType for #name {
                     type DefaultType = ::std::option::Option<Self>;

--- a/crates/gen/src/types/com_interface.rs
+++ b/crates/gen/src/types/com_interface.rs
@@ -34,10 +34,10 @@ impl ComInterface {
 
     pub fn gen(&self, gen: &Gen, include: TypeInclude) -> TokenStream {
         let name = self.0.gen_name(gen);
+        let guid = self.0.gen_guid(gen);
 
         if include == TypeInclude::Full {
             let abi_name = self.0.gen_abi_name(gen);
-            let guid = self.0.gen_guid(gen);
 
             let bases = self.interfaces();
 
@@ -228,10 +228,11 @@ impl ComInterface {
             quote! {
                 #[repr(transparent)]
                 #[derive(::std::cmp::PartialEq, ::std::cmp::Eq, ::std::clone::Clone, ::std::fmt::Debug)]
+                #[doc(hidden)]
                 pub struct #name(::windows::IUnknown);
                 unsafe impl ::windows::Interface for #name {
                     type Vtable = <::windows::IUnknown as ::windows::Interface>::Vtable;
-                    const IID: ::windows::Guid = ::windows::Guid::zeroed();
+                    const IID: ::windows::Guid = #guid;
                 }
             }
         }

--- a/crates/gen/src/types/interface.rs
+++ b/crates/gen/src/types/interface.rs
@@ -44,9 +44,9 @@ impl Interface {
         let struct_phantoms = self.0.gen_phantoms();
         let constraints = self.0.gen_constraints();
         let type_signature = self.0.gen_signature(&format!("{{{:#?}}}", &self.0.guid()));
+        let guid = self.0.gen_guid(gen);
 
         if include == TypeInclude::Full {
-            let guid = self.0.gen_guid(gen);
             let abi_name = self.0.gen_abi_name(gen);
             let abi_phantoms = self.0.gen_phantoms();
 
@@ -131,13 +131,13 @@ impl Interface {
             }
         } else {
             quote! {
-                // TODO: all minimal types hsould be doc hidden
                 #[repr(transparent)]
                 #[derive(::std::cmp::PartialEq, ::std::cmp::Eq, ::std::clone::Clone, ::std::fmt::Debug)]
+                #[doc(hidden)]
                 pub struct #name(::windows::IInspectable, #(#struct_phantoms,)*) where #constraints;
                 unsafe impl<#constraints> ::windows::Interface for #name {
                     type Vtable = <::windows::IUnknown as ::windows::Interface>::Vtable;
-                    const IID: ::windows::Guid = ::windows::Guid::zeroed();
+                    const IID: ::windows::Guid = #guid;
                 }
                 unsafe impl<#constraints> ::windows::RuntimeType for #name {
                     type DefaultType = ::std::option::Option<Self>;

--- a/tests/imports/tests/imports.rs
+++ b/tests/imports/tests/imports.rs
@@ -73,9 +73,10 @@ fn test_dependencies() {
     assert_eq!(imports["DXGI_FRAME_PRESENTATION_MODE"], TypeInclude::Full);
 
     let imports = get_imports("Windows.Foundation", "IUriRuntimeClassFactory");
-    assert_eq!(imports.len(), 2);
+    assert_eq!(imports.len(), 3);
     assert_eq!(imports["IUriRuntimeClassFactory"], TypeInclude::Full);
     assert_eq!(imports["Uri"], TypeInclude::Minimal);
+    assert_eq!(imports["IUriRuntimeClass"], TypeInclude::Minimal);
 
     let imports = get_imports("Windows.Foundation", "IAsyncAction");
     assert_eq!(imports.len(), 4);


### PR DESCRIPTION
COM and WinRT identity still needs to hold for types that are only partially defined. 