### PR TITLE
macros/lib: Don't copy DLL files outside of the workspace target folder

### DIFF
--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -125,9 +125,7 @@ pub fn build(stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
                     println!("cargo:rustc-link-search=native={}", source.to_str().expect("`CARGO_MANIFEST_DIR` not a valid path"));
                 }
 
-                let mut destination : ::std::path::PathBuf = #target_dir.into();
-                destination.pop();
-                destination.pop();
+                let mut destination: ::std::path::PathBuf = #target_dir.into();
 
                 let profile = ::std::env::var("PROFILE").expect("No `PROFILE` env variable set");
                 copy_to_profile(&source, &destination, &profile);


### PR DESCRIPTION
The previous commit now uses a different folder for `target_dir`, namely `target/` directly instead of `target/<profile>/deps`.  Popping this twice would go outside of the directory containing `target/` and copy DLL files into _every_ folder matching the `<profile>` name (ie. every `debug` folder inside my `Rust/` projects folder).

Fixes: 1291b32 ("Remove binary packaging support (#1067)")
