### PR TITLE
More refactoring for COM support

### DIFF
--- a/.github/readme.md
+++ b/.github/readme.md
@@ -26,7 +26,7 @@ windows = "0.18.0"
 
 This will allow Cargo to download, build, and cache Windows support as a package. Next, specify which types you need inside of a `build.rs` build script and the `windows` crate will generate the necessary bindings:
 
-```rust
+```ignore
 fn main() {
     windows::build! {
         Windows::Data::Xml::Dom::*,
@@ -39,7 +39,7 @@ fn main() {
 
 Finally, make use of any Windows APIs as needed.
 
-```rust
+```ignore
 mod bindings {
     windows::include_bindings!();
 }

--- a/.github/readme.md
+++ b/.github/readme.md
@@ -26,7 +26,7 @@ windows = "0.18.0"
 
 This will allow Cargo to download, build, and cache Windows support as a package. Next, specify which types you need inside of a `build.rs` build script and the `windows` crate will generate the necessary bindings:
 
-```ignore
+```rust
 fn main() {
     windows::build! {
         Windows::Data::Xml::Dom::*,
@@ -39,7 +39,7 @@ fn main() {
 
 Finally, make use of any Windows APIs as needed.
 
-```ignore
+```rust
 mod bindings {
     windows::include_bindings!();
 }

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
           rust: stable
           other: x86_64-pc-windows-msvc
         - os: windows-latest
-          rust: 1.53.0
+          rust: 1.54.0
           other: x86_64-pc-windows-msvc
         - os: windows-latest
           rust: nightly

--- a/crates/gen/src/parser/method_signature.rs
+++ b/crates/gen/src/parser/method_signature.rs
@@ -350,15 +350,15 @@ impl MethodSignature {
 
         if self.has_query_interface() {
             quote! {
-                panic!("one")
+                unimplemented!("one")
             }
         } else if self.has_retval() {
             quote! {
-                panic!("two")
+                unimplemented!("two")
             }
         } else if self.has_udt_return() {
             quote! {
-                panic!("three")
+                unimplemented!("three")
             }
         } else if let Some(return_type) = &self.return_type {
             if return_type.kind == ElementType::HRESULT {
@@ -367,12 +367,12 @@ impl MethodSignature {
                 }
             } else {
                 quote! {
-                    panic!("five")
+                    unimplemented!("five")
                 }
             }
         } else {
             quote! {
-                panic!("six")
+                unimplemented!("six")
             }
         }
     }

--- a/crates/gen/src/parser/method_signature.rs
+++ b/crates/gen/src/parser/method_signature.rs
@@ -344,9 +344,9 @@ impl MethodSignature {
 
     pub fn gen_win32_upcall(&self, inner: TokenStream, gen: &Gen) -> TokenStream {
         let invoke_args = self
-        .params
-        .iter()
-        .map(|param| param.gen_win32_invoke_arg(gen));
+            .params
+            .iter()
+            .map(|param| param.gen_win32_invoke_arg(gen));
 
         if self.has_query_interface() {
             quote! {

--- a/crates/gen/src/types/bool32.rs
+++ b/crates/gen/src/types/bool32.rs
@@ -8,6 +8,7 @@ pub fn gen_bool32() -> TokenStream {
 
         unsafe impl ::windows::Abi for BOOL {
             type Abi = Self;
+            type DefaultType = Self;
         }
         impl BOOL {
             #[inline]

--- a/crates/gen/src/types/bstr.rs
+++ b/crates/gen/src/types/bstr.rs
@@ -142,6 +142,7 @@ pub fn gen_bstr() -> TokenStream {
         }
         unsafe impl ::windows::Abi for BSTR {
             type Abi = *mut u16;
+            type DefaultType = Self;
 
             fn set_abi(&mut self) -> *mut *mut u16 {
                 debug_assert!(self.0.is_null());

--- a/crates/gen/src/types/class.rs
+++ b/crates/gen/src/types/class.rs
@@ -178,7 +178,6 @@ impl Class {
                         #(#factories)*
                     }
                     unsafe impl ::windows::RuntimeType for #name {
-                        type DefaultType = ::std::option::Option<Self>;
                         const SIGNATURE: ::windows::ConstBuffer = ::windows::ConstBuffer::from_slice(#type_signature);
                     }
                     unsafe impl ::windows::Interface for #name {
@@ -226,7 +225,6 @@ impl Class {
                     const IID: ::windows::Guid = #guid;
                 }
                 unsafe impl ::windows::RuntimeType for #name {
-                    type DefaultType = ::std::option::Option<Self>;
                     const SIGNATURE: ::windows::ConstBuffer = ::windows::ConstBuffer::from_slice(#type_signature);
                 }
             }

--- a/crates/gen/src/types/com_interface.rs
+++ b/crates/gen/src/types/com_interface.rs
@@ -45,31 +45,7 @@ impl ComInterface {
                 .map(|def| def.methods())
                 .flatten()
                 .map(|method| {
-                    let signature = method.signature(&[]);
-
-                    let params = signature.params.iter().map(|p| {
-                        let name = p.param.gen_name();
-                        let tokens = p.gen_win32_abi_param(gen);
-                        quote! { #name: #tokens }
-                    });
-
-                    let (udt_return_type, return_type) = if let Some(t) = &signature.return_type {
-                        if t.is_udt() {
-                            let mut t = t.clone();
-                            t.pointers += 1;
-                            let tokens = t.gen_win32_abi(gen);
-                            (quote! { result__: #tokens }, quote! {})
-                        } else {
-                            let tokens = t.gen_win32_abi(gen);
-                            (quote! {}, quote! { -> #tokens })
-                        }
-                    } else {
-                        (TokenStream::new(), TokenStream::new())
-                    };
-
-                    quote! {
-                        (this: ::windows::RawPtr, #(#params,)* #udt_return_type) #return_type
-                    }
+                    method.signature(&[]).gen_win32_abi(gen)
                 });
 
             let mut method_names = BTreeMap::<String, u32>::new();

--- a/crates/gen/src/types/com_interface.rs
+++ b/crates/gen/src/types/com_interface.rs
@@ -44,9 +44,7 @@ impl ComInterface {
                 .chain(std::iter::once(&self.0))
                 .map(|def| def.methods())
                 .flatten()
-                .map(|method| {
-                    method.signature(&[]).gen_win32_abi(gen)
-                });
+                .map(|method| method.signature(&[]).gen_win32_abi(gen));
 
             let mut method_names = BTreeMap::<String, u32>::new();
 

--- a/crates/gen/src/types/delegate.rs
+++ b/crates/gen/src/types/delegate.rs
@@ -76,7 +76,6 @@ impl Delegate {
                 #invoke
             }
             unsafe impl<#constraints> ::windows::RuntimeType for #name {
-                type DefaultType = ::std::option::Option<Self>;
                 const SIGNATURE: ::windows::ConstBuffer = #type_signature;
             }
             unsafe impl<#constraints> ::windows::Interface for #name {

--- a/crates/gen/src/types/enum.rs
+++ b/crates/gen/src/types/enum.rs
@@ -103,7 +103,6 @@ impl Enum {
 
             quote! {
                 unsafe impl ::windows::RuntimeType for #name {
-                    type DefaultType = Self;
                     const SIGNATURE: ::windows::ConstBuffer = ::windows::ConstBuffer::from_slice(#signature);
                 }
             }
@@ -123,6 +122,7 @@ impl Enum {
             }
             unsafe impl ::windows::Abi for #name {
                 type Abi = Self;
+                type DefaultType = Self;
             }
             #runtime_type
             #bitwise

--- a/crates/gen/src/types/interface.rs
+++ b/crates/gen/src/types/interface.rs
@@ -95,7 +95,6 @@ impl Interface {
                         #async_get
                     }
                     unsafe impl<#constraints> ::windows::RuntimeType for #name {
-                        type DefaultType = ::std::option::Option<Self>;
                         const SIGNATURE: ::windows::ConstBuffer = #type_signature;
                     }
                     #future
@@ -140,7 +139,6 @@ impl Interface {
                     const IID: ::windows::Guid = #guid;
                 }
                 unsafe impl<#constraints> ::windows::RuntimeType for #name {
-                    type DefaultType = ::std::option::Option<Self>;
                     const SIGNATURE: ::windows::ConstBuffer = #type_signature;
                 }
             }

--- a/crates/gen/src/types/ntstatus.rs
+++ b/crates/gen/src/types/ntstatus.rs
@@ -34,6 +34,7 @@ pub fn gen_ntstatus() -> TokenStream {
 
         unsafe impl ::windows::Abi for NTSTATUS {
             type Abi = Self;
+            type DefaultType = Self;
         }
     }
 }

--- a/crates/gen/src/types/pstr.rs
+++ b/crates/gen/src/types/pstr.rs
@@ -25,6 +25,7 @@ pub fn gen_pstr() -> TokenStream {
         }
         unsafe impl ::windows::Abi for PSTR {
             type Abi = Self;
+            type DefaultType = Self;
 
             fn drop_param(param: &mut ::windows::Param<'_, Self>) {
                 if let ::windows::Param::Boxed(value) = param {

--- a/crates/gen/src/types/pwstr.rs
+++ b/crates/gen/src/types/pwstr.rs
@@ -25,6 +25,7 @@ pub fn gen_pwstr() -> TokenStream {
         }
         unsafe impl ::windows::Abi for PWSTR {
             type Abi = Self;
+            type DefaultType = Self;
 
             fn drop_param(param: &mut ::windows::Param<'_, Self>) {
                 if let ::windows::Param::Boxed(value) = param {

--- a/crates/gen/src/types/struct.rs
+++ b/crates/gen/src/types/struct.rs
@@ -82,7 +82,6 @@ impl Struct {
 
             quote! {
                 unsafe impl ::windows::RuntimeType for #name {
-                    type DefaultType = Self;
                     const SIGNATURE: ::windows::ConstBuffer = ::windows::ConstBuffer::from_slice(#signature);
                 }
             }
@@ -148,6 +147,7 @@ impl Struct {
             quote! {
                 unsafe impl ::windows::Abi for #name {
                     type Abi = Self;
+                    type DefaultType = Self;
                 }
             }
         } else {
@@ -174,6 +174,7 @@ impl Struct {
                 pub #struct_or_union #abi_name{ #fields }
                 unsafe impl ::windows::Abi for #name {
                     type Abi = #abi_name;
+                    type DefaultType = Self;
                 }
             }
         };

--- a/crates/macros/src/implement.rs
+++ b/crates/macros/src/implement.rs
@@ -132,9 +132,8 @@ pub fn gen(
                         .gen_winrt_upcall(quote! { (*this).implementation.#method_ident }, &gen)
                 }
             } else {
-                quote! {
-                    panic!();
-                }
+                signature
+                        .gen_win32_upcall(quote! { (*this).implementation.#method_ident }, &gen)
             };
 
             shims.combine(&quote! {

--- a/crates/macros/src/implement.rs
+++ b/crates/macros/src/implement.rs
@@ -113,7 +113,7 @@ pub fn gen(
 
             let signature = method.signature(&def.generics);
 
-            let abi_signature = if is_winrt { 
+            let abi_signature = if is_winrt {
                 signature.gen_winrt_abi(&gen)
             } else {
                 signature.gen_win32_abi(&gen)
@@ -132,8 +132,7 @@ pub fn gen(
                         .gen_winrt_upcall(quote! { (*this).implementation.#method_ident }, &gen)
                 }
             } else {
-                signature
-                        .gen_win32_upcall(quote! { (*this).implementation.#method_ident }, &gen)
+                signature.gen_win32_upcall(quote! { (*this).implementation.#method_ident }, &gen)
             };
 
             shims.combine(&quote! {

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -44,9 +44,9 @@ pub mod Windows {
         impl ::std::cmp::Eq for DateTime {}
         unsafe impl ::windows::Abi for DateTime {
             type Abi = Self;
+            type DefaultType = Self;
         }
         unsafe impl ::windows::RuntimeType for DateTime {
-            type DefaultType = Self;
             const SIGNATURE: ::windows::ConstBuffer =
                 ::windows::ConstBuffer::from_slice(b"struct(Windows.Foundation.DateTime;i8)");
         }
@@ -543,7 +543,6 @@ pub mod Windows {
             }
         }
         unsafe impl ::windows::RuntimeType for IPropertyValue {
-            type DefaultType = ::std::option::Option<Self>;
             const SIGNATURE: ::windows::ConstBuffer =
                 ::windows::ConstBuffer::from_slice(b"{4bd682dd-7554-40e9-9a9b-82654ede7e62}");
         }
@@ -1521,7 +1520,6 @@ pub mod Windows {
             }
         }
         unsafe impl<T: ::windows::RuntimeType + 'static> ::windows::RuntimeType for IReference<T> {
-            type DefaultType = ::std::option::Option<Self>;
             const SIGNATURE: ::windows::ConstBuffer = {
                 ::windows::ConstBuffer::new()
                     .push_slice(b"pinterface(")
@@ -1645,7 +1643,6 @@ pub mod Windows {
             }
         }
         unsafe impl ::windows::RuntimeType for IStringable {
-            type DefaultType = ::std::option::Option<Self>;
             const SIGNATURE: ::windows::ConstBuffer =
                 ::windows::ConstBuffer::from_slice(b"{96369f54-8eb6-48f0-abce-c1b211e627c3}");
         }
@@ -1725,9 +1722,9 @@ pub mod Windows {
         impl ::std::cmp::Eq for Point {}
         unsafe impl ::windows::Abi for Point {
             type Abi = Self;
+            type DefaultType = Self;
         }
         unsafe impl ::windows::RuntimeType for Point {
-            type DefaultType = Self;
             const SIGNATURE: ::windows::ConstBuffer =
                 ::windows::ConstBuffer::from_slice(b"struct(Windows.Foundation.Point;f4;f4)");
         }
@@ -1791,9 +1788,9 @@ pub mod Windows {
         }
         unsafe impl ::windows::Abi for PropertyType {
             type Abi = Self;
+            type DefaultType = Self;
         }
         unsafe impl ::windows::RuntimeType for PropertyType {
-            type DefaultType = Self;
             const SIGNATURE: ::windows::ConstBuffer =
                 ::windows::ConstBuffer::from_slice(b"enum(Windows.Foundation.PropertyType;i4)");
         }
@@ -2052,7 +2049,7 @@ pub mod Windows {
                 })
             }
             pub fn CreateUInt8Array(
-                value: &[<u8 as ::windows::RuntimeType>::DefaultType],
+                value: &[<u8 as ::windows::Abi>::DefaultType],
             ) -> ::windows::Result<::windows::IInspectable> {
                 Self::IPropertyValueStatics(|this| unsafe {
                     let mut result__: <::windows::IInspectable as ::windows::Abi>::Abi =
@@ -2067,7 +2064,7 @@ pub mod Windows {
                 })
             }
             pub fn CreateInt16Array(
-                value: &[<i16 as ::windows::RuntimeType>::DefaultType],
+                value: &[<i16 as ::windows::Abi>::DefaultType],
             ) -> ::windows::Result<::windows::IInspectable> {
                 Self::IPropertyValueStatics(|this| unsafe {
                     let mut result__: <::windows::IInspectable as ::windows::Abi>::Abi =
@@ -2082,7 +2079,7 @@ pub mod Windows {
                 })
             }
             pub fn CreateUInt16Array(
-                value: &[<u16 as ::windows::RuntimeType>::DefaultType],
+                value: &[<u16 as ::windows::Abi>::DefaultType],
             ) -> ::windows::Result<::windows::IInspectable> {
                 Self::IPropertyValueStatics(|this| unsafe {
                     let mut result__: <::windows::IInspectable as ::windows::Abi>::Abi =
@@ -2097,7 +2094,7 @@ pub mod Windows {
                 })
             }
             pub fn CreateInt32Array(
-                value: &[<i32 as ::windows::RuntimeType>::DefaultType],
+                value: &[<i32 as ::windows::Abi>::DefaultType],
             ) -> ::windows::Result<::windows::IInspectable> {
                 Self::IPropertyValueStatics(|this| unsafe {
                     let mut result__: <::windows::IInspectable as ::windows::Abi>::Abi =
@@ -2112,7 +2109,7 @@ pub mod Windows {
                 })
             }
             pub fn CreateUInt32Array(
-                value: &[<u32 as ::windows::RuntimeType>::DefaultType],
+                value: &[<u32 as ::windows::Abi>::DefaultType],
             ) -> ::windows::Result<::windows::IInspectable> {
                 Self::IPropertyValueStatics(|this| unsafe {
                     let mut result__: <::windows::IInspectable as ::windows::Abi>::Abi =
@@ -2127,7 +2124,7 @@ pub mod Windows {
                 })
             }
             pub fn CreateInt64Array(
-                value: &[<i64 as ::windows::RuntimeType>::DefaultType],
+                value: &[<i64 as ::windows::Abi>::DefaultType],
             ) -> ::windows::Result<::windows::IInspectable> {
                 Self::IPropertyValueStatics(|this| unsafe {
                     let mut result__: <::windows::IInspectable as ::windows::Abi>::Abi =
@@ -2142,7 +2139,7 @@ pub mod Windows {
                 })
             }
             pub fn CreateUInt64Array(
-                value: &[<u64 as ::windows::RuntimeType>::DefaultType],
+                value: &[<u64 as ::windows::Abi>::DefaultType],
             ) -> ::windows::Result<::windows::IInspectable> {
                 Self::IPropertyValueStatics(|this| unsafe {
                     let mut result__: <::windows::IInspectable as ::windows::Abi>::Abi =
@@ -2157,7 +2154,7 @@ pub mod Windows {
                 })
             }
             pub fn CreateSingleArray(
-                value: &[<f32 as ::windows::RuntimeType>::DefaultType],
+                value: &[<f32 as ::windows::Abi>::DefaultType],
             ) -> ::windows::Result<::windows::IInspectable> {
                 Self::IPropertyValueStatics(|this| unsafe {
                     let mut result__: <::windows::IInspectable as ::windows::Abi>::Abi =
@@ -2172,7 +2169,7 @@ pub mod Windows {
                 })
             }
             pub fn CreateDoubleArray(
-                value: &[<f64 as ::windows::RuntimeType>::DefaultType],
+                value: &[<f64 as ::windows::Abi>::DefaultType],
             ) -> ::windows::Result<::windows::IInspectable> {
                 Self::IPropertyValueStatics(|this| unsafe {
                     let mut result__: <::windows::IInspectable as ::windows::Abi>::Abi =
@@ -2187,7 +2184,7 @@ pub mod Windows {
                 })
             }
             pub fn CreateChar16Array(
-                value: &[<u16 as ::windows::RuntimeType>::DefaultType],
+                value: &[<u16 as ::windows::Abi>::DefaultType],
             ) -> ::windows::Result<::windows::IInspectable> {
                 Self::IPropertyValueStatics(|this| unsafe {
                     let mut result__: <::windows::IInspectable as ::windows::Abi>::Abi =
@@ -2202,7 +2199,7 @@ pub mod Windows {
                 })
             }
             pub fn CreateBooleanArray(
-                value: &[<bool as ::windows::RuntimeType>::DefaultType],
+                value: &[<bool as ::windows::Abi>::DefaultType],
             ) -> ::windows::Result<::windows::IInspectable> {
                 Self::IPropertyValueStatics(|this| unsafe {
                     let mut result__: <::windows::IInspectable as ::windows::Abi>::Abi =
@@ -2217,7 +2214,7 @@ pub mod Windows {
                 })
             }
             pub fn CreateStringArray(
-                value: &[<::windows::HSTRING as ::windows::RuntimeType>::DefaultType],
+                value: &[<::windows::HSTRING as ::windows::Abi>::DefaultType],
             ) -> ::windows::Result<::windows::IInspectable> {
                 Self::IPropertyValueStatics(|this| unsafe {
                     let mut result__: <::windows::IInspectable as ::windows::Abi>::Abi =
@@ -2232,7 +2229,7 @@ pub mod Windows {
                 })
             }
             pub fn CreateInspectableArray(
-                value: &[<::windows::IInspectable as ::windows::RuntimeType>::DefaultType],
+                value: &[<::windows::IInspectable as ::windows::Abi>::DefaultType],
             ) -> ::windows::Result<::windows::IInspectable> {
                 Self::IPropertyValueStatics(|this| unsafe {
                     let mut result__: <::windows::IInspectable as ::windows::Abi>::Abi =
@@ -2247,7 +2244,7 @@ pub mod Windows {
                 })
             }
             pub fn CreateGuidArray(
-                value: &[<::windows::Guid as ::windows::RuntimeType>::DefaultType],
+                value: &[<::windows::Guid as ::windows::Abi>::DefaultType],
             ) -> ::windows::Result<::windows::IInspectable> {
                 Self::IPropertyValueStatics(|this| unsafe {
                     let mut result__: <::windows::IInspectable as ::windows::Abi>::Abi =
@@ -2262,7 +2259,7 @@ pub mod Windows {
                 })
             }
             pub fn CreateDateTimeArray(
-                value: &[<DateTime as ::windows::RuntimeType>::DefaultType],
+                value: &[<DateTime as ::windows::Abi>::DefaultType],
             ) -> ::windows::Result<::windows::IInspectable> {
                 Self::IPropertyValueStatics(|this| unsafe {
                     let mut result__: <::windows::IInspectable as ::windows::Abi>::Abi =
@@ -2277,7 +2274,7 @@ pub mod Windows {
                 })
             }
             pub fn CreateTimeSpanArray(
-                value: &[<TimeSpan as ::windows::RuntimeType>::DefaultType],
+                value: &[<TimeSpan as ::windows::Abi>::DefaultType],
             ) -> ::windows::Result<::windows::IInspectable> {
                 Self::IPropertyValueStatics(|this| unsafe {
                     let mut result__: <::windows::IInspectable as ::windows::Abi>::Abi =
@@ -2292,7 +2289,7 @@ pub mod Windows {
                 })
             }
             pub fn CreatePointArray(
-                value: &[<Point as ::windows::RuntimeType>::DefaultType],
+                value: &[<Point as ::windows::Abi>::DefaultType],
             ) -> ::windows::Result<::windows::IInspectable> {
                 Self::IPropertyValueStatics(|this| unsafe {
                     let mut result__: <::windows::IInspectable as ::windows::Abi>::Abi =
@@ -2307,7 +2304,7 @@ pub mod Windows {
                 })
             }
             pub fn CreateSizeArray(
-                value: &[<Size as ::windows::RuntimeType>::DefaultType],
+                value: &[<Size as ::windows::Abi>::DefaultType],
             ) -> ::windows::Result<::windows::IInspectable> {
                 Self::IPropertyValueStatics(|this| unsafe {
                     let mut result__: <::windows::IInspectable as ::windows::Abi>::Abi =
@@ -2322,7 +2319,7 @@ pub mod Windows {
                 })
             }
             pub fn CreateRectArray(
-                value: &[<Rect as ::windows::RuntimeType>::DefaultType],
+                value: &[<Rect as ::windows::Abi>::DefaultType],
             ) -> ::windows::Result<::windows::IInspectable> {
                 Self::IPropertyValueStatics(|this| unsafe {
                     let mut result__: <::windows::IInspectable as ::windows::Abi>::Abi =
@@ -2390,9 +2387,9 @@ pub mod Windows {
         impl ::std::cmp::Eq for Rect {}
         unsafe impl ::windows::Abi for Rect {
             type Abi = Self;
+            type DefaultType = Self;
         }
         unsafe impl ::windows::RuntimeType for Rect {
-            type DefaultType = Self;
             const SIGNATURE: ::windows::ConstBuffer =
                 ::windows::ConstBuffer::from_slice(b"struct(Windows.Foundation.Rect;f4;f4;f4;f4)");
         }
@@ -2427,9 +2424,9 @@ pub mod Windows {
         impl ::std::cmp::Eq for Size {}
         unsafe impl ::windows::Abi for Size {
             type Abi = Self;
+            type DefaultType = Self;
         }
         unsafe impl ::windows::RuntimeType for Size {
-            type DefaultType = Self;
             const SIGNATURE: ::windows::ConstBuffer =
                 ::windows::ConstBuffer::from_slice(b"struct(Windows.Foundation.Size;f4;f4)");
         }
@@ -2459,9 +2456,9 @@ pub mod Windows {
         impl ::std::cmp::Eq for TimeSpan {}
         unsafe impl ::windows::Abi for TimeSpan {
             type Abi = Self;
+            type DefaultType = Self;
         }
         unsafe impl ::windows::RuntimeType for TimeSpan {
-            type DefaultType = Self;
             const SIGNATURE: ::windows::ConstBuffer =
                 ::windows::ConstBuffer::from_slice(b"struct(Windows.Foundation.TimeSpan;i8)");
         }
@@ -2515,6 +2512,7 @@ pub mod Windows {
             pub struct BOOL(pub i32);
             unsafe impl ::windows::Abi for BOOL {
                 type Abi = Self;
+                type DefaultType = Self;
             }
             impl BOOL {
                 #[inline]
@@ -2711,6 +2709,7 @@ pub mod Windows {
             }
             unsafe impl ::windows::Abi for BSTR {
                 type Abi = *mut u16;
+                type DefaultType = Self;
                 fn set_abi(&mut self) -> *mut *mut u16 {
                     debug_assert!(self.0.is_null());
                     &mut self.0 as *mut _ as _
@@ -2762,6 +2761,7 @@ pub mod Windows {
             impl ::std::cmp::Eq for HANDLE {}
             unsafe impl ::windows::Abi for HANDLE {
                 type Abi = Self;
+                type DefaultType = Self;
             }
             impl HANDLE {
                 pub const INVALID: Self = Self(-1);
@@ -2799,6 +2799,7 @@ pub mod Windows {
             impl ::std::cmp::Eq for HINSTANCE {}
             unsafe impl ::windows::Abi for HINSTANCE {
                 type Abi = Self;
+                type DefaultType = Self;
             }
             #[repr(transparent)]
             #[derive(
@@ -2826,6 +2827,7 @@ pub mod Windows {
             }
             unsafe impl ::windows::Abi for PSTR {
                 type Abi = Self;
+                type DefaultType = Self;
                 fn drop_param(param: &mut ::windows::Param<'_, Self>) {
                     if let ::windows::Param::Boxed(value) = param {
                         if !value.0.is_null() {
@@ -2882,6 +2884,7 @@ pub mod Windows {
             }
             unsafe impl ::windows::Abi for PWSTR {
                 type Abi = Self;
+                type DefaultType = Self;
                 fn drop_param(param: &mut ::windows::Param<'_, Self>) {
                     if let ::windows::Param::Boxed(value) = param {
                         if !value.0.is_null() {
@@ -2998,6 +3001,7 @@ pub mod Windows {
             impl ::std::cmp::Eq for SECURITY_ATTRIBUTES {}
             unsafe impl ::windows::Abi for SECURITY_ATTRIBUTES {
                 type Abi = Self;
+                type DefaultType = Self;
             }
         }
         #[allow(
@@ -3161,6 +3165,7 @@ pub mod Windows {
                     }
                     unsafe impl ::windows::Abi for FORMAT_MESSAGE_OPTIONS {
                         type Abi = Self;
+                        type DefaultType = Self;
                     }
                     impl ::std::ops::BitOr for FORMAT_MESSAGE_OPTIONS {
                         type Output = Self;
@@ -3249,6 +3254,7 @@ pub mod Windows {
                     }
                     unsafe impl ::windows::Abi for WIN32_ERROR {
                         type Abi = Self;
+                        type DefaultType = Self;
                     }
                     impl ::std::ops::BitOr for WIN32_ERROR {
                         type Output = Self;
@@ -3391,6 +3397,7 @@ pub mod Windows {
                 }
                 unsafe impl ::windows::Abi for HEAP_FLAGS {
                     type Abi = Self;
+                    type DefaultType = Self;
                 }
                 impl ::std::ops::BitOr for HEAP_FLAGS {
                     type Output = Self;
@@ -3492,6 +3499,7 @@ pub mod Windows {
                 impl ::std::cmp::Eq for HeapHandle {}
                 unsafe impl ::windows::Abi for HeapHandle {
                     type Abi = Self;
+                    type DefaultType = Self;
                 }
             }
             #[allow(
@@ -3745,6 +3753,7 @@ pub mod Windows {
                 }
                 unsafe impl ::windows::Abi for WAIT_RETURN_CAUSE {
                     type Abi = Self;
+                    type DefaultType = Self;
                 }
                 impl ::std::ops::BitOr for WAIT_RETURN_CAUSE {
                     type Output = Self;

--- a/src/interfaces/inspectable.rs
+++ b/src/interfaces/inspectable.rs
@@ -42,8 +42,6 @@ unsafe impl Interface for IInspectable {
 }
 
 unsafe impl RuntimeType for IInspectable {
-    type DefaultType = Option<Self>;
-
     const SIGNATURE: crate::ConstBuffer =
         crate::ConstBuffer::from_slice(b"cinterface(IInspectable)");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,12 @@
-#![doc = include_str!("../.github/readme.md")]
+/*!
+The Rust language projection follows in the tradition established by [C++/WinRT](https://github.com/microsoft/cppwinrt)
+of building language projections for Windows using standard languages and compilers, providing a natural and idiomatic
+way for Rust developers to call Windows APIs. The [`windows`] crate lets you call any Windows API past, present, and
+future using code generated on the fly directly from the metadata describing the API and right into your Rust package
+where you can call them as if they were just another Rust module.
+
+Learn more here: <https://github.com/microsoft/windows-rs>
+*/
 
 #[macro_use]
 mod macros;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,12 +1,4 @@
-/*!
-The Rust language projection follows in the tradition established by [C++/WinRT](https://github.com/microsoft/cppwinrt)
-of building language projections for Windows using standard languages and compilers, providing a natural and idiomatic
-way for Rust developers to call Windows APIs. The [`windows`] crate lets you call any Windows API past, present, and
-future using code generated on the fly directly from the metadata describing the API and right into your Rust package
-where you can call them as if they were just another Rust module.
-
-Learn more here: <https://github.com/microsoft/windows-rs>
-*/
+#![doc = include_str!("../.github/readme.md")]
 
 #[macro_use]
 mod macros;

--- a/src/result/hresult.rs
+++ b/src/result/hresult.rs
@@ -149,6 +149,7 @@ impl HRESULT {
 
 unsafe impl Abi for HRESULT {
     type Abi = Self;
+    type DefaultType = Self;
 }
 
 impl<T> std::convert::From<Result<T>> for HRESULT {

--- a/src/runtime/guid.rs
+++ b/src/runtime/guid.rs
@@ -70,10 +70,10 @@ impl Guid {
 
 unsafe impl Abi for Guid {
     type Abi = Self;
+    type DefaultType = Self;
 }
 
 unsafe impl RuntimeType for Guid {
-    type DefaultType = Self;
     const SIGNATURE: crate::ConstBuffer = crate::ConstBuffer::from_slice(b"g16");
 }
 

--- a/src/runtime/hstring.rs
+++ b/src/runtime/hstring.rs
@@ -99,6 +99,7 @@ impl HSTRING {
 
 unsafe impl Abi for HSTRING {
     type Abi = RawPtr;
+    type DefaultType = Self;
 
     fn set_abi(&mut self) -> *mut RawPtr {
         debug_assert!(self.is_empty());
@@ -107,7 +108,6 @@ unsafe impl Abi for HSTRING {
 }
 
 unsafe impl RuntimeType for HSTRING {
-    type DefaultType = Self;
     const SIGNATURE: crate::ConstBuffer = crate::ConstBuffer::from_slice(b"string");
 }
 

--- a/src/traits/abi.rs
+++ b/src/traits/abi.rs
@@ -14,6 +14,8 @@ pub unsafe trait Abi: Sized {
     /// `Self` and `Abi` *must* have the same exact in-memory representation.
     type Abi;
 
+    type DefaultType;
+
     /// Casts the Rust object to its ABI type without copying the object.
     fn abi(&self) -> Self::Abi {
         // It is always safe to interpret an `Abi` type's binary representation (without moving
@@ -39,6 +41,7 @@ pub unsafe trait Abi: Sized {
 
 unsafe impl<T: Interface> Abi for T {
     type Abi = RawPtr;
+    type DefaultType = Option<T>;
 
     fn set_abi(&mut self) -> *mut Self::Abi {
         panic!("set_abi should not be used with interfaces since it implies nullable.");
@@ -57,6 +60,7 @@ unsafe impl<T: Interface> Abi for T {
 
 unsafe impl<T: Interface> Abi for Option<T> {
     type Abi = RawPtr;
+    type DefaultType = Self;
 
     fn set_abi(&mut self) -> *mut Self::Abi {
         debug_assert!(self.is_none());

--- a/src/traits/runtime_type.rs
+++ b/src/traits/runtime_type.rs
@@ -5,7 +5,6 @@ use crate::*;
 /// This trait is automatically used by the generated bindings and should not be
 /// used directly.
 pub unsafe trait RuntimeType: Abi + Clone {
-    type DefaultType; // TODO: move to Abi trait unless its only used for WinRT generics.
     const SIGNATURE: crate::ConstBuffer;
 }
 
@@ -13,11 +12,11 @@ macro_rules! primitive_runtime_types {
     ($(($t:ty, $s:literal)),+) => {
         $(
             unsafe impl RuntimeType for $t {
-                type DefaultType = Self;
                 const SIGNATURE: crate::ConstBuffer = crate::ConstBuffer::from_slice($s);
             }
             unsafe impl Abi for $t {
                 type Abi = Self;
+                type DefaultType = Self;
             }
         )*
     };
@@ -39,8 +38,10 @@ primitive_runtime_types! {
 
 unsafe impl Abi for isize {
     type Abi = Self;
+    type DefaultType = Self;
 }
 
 unsafe impl Abi for usize {
     type Abi = Self;
+    type DefaultType = Self;
 }

--- a/tests/implement/build.rs
+++ b/tests/implement/build.rs
@@ -3,7 +3,7 @@ fn main() {
         Windows::Foundation::Collections::{IIterable, IVectorView},
         Windows::Foundation::{IClosable, IStringable, Uri},
         Windows::Win32::Foundation::E_BOUNDS,
-        Windows::UI::Xaml::{Application, Controls::Button},
         Windows::Win32::System::WinRT::ISwapChainInterop,
+        Windows::UI::Xaml::{Application, Controls::Button},
     };
 }

--- a/tests/implement/build.rs
+++ b/tests/implement/build.rs
@@ -4,5 +4,6 @@ fn main() {
         Windows::Foundation::{IClosable, IStringable, Uri},
         Windows::Win32::Foundation::E_BOUNDS,
         Windows::UI::Xaml::{Application, Controls::Button},
+        Windows::Win32::System::WinRT::ISwapChainInterop,
     };
 }

--- a/tests/implement/tests/com.rs
+++ b/tests/implement/tests/com.rs
@@ -1,0 +1,38 @@
+use test_implement::*;
+use windows::*;
+use Windows::Foundation::IStringable;
+use Windows::Win32::System::WinRT::ISwapChainInterop;
+
+#[implement(
+    Windows::Foundation::IStringable,
+    Windows::Win32::System::WinRT::ISwapChainInterop
+)]
+struct Mix();
+
+#[allow(non_snake_case)]
+impl Mix {
+    fn ToString(&self) -> Result<HSTRING> {
+        Ok("Mix".into())
+    }
+
+    fn SetSwapChain(&self, _: &Option<IUnknown>) -> Result<()> {
+        Ok(())
+    }
+}
+
+#[test]
+fn mix() -> Result<()> {
+    let a: ISwapChainInterop = Mix().into();
+    unsafe { a.SetSwapChain(None)? };
+
+    let b: IStringable = a.cast()?;
+    assert!(b.ToString()? == "Mix");
+
+    let c: IStringable = Mix().into();
+    assert!(c.ToString()? == "Mix");
+
+    let d: ISwapChainInterop = c.cast()?;
+    unsafe { d.SetSwapChain(None)? };
+
+    Ok(())
+}

--- a/tests/implement/tests/into_impl.rs
+++ b/tests/implement/tests/into_impl.rs
@@ -37,7 +37,7 @@ impl<T: RuntimeType + 'static> Iterator<T> {
         Ok(owner.0.len() > self.current)
     }
 
-    fn GetMany(&self, _items: &mut [<T as RuntimeType>::DefaultType]) -> Result<u32> {
+    fn GetMany(&self, _items: &mut [<T as Abi>::DefaultType]) -> Result<u32> {
         panic!(); // TODO: arrays still need some work.
     }
 }


### PR DESCRIPTION
A very thin slice of COM interfaces will now work with the `implement` macro. This PR just lays the groundwork for fleshing out the remaining scenarios. Don't expect it to work in general just yet. #81