### PR TITLE
Constrain generic types to simplify generic implementations

### DIFF
--- a/crates/gen/src/types/struct.rs
+++ b/crates/gen/src/types/struct.rs
@@ -201,7 +201,14 @@ impl Struct {
         });
 
         let compare = if is_union | has_union | has_complex_array | is_packed {
-            quote! {}
+            quote! {
+                impl ::std::cmp::PartialEq for #name {
+                    fn eq(&self, _other: &Self) -> bool {
+                        unimplemented!()
+                    }
+                }
+                impl ::std::cmp::Eq for #name {}
+            }
         } else {
             let compare = fields
                 .iter()

--- a/crates/gen/src/types/struct.rs
+++ b/crates/gen/src/types/struct.rs
@@ -97,7 +97,8 @@ impl Struct {
             quote! {
                 impl ::std::clone::Clone for #name {
                     fn clone(&self) -> Self {
-                        unsafe { std::mem::transmute_copy(self) }
+                        // TODO: this can transmute for blittable but not non-blittable structs
+                        unimplemented!()
                     }
                 }
             }
@@ -204,6 +205,7 @@ impl Struct {
             quote! {
                 impl ::std::cmp::PartialEq for #name {
                     fn eq(&self, _other: &Self) -> bool {
+                        // TODO: figure out how to compare complex structs
                         unimplemented!()
                     }
                 }

--- a/crates/gen/src/types/struct.rs
+++ b/crates/gen/src/types/struct.rs
@@ -94,7 +94,13 @@ impl Struct {
                 #[derive(::std::clone::Clone, ::std::marker::Copy)]
             }
         } else if is_union || has_union || is_packed {
-            quote! {}
+            quote! {
+                impl ::std::clone::Clone for #name {
+                    fn clone(&self) -> Self {
+                        unsafe { std::mem::transmute_copy(self) }
+                    }
+                }
+            }
         } else {
             quote! {
                 #[derive(::std::clone::Clone)]
@@ -366,8 +372,8 @@ impl Struct {
         };
 
         quote! {
-            #repr
             #clone_or_copy
+            #repr
             pub #struct_or_union #name #body
             impl #name {
                 #(#constants)*

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -18,8 +18,8 @@ pub mod Windows {
         clippy::all
     )]
     pub mod Foundation {
-        #[repr(C)]
         #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
+        #[repr(C)]
         pub struct DateTime {
             pub UniversalTime: i64,
         }
@@ -1768,8 +1768,8 @@ pub mod Windows {
                 result__: *mut ::windows::RawPtr,
             ) -> ::windows::HRESULT,
         );
-        #[repr(C)]
         #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
+        #[repr(C)]
         pub struct Point {
             pub X: f32,
             pub Y: f32,
@@ -2421,8 +2421,8 @@ pub mod Windows {
         impl ::windows::RuntimeName for PropertyValue {
             const NAME: &'static str = "Windows.Foundation.PropertyValue";
         }
-        #[repr(C)]
         #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
+        #[repr(C)]
         pub struct Rect {
             pub X: f32,
             pub Y: f32,
@@ -2467,8 +2467,8 @@ pub mod Windows {
             const SIGNATURE: ::windows::ConstBuffer =
                 ::windows::ConstBuffer::from_slice(b"struct(Windows.Foundation.Rect;f4;f4;f4;f4)");
         }
-        #[repr(C)]
         #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
+        #[repr(C)]
         pub struct Size {
             pub Width: f32,
             pub Height: f32,
@@ -2504,8 +2504,8 @@ pub mod Windows {
             const SIGNATURE: ::windows::ConstBuffer =
                 ::windows::ConstBuffer::from_slice(b"struct(Windows.Foundation.Size;f4;f4)");
         }
-        #[repr(C)]
         #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
+        #[repr(C)]
         pub struct TimeSpan {
             pub Duration: i64,
         }
@@ -2807,8 +2807,8 @@ pub mod Windows {
             pub const E_NOINTERFACE: ::windows::HRESULT = ::windows::HRESULT(-2147467262i32 as _);
             pub const E_POINTER: ::windows::HRESULT = ::windows::HRESULT(-2147467261i32 as _);
             pub type FARPROC = unsafe extern "system" fn() -> isize;
-            #[repr(transparent)]
             #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
+            #[repr(transparent)]
             pub struct HANDLE(pub isize);
             impl HANDLE {}
             impl ::std::default::Default for HANDLE {
@@ -2843,8 +2843,8 @@ pub mod Windows {
                     self.0 == -1
                 }
             }
-            #[repr(transparent)]
             #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
+            #[repr(transparent)]
             pub struct HINSTANCE(pub isize);
             impl HINSTANCE {}
             impl ::std::default::Default for HINSTANCE {
@@ -3039,8 +3039,8 @@ pub mod Windows {
             clippy::all
         )]
         pub mod Security {
-            #[repr(C)]
             #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
+            #[repr(C)]
             pub struct SECURITY_ATTRIBUTES {
                 pub nLength: u32,
                 pub lpSecurityDescriptor: *mut ::std::ffi::c_void,
@@ -3543,8 +3543,8 @@ pub mod Windows {
                     #[cfg(not(windows))]
                     unimplemented!("Unsupported target OS");
                 }
-                #[repr(transparent)]
                 #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
+                #[repr(transparent)]
                 pub struct HeapHandle(pub isize);
                 impl HeapHandle {}
                 impl ::std::default::Default for HeapHandle {

--- a/src/traits/abi.rs
+++ b/src/traits/abi.rs
@@ -14,7 +14,7 @@ pub unsafe trait Abi: Sized + Clone {
     /// `Self` and `Abi` *must* have the same exact in-memory representation.
     type Abi;
 
-    type DefaultType;
+    type DefaultType: Sized + Clone + PartialEq;
 
     /// Converts from `Self::DefaultType` to `Result<T>`.
     fn ok(value: &Self::DefaultType) -> Result<Self> {

--- a/src/traits/abi.rs
+++ b/src/traits/abi.rs
@@ -7,7 +7,7 @@ use bindings::Windows::Win32::Foundation::E_POINTER;
 ///
 /// This trait is automatically used by the generated bindings and should not be
 /// used directly.
-pub unsafe trait Abi: Sized {
+pub unsafe trait Abi: Sized + Clone {
     /// The abi representation of the implementing type.
     ///
     /// # Safety
@@ -15,6 +15,14 @@ pub unsafe trait Abi: Sized {
     type Abi;
 
     type DefaultType;
+
+    /// Converts from `Self::DefaultType` to `Result<T>`.
+    fn ok(value: &Self::DefaultType) -> Result<Self> {
+        unsafe {
+            let value = value as *const _ as *const Self;
+            Ok((*value).clone())
+        }
+    }
 
     /// Casts the Rust object to its ABI type without copying the object.
     fn abi(&self) -> Self::Abi {
@@ -42,6 +50,18 @@ pub unsafe trait Abi: Sized {
 unsafe impl<T: Interface> Abi for T {
     type Abi = RawPtr;
     type DefaultType = Option<T>;
+
+    fn ok(value: &Self::DefaultType) -> Result<Self> {
+        unsafe {
+            // For some reason, Rust can't figure out that DefaultType is an Option here.
+            let value = value as *const _ as *const Option<Self>;
+
+            match &*value {
+                Some(value) => Ok(value.clone()),
+                None => Err(Error::fast_error(E_POINTER)),
+            }
+        }
+    }
 
     fn set_abi(&mut self) -> *mut Self::Abi {
         panic!("set_abi should not be used with interfaces since it implies nullable.");

--- a/src/traits/interface.rs
+++ b/src/traits/interface.rs
@@ -5,7 +5,7 @@ use bindings::Windows::Win32::System::WinRT::IWeakReferenceSource;
 ///
 /// This trait is automatically used by the generated bindings and should not be
 /// used directly.
-pub unsafe trait Interface: Sized + Abi {
+pub unsafe trait Interface: Sized + Abi + PartialEq {
     type Vtable;
     const IID: Guid;
 

--- a/src/traits/runtime_type.rs
+++ b/src/traits/runtime_type.rs
@@ -4,7 +4,7 @@ use crate::*;
 ///
 /// This trait is automatically used by the generated bindings and should not be
 /// used directly.
-pub unsafe trait RuntimeType: Abi + Clone {
+pub unsafe trait RuntimeType: Abi + Clone + PartialEq {
     const SIGNATURE: crate::ConstBuffer;
 }
 

--- a/tests/implement/tests/generic_default.rs
+++ b/tests/implement/tests/generic_default.rs
@@ -1,0 +1,83 @@
+use test_implement::*;
+use windows::*;
+use Windows::Foundation::Collections::*;
+use Windows::Foundation::*;
+use Windows::Win32::Foundation::E_BOUNDS;
+
+#[implement(
+    Windows::Foundation::Collections::IVectorView<T>,
+)]
+struct Thing<T>(Vec<T::DefaultType>)
+where
+    T: ::windows::RuntimeType + 'static;
+
+#[allow(non_snake_case)]
+impl<T: ::windows::RuntimeType + 'static> Thing<T> {
+    fn GetAt(&self, index: u32) -> Result<T> {
+        match self.0.get(index as usize) {
+            Some(value) => <T as Abi>::ok(value),
+            None => Err(Error::new(E_BOUNDS, "")),
+        }
+    }
+
+    fn Size(&self) -> Result<u32> {
+        Ok(self.0.len() as _)
+    }
+
+    fn IndexOf(&self, value: &T::DefaultType, result: &mut u32) -> Result<bool> {
+        match self.0.iter().position(|element| element == value) {
+            Some(index) => {
+                *result = index as _;
+                Ok(true)
+            }
+            None => Ok(false),
+        }
+    }
+
+    fn GetMany(&self, _startindex: u32, _items: &mut [T]) -> Result<u32> {
+        panic!();
+    }
+}
+
+#[test]
+fn test_implement() -> Result<()> {
+    let v: IVectorView<i32> = Thing(vec![10, 20, 30]).into();
+    assert_eq!(10, v.GetAt(0)?);
+    assert_eq!(20, v.GetAt(1)?);
+    assert_eq!(30, v.GetAt(2)?);
+    assert_eq!(3, v.Size()?);
+
+    let mut index = 0;
+    assert_eq!(true, v.IndexOf(20, &mut index)?);
+    assert_eq!(1, index);
+    assert_eq!(true, v.IndexOf(30, &mut index)?);
+    assert_eq!(2, index);
+    assert_eq!(false, v.IndexOf(123, &mut index)?);
+
+    let v: IVectorView<HSTRING> = Thing(vec!["10".into(), "20".into(), "30".into()]).into();
+    assert_eq!("10", v.GetAt(0)?);
+    assert_eq!("20", v.GetAt(1)?);
+    assert_eq!("30", v.GetAt(2)?);
+    assert_eq!(3, v.Size()?);
+
+    let mut index = 0;
+    assert_eq!(true, v.IndexOf("20", &mut index)?);
+    assert_eq!(1, index);
+    assert_eq!(true, v.IndexOf("30", &mut index)?);
+    assert_eq!(2, index);
+    assert_eq!(false, v.IndexOf("123", &mut index)?);
+
+    let v: IVectorView<IStringable> = Thing(vec![
+        Some(Uri::CreateUri("http://one/")?.into()),
+        Some(Uri::CreateUri("http://two/")?.into()),
+        Some(Uri::CreateUri("http://three/")?.into()),
+    ])
+    .into();
+
+    assert_eq!("http://one/", v.GetAt(0)?.ToString()?);
+    assert_eq!("http://two/", v.GetAt(1)?.ToString()?);
+    assert_eq!("http://three/", v.GetAt(2)?.ToString()?);
+    assert_eq!(3, v.Size()?);
+
+    Ok(())
+}


### PR DESCRIPTION
This change makes it a lot simpler to implement generic WinRT interfaces on generic types as the `DefaultType` associated type can now be used for most collection operations. 