### PR TITLE
Remove unnecessary target checks in tests

### DIFF
--- a/tests/legacy/return_struct/tests/free_function.rs
+++ b/tests/legacy/return_struct/tests/free_function.rs
@@ -2,7 +2,7 @@
 // returning structs where the return value is effectively a trailing out parameter.
 //
 // TODO: D2D1ConvertColorSpace is exported by ordinal rather than by name and Rust doesn't appear to support
-// this at the moment. It happens to work on x64 but not on x64, hence the cfg check below.
+// this at the moment. It happens to work on x64 but not on x86, hence the cfg check below.
 #[test]
 #[cfg(target_pointer_width = "64")]
 fn test() {

--- a/tests/win32/query/src/lib.rs
+++ b/tests/win32/query/src/lib.rs
@@ -1,4 +1,1 @@
-// Remove when upstream metadata generator supports other targets
-#![cfg(all(windows, target_pointer_width = "64"))]
-
 windows::include_bindings!();

--- a/tests/win32/query/tests/test.rs
+++ b/tests/win32/query/tests/test.rs
@@ -1,6 +1,3 @@
-// Remove when upstream metadata generator supports other targets
-#![cfg(all(windows, target_pointer_width = "64"))]
-
 use test_win32_query::*;
 use windows::*;
 use Component::Win32::Query::*;

--- a/tests/win32/simple/src/lib.rs
+++ b/tests/win32/simple/src/lib.rs
@@ -1,4 +1,1 @@
-// Remove when upstream metadata generator supports other targets
-#![cfg(all(windows, target_pointer_width = "64"))]
-
 windows::include_bindings!();

--- a/tests/win32/simple/tests/test.rs
+++ b/tests/win32/simple/tests/test.rs
@@ -1,6 +1,3 @@
-// Remove when upstream metadata generator supports other targets
-#![cfg(all(windows, target_pointer_width = "64"))]
-
 use test_win32_simple::*;
 use windows::*;
 use Component::Win32::Simple::*;


### PR DESCRIPTION
While the win32 winmd generator doesn't support other arches, the Rust tests still do.