### PR TITLE
Document the usage of `HRESULT::from_thread()`

### DIFF
--- a/src/result/hresult.rs
+++ b/src/result/hresult.rs
@@ -80,6 +80,29 @@ impl HRESULT {
     }
 
     /// Retrieves the error code stored on the calling thread.
+    ///
+    /// Example usage:
+    /// ```rust
+    /// # struct HWND(isize);
+    /// # impl HWND {
+    /// #     fn is_null(&self) -> bool { self.0 == 0 }
+    /// # }
+    /// #
+    /// # // Use dummy function as example
+    /// # #[allow(non_snake_case)]
+    /// # fn CreateWindowExA() -> HWND { HWND(1234) }
+    /// #
+    /// # use windows::HRESULT;
+    /// fn create_window() -> windows::Result<HWND> {
+    ///     let hwnd = CreateWindowExA(/* args */);
+    ///
+    ///     if hwnd.is_null() {
+    ///         return Err(HRESULT::from_thread().into());
+    ///     }
+    ///
+    ///     Ok(hwnd)
+    /// }
+    /// ```
     #[inline]
     pub fn from_thread() -> Self {
         Self::from_win32(unsafe { GetLastError().0 })


### PR DESCRIPTION
This small amount of documentation should be helpful to anyone looking through the windows-rs docs for a way to handle Win32 errors.

This example is tested when running `cargo test --all`, so it shouldn't be at risk of becoming outdated.

<details>
<summary>Screenshot of generated documentation</summary>

![image](https://user-images.githubusercontent.com/5243039/125567860-bcf534ac-b243-4b89-b07f-516b725910f7.png)
</details>