### PR TITLE
Avoid invalid code gen for Win32 array parameters

### DIFF
--- a/crates/gen/src/parser/method_signature.rs
+++ b/crates/gen/src/parser/method_signature.rs
@@ -450,7 +450,10 @@ impl MethodSignature {
 impl MethodParam {
     fn is_retval(&self) -> bool {
         let flags = self.param.flags();
-        if flags.input() || !flags.output() {
+
+        // TODO: NativeArrayInfo indicates and array parameter #479
+        if flags.input() || !flags.output() || self.param.has_attribute("NativeArrayInfoAttribute")
+        {
             return false;
         }
 


### PR DESCRIPTION
Win32 array parameters still need a lot of work (#479) but this fix just avoids generating invalid transformations in the short term. #1039 