### PR TITLE
Trim down use of Abi trait

### DIFF
--- a/crates/gen/src/bstr.rs
+++ b/crates/gen/src/bstr.rs
@@ -143,11 +143,6 @@ pub fn gen_bstr() -> TokenStream {
         unsafe impl ::windows::Abi for BSTR {
             type Abi = ::std::mem::ManuallyDrop<Self>;
             type DefaultType = Self;
-
-            fn set_abi(&mut self) -> *mut Self::Abi {
-                debug_assert!(self.0.is_null());
-                &mut self.0 as *mut _ as _
-            }
         }
         pub type BSTR_abi = *mut u16;
     }

--- a/crates/gen/src/name.rs
+++ b/crates/gen/src/name.rs
@@ -64,35 +64,11 @@ pub fn gen_name(def: &ElementType, gen: &Gen) -> TokenStream {
 
 pub fn gen_abi_type_name(def: &ElementType, gen: &Gen) -> TokenStream {
     match def {
-        ElementType::Void => quote! { ::std::ffi::c_void },
-        ElementType::Bool => quote! { bool },
-        ElementType::Char => quote! { u16 },
-        ElementType::I8 => quote! { i8 },
-        ElementType::U8 => quote! { u8 },
-        ElementType::I16 => quote! { i16 },
-        ElementType::U16 => quote! { u16 },
-        ElementType::I32 => quote! { i32 },
-        ElementType::U32 => quote! { u32 },
-        ElementType::I64 => quote! { i64 },
-        ElementType::U64 => quote! { u64 },
-        ElementType::F32 => quote! { f32 },
-        ElementType::F64 => quote! { f64 },
-        ElementType::ISize => quote! { isize },
-        ElementType::USize => quote! { usize },
         ElementType::String => {
             quote! { ::std::mem::ManuallyDrop<::windows::HSTRING> }
         }
-        ElementType::IInspectable => {
+        ElementType::IUnknown | ElementType::IInspectable => {
             quote! { ::windows::RawPtr }
-        }
-        ElementType::Guid => {
-            quote! { ::windows::Guid }
-        }
-        ElementType::IUnknown => {
-            quote! { ::windows::RawPtr }
-        }
-        ElementType::HRESULT => {
-            quote! { ::windows::HRESULT }
         }
         ElementType::Array((kind, len)) => {
             let name = gen_abi_sig(kind, gen);
@@ -104,7 +80,7 @@ pub fn gen_abi_type_name(def: &ElementType, gen: &Gen) -> TokenStream {
             quote! { <#name as ::windows::Abi>::Abi }
         }
         ElementType::TypeDef(def) => gen_abi_type(def, gen),
-        _ => unimplemented!(),
+        _ => gen_name(def, gen),
     }
 }
 

--- a/crates/gen/src/pstr.rs
+++ b/crates/gen/src/pstr.rs
@@ -27,7 +27,7 @@ pub fn gen_pstr() -> TokenStream {
             type Abi = Self;
             type DefaultType = Self;
 
-            fn drop_param(param: &mut ::windows::Param<'_, Self>) {
+            unsafe fn drop_param(param: &mut ::windows::Param<'_, Self>) {
                 if let ::windows::Param::Boxed(value) = param {
                     if !value.0.is_null() {
                         unsafe { ::std::boxed::Box::from_raw(value.0); }

--- a/crates/gen/src/pwstr.rs
+++ b/crates/gen/src/pwstr.rs
@@ -27,7 +27,7 @@ pub fn gen_pwstr() -> TokenStream {
             type Abi = Self;
             type DefaultType = Self;
 
-            fn drop_param(param: &mut ::windows::Param<'_, Self>) {
+            unsafe fn drop_param(param: &mut ::windows::Param<'_, Self>) {
                 if let ::windows::Param::Boxed(value) = param {
                     if !value.0.is_null() {
                         unsafe { ::std::boxed::Box::from_raw(value.0); }

--- a/crates/macros/src/implement.rs
+++ b/crates/macros/src/implement.rs
@@ -193,7 +193,8 @@ pub fn gen(
                     }
                     impl<#constraints> ::windows::ToImpl<#interface_ident> for #impl_ident {
                         unsafe fn to_impl(interface: &#interface_ident) -> &mut Self {
-                            let this = (::windows::Abi::abi(interface) as *mut ::windows::RawPtr).sub(2 + #interface_count) as *mut #box_ident::<#(#generics,)*>;
+                            let this: ::windows::RawPtr = std::mem::transmute_copy(interface);
+                            let this = (this as *mut ::windows::RawPtr).sub(2 + #interface_count) as *mut #box_ident::<#(#generics,)*>;
                             &mut (*this).implementation
                         }
                     }
@@ -271,7 +272,7 @@ pub fn gen(
         impl <#constraints> ::windows::Compose for #impl_ident {
             unsafe fn compose<'a>(implementation: Self) -> (::windows::IInspectable, &'a mut std::option::Option<::windows::IInspectable>) {
                 let inspectable: ::windows::IInspectable = implementation.into();
-                let this = (::windows::Abi::abi(&inspectable) as *mut ::windows::RawPtr).sub(1) as *mut #box_ident::<#(#generics,)*>;
+                let this = (&inspectable as *const _ as *mut ::windows::RawPtr).sub(1) as *mut #box_ident::<#(#generics,)*>;
                 (inspectable, &mut (*this).base)
             }
         }

--- a/src/bindings.rs
+++ b/src/bindings.rs
@@ -296,7 +296,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).26)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -310,7 +310,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).27)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -324,7 +324,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).28)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -338,7 +338,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).29)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -352,7 +352,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).30)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -366,7 +366,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).31)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -380,7 +380,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).32)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -394,7 +394,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).33)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -408,7 +408,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).34)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -422,7 +422,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).35)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -436,7 +436,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).36)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -450,7 +450,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).37)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -464,7 +464,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).38)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -478,7 +478,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).39)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -492,7 +492,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).40)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -506,7 +506,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).41)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -520,7 +520,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).42)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -534,7 +534,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).43)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -548,7 +548,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).44)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -1310,7 +1310,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).26)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -1324,7 +1324,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).27)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -1338,7 +1338,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).28)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -1352,7 +1352,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).29)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -1366,7 +1366,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).30)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -1380,7 +1380,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).31)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -1394,7 +1394,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).32)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -1408,7 +1408,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).33)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -1422,7 +1422,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).34)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -1436,7 +1436,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).35)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -1450,7 +1450,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).36)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -1464,7 +1464,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).37)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -1478,7 +1478,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).38)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -1492,7 +1492,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).39)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -1506,7 +1506,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).40)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -1520,7 +1520,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).41)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -1534,7 +1534,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).42)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -1548,7 +1548,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).43)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -1562,7 +1562,7 @@ pub mod Windows {
                     (::windows::Interface::vtable(this).44)(
                         ::std::mem::transmute_copy(this),
                         value.set_abi_len(),
-                        value.set_abi(),
+                        value as *mut _ as _,
                     )
                     .ok()
                 }
@@ -2817,10 +2817,6 @@ pub mod Windows {
             unsafe impl ::windows::Abi for BSTR {
                 type Abi = ::std::mem::ManuallyDrop<Self>;
                 type DefaultType = Self;
-                fn set_abi(&mut self) -> *mut Self::Abi {
-                    debug_assert!(self.0.is_null());
-                    &mut self.0 as *mut _ as _
-                }
             }
             pub type BSTR_abi = *mut u16;
             pub const CO_E_NOTINITIALIZED: ::windows::HRESULT =
@@ -2934,7 +2930,7 @@ pub mod Windows {
             unsafe impl ::windows::Abi for PSTR {
                 type Abi = Self;
                 type DefaultType = Self;
-                fn drop_param(param: &mut ::windows::Param<'_, Self>) {
+                unsafe fn drop_param(param: &mut ::windows::Param<'_, Self>) {
                     if let ::windows::Param::Boxed(value) = param {
                         if !value.0.is_null() {
                             unsafe {
@@ -2991,7 +2987,7 @@ pub mod Windows {
             unsafe impl ::windows::Abi for PWSTR {
                 type Abi = Self;
                 type DefaultType = Self;
-                fn drop_param(param: &mut ::windows::Param<'_, Self>) {
+                unsafe fn drop_param(param: &mut ::windows::Param<'_, Self>) {
                     if let ::windows::Param::Boxed(value) = param {
                         if !value.0.is_null() {
                             unsafe {

--- a/src/result/error.rs
+++ b/src/result/error.rs
@@ -30,7 +30,7 @@ impl Error {
         // Need to ignore the result, as that is the delay-load error, which would mean
         // that there's no WinRT to tell about the error.
         unsafe {
-            let _ = RoOriginateError(code, message.abi() as _);
+            let _ = RoOriginateError(code, std::mem::transmute_copy(&message));
         }
 
         let info = unsafe { GetErrorInfo(0).and_then(|e| e.cast()).ok() };

--- a/src/runtime/array.rs
+++ b/src/runtime/array.rs
@@ -92,18 +92,8 @@ impl<T: RuntimeType> Array<T> {
     ///
     /// This function is safe but writing to the pointer is not. Calling this without
     /// a subsequent call to `set_abi` is likely to either leak memory or cause UB
-    pub fn set_abi_len(&mut self) -> *mut u32 {
+    pub unsafe fn set_abi_len(&mut self) -> *mut u32 {
         &mut self.len
-    }
-
-    #[doc(hidden)]
-    /// Get a mutable pointer to the array's data
-    ///
-    /// This function is safe but writing to the pointer is not. Calling this without
-    /// a subsequent call to `set_abi_len` is likely to either leak memory or cause UB
-    pub fn set_abi(&mut self) -> *mut *mut T::Abi {
-        self.clear();
-        &mut self.data as *mut _ as *mut _
     }
 
     #[doc(hidden)]

--- a/src/runtime/hstring.rs
+++ b/src/runtime/hstring.rs
@@ -100,12 +100,6 @@ impl HSTRING {
 unsafe impl Abi for HSTRING {
     type Abi = std::mem::ManuallyDrop<Self>;
     type DefaultType = Self;
-
-    // TODO: this should just be implemented by the Abi trait for all types
-    fn set_abi(&mut self) -> *mut Self::Abi {
-        debug_assert!(self.is_empty());
-        &mut self.0 as *mut _ as _
-    }
 }
 
 unsafe impl RuntimeType for HSTRING {
@@ -322,24 +316,6 @@ mod tests {
     fn debug_format() {
         let value = StringType::from("Hello world");
         assert!(format!("{:?}", value) == "Hello world");
-    }
-
-    #[test]
-    fn abi_transfer() {
-        fn perform_transfer(from: StringType, to: &mut StringType) {
-            let from = std::mem::ManuallyDrop::new(from);
-            unsafe {
-                let to = to.set_abi();
-                let from = from.abi();
-                *to = from
-            };
-        }
-
-        let from = StringType::from("Hello");
-        let mut to = StringType::new();
-        perform_transfer(from, &mut to);
-
-        assert!(format!("{}", to) == "Hello");
     }
 
     #[test]

--- a/src/runtime/param.rs
+++ b/src/runtime/param.rs
@@ -14,9 +14,9 @@ impl<'a, T: Abi> Param<'a, T> {
     /// # Safety
     pub unsafe fn abi(&self) -> T::Abi {
         match self {
-            Param::Borrowed(value) => value.abi(),
-            Param::Owned(value) => value.abi(),
-            Param::Boxed(value) => value.abi(),
+            Param::Borrowed(value) => std::mem::transmute_copy(*value),
+            Param::Owned(value) => std::mem::transmute_copy(value),
+            Param::Boxed(value) => std::mem::transmute_copy(value),
             Param::None => std::mem::zeroed(),
         }
     }
@@ -24,6 +24,6 @@ impl<'a, T: Abi> Param<'a, T> {
 
 impl<'a, T: Abi> Drop for Param<'a, T> {
     fn drop(&mut self) {
-        T::drop_param(self);
+        unsafe { T::drop_param(self) }
     }
 }

--- a/src/runtime/weak_ref_count.rs
+++ b/src/runtime/weak_ref_count.rs
@@ -67,8 +67,9 @@ impl WeakRefCount {
         }
 
         let tear_off = TearOff::new(object, count_or_pointer as _);
+        let tear_off_ptr: RawPtr = std::mem::transmute_copy(&tear_off);
         let encoding: usize =
-            ((tear_off.abi() as usize) >> 1) | (1 << (std::mem::size_of::<usize>() * 8 - 1));
+            ((tear_off_ptr as usize) >> 1) | (1 << (std::mem::size_of::<usize>() * 8 - 1));
 
         loop {
             match self.0.compare_exchange_weak(
@@ -89,7 +90,7 @@ impl WeakRefCount {
                 return TearOff::from_encoding(count_or_pointer);
             }
 
-            TearOff::from_strong_ptr(std::mem::transmute_copy(&tear_off))
+            TearOff::from_strong_ptr(tear_off_ptr)
                 .strong_count
                 .0
                 .store(count_or_pointer as _, Ordering::SeqCst);

--- a/src/traits/abi.rs
+++ b/src/traits/abi.rs
@@ -1,51 +1,23 @@
 use crate::*;
 
-/// Provides a generic way of referring to and converting between a Rust object
-/// and its ABI equivalent.
-///
-/// This trait is automatically used by the generated bindings and should not be
-/// used directly.
+#[doc(hidden)]
 pub unsafe trait Abi: Sized + Clone {
-    /// The abi representation of the implementing type.
-    ///
-    /// # Safety
-    /// `Self` and `Abi` *must* have the same exact in-memory representation.
-
-    // TODO: this type should not exist - the Windows crate should just use ManuallyDrop<Self> in all cases
     type Abi;
-
     type DefaultType: Sized + Clone + PartialEq;
 
-    /// Converts from `Self::DefaultType` to `Result<T>`.
-    fn ok(value: &Self::DefaultType) -> Result<Self> {
-        unsafe {
-            let value = value as *const _ as *const Self;
-            Ok((*value).clone())
-        }
-    }
-
-    /// Casts the Rust object to its ABI type without copying the object.
-    fn abi(&self) -> Self::Abi {
-        // It is always safe to interpret an `Abi` type's binary representation (without moving
-        // the value) as the memory layout must be identical.
-        unsafe { std::mem::transmute_copy(self) }
-    }
-
-    /// Returns a pointer for setting the object's value via an ABI call.
-    // Note: This default implementation is always correct. Only override if you need to assert something for debugging purposes.
-    fn set_abi(&mut self) -> *mut Self::Abi {
-        // TODO: ideally we can debug_assert that the object has a zero memory layout.
-        self as *mut _ as *mut _
+    /// # Safety
+    unsafe fn from_default(value: &Self::DefaultType) -> Result<Self> {
+        let value = value as *const _ as *const Self;
+        Ok((*value).clone())
     }
 
     /// # Safety
-    /// Casts the ABI representation to a Rust object by taking ownership of the bits.
-    /// This default implementation is correct for all but interfaces.
     unsafe fn from_abi(abi: Self::Abi) -> Result<Self> {
         Ok(std::mem::transmute_copy(&abi))
     }
 
-    fn drop_param(_: &mut Param<Self>) {}
+    /// # Safety
+    unsafe fn drop_param(_: &mut Param<Self>) {}
 }
 
 unsafe impl<T> Abi for *mut T {
@@ -62,20 +34,13 @@ unsafe impl<T: Interface> Abi for T {
     type Abi = RawPtr;
     type DefaultType = Option<T>;
 
-    fn ok(value: &Self::DefaultType) -> Result<Self> {
-        unsafe {
-            // For some reason, Rust can't figure out that DefaultType is an Option here.
-            let value = value as *const _ as *const Option<Self>;
+    unsafe fn from_default(value: &Self::DefaultType) -> Result<Self> {
+        let value = value as *const _ as *const Option<Self>;
 
-            match &*value {
-                Some(value) => Ok(value.clone()),
-                None => Err(Error::OK),
-            }
+        match &*value {
+            Some(value) => Ok(value.clone()),
+            None => Err(Error::OK),
         }
-    }
-
-    fn set_abi(&mut self) -> *mut Self::Abi {
-        panic!("set_abi should not be used with interfaces since it implies nullable.");
     }
 
     unsafe fn from_abi(abi: Self::Abi) -> Result<Self> {
@@ -92,13 +57,4 @@ unsafe impl<T: Interface> Abi for T {
 unsafe impl<T: Interface> Abi for Option<T> {
     type Abi = RawPtr;
     type DefaultType = Self;
-
-    fn set_abi(&mut self) -> *mut Self::Abi {
-        debug_assert!(self.is_none());
-        self as *mut _ as *mut _
-    }
-
-    unsafe fn from_abi(_: Self::Abi) -> Result<Self> {
-        panic!("Option<T> should not not be used for return types. Use Result<T> instead.");
-    }
 }

--- a/tests/legacy/bstr/tests/bstr.rs
+++ b/tests/legacy/bstr/tests/bstr.rs
@@ -1,5 +1,4 @@
 use test_bstr::Windows::Win32::Foundation::BSTR;
-use windows::Abi;
 
 #[test]
 fn test() {
@@ -19,7 +18,6 @@ fn clone() {
     let b = a.clone();
     assert_eq!(a, "");
     assert_eq!(b, "");
-    assert_eq!(a.abi(), b.abi());
 
     let a = BSTR::new();
     assert_eq!(a.is_empty(), true);

--- a/tests/legacy/implement/tests/generic_default.rs
+++ b/tests/legacy/implement/tests/generic_default.rs
@@ -15,7 +15,7 @@ where
 impl<T: ::windows::RuntimeType + 'static> Thing<T> {
     fn GetAt(&self, index: u32) -> Result<T> {
         match self.0.get(index as usize) {
-            Some(value) => <T as Abi>::ok(value),
+            Some(value) => unsafe { <T as Abi>::from_default(value) },
             None => Err(Error::new(E_BOUNDS, "")),
         }
     }

--- a/tests/legacy/win32/tests/win32.rs
+++ b/tests/legacy/win32/tests/win32.rs
@@ -17,12 +17,11 @@ use test_win32::Windows::Win32::{
     },
 };
 
-use windows::{Abi, Guid};
+use windows::Guid;
 
 #[test]
 fn signed_enum32() {
     assert!(ACCESS_MODE::default() == 0.into());
-    assert!(REVOKE_ACCESS.abi() == REVOKE_ACCESS);
     let e: ACCESS_MODE = REVOKE_ACCESS;
     assert!(e == REVOKE_ACCESS);
 }
@@ -30,7 +29,6 @@ fn signed_enum32() {
 #[test]
 fn unsigned_enum32() {
     assert!(DXGI_ADAPTER_FLAG::default() == 0.into());
-    assert!(DXGI_ADAPTER_FLAG_SOFTWARE.abi() == DXGI_ADAPTER_FLAG_SOFTWARE);
 
     let both = DXGI_ADAPTER_FLAG_SOFTWARE | DXGI_ADAPTER_FLAG_REMOTE;
     assert!(both == 3.into());

--- a/tests/legacy/winrt/tests/delegates.rs
+++ b/tests/legacy/winrt/tests/delegates.rs
@@ -7,7 +7,7 @@ use test_winrt::{
     Windows::Foundation::{AsyncActionCompletedHandler, AsyncStatus, TypedEventHandler, Uri},
 };
 
-use windows::{Abi, Interface};
+use windows::Interface;
 
 #[test]
 fn non_generic() -> windows::Result<()> {
@@ -48,10 +48,8 @@ fn generic() -> windows::Result<()> {
     let uri = Uri::CreateUri("http://kennykerr.ca")?;
     let (tx, rx) = std::sync::mpsc::channel();
 
-    let uri_clone = uri.clone();
-    let d = Handler::new(move |sender, port| {
+    let d = Handler::new(move |_, port| {
         tx.send(true).unwrap();
-        assert!(uri_clone.abi() == sender.abi());
 
         // TODO: ideally primitives would be passed by value
         assert!(*port == 80);
@@ -77,12 +75,11 @@ fn event() -> windows::Result<()> {
     set.MapChanged(MapChangedEventHandler::<
         windows::HSTRING,
         windows::IInspectable,
-    >::new(move |sender, args| {
+    >::new(move |_, args| {
         let args = args.as_ref().unwrap();
         tx.send(true).unwrap();
         let set = set_clone.clone();
-        let map: IObservableMap<windows::HSTRING, windows::IInspectable> = set.into();
-        assert!(map.abi() == sender.abi());
+        let _: IObservableMap<windows::HSTRING, windows::IInspectable> = set.into();
         assert!(args.Key()? == "A");
         assert!(args.CollectionChange()? == CollectionChange::ItemInserted);
         Ok(())

--- a/tests/legacy/winrt/tests/interface.rs
+++ b/tests/legacy/winrt/tests/interface.rs
@@ -1,5 +1,5 @@
-use test_winrt::Windows::Foundation::{IStringable, Uri};
-use windows::{Abi, Interface};
+use test_winrt::Windows::Foundation::IStringable;
+use windows::Interface;
 
 #[test]
 fn interface() -> windows::Result<()> {
@@ -8,21 +8,6 @@ fn interface() -> windows::Result<()> {
         windows::Guid::from("96369F54-8EB6-48F0-ABCE-C1B211E627C3")
     );
 
-    let uri = &Uri::CreateUri("http://kennykerr.ca")?;
-
     // TODO: Find an example where the default constructor is not exclusive.
-
-    // The class and the non-default interface have different vtable types, which
-    // means we need to cast in order to compare their pointers (which won't match).
-    let s: IStringable = uri.into();
-    assert!(s.ToString()? == "http://kennykerr.ca/");
-
-    assert!(s.abi() != uri.abi());
-
-    // Here two different values of the same class won't share the same value as
-    // they are unique instances even though they have the same vtable layout.
-    let other = &Uri::CreateUri("http://microsoft.com")?;
-    assert!(uri.abi() != other.abi());
-
     Ok(())
 }


### PR DESCRIPTION
Can't quite get rid of it completely as using `ManuallyDrop` everywhere is too painful but this at least limits the `Abi` trait to the essentials. 