### PR TITLE
Allow implementations to query themselves

### DIFF
--- a/crates/macros/src/implement.rs
+++ b/crates/macros/src/implement.rs
@@ -213,16 +213,11 @@ pub fn gen(
     tokens.combine(&quote! {
         impl <#constraints> #impl_ident {
             #constructors
-            fn cast<T: ::windows::Interface>(&self) -> ::windows::Result<T> {
+            fn cast<ResultType: ::windows::Interface>(&self) -> ::windows::Result<ResultType> {
                 unsafe {
-                    let boxed = (self as *const #impl_ident as *mut #impl_ident as *mut ::windows::RawPtr).sub(2 + #interfaces_len) as *mut #box_ident;
+                    let boxed = (self as *const #impl_ident as *mut #impl_ident as *mut ::windows::RawPtr).sub(2 + #interfaces_len) as *mut #box_ident::<#(#generics,)*>;
                     let mut result = None;
-
-                    (*boxed).QueryInterface(
-                        &T::IID,
-                        &mut result as *mut _ as _,
-                    )
-                    .and_some(result)
+                    (*boxed).QueryInterface(&ResultType::IID, &mut result as *mut _ as _).and_some(result)
                 }
             }
         }

--- a/crates/macros/src/implement.rs
+++ b/crates/macros/src/implement.rs
@@ -213,6 +213,18 @@ pub fn gen(
     tokens.combine(&quote! {
         impl <#constraints> #impl_ident {
             #constructors
+            fn cast<T: ::windows::Interface>(&self) -> ::windows::Result<T> {
+                unsafe {
+                    let boxed = (self as *const #impl_ident as *mut #impl_ident as *mut ::windows::RawPtr).sub(2 + #interfaces_len) as *mut #box_ident;
+                    let mut result = None;
+
+                    (*boxed).QueryInterface(
+                        &T::IID,
+                        &mut result as *mut _ as _,
+                    )
+                    .and_some(result)
+                }
+            }
         }
         impl <#constraints> ::std::convert::From<#impl_ident> for ::windows::IUnknown {
             fn from(implementation: #impl_ident) -> Self {

--- a/tests/implement/tests/cast_self.rs
+++ b/tests/implement/tests/cast_self.rs
@@ -1,0 +1,20 @@
+use test_implement::*;
+use windows::*;
+use Windows::UI::Xaml::*;
+
+// TODO: This is a compile-only test for now until #81 is further along and can provide composable test classes.
+
+#[implement(extend Windows::UI::Xaml::Application, override OnLaunched)]
+struct App();
+
+#[allow(non_snake_case)]
+impl App {
+    fn OnLaunched(
+        &self,
+        _: &Option<Windows::ApplicationModel::Activation::LaunchActivatedEventArgs>,
+    ) -> Result<()> {
+        let app: Application = self.cast()?;
+        assert!(app.FocusVisualKind()? == FocusVisualKind::DottedLine);
+        Ok(())
+    }
+}


### PR DESCRIPTION
Implementations often need to query themselves in order to gain access to aggregated functionality from base classes. In future, I will likely inject any inherited members but the cast unblocks some key scenarios in the short term and is generally useful.

Fixes #1030