### PR TITLE
Add impl IntoParam<PWSTR> for Option<String>

### DIFF
--- a/crates/gen/src/pwstr.rs
+++ b/crates/gen/src/pwstr.rs
@@ -46,5 +46,21 @@ pub fn gen_pwstr() -> TokenStream {
                 ::windows::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(self.encode_utf16().chain(::std::iter::once(0)).collect::<std::vec::Vec<u16>>().into_boxed_slice()) as _))
             }
         }
+        impl<'a> ::windows::IntoParam<'a, PWSTR> for Option<&'a str> {
+            fn into_param(self) -> ::windows::Param<'a, PWSTR> {
+                match self {
+                    Some(s) => s.into_param(),
+                    None => windows::Param::None,
+                }
+            }
+        }
+        impl<'a> ::windows::IntoParam<'a, PWSTR> for Option<String> {
+            fn into_param(self) -> ::windows::Param<'a, PWSTR> {
+                match self {
+                    Some(s) => s.into_param(),
+                    None => windows::Param::None,
+                }
+            }
+        }
     }
 }

--- a/tests/ntstatus/tests/ntstatus.rs
+++ b/tests/ntstatus/tests/ntstatus.rs
@@ -1,5 +1,5 @@
 use test_ntstatus::{
-    Windows::Win32::Foundation::*, Windows::Win32::Security::Cryptography::Core::*,
+    Windows::Win32::Foundation::*, Windows::Win32::Security::Cryptography::Core::*, Windows::Win32::Foundation::PWSTR,
 };
 
 use windows::{Guid, Result, HRESULT};
@@ -23,7 +23,7 @@ fn test() -> Result<()> {
 
     unsafe {
         let mut provider = BCRYPT_ALG_HANDLE::default();
-        BCryptOpenAlgorithmProvider(&mut provider, "RNG", None, Default::default())?;
+        BCryptOpenAlgorithmProvider(&mut provider, "RNG", Option::<PWSTR>::None, Default::default())?;
 
         let mut random = Guid::zeroed();
 


### PR DESCRIPTION
Hi,

The PR provides `IntoParam<PWSTR>` to convert `Option<String>`,  `Option<&str>` considering `None` be `PWSTR::NULL`.
This suppose to be useful in cases where necessary conditionally pass a `PWSTR::NULL`  or some string as an argument to a function which takes `impl IntoParams` as an argument.

So essentially we would like to do something like this.

```rust
foo(if something {PWSTR::NULL} else { some_string })
```

But we can't unless 2 branches returns the same type. Exactly we could pass not `PWSTR::NULL` but empty string. But its not the same thing from abi perspective.

The implementation on user side may be error prone.
For example this (the one which I used to solve the issue initially).

```rust
 fn pwstr_param(s: Option<String>) -> PWSTR {
     use windows::IntoParam;
     match s {
         Some(s) => {
             // memory leak
             let mut p: windows::Param<PWSTR> = s.into_param();
             p.abi()
         }
         None => {
             PWSTR::NULL
         } 
    }
}
```

The example compiles (and works) but we drop `p` at the end of a function and it calls a destruction of boxed memory.

So I decided to provide this implementation to resolve the former pattern.

PS: I am not sure if it was necessary to run some code generation.