### PR TITLE
Prepares HRESULT to transparently store NTSTATUS values

### DIFF
--- a/src/result/hresult.rs
+++ b/src/result/hresult.rs
@@ -5,7 +5,33 @@ use bindings::{
     Windows::Win32::System::Diagnostics::Debug::*,
 };
 
-/// A primitive error code value returned by most COM functions.
+/// Transparently encodes Windows-specific status values.
+///
+/// Status values in Windows fall into one of three categories:
+///
+/// * [`NTSTATUS`](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/87fba13e-bf06-450e-83b1-9241dc81e781) values:  
+///   Commonly used by APIs shared between kernel and user mode.
+///
+/// * [System error codes](https://docs.microsoft.com/en-us/windows/win32/debug/system-error-codes):  
+///   Reported by the API encompassing the Win32 subsystem.
+///
+/// * [`HRESULT`](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/0642cb2f-2075-4469-918c-4441e69c548a) values:  
+///   Primarily used by COM and the Windows Runtime.
+///
+/// Status values from all categories can be represented as an `HRESULT` value that preserves
+/// the original status value as well as the category.
+///
+/// The layout for `NTSTATUS` and `HRESULT` both reserve bit 28 (bit N) to indicate whether
+/// the value represents an `NTSTATUS` code. If it is set, the value represents an
+/// `NTSTATUS` (except that this bit is set).
+///
+/// Otherwise the value represents an `HRESULT`. System error codes converted to an
+/// `HRESULT` set the facility (bits 16 through 26) to `FACILITY_WIN32` (7).
+///
+/// The layout for `NTSTATUS` reserves the two MSBs (Sev) to indicate the outcome of an
+/// operation. Mapping `NTSTATUS` values to a boolean success/failure indicator is thus lossy.
+/// This implementation follows the convention established by `NT_SUCCESS` in only evaluating
+/// the MSB to indicate success, and attributes everything else to an error.
 #[repr(transparent)]
 #[derive(Copy, Clone, Default, Debug, Eq, PartialEq)]
 #[must_use]
@@ -120,29 +146,74 @@ impl HRESULT {
         })
     }
 
+    #[doc(hidden)]
+    /// Returns the win32 error code if the stored value represents a system error code,
+    /// `None` otherwise.
+    pub fn win32_code(&self) -> Option<u32> {
+        let hresult = self.0;
+        // Checking the facility isn't sufficient. `NTSTATUS` codes also define a standard
+        // facility `FACILITY_NTWIN32` with value 7, so we have to verify that the stored
+        // value isn't an `NTSTATUS` code first.
+        if self.ntstatus_code().is_none() && ((hresult >> 16) & 0x7FF) == 7 {
+            Some(hresult & 0xFFFF)
+        } else {
+            None
+        }
+    }
+
+    // Bitmask that determines whether the stored HRESULT refers to an NTSTATUS (0b1) or
+    // an HRESULT (0b0)
+    const FACILITY_NT_BIT: u32 = 1_u32 << 28;
+
+    #[doc(hidden)]
+    /// Used internally to map an `NTSTATUS` value to an `HRESULT` value.
+    ///
+    /// This is equivalent to [HRESULT_FROM_NT](https://docs.microsoft.com/en-us/windows/win32/api/winerror/nf-winerror-hresult_from_nt).
+    pub fn from_ntstatus(error: u32) -> Self {
+        debug_assert!(error & Self::FACILITY_NT_BIT == 0, "Invalid NTSTATUS code");
+        Self(error | Self::FACILITY_NT_BIT)
+    }
+
+    #[doc(hidden)]
+    /// Returns the `NTSTATUS` code if the stored value represents an `NTSTATUS` code,
+    /// `None` otherwise.
+    pub fn ntstatus_code(&self) -> Option<u32> {
+        let hresult = self.0;
+        if hresult & Self::FACILITY_NT_BIT != 0 {
+            Some(hresult & !Self::FACILITY_NT_BIT)
+        } else {
+            None
+        }
+    }
+
     /// The error message describing the error.
     pub fn message(&self) -> String {
-        let mut message = HeapString(std::ptr::null_mut());
+        if let Some(code) = self.ntstatus_code() {
+            // `FormatMessageW` cannot be used with `NTSTATUS` codes
+            format!("NTSTATUS: {:#010X}", code)
+        } else {
+            let mut message = HeapString(std::ptr::null_mut());
 
-        unsafe {
-            let size = FormatMessageW(
-                FORMAT_MESSAGE_ALLOCATE_BUFFER
-                    | FORMAT_MESSAGE_FROM_SYSTEM
-                    | FORMAT_MESSAGE_IGNORE_INSERTS,
-                std::ptr::null(),
-                self.0,
-                0,
-                PWSTR(std::mem::transmute(&mut message.0)),
-                0,
-                std::ptr::null_mut(),
-            );
+            unsafe {
+                let size = FormatMessageW(
+                    FORMAT_MESSAGE_ALLOCATE_BUFFER
+                        | FORMAT_MESSAGE_FROM_SYSTEM
+                        | FORMAT_MESSAGE_IGNORE_INSERTS,
+                    std::ptr::null(),
+                    self.0,
+                    0,
+                    PWSTR(std::mem::transmute(&mut message.0)),
+                    0,
+                    std::ptr::null_mut(),
+                );
 
-            String::from_utf16_lossy(std::slice::from_raw_parts(
-                message.0 as *const u16,
-                size as usize,
-            ))
-            .trim_end()
-            .to_owned()
+                String::from_utf16_lossy(std::slice::from_raw_parts(
+                    message.0 as *const u16,
+                    size as usize,
+                ))
+                .trim_end()
+                .to_owned()
+            }
         }
     }
 }


### PR DESCRIPTION
Introducing idiomatic Rust error handling for `NTSTATUS` values requires two steps:

1. Allowing `HRESULT` to transparently encode `NTSTATUS` values.
2. Extending/augmenting/enlightening the generated `NTSTATUS` struct.

This PR proposes a solution to solving the first (for the moment). The core idea revolves around the fact that any [`NTSTATUS`](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/87fba13e-bf06-450e-83b1-9241dc81e781) value can be mapped to an [`HRESULT`](https://docs.microsoft.com/en-us/openspecs/windows_protocols/ms-erref/0642cb2f-2075-4469-918c-4441e69c548a) value, that is distinct from any other `HRESULT` value. This makes `HRESULT` the perfect container to store any Win32 system error code, `NTSTATUS`, or (regular) `HRESULT`.

The following changes were done:

* Added `HRESULT::from_ntstatus()`:  
  This turns `NTSTATUS` values into `HRESULT`s, similar to `from_win32()`. Outside of testing, this is not used, but rather is in preparation of a future `impl From<NTSTATUS> for windows::Result`.
* Added `HRESULT::ntstatus_code()`:  
  Similar to `win32_code()` verifies whether the stored value is an `NTSTATUS` value and, if so, returns the decoded `NTSTATUS` value.
* Adjusted `HRESULT::message()`:  
  Since `FormatMessage` can only be used with (regular) `HRESULT`s, this function produces a generic message for `NTSTATUS` values (e.g. `"NTSTATUS: 0xC0000005"`).
* `std::fmt::Debug for Error` did not need adjustments. In case of an `NTSTATUS`, the `message` already contains the decoded value and an additional debug field is not required.

If that all looks reasonable, I would try working on the second part. For that I would need a bit of guidance, though (e.g. would this be best done in `gen_replacement()` or `gen_extensions()`, and so on).