### PR TITLE
Faster type reader

### DIFF
--- a/crates/reader/src/type_tree.rs
+++ b/crates/reader/src/type_tree.rs
@@ -14,6 +14,8 @@ pub struct TypeEntry {
     pub include: TypeInclude,
 }
 
+// The TypeTree needs to use a BTreeMap rather than the fast HashMap because it affects code gen and we need
+// the code gen to be stable.
 pub struct TypeTree {
     pub namespace: &'static str,
     pub types: BTreeMap<&'static str, TypeEntry>,


### PR DESCRIPTION
Using `strlen` is faster than the manual loop in debug builds (typical for proc macro usage).