### PR TITLE
Document feature requirements

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ Learn more here: <https://github.com/microsoft/windows-rs>
 */
 
 #![doc(html_no_source)]
+#![feature(doc_cfg)]
 
 extern crate self as windows;
 mod Windows;


### PR DESCRIPTION
Fixes #1246 

@jyn514 It would be great if it could detect when a feature enables other features and only show the smallest set of features. For example, here `Win32_Storage_CloudFilters` enables `Win32_Storage` which enables `Win32` so it would ideally elide those for brevity and only list the features that must be enabled to actually enable the function. From the Windows crate's Cargo.toml:

```
Win32_Storage = ["Win32"]
Win32_Storage_CloudFilters = ["Win32_Storage"]
```

This is because it is modeling a module hierarchy. 

![image](https://user-images.githubusercontent.com/9845234/139539892-152b9e7c-3967-404c-a395-b7b6f9e39188.png)
