### PR TITLE
Fix invalid indirection in implement macro

### DIFF
--- a/crates/gen/src/winrt.rs
+++ b/crates/gen/src/winrt.rs
@@ -81,7 +81,7 @@ pub fn gen_winrt_abi(sig: &MethodSignature, gen: &Gen) -> TokenStream {
     }
 }
 
-pub fn gen_winrt_invoke_arg(param: &MethodParam, gen: &Gen) -> TokenStream {
+fn gen_winrt_invoke_arg(param: &MethodParam, gen: &Gen) -> TokenStream {
     let name = gen_param_name(&param.param);
     let kind = gen_name(&param.signature.kind, gen);
 

--- a/crates/macros/src/implement.rs
+++ b/crates/macros/src/implement.rs
@@ -159,7 +159,11 @@ pub fn gen(
                     )
                 }
             } else {
-                gen_win32_upcall(&signature, quote! { (*this).implementation.#method_ident })
+                gen_win32_upcall(
+                    &signature,
+                    quote! { (*this).implementation.#method_ident },
+                    &gen,
+                )
             };
 
             shims.combine(&quote! {

--- a/tests/win32/class_factory/tests/test.rs
+++ b/tests/win32/class_factory/tests/test.rs
@@ -25,8 +25,8 @@ struct Factory();
 impl Factory {
     pub fn CreateInstance(
         &self,
-        outer: Option<&IUnknown>,
-        iid: &Guid,
+        outer: &Option<IUnknown>,
+        iid: *const Guid,
         object: *mut RawPtr,
     ) -> HRESULT {
         assert!(outer.is_none());


### PR DESCRIPTION
An invalid implementation signature will now also result in a compiler error rather than a crash.

Fixes #1155