### PR TITLE
Only call the win32 winmd generator for x64 builds

### DIFF
--- a/tests/component/build.cmd
+++ b/tests/component/build.cmd
@@ -1,5 +1,5 @@
 pushd .metadata
-dotnet clean && dotnet build /p:OutputWinmd=..\target\%2\%1\Component.Win32.winmd /p:Platform=%2 /p:Configuration=%1
+if "%3" == "x64" dotnet clean && dotnet build /p:OutputWinmd=..\target\%2\%1\Component.Win32.winmd /p:Platform=%2 /p:Configuration=%1
 popd
 
 copy target\%2\%1\Component.dll ..\..\.windows\%3


### PR DESCRIPTION
The generator currently only works in x64 builds.

Blocking issues:
https://github.com/microsoft/win32metadata/issues/605
https://github.com/microsoft/win32metadata/issues/626