### PR TITLE
Implement `IntoParam` for convertible handles

### DIFF
--- a/tests/win32/handles/build.rs
+++ b/tests/win32/handles/build.rs
@@ -1,6 +1,7 @@
 fn main() {
     windows::build! {
         Windows::Win32::Foundation::{BOOLEAN, HANDLE, HWND, PSTR, PWSTR},
+        Windows::Win32::Graphics::Gdi::HBITMAP,
         Windows::Win32::System::Diagnostics::Debug::{SetLastError, WIN32_ERROR},
         Windows::Win32::System::Threading::LPPROC_THREAD_ATTRIBUTE_LIST,
     };

--- a/tests/win32/handles/tests/test.rs
+++ b/tests/win32/handles/tests/test.rs
@@ -1,6 +1,7 @@
 use test_win32_handles::*;
 use windows::*;
 use Windows::Win32::Foundation::*;
+use Windows::Win32::Graphics::Gdi::*;
 use Windows::Win32::System::Diagnostics::Debug::*;
 use Windows::Win32::System::Threading::LPPROC_THREAD_ATTRIBUTE_LIST;
 
@@ -101,4 +102,16 @@ fn lpproc_thread_attribute_list() {
     );
 
     assert!(std::mem::size_of::<LPPROC_THREAD_ATTRIBUTE_LIST>() == std::mem::size_of::<usize>());
+}
+
+#[test]
+fn hbitmap() {
+    fn expect_object<'a>(value: impl IntoParam<'a, HGDIOBJ>) {
+        unsafe {
+            assert!(value.into_param().abi().0 == 123);
+        }
+    }
+
+    expect_object(HBITMAP(123));
+    expect_object(HGDIOBJ(123));
 }


### PR DESCRIPTION
Fixes #1156

Only handles are convertible but 0.20.0 had a regression where only non-handle structs were checked for convertibility. 

I also added a test for convertible handles so this won't slip through again.

cc @mlehmannm