### PR TITLE
Run cargo-clippy in the CI for every push

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,15 @@ jobs:
     - name: run cargo fmt
       run: cargo fmt --all -- --check
 
+  cargo_clippy:
+    runs-on: windows-latest
+    name: check cargo clippy
+    steps:
+    - uses: actions/checkout@v2
+    - name: run cargo clippy
+      # TODO: Add  --all-targets when the tests adhere to clippy lints
+      run: cargo clippy --all -- -D warnings
+
   cargo_doc:
     runs-on: ubuntu-latest
     name: check cargo docs


### PR DESCRIPTION
`clippy` is extremely handy in pointing out code smells, and has a hoist of suggestions to (usually) write the same Rust code in a more concise way. Seeing some earlier `clippy` passes committed to this repo I can't help but request for lints to be checked in every PR rather than procrastinating them to larger batches. It's easier to fix a few to appease the CI every now and then - and keep the code free of apparent smells at all times - than it is to deal with large swaths the fact. I hope you agree.

This PR is pretty much draft (but draft status prevents CI from running) to show what that'd look like, but keep in mind that `-Dwarnings` stops clippy after the first crate with a non-zero exit-code; there are far more warnings than shown here.