### PR TITLE
Exclude `.windows` folder from package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ description = "Rust for Windows"
 repository = "https://github.com/microsoft/windows-rs"
 documentation = "https://docs.rs/windows"
 readme = ".github/readme.md"
-exclude = [".github", "docs"]
+exclude = [".github", ".windows", "docs"]
 
 [dependencies]
 windows_macros = { path = "crates/macros",  version = "0.19.0", optional = true }


### PR DESCRIPTION
The `.windows` folder in this crate is only used for testing and should not be included in the published crate. 