### PR TITLE
Enables experimental support for raw-dylib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,3 +31,4 @@ targets = ["x86_64-pc-windows-msvc"]
 [features]
 default = ["macros"]
 macros = ["gen", "windows_macros"]
+raw_dylib = ["gen/raw_dylib"] # TODO: remove feature once raw-dylib has stablized

--- a/crates/gen/Cargo.toml
+++ b/crates/gen/Cargo.toml
@@ -7,3 +7,6 @@ license = "MIT OR Apache-2.0"
 description = "Code generation for the windows crate"
 
 [dependencies]
+
+[features]
+raw_dylib = []

--- a/tests/raw_dylib/tests/test.rs
+++ b/tests/raw_dylib/tests/test.rs
@@ -1,8 +1,0 @@
-use bindings::Windows::Win32::Gaming::HasExpandedResources;
-
-#[test]
-fn test() {
-    unsafe {
-        HasExpandedResources().unwrap();
-    }
-}

--- a/tests/raw_dylib/tests/test.rs
+++ b/tests/raw_dylib/tests/test.rs
@@ -1,0 +1,8 @@
+use bindings::Windows::Win32::Gaming::HasExpandedResources;
+
+#[test]
+fn test() {
+    unsafe {
+        HasExpandedResources().unwrap();
+    }
+}


### PR DESCRIPTION
The `raw-dylib` linking support that @ricobbe has been working on has made it into nightly builds. This update conditionally takes advantage of `raw-dylib` for Win32 functions when the `raw_dylib` feature is selected. Unfortunately, a test could not be added because cargo ends up sharing the feature-enabled `windows` crate with all tests and I'm not yet ready to turn it on everywhere. Still, this lets us start experimenting with the feature in other crates. Once this is published I'll update [some of the samples](https://github.com/microsoft/windows-samples-rs) to use this feature. 

Fixes #463