### PR TITLE
Move gen code from macros crate to gen crate

### DIFF
--- a/crates/gen/src/build.rs
+++ b/crates/gen/src/build.rs
@@ -1,0 +1,101 @@
+use super::*;
+
+pub fn gen_build() -> TokenStream {
+    let tokens = RawString(gen_source_tree().into_string());
+    let target_dir = RawString(target_dir());
+    let workspace_dir = RawString(workspace_dir());
+
+    quote! {
+        {
+            // The following must be injected into the token stream because the `OUT_DIR` and `PROFILE`
+            // environment variables are only set when the build script run and not when it is being compiled.
+
+            use ::std::io::Write;
+            let mut path = ::std::path::PathBuf::from(
+                ::std::env::var("OUT_DIR").expect("No `OUT_DIR` env variable set"),
+            );
+
+            path.push("windows.rs");
+            ::std::fs::write(&path, #tokens).expect("Could not write generated code to windows.rs");
+
+            let mut cmd = ::std::process::Command::new("rustfmt");
+            cmd.arg(&path);
+            let _ = cmd.output();
+
+            fn copy(source: &::std::path::Path, destination: &mut ::std::path::PathBuf) {
+                if let ::std::result::Result::Ok(entries) = ::std::fs::read_dir(source) {
+                    for entry in entries.filter_map(|entry| entry.ok()) {
+                        if let ::std::result::Result::Ok(entry_type) = entry.file_type() {
+                            let path = entry.path();
+                            if let ::std::option::Option::Some(last_path_component) = path.file_name() {
+                                let _ = ::std::fs::create_dir_all(&destination);
+                                destination.push(last_path_component);
+                                if entry_type.is_file() {
+                                    let _ = ::std::fs::copy(path, &destination);
+                                } else if entry_type.is_dir() {
+                                    let _ = ::std::fs::create_dir(&destination);
+                                    copy(&path, destination);
+                                }
+                                destination.pop();
+                            }
+                        }
+                    }
+                }
+            }
+
+            fn copy_to_profile(source: &::std::path::Path, destination: &::std::path::Path, profile: &str) {
+                if let ::std::result::Result::Ok(files) = ::std::fs::read_dir(destination) {
+                    for file in files.filter_map(|file| file.ok())  {
+                        if let ::std::result::Result::Ok(file_type) = file.file_type() {
+                            if file_type.is_dir() {
+                                let mut path = file.path();
+                                if let ::std::option::Option::Some(filename) = path.file_name() {
+                                    if filename == profile {
+                                        copy(source, &mut path);
+                                    } else {
+                                        copy_to_profile(source, &path, profile);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+
+            let mut source : ::std::path::PathBuf = #workspace_dir.into();
+            source.push(".windows");
+
+            if source.exists() {
+                println!("cargo:rerun-if-changed={}", source.to_str().expect("`CARGO_MANIFEST_DIR` not a valid path"));
+
+                // The `target_arch` cfg is not set for build scripts so we need to sniff it out from the environment variable.
+                source.push(match ::std::env::var("CARGO_CFG_TARGET_ARCH").expect("No `CARGO_CFG_TARGET_ARCH` env variable set").as_str() {
+                    "x86_64" => "x64",
+                    "x86" => "x86",
+                    "arm" => "arm",
+                    "aarch64" => "arm64",
+                    unimplemented => unimplemented!("`{}` architecture set by `CARGO_CFG_TARGET_ARCH`", unimplemented),
+                });
+
+                if source.exists() {
+                    println!("cargo:rustc-link-search=native={}", source.to_str().expect("`CARGO_MANIFEST_DIR` not a valid path"));
+                }
+
+                let mut destination: ::std::path::PathBuf = #target_dir.into();
+
+                let profile = ::std::env::var("PROFILE").expect("No `PROFILE` env variable set");
+                copy_to_profile(&source, &destination, &profile);
+            }
+        }
+    }
+}
+
+struct RawString(String);
+
+impl ToTokens for RawString {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        tokens.push_str("r#\"");
+        tokens.push_str(&self.0);
+        tokens.push_str("\"#");
+    }
+}

--- a/crates/gen/src/lib.rs
+++ b/crates/gen/src/lib.rs
@@ -1,6 +1,7 @@
 mod r#async;
 mod bool32;
 mod bstr;
+mod build;
 mod callback;
 mod class;
 mod com_interface;
@@ -32,10 +33,10 @@ mod vector3;
 mod vector4;
 mod win32;
 mod winrt;
-mod build;
 
 // TODO: These public things are mostly/all used by the implement macro
 // move that logic into here so the macro crate is just forwarding to the gen crate
+pub use build::*;
 pub use gen::*;
 pub use helpers::*;
 pub use interface_info::*;
@@ -44,7 +45,6 @@ pub use to_ident::*;
 pub use tree::*;
 pub use win32::*;
 pub use winrt::*;
-pub use build::*;
 
 use bool32::*;
 use bstr::*;

--- a/crates/gen/src/lib.rs
+++ b/crates/gen/src/lib.rs
@@ -32,6 +32,7 @@ mod vector3;
 mod vector4;
 mod win32;
 mod winrt;
+//mod build;
 
 // TODO: These public things are mostly/all used by the implement macro
 // move that logic into here so the macro crate is just forwarding to the gen crate
@@ -41,6 +42,9 @@ pub use interface_info::*;
 pub use name::*;
 pub use to_ident::*;
 pub use tree::*;
+pub use win32::*;
+pub use winrt::*;
+//pub use build::*;
 
 use bool32::*;
 use bstr::*;
@@ -70,5 +74,3 @@ use timespan::*;
 use vector2::*;
 use vector3::*;
 use vector4::*;
-pub use win32::*;
-pub use winrt::*;

--- a/crates/gen/src/lib.rs
+++ b/crates/gen/src/lib.rs
@@ -32,7 +32,7 @@ mod vector3;
 mod vector4;
 mod win32;
 mod winrt;
-//mod build;
+mod build;
 
 // TODO: These public things are mostly/all used by the implement macro
 // move that logic into here so the macro crate is just forwarding to the gen crate
@@ -44,7 +44,7 @@ pub use to_ident::*;
 pub use tree::*;
 pub use win32::*;
 pub use winrt::*;
-//pub use build::*;
+pub use build::*;
 
 use bool32::*;
 use bstr::*;

--- a/crates/gen/src/tree.rs
+++ b/crates/gen/src/tree.rs
@@ -1,6 +1,15 @@
 use super::*;
 
-pub fn gen_tree(tree: &TypeTree) -> impl Iterator<Item = TokenStream> + '_ {
+pub fn gen_source_tree() -> TokenStream {
+    let reader = TypeReader::get();
+
+    namespace_iter(&reader.types).fold(TokenStream::new(), |mut accum, n| {
+        accum.combine(&n);
+        accum
+    })
+}
+
+pub fn namespace_iter(tree: &TypeTree) -> impl Iterator<Item = TokenStream> + '_ {
     let gen = Gen::Relative(tree.namespace);
 
     tree.types
@@ -16,7 +25,7 @@ fn gen_namespaces<'a>(
         if tree.include {
             let name = to_ident(name);
 
-            let tokens = gen_tree(tree);
+            let tokens = namespace_iter(tree);
 
             quote! {
                 // TODO: https://github.com/microsoft/windows-rs/issues/212

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -44,8 +44,8 @@ impl ToTokens for RawString {
 /// ```
 #[proc_macro]
 pub fn build(stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let build = parse_macro_input!(stream as BuildMacro);
-    let tokens = RawString(build.to_tokens_string());
+    parse_macro_input!(stream as BuildMacro);
+    let tokens = RawString(gen_source_tree().into_string());
     let target_dir = RawString(target_dir());
     let workspace_dir = RawString(workspace_dir());
 
@@ -138,11 +138,11 @@ pub fn build(stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
 
 #[proc_macro]
 pub fn generate(stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
-    let build = parse_macro_input!(stream as BuildMacro);
+    parse_macro_input!(stream as BuildMacro);
 
     let mut tokens = String::new();
     tokens.push_str("r#\"");
-    tokens.push_str(&build.to_tokens_string());
+    tokens.push_str(&gen_source_tree().into_string());
     tokens.push_str("\"#");
     tokens.parse().unwrap()
 }

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -9,16 +9,6 @@ use quote::*;
 use reader::*;
 use syn::parse_macro_input;
 
-struct RawString(String);
-
-impl ToTokens for RawString {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        tokens.push_str("r#\"");
-        tokens.push_str(&self.0);
-        tokens.push_str("\"#");
-    }
-}
-
 /// A macro for generating WinRT modules to a .rs file at build time.
 ///
 /// This macro can be used to import WinRT APIs from any Windows metadata (winmd) file.
@@ -45,95 +35,7 @@ impl ToTokens for RawString {
 #[proc_macro]
 pub fn build(stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
     parse_macro_input!(stream as BuildMacro);
-    let tokens = RawString(gen_source_tree().into_string());
-    let target_dir = RawString(target_dir());
-    let workspace_dir = RawString(workspace_dir());
-
-    let tokens = quote! {
-        {
-            // The following must be injected into the token stream because the `OUT_DIR` and `PROFILE`
-            // environment variables are only set when the build script run and not when it is being compiled.
-
-            use ::std::io::Write;
-            let mut path = ::std::path::PathBuf::from(
-                ::std::env::var("OUT_DIR").expect("No `OUT_DIR` env variable set"),
-            );
-
-            path.push("windows.rs");
-            ::std::fs::write(&path, #tokens).expect("Could not write generated code to windows.rs");
-
-            let mut cmd = ::std::process::Command::new("rustfmt");
-            cmd.arg(&path);
-            let _ = cmd.output();
-
-            fn copy(source: &::std::path::Path, destination: &mut ::std::path::PathBuf) {
-                if let ::std::result::Result::Ok(entries) = ::std::fs::read_dir(source) {
-                    for entry in entries.filter_map(|entry| entry.ok()) {
-                        if let ::std::result::Result::Ok(entry_type) = entry.file_type() {
-                            let path = entry.path();
-                            if let ::std::option::Option::Some(last_path_component) = path.file_name() {
-                                let _ = ::std::fs::create_dir_all(&destination);
-                                destination.push(last_path_component);
-                                if entry_type.is_file() {
-                                    let _ = ::std::fs::copy(path, &destination);
-                                } else if entry_type.is_dir() {
-                                    let _ = ::std::fs::create_dir(&destination);
-                                    copy(&path, destination);
-                                }
-                                destination.pop();
-                            }
-                        }
-                    }
-                }
-            }
-
-            fn copy_to_profile(source: &::std::path::Path, destination: &::std::path::Path, profile: &str) {
-                if let ::std::result::Result::Ok(files) = ::std::fs::read_dir(destination) {
-                    for file in files.filter_map(|file| file.ok())  {
-                        if let ::std::result::Result::Ok(file_type) = file.file_type() {
-                            if file_type.is_dir() {
-                                let mut path = file.path();
-                                if let ::std::option::Option::Some(filename) = path.file_name() {
-                                    if filename == profile {
-                                        copy(source, &mut path);
-                                    } else {
-                                        copy_to_profile(source, &path, profile);
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-
-            let mut source : ::std::path::PathBuf = #workspace_dir.into();
-            source.push(".windows");
-
-            if source.exists() {
-                println!("cargo:rerun-if-changed={}", source.to_str().expect("`CARGO_MANIFEST_DIR` not a valid path"));
-
-                // The `target_arch` cfg is not set for build scripts so we need to sniff it out from the environment variable.
-                source.push(match ::std::env::var("CARGO_CFG_TARGET_ARCH").expect("No `CARGO_CFG_TARGET_ARCH` env variable set").as_str() {
-                    "x86_64" => "x64",
-                    "x86" => "x86",
-                    "arm" => "arm",
-                    "aarch64" => "arm64",
-                    unimplemented => unimplemented!("`{}` architecture set by `CARGO_CFG_TARGET_ARCH`", unimplemented),
-                });
-
-                if source.exists() {
-                    println!("cargo:rustc-link-search=native={}", source.to_str().expect("`CARGO_MANIFEST_DIR` not a valid path"));
-                }
-
-                let mut destination: ::std::path::PathBuf = #target_dir.into();
-
-                let profile = ::std::env::var("PROFILE").expect("No `PROFILE` env variable set");
-                copy_to_profile(&source, &destination, &profile);
-            }
-        }
-    };
-
-    tokens.as_str().parse().unwrap()
+    gen_build().as_str().parse().unwrap()
 }
 
 #[proc_macro]

--- a/crates/reader/src/type_reader.rs
+++ b/crates/reader/src/type_reader.rs
@@ -113,6 +113,7 @@ impl TypeReader {
         }
     }
 
+    // TODO: use TypeName?
     pub fn import_type(&mut self, namespace: &str, name: &str) -> bool {
         self.import_type_include(namespace, name, TypeInclude::Full)
     }

--- a/crates/reader/src/type_reader.rs
+++ b/crates/reader/src/type_reader.rs
@@ -113,7 +113,6 @@ impl TypeReader {
         }
     }
 
-    // TODO: use TypeName?
     pub fn import_type(&mut self, namespace: &str, name: &str) -> bool {
         self.import_type_include(namespace, name, TypeInclude::Full)
     }


### PR DESCRIPTION
More refactoring to centralize `build` macro's code gen and keep the macros crate as small as possible. Next up is moving the `implement` macro's gen code.