### PR TITLE
Version 0.26.0

### DIFF
--- a/.github/changelog.md
+++ b/.github/changelog.md
@@ -1,3 +1,9 @@
+# 0.26
+
+- `no_std` support by default (use the `std` feature to enable use of the standard library)
+- Updated Win32 metadata (mostly DirectX namespaces have been reorganized for improved compile time)
+- Other small improvements and fixes
+
 # 0.25
 
 - Multi-architecture support

--- a/.github/readme.md
+++ b/.github/readme.md
@@ -14,8 +14,9 @@ Start by adding the following to your Cargo.toml file:
 
 ```toml
 [dependencies.windows]
-version = "0.25.0"
+version = "0.26.0"
 features = [
+    "std",
     "Data_Xml_Dom",
     "Win32_Foundation",
     "Win32_Security",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "windows"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -29,24 +29,24 @@ default-target = "x86_64-pc-windows-msvc"
 targets = []
 
 [dependencies]
-windows_macros = { path = "crates/deps/macros",  version = "0.25.0", optional = true }
-windows_reader = { path = "crates/deps/reader", version = "0.25.0", optional = true }
-windows_gen = { path = "crates/deps/gen",  version = "0.25.0", optional = true }
+windows_macros = { path = "crates/deps/macros",  version = "0.26.0", optional = true }
+windows_reader = { path = "crates/deps/reader", version = "0.26.0", optional = true }
+windows_gen = { path = "crates/deps/gen",  version = "0.26.0", optional = true }
 
 [target.i686-pc-windows-msvc.dependencies]
-windows_i686_msvc = { path = "crates/targets/i686_msvc", version = "0.25.0" }
+windows_i686_msvc = { path = "crates/targets/i686_msvc", version = "0.26.0" }
 
 [target.x86_64-pc-windows-msvc.dependencies]
-windows_x86_64_msvc = { path = "crates/targets/x86_64_msvc", version = "0.25.0" }
+windows_x86_64_msvc = { path = "crates/targets/x86_64_msvc", version = "0.26.0" }
 
 [target.aarch64-pc-windows-msvc.dependencies]
-windows_aarch64_msvc = { path = "crates/targets/aarch64_msvc", version = "0.25.0" }
+windows_aarch64_msvc = { path = "crates/targets/aarch64_msvc", version = "0.26.0" }
 
 [target.i686-pc-windows-gnu.dependencies]
-windows_i686_gnu = { path = "crates/targets/i686_gnu", version = "0.25.0" }
+windows_i686_gnu = { path = "crates/targets/i686_gnu", version = "0.26.0" }
 
 [target.x86_64-pc-windows-gnu.dependencies]
-windows_x86_64_gnu = { path = "crates/targets/x86_64_gnu", version = "0.25.0" }
+windows_x86_64_gnu = { path = "crates/targets/x86_64_gnu", version = "0.26.0" }
 
 [features]
 default = []

--- a/crates/deps/gen/Cargo.toml
+++ b/crates/deps/gen/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "windows_gen"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Code gen support for the windows crate"
 
 [dependencies]
-quote = { package = "windows_quote", path = "../quote", version = "0.25.0" }
-reader = { package = "windows_reader", path = "../reader", version = "0.25.0" }
+quote = { package = "windows_quote", path = "../quote", version = "0.26.0" }
+reader = { package = "windows_reader", path = "../reader", version = "0.26.0" }

--- a/crates/deps/macros/Cargo.toml
+++ b/crates/deps/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_macros"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -10,7 +10,7 @@ description = "Macros for the windows crate"
 proc-macro = true
 
 [dependencies]
-gen = { package = "windows_gen", path = "../gen", version = "0.25.0" }
-reader = { package = "windows_reader", path = "../reader", version = "0.25.0" }
+gen = { package = "windows_gen", path = "../gen", version = "0.26.0" }
+reader = { package = "windows_reader", path = "../reader", version = "0.26.0" }
 syn = { version = "1.0", default-features = false, features = ["parsing", "proc-macro", "printing", "full", "derive"] }
-quote = { package = "windows_quote", path = "../quote", version = "0.25.0" }
+quote = { package = "windows_quote", path = "../quote", version = "0.26.0" }

--- a/crates/deps/quote/Cargo.toml
+++ b/crates/deps/quote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_quote"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/deps/reader/Cargo.toml
+++ b/crates/deps/reader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_reader"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/aarch64_msvc/Cargo.toml
+++ b/crates/targets/aarch64_msvc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_aarch64_msvc"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/i686_gnu/Cargo.toml
+++ b/crates/targets/i686_gnu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_i686_gnu"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/i686_msvc/Cargo.toml
+++ b/crates/targets/i686_msvc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_i686_msvc"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/x86_64_gnu/Cargo.toml
+++ b/crates/targets/x86_64_gnu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_x86_64_gnu"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/x86_64_msvc/Cargo.toml
+++ b/crates/targets/x86_64_msvc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_x86_64_msvc"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/tools/api/Cargo.toml
+++ b/crates/tools/api/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2018"
 publish = false
 
 [dependencies]
-reader = { package = "windows_reader", path = "../../deps/reader", version = "0.25.0" }
-gen = { package = "windows_gen", path = "../../deps/gen", version = "0.25.0" }
+reader = { package = "windows_reader", path = "../../deps/reader", version = "0.26.0" }
+gen = { package = "windows_gen", path = "../../deps/gen", version = "0.26.0" }
 rayon = "1.5.1"

--- a/crates/tools/api/src/main.rs
+++ b/crates/tools/api/src/main.rs
@@ -31,7 +31,7 @@ fn write_toml(output: &std::path::Path, tree: &reader::TypeTree) {
         r#"
 [package]
 name = "windows"
-version = "0.25.0"
+version = "0.26.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -59,24 +59,24 @@ default-target = "x86_64-pc-windows-msvc"
 targets = []
 
 [dependencies]
-windows_macros = { path = "crates/deps/macros",  version = "0.25.0", optional = true }
-windows_reader = { path = "crates/deps/reader", version = "0.25.0", optional = true }
-windows_gen = { path = "crates/deps/gen",  version = "0.25.0", optional = true }
+windows_macros = { path = "crates/deps/macros",  version = "0.26.0", optional = true }
+windows_reader = { path = "crates/deps/reader", version = "0.26.0", optional = true }
+windows_gen = { path = "crates/deps/gen",  version = "0.26.0", optional = true }
 
 [target.i686-pc-windows-msvc.dependencies]
-windows_i686_msvc = { path = "crates/targets/i686_msvc", version = "0.25.0" }
+windows_i686_msvc = { path = "crates/targets/i686_msvc", version = "0.26.0" }
 
 [target.x86_64-pc-windows-msvc.dependencies]
-windows_x86_64_msvc = { path = "crates/targets/x86_64_msvc", version = "0.25.0" }
+windows_x86_64_msvc = { path = "crates/targets/x86_64_msvc", version = "0.26.0" }
 
 [target.aarch64-pc-windows-msvc.dependencies]
-windows_aarch64_msvc = { path = "crates/targets/aarch64_msvc", version = "0.25.0" }
+windows_aarch64_msvc = { path = "crates/targets/aarch64_msvc", version = "0.26.0" }
 
 [target.i686-pc-windows-gnu.dependencies]
-windows_i686_gnu = { path = "crates/targets/i686_gnu", version = "0.25.0" }
+windows_i686_gnu = { path = "crates/targets/i686_gnu", version = "0.26.0" }
 
 [target.x86_64-pc-windows-gnu.dependencies]
-windows_x86_64_gnu = { path = "crates/targets/x86_64_gnu", version = "0.25.0" }
+windows_x86_64_gnu = { path = "crates/targets/x86_64_gnu", version = "0.26.0" }
 
 [features]
 default = []

--- a/crates/tools/bindings/Cargo.toml
+++ b/crates/tools/bindings/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2018"
 publish = false
 
 [dependencies]
-reader = { package = "windows_reader", path = "../../deps/reader", version = "0.25.0" }
-macros = { package = "windows_macros", path = "../../deps/macros", version = "0.25.0" }
+reader = { package = "windows_reader", path = "../../deps/reader", version = "0.26.0" }
+macros = { package = "windows_macros", path = "../../deps/macros", version = "0.26.0" }

--- a/crates/tools/fmt/Cargo.toml
+++ b/crates/tools/fmt/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2018"
 publish = false
 
 [dependencies]
-windows_reader = { path = "../../deps/reader", version = "0.25.0" }
+windows_reader = { path = "../../deps/reader", version = "0.26.0" }

--- a/crates/tools/gnu/Cargo.toml
+++ b/crates/tools/gnu/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2018"
 publish = false
 
 [dependencies]
-reader = { package = "windows_reader", path = "../../deps/reader", version = "0.25.0" }
+reader = { package = "windows_reader", path = "../../deps/reader", version = "0.26.0" }

--- a/crates/tools/msvc/Cargo.toml
+++ b/crates/tools/msvc/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2018"
 publish = false
 
 [dependencies]
-reader = { package = "windows_reader", path = "../../deps/reader", version = "0.25.0" }
+reader = { package = "windows_reader", path = "../../deps/reader", version = "0.26.0" }


### PR DESCRIPTION
- `no_std` support by default (use the `std` feature to enable use of the standard library)
- Updated Win32 metadata (mostly DirectX namespaces have been reorganized for improved compile time)
- Other small improvements and fixes