### PR TITLE
More flexible macro formatting

### DIFF
--- a/crates/fmt/src/main.rs
+++ b/crates/fmt/src/main.rs
@@ -1,84 +1,82 @@
-use std::ffi::OsStr;
-use std::io::Result;
-use std::io::Write;
-use std::path::*;
-use std::process::Command;
-use std::process::Stdio;
-
-fn format_file(file: &Path, pattern: &str) -> Result<()> {
+fn update_file(path: &std::path::Path, pattern: &str) -> std::io::Result<()> {
     const SHIM: &str = "use format_build_macro::";
     const SHIM_CURLY: &str = "use format_build_macro::{";
 
-    let contents = std::fs::read(file)?;
-    let contents = String::from_utf8(contents).expect("Failed to parse UTF-8");
+    let before = String::from_utf8(std::fs::read(path)?).expect("Failed to parse UTF-8");
+    let after = before.replace(pattern, SHIM);
 
-    // Replace macro call with our `use` pattern
-    let contents = contents.replace(pattern, SHIM);
+    if before != after {
+        std::fs::write(path, after)?;
 
-    // Spawn `rustfmt` and pipe string through it, instead of writing it to disk
-    let mut child = Command::new("rustfmt")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .spawn()
-        .expect("Failed to spawn `rustfmt`");
-    let mut stdin = child.stdin.take().expect("Failed to open stdin");
-    stdin.write_all(contents.as_bytes())?;
-    drop(stdin);
+        let mut cmd = ::std::process::Command::new("rustfmt");
+        cmd.arg(&path);
+        cmd.output()?;
 
-    // Read formatted output from `rustfmt`
-    let output = child.wait_with_output().expect("Failed to read stdout");
-    let contents = String::from_utf8(output.stdout).expect("Failed to parse UTF-8");
+        let contents = String::from_utf8(std::fs::read(&path)?).expect("Failed to parse UTF-8");
 
-    // Some build macros contain a single item, where curly braces are removed
-    if contents.contains(SHIM_CURLY) {
-        std::fs::write(file, contents.replace(SHIM, pattern))?;
-    } else if let Some(macro_start) = contents.find(SHIM) {
-        // If curly braces have been removed, find the `use` statement and terminating semicolon
-        let usetree_start = macro_start + SHIM.len();
-        let semi = contents[usetree_start..].find(';').expect("Semi");
+        if contents.contains(SHIM_CURLY) {
+            let after = contents.replace(SHIM, pattern);
+            std::fs::write(path, after)?;
+        } else if let Some(macro_start) = contents.find(SHIM) {
+            // If curly braces have been removed, find the `use` statement and terminating semicolon
+            let usetree_start = macro_start + SHIM.len();
+            let semi = contents[usetree_start..].find(';').expect("Semi");
 
-        let indent = contents[..macro_start]
-            .chars()
-            .rev()
-            .take_while(|&c| c == ' ')
-            .count();
+            let indent = contents[..macro_start]
+                .chars()
+                .rev()
+                .take_while(|&c| c == ' ')
+                .count();
 
-        let indent = std::iter::repeat(' ').take(indent).collect::<String>();
+            let indent = std::iter::repeat(' ').take(indent).collect::<String>();
 
-        // Replace `use` with macro call and insert curly braces around the UseTree
-        let macro_ = format!(
-            "{}{{\n    {}{},\n{}}}",
-            pattern,
-            indent,
-            contents[usetree_start..usetree_start + semi].replace('\n', "\n    "),
-            indent,
-        );
-        let mut contents = contents;
-        contents.replace_range(macro_start..usetree_start + semi, &macro_);
-        std::fs::write(file, contents)?;
-    }
+            // Replace `use` with macro call and insert curly braces around the UseTree
+            let macro_ = format!(
+                "{}{{\n    {}{},\n{}}}",
+                pattern,
+                indent,
+                contents[usetree_start..usetree_start + semi].replace('\n', "\n    "),
+                indent,
+            );
 
-    Ok(())
-}
-
-fn walk_path(path: &Path) -> Result<()> {
-    if path.is_dir() {
-        for entry in path.read_dir()? {
-            walk_path(&entry?.path())?;
+            let mut contents = contents;
+            contents.replace_range(macro_start..usetree_start + semi, &macro_);
+            std::fs::write(path, contents)?;
         }
-    } else if path.file_name() == Some(OsStr::new("build.rs")) {
-        format_file(path, "windows::build! ")?;
     }
 
     Ok(())
 }
 
-fn main() -> Result<()> {
-    let dir: std::path::PathBuf = windows_gen::workspace_dir().into();
-    walk_path(&dir)?;
+fn update_dir(dir: &std::path::Path) -> std::io::Result<()> {
+    if dir.is_dir() {
+        for entry in std::fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
 
-    format_file(
-        &dir.join("crates/bindings/src/main.rs"),
-        "let tokens = windows_macros::generate! ",
-    )
+            if path.is_dir() {
+                update_dir(&path)?;
+            } else if path.file_name() == Some(std::ffi::OsStr::new("build.rs")) {
+                update_file(&path, "windows::build! ")?;
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn main() -> std::io::Result<()> {
+    let dir: std::path::PathBuf = std::env::args()
+        .nth(1)
+        .unwrap_or_else(windows_gen::workspace_dir)
+        .into();
+    update_dir(&dir)?;
+
+    let bindings = dir.join("crates/bindings/src/main.rs");
+
+    if bindings.exists() {
+        update_file(&bindings, "let tokens = windows_macros::generate! ")?;
+    }
+
+    Ok(())
 }

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -45,12 +45,8 @@ pub fn build(stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
     let build = parse_macro_input!(stream as BuildMacro);
     let tokens = RawString(build.into_tokens_string());
     let target_dir = std::env::var("PATH").expect("No `PATH` env variable set");
-
-    let target_dir = if let Some(end) = target_dir.find(';') {
-        RawString(target_dir[..end].to_string())
-    } else {
-        RawString("".to_string())
-    };
+    let end = target_dir.find(';').expect("Path not ending in `;`");
+    let target_dir = RawString(target_dir[..end].to_string());
 
     let tokens = quote! {
         {
@@ -127,20 +123,17 @@ pub fn build(stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
             println!("cargo:rustc-link-search=native={}", source.to_str().expect("`CARGO_MANIFEST_DIR` not a valid path"));
 
             let mut destination : ::std::path::PathBuf = #target_dir.into();
+            destination.pop();
+            destination.pop();
 
-            if destination.exists() {
-                destination.pop();
-                destination.pop();
+            let profile = ::std::env::var("PROFILE").expect("No `PROFILE` env variable set");
+            copy_to_profile(&source, &destination, &profile);
 
-                let profile = ::std::env::var("PROFILE").expect("No `PROFILE` env variable set");
-                copy_to_profile(&source, &destination, &profile);
-
-                destination.push(".windows");
-                destination.push("winmd");
-                source.pop();
-                source.push("winmd");
-                copy(&source, &mut destination);
-            }
+            destination.push(".windows");
+            destination.push("winmd");
+            source.pop();
+            source.push("winmd");
+            copy(&source, &mut destination);
         }
     };
 


### PR DESCRIPTION
Tweaks windows_fmt to support formatting other dirs and removes piping as it defeats file and line error reporting. 

Also reverts #960 as ineffective. 