### PR TITLE
Disable whole program optimization for static libs

### DIFF
--- a/tests/static_component/static_component.vcxproj
+++ b/tests/static_component/static_component.vcxproj
@@ -21,7 +21,6 @@
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'" Label="Configuration">
     <UseDebugLibraries>false</UseDebugLibraries>
-    <WholeProgramOptimization>true</WholeProgramOptimization>
     <LinkIncremental>false</LinkIncremental>
   </PropertyGroup>
   <ItemGroup Label="ProjectConfigurations">


### PR DESCRIPTION
Disables /GL (whole program optimization) for release static libs. Whole Program Optimization is designed for use with Link-time code generation and, if used on its own, generates libs that are generally unusable downstream.