### PR TITLE
Make documentation more accessible

### DIFF
--- a/.github/readme.md
+++ b/.github/readme.md
@@ -1,12 +1,14 @@
 [![crates.io](https://img.shields.io/crates/v/windows.svg)](https://crates.io/crates/windows)
-[![docs.rs](https://docs.rs/windows/badge.svg)](https://docs.rs/windows)
+[![docs.rs](https://docs.rs/windows/badge.svg)](https://microsoft.github.io/windows-docs-rs/)
 [![build](https://github.com/microsoft/windows-rs/workflows/build/badge.svg?event=push)](https://github.com/microsoft/windows-rs/actions)
 
 ## Rust for the Windows SDK
 
 The `windows` crate lets you call any Windows API past, present, and future using code generated on the fly directly from the metadata describing the API and right into your Rust package where you can call them as if they were just another Rust module. The Rust language projection follows in the tradition established by [C++/WinRT](https://github.com/microsoft/cppwinrt) of building language projections for Windows using standard languages and compilers, providing a natural and idiomatic way for Rust developers to call Windows APIs.
 
-Looking for specific APIs? The default set of APIs are searchable and [documented here](https://microsoft.github.io/windows-docs-rs/). More examples [can be found here](https://github.com/microsoft/windows-samples-rs). You can also find [the changelog here](https://github.com/microsoft/windows-rs/blob/master/.github/changelog.md).
+* [Documentation](https://microsoft.github.io/windows-docs-rs/)
+* [Samples](https://github.com/microsoft/windows-samples-rs/)
+* [Changelog](https://github.com/microsoft/windows-rs/blob/master/.github/changelog.md)
 
 Start by adding the following to your Cargo.toml file:
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Rust for Windows"
 repository = "https://github.com/microsoft/windows-rs"
-documentation = "https://docs.rs/windows"
+documentation = "https://microsoft.github.io/windows-docs-rs/"
 readme = ".github/readme.md"
 exclude = [".github", ".windows", "docs", "tests"]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Rust for Windows"
 repository = "https://github.com/microsoft/windows-rs"
-documentation = "https://microsoft.github.io/windows-docs-rs/"
+documentation = "https://docs.rs/windows"
 readme = ".github/readme.md"
 exclude = [".github", ".windows", "docs", "tests"]
 

--- a/crates/tools/api/src/main.rs
+++ b/crates/tools/api/src/main.rs
@@ -37,7 +37,7 @@ edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Rust for Windows"
 repository = "https://github.com/microsoft/windows-rs"
-documentation = "https://docs.rs/windows"
+documentation = "https://microsoft.github.io/windows-docs-rs/"
 readme = ".github/readme.md"
 exclude = [".github", ".windows", "docs", "tests"]
 


### PR DESCRIPTION
@Jasper-Bekkers looks like it will be some time before docs.rs can handle the documentation for the Windows crate so I'm including your suggestion to update the Cargo.toml to point to the generated documentation directly. 