### PR TITLE
Fix clippy warnings in core crates

### DIFF
--- a/crates/fmt/src/main.rs
+++ b/crates/fmt/src/main.rs
@@ -28,7 +28,7 @@ fn update_file(path: &std::path::Path, pattern: &str) -> std::io::Result<()> {
                 .take_while(|&c| c == ' ')
                 .count();
 
-            let indent = std::iter::repeat(' ').take(indent).collect::<String>();
+            let indent = " ".repeat(indent);
 
             // Replace `use` with macro call and insert curly braces around the UseTree
             let macro_ = format!(

--- a/crates/gen/src/iterator.rs
+++ b/crates/gen/src/iterator.rs
@@ -4,7 +4,7 @@ use super::*;
 // interfaces that implement any of these interfaces. It also favors high-speed iteration and
 // only falls back to IIterator<T> if nothing faster is available. VectorIterator and
 // VectorViewIterator are faster iterators than IIterator<T> because they only require a single
-// vcall per iteration wheras IIterator<T> requires two.
+// vcall per iteration whereas IIterator<T> requires two.
 pub fn gen_iterator(def: &tables::TypeDef, interfaces: &[InterfaceInfo], gen: &Gen) -> TokenStream {
     match def.type_name() {
         // If the type is IIterator<T> then simply implement the Iterator trait over top.

--- a/crates/gen/src/parser/interface_info.rs
+++ b/crates/gen/src/parser/interface_info.rs
@@ -82,7 +82,7 @@ impl InterfaceInfo {
                     }
                     impl<'a, #constraints> ::windows::IntoParam<'a, #into> for &'a #from {
                         fn into_param(self) -> ::windows::Param<'a, #into> {
-                            // tODO: The various conversions are adding ref counting bumps unecessarily
+                            // TODO: The various conversions are adding ref counting bumps unnecessarily
                             ::windows::Param::Owned(::std::convert::Into::<#into>::into(::std::clone::Clone::clone(self)))
                         }
                     }

--- a/crates/gen/src/tables/method_def.rs
+++ b/crates/gen/src/tables/method_def.rs
@@ -160,9 +160,9 @@ mod tests {
         let s = s.return_type.unwrap();
         assert!(s.kind == ElementType::String);
         assert_eq!(s.pointers, 0);
-        assert_eq!(s.by_ref, false);
-        assert_eq!(s.is_const, false);
-        assert_eq!(s.is_array, false);
+        assert!(!s.by_ref);
+        assert!(!s.is_const);
+        assert!(!s.is_array);
     }
 
     #[test]
@@ -178,16 +178,16 @@ mod tests {
         let r = s.return_type.unwrap();
         assert_eq!(r.kind.gen_name(&Gen::Absolute).as_str(), "V");
         assert_eq!(r.pointers, 0);
-        assert_eq!(r.by_ref, false);
-        assert_eq!(r.is_const, false);
-        assert_eq!(r.is_array, false);
+        assert!(!r.by_ref);
+        assert!(!r.is_const);
+        assert!(!r.is_array);
 
         let p = &s.params[0];
         assert_eq!(p.param.name(), "key");
         assert_eq!(p.signature.kind.gen_name(&Gen::Absolute).as_str(), "K");
         assert_eq!(p.signature.pointers, 0);
-        assert_eq!(p.signature.by_ref, false);
-        assert_eq!(p.signature.is_const, false);
-        assert_eq!(p.signature.is_array, false);
+        assert!(!p.signature.by_ref);
+        assert!(!p.signature.is_const);
+        assert!(!p.signature.is_array);
     }
 }

--- a/crates/gen/src/types/struct.rs
+++ b/crates/gen/src/types/struct.rs
@@ -479,17 +479,11 @@ mod tests {
 
     #[test]
     fn test_blittable() {
-        assert_eq!(
-            TypeReader::get()
-                .expect_type_def(TypeName::new("Windows.Foundation", "Point"))
-                .is_blittable(),
-            true
-        );
-        assert_eq!(
-            TypeReader::get()
-                .expect_type_def(TypeName::new("Windows.UI.Xaml.Interop", "TypeName"))
-                .is_blittable(),
-            false
-        );
+        assert!(TypeReader::get()
+            .expect_type_def(TypeName::new("Windows.Foundation", "Point"))
+            .is_blittable(),);
+        assert!(!TypeReader::get()
+            .expect_type_def(TypeName::new("Windows.UI.Xaml.Interop", "TypeName"))
+            .is_blittable(),);
     }
 }

--- a/src/interfaces/unknown.rs
+++ b/src/interfaces/unknown.rs
@@ -45,7 +45,7 @@ impl Drop for IUnknown {
 
 impl PartialEq for IUnknown {
     fn eq(&self, other: &Self) -> bool {
-        // Since COM objects may implement multiple intefaces, COM identity can only
+        // Since COM objects may implement multiple interfaces, COM identity can only
         // be determined by querying for `IUnknown` explicitly and then comparing the
         // pointer values. This works since `QueryInterface` is required to return
         // the same pointer value for queries for `IUnknown`.

--- a/src/runtime/array.rs
+++ b/src/runtime/array.rs
@@ -153,7 +153,7 @@ mod tests {
     fn empty() {
         let empty = Array::<bool>::new();
         assert!(empty.is_empty());
-        assert!(empty.len() == 0);
+        assert!(empty.is_empty());
     }
 
     #[test]

--- a/src/runtime/hstring.rs
+++ b/src/runtime/hstring.rs
@@ -282,7 +282,7 @@ mod tests {
     fn hstring_works() {
         let empty = StringType::new();
         assert!(empty.is_empty());
-        assert!(empty.len() == 0);
+        assert!(empty.is_empty());
 
         let mut hello = StringType::from("Hello");
         assert!(!hello.is_empty());
@@ -294,9 +294,9 @@ mod tests {
 
         let hello2 = hello.clone();
         hello.clear();
-        assert!(hello.len() == 0);
+        assert!(hello.is_empty());
         hello.clear();
-        assert!(hello.len() == 0);
+        assert!(hello.is_empty());
         assert!(!hello2.is_empty());
         assert!(hello2.len() == 5);
 
@@ -344,7 +344,7 @@ mod tests {
     #[test]
     fn from_empty_string() {
         let h = StringType::from("");
-        assert!(format!("{}", h) == "");
+        assert!(format!("{}", h).is_empty());
     }
 
     #[test]

--- a/src/runtime/ref_count.rs
+++ b/src/runtime/ref_count.rs
@@ -23,10 +23,10 @@ impl RefCount {
     pub fn release(&self) -> u32 {
         let remaining = self.0.fetch_sub(1, Ordering::Release) - 1;
 
-        if remaining == 0 {
-            fence(Ordering::Acquire);
-        } else if remaining < 0 {
-            panic!("Object has been over-released.");
+        match remaining.cmp(&0) {
+            std::cmp::Ordering::Equal => fence(Ordering::Acquire),
+            std::cmp::Ordering::Less => panic!("Object has been over-released."),
+            std::cmp::Ordering::Greater => {}
         }
 
         remaining as u32

--- a/src/runtime/weak_ref_count.rs
+++ b/src/runtime/weak_ref_count.rs
@@ -141,6 +141,7 @@ struct TearOff {
 }
 
 impl TearOff {
+    #[allow(clippy::new_ret_no_self)]
     unsafe fn new(object: RawPtr, strong_count: u32) -> IWeakReferenceSource {
         std::mem::transmute(Box::new(TearOff {
             strong_vtable: &Self::STRONG_VTABLE,
@@ -253,7 +254,7 @@ impl TearOff {
         let this = Self::from_strong_ptr(ptr);
 
         // Forward strong `Release` to the object so that it can destroy itself. It will then
-        // decrement its weak reference and allow the tear-off to be released as needd.
+        // decrement its weak reference and allow the tear-off to be released as needed.
         ((*(*(this.object as *mut *mut _) as *mut IUnknown_abi)).2)((*this).object)
     }
 
@@ -276,7 +277,7 @@ impl TearOff {
         let this = Self::from_strong_ptr(ptr);
 
         // The strong vtable hands out a reference to the weak vtable. This is always safe and
-        // straightforward since a strong refernece guarantees there is at lerast one weak
+        // straightforward since a strong reference guarantees there is at least one weak
         // reference.
         *interface = &mut this.weak_vtable as *mut _ as _;
         this.weak_count.add_ref();
@@ -308,7 +309,7 @@ impl TearOff {
             {
                 // Let the object respond to the upgrade query.
                 let result = this.query_interface(iid, interface);
-                // Decrement the temporary reference account used to stablize the object.
+                // Decrement the temporary reference account used to stabilize the object.
                 this.strong_count.0.fetch_sub(1, Ordering::Relaxed);
                 // Return the result of the query.
                 return result;

--- a/src/traits/to_impl.rs
+++ b/src/traits/to_impl.rs
@@ -3,8 +3,9 @@ use super::*;
 /// A trait for retrieving the implementation behind a COM or WinRT interface.
 ///
 /// This trait is automatically implemented when using the [`implement`] macro but
-/// is considered unsafe since different implemenetations of the `from` interface
+/// is considered unsafe since different implementations of the `from` interface
 // may exist.
 pub trait ToImpl<T: Interface> {
+    #[allow(clippy::mut_from_ref)]
     unsafe fn to_impl(from: &T) -> &mut Self;
 }

--- a/tests/winrt/tests/boxing.rs
+++ b/tests/winrt/tests/boxing.rs
@@ -89,7 +89,7 @@ fn explicit_boxing() -> windows::Result<()> {
     let pv: IPropertyValue = object.cast()?;
     let mut array = windows::Array::new();
     assert!(array.is_empty());
-    assert!(array.len() == 0);
+    assert!(array.is_empty());
 
     pv.GetUInt32Array(&mut array)?;
     assert!(array[..] == [1, 2, 3]);
@@ -101,7 +101,7 @@ fn explicit_boxing() -> windows::Result<()> {
     let pv: IPropertyValue = object.cast()?;
     let mut array = windows::Array::new();
     assert!(array.is_empty());
-    assert!(array.len() == 0);
+    assert!(array.is_empty());
 
     pv.GetStringArray(&mut array)?;
     assert!(array[..] == ["Hello", "Rust", "WinRT"]);

--- a/tests/winrt/tests/collisions.rs
+++ b/tests/winrt/tests/collisions.rs
@@ -36,7 +36,7 @@ fn email() -> windows::Result<()> {
 
     // Default constructor via IActivationFactory
     let a = EmailAttachment::new()?;
-    assert!(a.FileName()? == "");
+    assert!(a.FileName()?.is_empty());
 
     // create from IEmailAttachmentFactory
     let b = EmailAttachment::Create("create.txt", &reference)?;

--- a/tests/winrt/tests/composition.rs
+++ b/tests/winrt/tests/composition.rs
@@ -171,8 +171,8 @@ fn composition() -> windows::Result<()> {
             }
     );
 
-    assert!(iterator.MoveNext()? == false);
-    assert!(iterator.HasCurrent()? == false);
+    assert!(!(iterator.MoveNext()?));
+    assert!(!(iterator.HasCurrent()?));
 
     Ok(())
 }

--- a/tests/winrt/tests/enum.rs
+++ b/tests/winrt/tests/enum.rs
@@ -60,6 +60,6 @@ fn unsigned_enum() {
         | AppointmentDaysOfWeek::Friday;
 
     assert!(days == AppointmentDaysOfWeek::Monday | AppointmentDaysOfWeek::Wednesday);
-    days = days & AppointmentDaysOfWeek::Wednesday;
+    days &= AppointmentDaysOfWeek::Wednesday;
     assert!(days == AppointmentDaysOfWeek::Wednesday);
 }


### PR DESCRIPTION
For #996

`cargo clippy --all -- -A clippy::missing_safety_doc` can now run without any warnings.  Note that this excludes every `#[test]` unless `--all-targets` is passed, which does not lint cleanly yet.

---

@kennykerr What do you think about gradually introducing `clippy` to windows-rs instead? It's quite the burden to fix tons of warnings in the tests (that usually intentionally write things a certain "inefficient" way for validation) or to write appropriate `# safety` docs, when it is anyway much more relevant to keep the published crates clean and held to a certain standard instead.
After this PR we can reopen #996 and I can subsequently change the command to the one listed above. I'll document the desire to enable `--all-targets` at some point, as well as removing `-A clippy::missing_safety_doc`.