### PR TITLE
Improved support for nullptr/None result values

### DIFF
--- a/crates/bindings/src/main.rs
+++ b/crates/bindings/src/main.rs
@@ -3,7 +3,7 @@ fn main() -> std::io::Result<()> {
         Windows::{
             Foundation::{IReference, IStringable, PropertyValue},
             Win32::{
-                Foundation::{S_OK, CloseHandle, CO_E_NOTINITIALIZED, E_NOINTERFACE},
+                Foundation::{CloseHandle, CO_E_NOTINITIALIZED, E_NOINTERFACE, S_OK},
                 System::{
                     Com::{CoCreateGuid, CoTaskMemAlloc, CoTaskMemFree, IAgileObject},
                     Diagnostics::Debug::{FormatMessageW, GetLastError},

--- a/crates/bindings/src/main.rs
+++ b/crates/bindings/src/main.rs
@@ -3,7 +3,7 @@ fn main() -> std::io::Result<()> {
         Windows::{
             Foundation::{IReference, IStringable, PropertyValue},
             Win32::{
-                Foundation::{CloseHandle, CO_E_NOTINITIALIZED, E_NOINTERFACE, E_POINTER},
+                Foundation::{S_OK, CloseHandle, CO_E_NOTINITIALIZED, E_NOINTERFACE},
                 System::{
                     Com::{CoCreateGuid, CoTaskMemAlloc, CoTaskMemFree, IAgileObject},
                     Diagnostics::Debug::{FormatMessageW, GetLastError},

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -2805,7 +2805,6 @@ pub mod Windows {
                 unimplemented!("Unsupported target OS");
             }
             pub const E_NOINTERFACE: ::windows::HRESULT = ::windows::HRESULT(-2147467262i32 as _);
-            pub const E_POINTER: ::windows::HRESULT = ::windows::HRESULT(-2147467261i32 as _);
             pub type FARPROC = unsafe extern "system" fn() -> isize;
             #[derive(:: std :: clone :: Clone, :: std :: marker :: Copy)]
             #[repr(transparent)]
@@ -2989,6 +2988,7 @@ pub mod Windows {
                     ) as _))
                 }
             }
+            pub const S_OK: ::windows::HRESULT = ::windows::HRESULT(0i32 as _);
             pub unsafe fn SysAllocStringLen<'a>(
                 strin: impl ::windows::IntoParam<'a, PWSTR>,
                 ui: u32,

--- a/src/result/error.rs
+++ b/src/result/error.rs
@@ -2,7 +2,7 @@ use crate::*;
 use std::convert::TryInto;
 
 use bindings::{
-    Windows::Win32::Foundation::BSTR,
+    Windows::Win32::Foundation::{S_OK, BSTR},
     Windows::Win32::System::OleAutomation::{GetErrorInfo, SetErrorInfo},
     Windows::Win32::System::WinRT::{ILanguageExceptionErrorInfo2, IRestrictedErrorInfo},
 };
@@ -15,6 +15,8 @@ pub struct Error {
 }
 
 impl Error {
+    pub const OK: Self = Self { code: S_OK, info: None };
+
     /// This creates a new WinRT error object, capturing the stack and other information about the
     /// point of failure.
     pub fn new(code: HRESULT, message: &str) -> Self {
@@ -35,10 +37,6 @@ impl Error {
     }
 
     #[doc(hidden)]
-    /// Used internally to create an Error object without error info. Typically used with [`Interface::query`]
-    /// (`E_NOINTERFACE`) or the absence of an object to return (`E_POINTER`) to avoid the
-    /// code gen overhead for casts that should be cheap (few instructions). Think of it as a way to create
-    /// recoverable errors that don't need the overhead of debugging origination info.
     pub const fn fast_error(code: HRESULT) -> Self {
         Self { code, info: None }
     }

--- a/src/result/error.rs
+++ b/src/result/error.rs
@@ -2,7 +2,7 @@ use crate::*;
 use std::convert::TryInto;
 
 use bindings::{
-    Windows::Win32::Foundation::{S_OK, BSTR},
+    Windows::Win32::Foundation::{BSTR, S_OK},
     Windows::Win32::System::OleAutomation::{GetErrorInfo, SetErrorInfo},
     Windows::Win32::System::WinRT::{ILanguageExceptionErrorInfo2, IRestrictedErrorInfo},
 };
@@ -15,7 +15,11 @@ pub struct Error {
 }
 
 impl Error {
-    pub const OK: Self = Self { code: S_OK, info: None };
+    /// An error object without any failure information.
+    pub const OK: Self = Self {
+        code: S_OK,
+        info: None,
+    };
 
     /// This creates a new WinRT error object, capturing the stack and other information about the
     /// point of failure.

--- a/src/result/hresult.rs
+++ b/src/result/hresult.rs
@@ -1,7 +1,7 @@
 use crate::*;
 
 use bindings::{
-    Windows::Win32::Foundation::{E_POINTER, PWSTR},
+    Windows::Win32::Foundation::{ PWSTR},
     Windows::Win32::System::Diagnostics::Debug::*,
 };
 
@@ -52,7 +52,7 @@ impl HRESULT {
             if let Some(result) = some {
                 Ok(result)
             } else {
-                Err(Error::fast_error(E_POINTER))
+                Err(Error::OK)
             }
         } else {
             Err(Error::from(self))

--- a/src/result/hresult.rs
+++ b/src/result/hresult.rs
@@ -1,9 +1,6 @@
 use crate::*;
 
-use bindings::{
-    Windows::Win32::Foundation::{ PWSTR},
-    Windows::Win32::System::Diagnostics::Debug::*,
-};
+use bindings::{Windows::Win32::Foundation::PWSTR, Windows::Win32::System::Diagnostics::Debug::*};
 
 /// A primitive error code value returned by most COM functions.
 #[repr(transparent)]

--- a/src/traits/abi.rs
+++ b/src/traits/abi.rs
@@ -1,7 +1,5 @@
 use crate::*;
 
-use bindings::Windows::Win32::Foundation::E_POINTER;
-
 /// Provides a generic way of referring to and converting between a Rust object
 /// and its ABI equivalent.
 ///
@@ -64,7 +62,7 @@ unsafe impl<T: Interface> Abi for T {
 
             match &*value {
                 Some(value) => Ok(value.clone()),
-                None => Err(Error::fast_error(E_POINTER)),
+                None => Err(Error::OK),
             }
         }
     }
@@ -77,7 +75,7 @@ unsafe impl<T: Interface> Abi for T {
         let abi: RawPtr = std::mem::transmute_copy(&abi);
 
         if abi.is_null() {
-            Err(Error::fast_error(E_POINTER))
+            Err(Error::OK)
         } else {
             Ok(std::mem::transmute_copy(&abi))
         }

--- a/tests/implement_null_result/Cargo.toml
+++ b/tests/implement_null_result/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "test_implement_null_result"
+version = "0.0.0"
+authors = ["Microsoft"]
+edition = "2018"
+
+[dependencies]
+windows = { path = "../.." }
+
+[build-dependencies]
+windows = { path = "../.." }

--- a/tests/implement_null_result/build.rs
+++ b/tests/implement_null_result/build.rs
@@ -1,0 +1,5 @@
+fn main() {
+    windows::build! {
+        Windows::Win32::Foundation::S_OK, Windows::UI::Xaml::Markup::IXamlType2,
+    };
+}

--- a/tests/implement_null_result/src/lib.rs
+++ b/tests/implement_null_result/src/lib.rs
@@ -1,0 +1,1 @@
+windows::include_bindings!();

--- a/tests/implement_null_result/tests/test.rs
+++ b/tests/implement_null_result/tests/test.rs
@@ -1,0 +1,28 @@
+use test_implement_null_result::*;
+use windows::*;
+use Windows::Win32::Foundation::S_OK;
+use Windows::UI::Xaml::Markup::{IXamlType, IXamlType2};
+
+#[implement(Windows::UI::Xaml::Markup::IXamlType2)]
+struct Test();
+
+#[allow(non_snake_case)]
+impl Test {
+    fn BoxedType(&self) -> Result<IXamlType> {
+        Err(Error::OK)
+    }
+}
+
+#[test]
+fn test() -> Result<()> {
+    let a: IXamlType2 = Test().into();
+
+    let b = a.BoxedType();
+    assert!(b.is_err());
+
+    let e = b.unwrap_err();
+    assert!(e.code() == S_OK);
+    assert!(e.info().is_none());
+
+    Ok(())
+}

--- a/tests/winrt/build.rs
+++ b/tests/winrt/build.rs
@@ -29,7 +29,7 @@ fn main() {
             InMemoryRandomAccessStream, RandomAccessStreamReference,
         },
 
-        Windows::Win32::Foundation::{E_NOINTERFACE, E_POINTER},
+        Windows::Win32::Foundation::E_NOINTERFACE,
         Windows::Win32::System::WinRT::CreateDispatcherQueueController,
         Windows::AI::MachineLearning::*,
         Windows::UI::Composition::{

--- a/tests/winrt/tests/collisions.rs
+++ b/tests/winrt/tests/collisions.rs
@@ -4,7 +4,6 @@ use test_winrt::{
         WiFiDirectConnectionParameters, WiFiDirectDevice, WiFiDirectDeviceSelectorType,
     },
     Windows::Storage::Streams::{InMemoryRandomAccessStream, RandomAccessStreamReference},
-    Windows::Win32::Foundation::E_POINTER,
 };
 
 // WiFiDirectDevice has a pair of static factory interfaces with overloads. This test

--- a/tests/winrt/tests/collisions.rs
+++ b/tests/winrt/tests/collisions.rs
@@ -16,7 +16,7 @@ fn wifi() -> windows::Result<()> {
     assert!(!a.is_empty());
 
     // from_id_async from IWiFiDirectDeviceStatics
-    assert!(WiFiDirectDevice::FromIdAsync(a)?.get() == Err(windows::Error::fast_error(E_POINTER)));
+    assert!(WiFiDirectDevice::FromIdAsync(a)?.get() == Err(windows::Error::OK));
 
     // get_device_selector overload from IWiFiDirectDeviceStatics2 is renamed to get_device_selector2
     let c = WiFiDirectDevice::GetDeviceSelector2(WiFiDirectDeviceSelectorType::DeviceInterface)?;


### PR DESCRIPTION
In some cases, WinRT or COM APIs will return a null pointer value successfully. This update makes it simpler to implement such an interface. Fixes #1060. 