### PR TITLE
Silence clippy safety warnings

### DIFF
--- a/src/result/hresult.rs
+++ b/src/result/hresult.rs
@@ -70,6 +70,7 @@ impl HRESULT {
         Ok(op())
     }
 
+    /// # Safety
     /// If the [`Result`] is [`Ok`] converts the `T::Abi` into `T`.
     pub unsafe fn from_abi<T: Abi>(self, abi: T::Abi) -> Result<T> {
         if self.is_ok() {

--- a/src/runtime/weak_ref_count.rs
+++ b/src/runtime/weak_ref_count.rs
@@ -84,6 +84,7 @@ impl WeakRefCount {
         }
     }
 
+    /// # Safety
     pub unsafe fn query(&self, iid: &::windows::Guid, object: RawPtr) -> RawPtr {
         if iid != &IWeakReferenceSource::IID {
             return std::ptr::null_mut();

--- a/src/traits/abi.rs
+++ b/src/traits/abi.rs
@@ -38,8 +38,9 @@ pub unsafe trait Abi: Sized + Clone {
         self as *mut _ as *mut _
     }
 
+    /// # Safety
     /// Casts the ABI representation to a Rust object by taking ownership of the bits.
-    // Note: This default implementation is correct for all but interfaces.
+    /// This default implementation is correct for all but interfaces.
     unsafe fn from_abi(abi: Self::Abi) -> Result<Self> {
         Ok(std::mem::transmute_copy(&abi))
     }

--- a/src/traits/compose.rs
+++ b/src/traits/compose.rs
@@ -2,5 +2,6 @@ use crate::*;
 
 #[doc(hidden)]
 pub trait Compose {
+    /// # Safety
     unsafe fn compose<'a>(implementation: Self) -> (IInspectable, &'a mut Option<IInspectable>);
 }

--- a/src/traits/interface.rs
+++ b/src/traits/interface.rs
@@ -9,11 +9,13 @@ pub unsafe trait Interface: Sized + Abi + PartialEq {
     type Vtable;
     const IID: Guid;
 
+    /// # Safety
     /// Returns the vtable for the current interface.
     unsafe fn vtable(&self) -> &Self::Vtable {
         self.assume_vtable::<Self>()
     }
 
+    /// # Safety
     /// Returns the vtable for an assumed interface. The name comes from [`Box::assume_init()`] as
     /// it assumes the vtable is implemented by the current interface's vtable (e.g. a parent interface).
     unsafe fn assume_vtable<T: Interface>(&self) -> &T::Vtable {
@@ -21,6 +23,7 @@ pub unsafe trait Interface: Sized + Abi + PartialEq {
         &(*(*(this as *mut *mut _) as *mut _))
     }
 
+    /// # Safety
     unsafe fn query(&self, iid: *const Guid, interface: *mut RawPtr) -> HRESULT {
         (self.assume_vtable::<IUnknown>().0)(std::mem::transmute_copy(self), iid, interface)
     }

--- a/src/traits/to_impl.rs
+++ b/src/traits/to_impl.rs
@@ -6,6 +6,7 @@ use super::*;
 /// is considered unsafe since different implementations of the `from` interface
 // may exist.
 pub trait ToImpl<T: Interface> {
+    /// # Safety
     #[allow(clippy::mut_from_ref)]
     unsafe fn to_impl(from: &T) -> &mut Self;
 }


### PR DESCRIPTION
A doc sweep will be required eventually, but this at least helps us get clippy clean, for the most part.