### PR TITLE
`IntoParam<PWSTR>` for OString & OsStr

### DIFF
--- a/crates/gen/src/pwstr.rs
+++ b/crates/gen/src/pwstr.rs
@@ -46,5 +46,17 @@ pub fn gen_pwstr() -> TokenStream {
                 ::windows::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(self.encode_utf16().chain(::std::iter::once(0)).collect::<std::vec::Vec<u16>>().into_boxed_slice()) as _))
             }
         }
+        impl<'a> ::windows::IntoParam<'a, PWSTR> for &'a ::std::ffi::OsStr {
+            fn into_param(self) -> ::windows::Param<'a, PWSTR> {
+                use std::os::windows::ffi::OsStrExt;
+                ::windows::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(self.encode_wide().chain(::std::iter::once(0)).collect::<std::vec::Vec<u16>>().into_boxed_slice()) as _))
+            }
+        }
+        impl<'a> ::windows::IntoParam<'a, PWSTR> for ::std::ffi::OsString {
+            fn into_param(self) -> ::windows::Param<'a, PWSTR> {
+                use std::os::windows::ffi::OsStrExt;
+                ::windows::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(self.encode_wide().chain(::std::iter::once(0)).collect::<std::vec::Vec<u16>>().into_boxed_slice()) as _))
+            }
+        }
     }
 }


### PR DESCRIPTION
Initially when you got [`PathBuf`](https://doc.rust-lang.org/std/path/struct.PathBuf.html) or [`Path`](https://doc.rust-lang.org/std/path/struct.Path.html) (Both are `OsString` and `OsStr` in behind), you would have to convert to UTF-8, which is unnecessary (PWSTR is UTF-16 too) and lossy. This PR fixes it by implementing `IntoParam<PWSTR` for OsString & OsStr.
There's inconsistency between functions, some takes `IntoParam<PWSTR>`, others just take `PWSTR`. The function I encountered (`SHGetFileInfoW`) was taking `IntoParam<PWSTR>`, perhaps I should implement `From<OsString/OsStr>` too?