### PR TITLE
Simplify type remapping

### DIFF
--- a/crates/gen/src/parser/element_type.rs
+++ b/crates/gen/src/parser/element_type.rs
@@ -22,7 +22,6 @@ pub enum ElementType {
     IUnknown,
     IInspectable,
     HRESULT,
-    Matrix3x2,
     TypeName,
     GenericParam(String),
     Array((Box<Signature>, u32)),
@@ -148,10 +147,6 @@ impl ElementType {
             Self::HRESULT => {
                 quote! { ::windows::HRESULT }
             }
-            Self::Matrix3x2 => {
-                let numerics = gen.namespace("Windows.Foundation.Numerics");
-                quote! { #numerics Matrix3x2 }
-            }
             Self::Array((kind, len)) => {
                 let name = kind.gen_win32(gen);
                 let len = Literal::u32_unsuffixed(*len);
@@ -199,10 +194,6 @@ impl ElementType {
             }
             Self::HRESULT => {
                 quote! { ::windows::HRESULT }
-            }
-            Self::Matrix3x2 => {
-                let numerics = gen.namespace("Windows.Foundation.Numerics");
-                quote! { #numerics Matrix3x2 }
             }
             Self::Array((kind, len)) => {
                 let name = kind.gen_win32_abi(gen);
@@ -278,16 +269,6 @@ impl ElementType {
         match self {
             Self::TypeDef(t) => t.definition(include),
             Self::Array((signature, _)) => signature.definition(include),
-            // TODO: find a cleaner way to map this dependency
-            Self::Matrix3x2 => {
-                vec![TypeEntry {
-                    include,
-                    def: TypeRow::TypeDef(
-                        TypeReader::get()
-                            .resolve_type_def("Windows.Foundation.Numerics", "Matrix3x2"),
-                    ),
-                }]
-            }
             _ => Vec::new(),
         }
     }
@@ -316,7 +297,6 @@ impl ElementType {
             | Self::IInspectable
             | Self::Guid
             | Self::IUnknown
-            | Self::Matrix3x2
             | Self::GenericParam(_) => true,
             _ => false,
         }
@@ -354,7 +334,7 @@ impl ElementType {
     pub fn is_udt(&self) -> bool {
         match self {
             Self::TypeDef(t) => t.is_udt(),
-            Self::Guid | Self::Matrix3x2 => true,
+            Self::Guid => true,
             _ => false,
         }
     }

--- a/crates/gen/src/parser/type_reader.rs
+++ b/crates/gen/src/parser/type_reader.rs
@@ -334,6 +334,12 @@ impl TypeReader {
             }
         }
 
+        for (from, to) in &REMAP_TYPES {
+            if full_name == *from {
+                return TypeReader::get().resolve_type_def(to.0, to.1).into();
+            }
+        }
+
         code.resolve().into()
     }
 
@@ -395,7 +401,12 @@ fn is_well_known(namespace: &'static str, name: &'static str) -> bool {
     false
 }
 
-const WELL_KNOWN_TYPES: [(&str, &str, ElementType); 10] = [
+const REMAP_TYPES: [((&str, &str), (&str, &str)); 1] = [((
+    ("Windows.Win32.Graphics.Direct2D", "D2D_MATRIX_3X2_F"),
+    ("Windows.Foundation.Numerics", "Matrix3x2"),
+))];
+
+const WELL_KNOWN_TYPES: [(&str, &str, ElementType); 9] = [
     ("System", "Guid", ElementType::Guid),
     (
         "Windows.Win32.System.Com",
@@ -419,11 +430,6 @@ const WELL_KNOWN_TYPES: [(&str, &str, ElementType); 10] = [
         "Windows.Win32.System.SystemServices",
         "ULARGE_INTEGER",
         ElementType::U64,
-    ),
-    (
-        "Windows.Win32.Graphics.Direct2D",
-        "D2D_MATRIX_3X2_F",
-        ElementType::Matrix3x2,
     ),
     ("System", "Type", ElementType::TypeName),
 ];


### PR DESCRIPTION
A bit of refactoring to simplify type remapping and avoid making `Matrix3x2` a special snowflake. 

It should now be a lot easier to remap equivalent types as needed and simplify fixing #456