### PR TITLE
Doc improvements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -32,7 +32,7 @@ pub use runtime::{
     create_instance, factory, initialize_mta, initialize_sta, Array, FactoryCache, Guid, Param,
     RefCount, Waiter, Weak, WeakRefCount, HSTRING,
 };
-pub use traits::{Abi, Compose, Interface, IntoParam, RuntimeName, RuntimeType, ToImpl};
+pub use traits::*;
 
 #[cfg(feature = "macros")]
 pub use windows_macros::{build, implement};

--- a/src/runtime/factory_cache.rs
+++ b/src/runtime/factory_cache.rs
@@ -5,8 +5,7 @@ use std::sync::atomic::{AtomicPtr, Ordering};
 
 type DllGetActivationFactory = extern "system" fn(name: RawPtr, factory: *mut RawPtr) -> HRESULT;
 
-/// Attempts to load and cache the factory interface for the given WinRT class. This is automatically
-// used by the generated bindings and should not generally be used directly.
+#[doc(hidden)]
 pub struct FactoryCache<C, I> {
     shared: AtomicPtr<std::ffi::c_void>,
     _c: PhantomData<C>,

--- a/src/runtime/ref_count.rs
+++ b/src/runtime/ref_count.rs
@@ -1,6 +1,6 @@
 use std::sync::atomic::{fence, AtomicI32, Ordering};
 
-/// A thread-safe reference count for use with COM/HSTRING implementations.
+#[doc(hidden)]
 #[repr(transparent)]
 #[derive(Default)]
 pub struct RefCount(pub(crate) AtomicI32);

--- a/src/runtime/waiter.rs
+++ b/src/runtime/waiter.rs
@@ -5,7 +5,7 @@ use bindings::{
     Windows::Win32::System::Threading::{CreateEventA, SetEvent, WaitForSingleObject},
 };
 
-/// A simple blocking waiter used by the generated bindings and should not be used directly.
+#[doc(hidden)]
 pub struct Waiter(HANDLE);
 pub struct WaiterSignaler(HANDLE);
 

--- a/src/runtime/weak_ref_count.rs
+++ b/src/runtime/weak_ref_count.rs
@@ -15,7 +15,7 @@ use bindings::Windows::Win32::{
 };
 use std::sync::atomic::{AtomicIsize, Ordering};
 
-/// A thread-safe reference count for use with COM weak reference implementations.
+#[doc(hidden)]
 #[repr(transparent)]
 #[derive(Default)]
 pub struct WeakRefCount(AtomicIsize);

--- a/src/traits/compose.rs
+++ b/src/traits/compose.rs
@@ -1,5 +1,6 @@
 use crate::*;
 
+#[doc(hidden)]
 pub trait Compose {
     unsafe fn compose<'a>(implementation: Self) -> (IInspectable, &'a mut Option<IInspectable>);
 }

--- a/src/traits/into_param.rs
+++ b/src/traits/into_param.rs
@@ -1,5 +1,6 @@
 use super::*;
 
+#[doc(hidden)]
 pub trait IntoParam<'a, T: Abi> {
     fn into_param(self) -> Param<'a, T>;
 }

--- a/src/traits/to_impl.rs
+++ b/src/traits/to_impl.rs
@@ -1,5 +1,10 @@
 use super::*;
 
+/// A trait for retrieving the implementation behind a COM or WinRT interface.
+///
+/// This trait is automatically implemented when using the [`implement`] macro but
+/// is considered unsafe since different implemenetations of the `from` interface
+// may exist.
 pub unsafe trait ToImpl<T: Interface> {
     fn to_impl(from: &T) -> &mut Self;
 }


### PR DESCRIPTION
Minor improvements to documentation. Hides some implementation details and documents the new `ToImpl` trait used by implementors. 