### PR TITLE
Simplify use of the Windows crate from other library crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ exclude = [".github", ".windows", "docs", "tests"]
 
 [dependencies]
 windows_macros = { path = "crates/macros",  version = "0.20.1", optional = true }
+windows_reader = { path = "crates/reader", version = "0.20.1", optional = true }
 gen = { package = "windows_gen", path = "crates/gen",  version = "0.20.1", optional = true }
 const-sha1 = "0.2"
 
@@ -28,5 +29,5 @@ targets = ["x86_64-pc-windows-msvc"]
 
 [features]
 default = ["macros"]
-macros = ["gen", "windows_macros"]
+macros = ["gen", "windows_macros", "windows_reader"]
 raw_dylib = ["gen/raw_dylib"] # TODO: remove feature once raw-dylib has stablized

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -38,6 +38,7 @@ pub fn build(stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
     gen_build().as_str().parse().unwrap()
 }
 
+/// A macro for generating WinRT modules ahead of time.
 #[proc_macro]
 pub fn generate(stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
     parse_macro_input!(stream as BuildMacro);

--- a/crates/macros/src/lib.rs
+++ b/crates/macros/src/lib.rs
@@ -9,19 +9,19 @@ use quote::*;
 use reader::*;
 use syn::parse_macro_input;
 
-/// A macro for generating WinRT modules to a .rs file at build time.
+/// A macro for generating Windows API bindings to a .rs file at build time.
 ///
-/// This macro can be used to import WinRT APIs from any Windows metadata (winmd) file.
+/// This macro can be used to import Windows APIs from any Windows metadata (winmd) file.
 /// It is only intended for use from a crate's build.rs script.
 ///
 /// The macro generates a single `build` function which can be used in build scripts
-/// to generate the WinRT bindings. After using the `build` macro, call the
+/// to generate the Windows bindings. After using the `build` macro, call the
 /// generated `build` function somewhere in the build.rs script's main function.
 ///
 /// # Usage
 /// To use, you must then specify which types you want to use. These
 /// follow the same convention as Rust `use` paths. Types know which other types they depend on so
-/// `build` will generate any other WinRT types needed for the specified type to work.
+/// `build` will generate any other Windows types needed for the specified type to work.
 ///
 /// # Example
 /// The following `build!` generates all types inside of the `Microsoft::AI::MachineLearning`
@@ -38,7 +38,7 @@ pub fn build(stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
     gen_build().as_str().parse().unwrap()
 }
 
-/// A macro for generating WinRT modules ahead of time.
+/// A macro for generating Windows API bindings ahead of time.
 #[proc_macro]
 pub fn generate(stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
     parse_macro_input!(stream as BuildMacro);
@@ -50,7 +50,7 @@ pub fn generate(stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
     tokens.parse().unwrap()
 }
 
-/// Rust structs can use the [`macro@implement`] attribute macro to implement entire WinRT
+/// Rust structs can use the [`macro@implement`] attribute macro to implement entire WinRT or COM
 /// classes or any combination of existing COM and WinRT interfaces.
 ///
 /// If the attribute [`proc_macro::TokenStream`] contains the name of a WinRT class then all

--- a/crates/reader/src/workspace.rs
+++ b/crates/reader/src/workspace.rs
@@ -29,6 +29,7 @@ fn json_value(key: &str) -> String {
     json[beginning_index..beginning_index + ending_index].replace("\\\\", "\\")
 }
 
+#[doc(hidden)]
 pub fn workspace_dir() -> String {
     json_value("workspace_root")
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,7 +35,10 @@ pub use runtime::{
 pub use traits::*;
 
 #[cfg(feature = "macros")]
-pub use windows_macros::{build, implement};
+pub use windows_macros::{build, generate, implement};
+
+#[cfg(feature = "macros")]
+pub use windows_reader::workspace_dir;
 
 extern crate self as windows;
 

--- a/src/runtime/guid.rs
+++ b/src/runtime/guid.rs
@@ -8,10 +8,10 @@ use bindings::Windows::Win32::System::Com::CoCreateGuid;
 #[repr(C)]
 #[derive(Clone, Copy, Default, PartialEq, Eq)]
 pub struct Guid {
-    data1: u32,
-    data2: u16,
-    data3: u16,
-    data4: [u8; 8],
+    pub data1: u32,
+    pub data2: u16,
+    pub data3: u16,
+    pub data4: [u8; 8],
 }
 
 impl Guid {


### PR DESCRIPTION
These changes were made to support porting the `miow` crate from `winapi` to the `windows` crate.