### PR TITLE
Use explicit version in cargo.toml (avoid cargo-deny errors)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ gen = { package = "windows_gen", path = "crates/gen",  version = "0.18.0", optio
 const-sha1 = "0.2"
 
 [dev-dependencies]
-gen = { package = "windows_gen", path = "crates/gen" }
+gen = { package = "windows_gen", path = "crates/gen", version = "0.18.0" }
 
 [workspace]
 members = [

--- a/crates/bindings/Cargo.toml
+++ b/crates/bindings/Cargo.toml
@@ -4,5 +4,5 @@ version = "0.0.0"
 edition = "2018"
 
 [dependencies]
-windows_macros = { path = "../macros" }
-windows_reader = { path = "../reader" }
+windows_macros = { path = "../macros", version = "0.18.0" }
+windows_reader = { path = "../reader", version = "0.18.0" }

--- a/crates/fmt/Cargo.toml
+++ b/crates/fmt/Cargo.toml
@@ -4,4 +4,4 @@ version = "0.0.0"
 edition = "2018"
 
 [dependencies]
-windows_reader = { path = "../reader" }
+windows_reader = { path = "../reader", version = "0.18.0" }


### PR DESCRIPTION
Small improvement to make sure we are cargo-deny friendly.