### PR TITLE
Correct `ToImpl` safety requirement

### DIFF
--- a/crates/macros/src/implement.rs
+++ b/crates/macros/src/implement.rs
@@ -141,12 +141,10 @@ pub fn gen(
                             }
                         }
                     }
-                    unsafe impl<#constraints> ::windows::ToImpl<#interface_ident> for #impl_ident {
-                        fn to_impl(interface: &#interface_ident) -> &mut Self {
-                            unsafe {
-                                let this = (::windows::Abi::abi(interface) as *mut ::windows::RawPtr).sub(2 + #interface_count) as *mut #box_ident::<#(#generics,)*>;
-                                &mut (*this).implementation
-                            }
+                    impl<#constraints> ::windows::ToImpl<#interface_ident> for #impl_ident {
+                        unsafe fn to_impl(interface: &#interface_ident) -> &mut Self {
+                            let this = (::windows::Abi::abi(interface) as *mut ::windows::RawPtr).sub(2 + #interface_count) as *mut #box_ident::<#(#generics,)*>;
+                            &mut (*this).implementation
                         }
                     }
                 });

--- a/src/traits/to_impl.rs
+++ b/src/traits/to_impl.rs
@@ -5,6 +5,6 @@ use super::*;
 /// This trait is automatically implemented when using the [`implement`] macro but
 /// is considered unsafe since different implemenetations of the `from` interface
 // may exist.
-pub unsafe trait ToImpl<T: Interface> {
-    fn to_impl(from: &T) -> &mut Self;
+pub trait ToImpl<T: Interface> {
+    unsafe fn to_impl(from: &T) -> &mut Self;
 }

--- a/tests/implement/tests/into_impl.rs
+++ b/tests/implement/tests/into_impl.rs
@@ -17,7 +17,7 @@ where
 #[allow(non_snake_case)]
 impl<T: RuntimeType + 'static> Iterator<T> {
     fn Current(&self) -> Result<T> {
-        let owner = Iterable::to_impl(&self.owner);
+        let owner = unsafe { Iterable::to_impl(&self.owner) };
 
         if owner.0.len() > self.current {
             Ok(owner.0[self.current].clone())
@@ -27,12 +27,12 @@ impl<T: RuntimeType + 'static> Iterator<T> {
     }
 
     fn HasCurrent(&self) -> Result<bool> {
-        let owner = Iterable::to_impl(&self.owner);
+        let owner = unsafe { Iterable::to_impl(&self.owner) };
         Ok(owner.0.len() > self.current)
     }
 
     fn MoveNext(&mut self) -> Result<bool> {
-        let owner = Iterable::to_impl(&self.owner);
+        let owner = unsafe { Iterable::to_impl(&self.owner) };
         self.current += 1;
         Ok(owner.0.len() > self.current)
     }


### PR DESCRIPTION
The `to_impl` function should be unsafe rather than the `ToImpl` trait so that callsites are forced to make the decision about the safety of the call. 