### PR TITLE
`std` and `alloc` improvements

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,7 @@ windows_x86_64_gnu = { path = "crates/targets/x86_64_gnu", version = "0.26.0" }
 [features]
 default = []
 std = []
+alloc = []
 deprecated = []
 build = ["windows_gen", "windows_macros", "windows_reader"]
 AI = []

--- a/crates/deps/gen/src/bstr.rs
+++ b/crates/deps/gen/src/bstr.rs
@@ -48,40 +48,34 @@ pub fn gen_bstr() -> TokenStream {
                 Self::from_wide(self.as_wide())
             }
         }
-        // TODO: these str traits should work with no_std
-        #[cfg(feature = "std")]
         impl ::core::convert::From<&str> for BSTR {
             fn from(value: &str) -> Self {
-                let value: ::std::vec::Vec<u16> = value.encode_utf16().collect();
+                let value: ::windows::runtime::alloc::vec::Vec<u16> = value.encode_utf16().collect();
                 Self::from_wide(&value)
             }
         }
-        #[cfg(feature = "std")]
-        impl ::core::convert::From<::std::string::String> for BSTR {
-            fn from(value: ::std::string::String) -> Self {
+        impl ::core::convert::From<::windows::runtime::alloc::string::String> for BSTR {
+            fn from(value: ::windows::runtime::alloc::string::String) -> Self {
                 value.as_str().into()
             }
         }
-        #[cfg(feature = "std")]
-        impl  ::core::convert::From<&::std::string::String> for BSTR {
-            fn from(value: &::std::string::String) -> Self {
+        impl  ::core::convert::From<&::windows::runtime::alloc::string::String> for BSTR {
+            fn from(value: &::windows::runtime::alloc::string::String) -> Self {
                 value.as_str().into()
             }
         }
-        #[cfg(feature = "std")]
-        impl<'a> ::core::convert::TryFrom<&'a BSTR> for ::std::string::String {
-            type Error = ::std::string::FromUtf16Error;
+        impl<'a> ::core::convert::TryFrom<&'a BSTR> for ::windows::runtime::alloc::string::String {
+            type Error = ::windows::runtime::alloc::string::FromUtf16Error;
 
             fn try_from(value: &BSTR) -> ::core::result::Result<Self, Self::Error> {
-                ::std::string::String::from_utf16(value.as_wide())
+                ::windows::runtime::alloc::string::String::from_utf16(value.as_wide())
             }
         }
-        #[cfg(feature = "std")]
-        impl ::core::convert::TryFrom<BSTR> for ::std::string::String {
-            type Error = ::std::string::FromUtf16Error;
+        impl ::core::convert::TryFrom<BSTR> for ::windows::runtime::alloc::string::String {
+            type Error = ::windows::runtime::alloc::string::FromUtf16Error;
 
             fn try_from(value: BSTR) -> ::core::result::Result<Self, Self::Error> {
-                ::std::string::String::try_from(&value)
+                ::windows::runtime::alloc::string::String::try_from(&value)
             }
         }
         impl ::core::default::Default for BSTR {
@@ -108,9 +102,8 @@ pub fn gen_bstr() -> TokenStream {
                 self.as_wide() == other.as_wide()
             }
         }
-        #[cfg(feature = "std")]
-        impl ::core::cmp::PartialEq<::std::string::String> for BSTR {
-            fn eq(&self, other: &::std::string::String) -> bool {
+        impl ::core::cmp::PartialEq<::windows::runtime::alloc::string::String> for BSTR {
+            fn eq(&self, other: &::windows::runtime::alloc::string::String) -> bool {
                 self == other.as_str()
             }
         }
@@ -141,14 +134,14 @@ pub fn gen_bstr() -> TokenStream {
             type Abi = ::core::mem::ManuallyDrop<Self>;
         }
         pub type BSTR_abi = *mut u16;
-        #[cfg(feature = "std")]
+        #[cfg(feature = "alloc")]
         impl<'a> ::windows::runtime::IntoParam<'a, BSTR> for &str {
             fn into_param(self) -> ::windows::runtime::Param<'a, BSTR> {
                 ::windows::runtime::Param::Owned(self.into())
             }
         }
-        #[cfg(feature = "std")]
-        impl<'a> ::windows::runtime::IntoParam<'a, BSTR> for ::std::string::String {
+        #[cfg(feature = "alloc")]
+        impl<'a> ::windows::runtime::IntoParam<'a, BSTR> for ::windows::runtime::alloc::string::String {
             fn into_param(self) -> ::windows::runtime::Param<'a, BSTR> {
                 ::windows::runtime::Param::Owned(self.into())
             }

--- a/crates/deps/gen/src/pstr.rs
+++ b/crates/deps/gen/src/pstr.rs
@@ -18,23 +18,23 @@ pub fn gen_pstr() -> TokenStream {
         unsafe impl ::windows::runtime::Abi for PSTR {
             type Abi = Self;
 
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             unsafe fn drop_param(param: &mut ::windows::runtime::Param<'_, Self>) {
                 if let ::windows::runtime::Param::Boxed(value) = param {
                     if !value.is_null() {
-                        unsafe { ::std::boxed::Box::from_raw(value.0); }
+                        unsafe { ::windows::runtime::alloc::boxed::Box::from_raw(value.0); }
                     }
                 }
             }
         }
-        #[cfg(feature = "std")]
+        #[cfg(feature = "alloc")]
         impl<'a> ::windows::runtime::IntoParam<'a, PSTR> for &str {
             fn into_param(self) -> ::windows::runtime::Param<'a, PSTR> {
-                ::windows::runtime::Param::Boxed(PSTR(::std::boxed::Box::<[u8]>::into_raw(self.bytes().chain(::std::iter::once(0)).collect::<std::vec::Vec<u8>>().into_boxed_slice()) as _))
+                ::windows::runtime::Param::Boxed(PSTR(::windows::runtime::alloc::boxed::Box::<[u8]>::into_raw(self.bytes().chain(::core::iter::once(0)).collect::<::windows::runtime::alloc::vec::Vec<u8>>().into_boxed_slice()) as _))
             }
         }
-        #[cfg(feature = "std")]
-        impl<'a> ::windows::runtime::IntoParam<'a, PSTR> for String {
+        #[cfg(feature = "alloc")]
+        impl<'a> ::windows::runtime::IntoParam<'a, PSTR> for ::windows::runtime::alloc::string::String {
             fn into_param(self) -> ::windows::runtime::Param<'a, PSTR> {
                 ::windows::runtime::IntoParam::into_param(self.as_str())
             }

--- a/crates/deps/gen/src/pwstr.rs
+++ b/crates/deps/gen/src/pwstr.rs
@@ -18,35 +18,35 @@ pub fn gen_pwstr() -> TokenStream {
         unsafe impl ::windows::runtime::Abi for PWSTR {
             type Abi = Self;
 
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             unsafe fn drop_param(param: &mut ::windows::runtime::Param<'_, Self>) {
                 if let ::windows::runtime::Param::Boxed(value) = param {
                     if !value.is_null() {
-                        unsafe { ::std::boxed::Box::from_raw(value.0); }
+                        unsafe { ::windows::runtime::alloc::boxed::Box::from_raw(value.0); }
                     }
                 }
             }
         }
-        #[cfg(feature = "std")]
+        #[cfg(feature = "alloc")]
         impl<'a> ::windows::runtime::IntoParam<'a, PWSTR> for &str {
             fn into_param(self) -> ::windows::runtime::Param<'a, PWSTR> {
-                ::windows::runtime::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(self.encode_utf16().chain(::core::iter::once(0)).collect::<std::vec::Vec<u16>>().into_boxed_slice()) as _))
+                ::windows::runtime::Param::Boxed(PWSTR(::windows::runtime::alloc::boxed::Box::<[u16]>::into_raw(self.encode_utf16().chain(::core::iter::once(0)).collect::<::windows::runtime::alloc::vec::Vec<u16>>().into_boxed_slice()) as _))
             }
         }
-        #[cfg(feature = "std")]
-        impl<'a> ::windows::runtime::IntoParam<'a, PWSTR> for String {
+        #[cfg(feature = "alloc")]
+        impl<'a> ::windows::runtime::IntoParam<'a, PWSTR> for ::windows::runtime::alloc::string::String {
             fn into_param(self) -> ::windows::runtime::Param<'a, PWSTR> {
                 ::windows::runtime::IntoParam::into_param(self.as_str())
             }
         }
-        #[cfg(all(windows, feature = "std"))]
+        #[cfg(feature = "std")]
         impl<'a> ::windows::runtime::IntoParam<'a, PWSTR> for &::std::ffi::OsStr {
             fn into_param(self) -> ::windows::runtime::Param<'a, PWSTR> {
                 use ::std::os::windows::ffi::OsStrExt;
-                ::windows::runtime::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(self.encode_wide().chain(::core::iter::once(0)).collect::<std::vec::Vec<u16>>().into_boxed_slice()) as _))
+                ::windows::runtime::Param::Boxed(PWSTR(::windows::runtime::alloc::boxed::Box::<[u16]>::into_raw(self.encode_wide().chain(::core::iter::once(0)).collect::<::windows::runtime::alloc::vec::Vec<u16>>().into_boxed_slice()) as _))
             }
         }
-        #[cfg(all(windows, feature = "std"))]
+        #[cfg(feature = "std")]
         impl<'a> ::windows::runtime::IntoParam<'a, PWSTR> for ::std::ffi::OsString {
             fn into_param(self) -> ::windows::runtime::Param<'a, PWSTR> {
                 ::windows::runtime::IntoParam::into_param(self.as_os_str())

--- a/crates/tests/legacy/helpers/Cargo.toml
+++ b/crates/tests/legacy/helpers/Cargo.toml
@@ -11,5 +11,5 @@ windows = { path = "../../../.." }
 windows = { path = "../../../..", features = ["build"] }
 
 [features]
-default = ["std"]
-std = []
+default = ["alloc"]
+alloc = []

--- a/crates/tests/legacy/interop/Cargo.toml
+++ b/crates/tests/legacy/interop/Cargo.toml
@@ -8,4 +8,8 @@ edition = "2018"
 windows = { path = "../../../.." }
 
 [build-dependencies]
-windows = { path = "../../../..", features = ["build"] }
+windows = { path = "../../../..", features = ["build", "alloc"] }
+
+[features]
+default = ["alloc"]
+alloc = []

--- a/crates/tests/legacy/ntstatus/Cargo.toml
+++ b/crates/tests/legacy/ntstatus/Cargo.toml
@@ -11,5 +11,5 @@ windows = { path = "../../../.." }
 windows = { path = "../../../..", features = ["build"] }
 
 [features]
-default = ["std"]
-std = []
+default = ["alloc"]
+alloc = []

--- a/crates/tests/legacy/pwstr/Cargo.toml
+++ b/crates/tests/legacy/pwstr/Cargo.toml
@@ -5,11 +5,12 @@ authors = ["Microsoft"]
 edition = "2018"
 
 [dependencies]
-windows = { path = "../../../.." }
+windows = { path = "../../../..", features = ["build", "alloc"] }
 
 [build-dependencies]
-windows = { path = "../../../..", features = ["build"] }
+windows = { path = "../../../..", features = ["build", "alloc"] }
 
 [features]
-default = ["std"]
+default = ["alloc", "std"]
+alloc = []
 std = []

--- a/crates/tests/legacy/structs/Cargo.toml
+++ b/crates/tests/legacy/structs/Cargo.toml
@@ -11,5 +11,5 @@ windows = { path = "../../../.." }
 windows = { path = "../../../..", features = ["build"] }
 
 [features]
-default = ["std"]
-std = []
+default = ["alloc"]
+alloc = []

--- a/crates/tests/legacy/win32/Cargo.toml
+++ b/crates/tests/legacy/win32/Cargo.toml
@@ -15,5 +15,5 @@ helpers = { package = "test_helpers", path = "../helpers" }
 windows = { path = "../../../..", features = ["build"] }
 
 [features]
-default = ["std"]
-std = []
+default = ["alloc"]
+alloc = []

--- a/crates/tests/legacy/winrt/Cargo.toml
+++ b/crates/tests/legacy/winrt/Cargo.toml
@@ -5,7 +5,7 @@ authors = ["Microsoft"]
 edition = "2018"
 
 [dependencies]
-windows = { path = "../../../.." }
+windows = { path = "../../../..", features = ["std", "alloc"] }
 gen = { package = "windows_gen", path = "../../../../crates/deps/gen" }
 reader = { package = "windows_reader", path = "../../../../crates/deps/reader" }
 

--- a/crates/tests/win32/bstr/Cargo.toml
+++ b/crates/tests/win32/bstr/Cargo.toml
@@ -11,5 +11,5 @@ windows = { path = "../../../.." }
 windows = { path = "../../../..", features = ["build"] }
 
 [features]
-default = ["std"]
-std = []
+default = ["alloc"]
+alloc = []

--- a/crates/tests/winrt/async/Cargo.toml
+++ b/crates/tests/winrt/async/Cargo.toml
@@ -14,5 +14,6 @@ windows = { path = "../../../..", features = ["build"] }
 futures = "0.3"
 
 [features]
-default = ["std"]
+default = ["alloc", "std"]
+alloc = []
 std = []

--- a/crates/tools/api/src/main.rs
+++ b/crates/tools/api/src/main.rs
@@ -81,6 +81,7 @@ windows_x86_64_gnu = { path = "crates/targets/x86_64_gnu", version = "0.26.0" }
 [features]
 default = []
 std = []
+alloc = []
 deprecated = []
 build = ["windows_gen", "windows_macros", "windows_reader"]
 "#

--- a/src/Windows/Win32/Foundation/mod.rs
+++ b/src/Windows/Win32/Foundation/mod.rs
@@ -219,37 +219,32 @@ impl ::core::clone::Clone for BSTR {
         Self::from_wide(self.as_wide())
     }
 }
-#[cfg(feature = "std")]
 impl ::core::convert::From<&str> for BSTR {
     fn from(value: &str) -> Self {
-        let value: ::std::vec::Vec<u16> = value.encode_utf16().collect();
+        let value: ::windows::runtime::alloc::vec::Vec<u16> = value.encode_utf16().collect();
         Self::from_wide(&value)
     }
 }
-#[cfg(feature = "std")]
-impl ::core::convert::From<::std::string::String> for BSTR {
-    fn from(value: ::std::string::String) -> Self {
+impl ::core::convert::From<::windows::runtime::alloc::string::String> for BSTR {
+    fn from(value: ::windows::runtime::alloc::string::String) -> Self {
         value.as_str().into()
     }
 }
-#[cfg(feature = "std")]
-impl ::core::convert::From<&::std::string::String> for BSTR {
-    fn from(value: &::std::string::String) -> Self {
+impl ::core::convert::From<&::windows::runtime::alloc::string::String> for BSTR {
+    fn from(value: &::windows::runtime::alloc::string::String) -> Self {
         value.as_str().into()
     }
 }
-#[cfg(feature = "std")]
-impl<'a> ::core::convert::TryFrom<&'a BSTR> for ::std::string::String {
-    type Error = ::std::string::FromUtf16Error;
+impl<'a> ::core::convert::TryFrom<&'a BSTR> for ::windows::runtime::alloc::string::String {
+    type Error = ::windows::runtime::alloc::string::FromUtf16Error;
     fn try_from(value: &BSTR) -> ::core::result::Result<Self, Self::Error> {
-        ::std::string::String::from_utf16(value.as_wide())
+        ::windows::runtime::alloc::string::String::from_utf16(value.as_wide())
     }
 }
-#[cfg(feature = "std")]
-impl ::core::convert::TryFrom<BSTR> for ::std::string::String {
-    type Error = ::std::string::FromUtf16Error;
+impl ::core::convert::TryFrom<BSTR> for ::windows::runtime::alloc::string::String {
+    type Error = ::windows::runtime::alloc::string::FromUtf16Error;
     fn try_from(value: BSTR) -> ::core::result::Result<Self, Self::Error> {
-        ::std::string::String::try_from(&value)
+        ::windows::runtime::alloc::string::String::try_from(&value)
     }
 }
 impl ::core::default::Default for BSTR {
@@ -276,9 +271,8 @@ impl ::core::cmp::PartialEq for BSTR {
         self.as_wide() == other.as_wide()
     }
 }
-#[cfg(feature = "std")]
-impl ::core::cmp::PartialEq<::std::string::String> for BSTR {
-    fn eq(&self, other: &::std::string::String) -> bool {
+impl ::core::cmp::PartialEq<::windows::runtime::alloc::string::String> for BSTR {
+    fn eq(&self, other: &::windows::runtime::alloc::string::String) -> bool {
         self == other.as_str()
     }
 }
@@ -308,14 +302,14 @@ unsafe impl ::windows::runtime::Abi for BSTR {
     type Abi = ::core::mem::ManuallyDrop<Self>;
 }
 pub type BSTR_abi = *mut u16;
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<'a> ::windows::runtime::IntoParam<'a, BSTR> for &str {
     fn into_param(self) -> ::windows::runtime::Param<'a, BSTR> {
         ::windows::runtime::Param::Owned(self.into())
     }
 }
-#[cfg(feature = "std")]
-impl<'a> ::windows::runtime::IntoParam<'a, BSTR> for ::std::string::String {
+#[cfg(feature = "alloc")]
+impl<'a> ::windows::runtime::IntoParam<'a, BSTR> for ::windows::runtime::alloc::string::String {
     fn into_param(self) -> ::windows::runtime::Param<'a, BSTR> {
         ::windows::runtime::Param::Owned(self.into())
     }
@@ -5480,25 +5474,25 @@ impl ::core::default::Default for PSTR {
 }
 unsafe impl ::windows::runtime::Abi for PSTR {
     type Abi = Self;
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     unsafe fn drop_param(param: &mut ::windows::runtime::Param<'_, Self>) {
         if let ::windows::runtime::Param::Boxed(value) = param {
             if !value.is_null() {
                 unsafe {
-                    ::std::boxed::Box::from_raw(value.0);
+                    ::windows::runtime::alloc::boxed::Box::from_raw(value.0);
                 }
             }
         }
     }
 }
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<'a> ::windows::runtime::IntoParam<'a, PSTR> for &str {
     fn into_param(self) -> ::windows::runtime::Param<'a, PSTR> {
-        ::windows::runtime::Param::Boxed(PSTR(::std::boxed::Box::<[u8]>::into_raw(self.bytes().chain(::std::iter::once(0)).collect::<std::vec::Vec<u8>>().into_boxed_slice()) as _))
+        ::windows::runtime::Param::Boxed(PSTR(::windows::runtime::alloc::boxed::Box::<[u8]>::into_raw(self.bytes().chain(::core::iter::once(0)).collect::<::windows::runtime::alloc::vec::Vec<u8>>().into_boxed_slice()) as _))
     }
 }
-#[cfg(feature = "std")]
-impl<'a> ::windows::runtime::IntoParam<'a, PSTR> for String {
+#[cfg(feature = "alloc")]
+impl<'a> ::windows::runtime::IntoParam<'a, PSTR> for ::windows::runtime::alloc::string::String {
     fn into_param(self) -> ::windows::runtime::Param<'a, PSTR> {
         ::windows::runtime::IntoParam::into_param(self.as_str())
     }
@@ -5518,37 +5512,37 @@ impl ::core::default::Default for PWSTR {
 }
 unsafe impl ::windows::runtime::Abi for PWSTR {
     type Abi = Self;
-    #[cfg(feature = "std")]
+    #[cfg(feature = "alloc")]
     unsafe fn drop_param(param: &mut ::windows::runtime::Param<'_, Self>) {
         if let ::windows::runtime::Param::Boxed(value) = param {
             if !value.is_null() {
                 unsafe {
-                    ::std::boxed::Box::from_raw(value.0);
+                    ::windows::runtime::alloc::boxed::Box::from_raw(value.0);
                 }
             }
         }
     }
 }
-#[cfg(feature = "std")]
+#[cfg(feature = "alloc")]
 impl<'a> ::windows::runtime::IntoParam<'a, PWSTR> for &str {
     fn into_param(self) -> ::windows::runtime::Param<'a, PWSTR> {
-        ::windows::runtime::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(self.encode_utf16().chain(::core::iter::once(0)).collect::<std::vec::Vec<u16>>().into_boxed_slice()) as _))
+        ::windows::runtime::Param::Boxed(PWSTR(::windows::runtime::alloc::boxed::Box::<[u16]>::into_raw(self.encode_utf16().chain(::core::iter::once(0)).collect::<::windows::runtime::alloc::vec::Vec<u16>>().into_boxed_slice()) as _))
     }
 }
-#[cfg(feature = "std")]
-impl<'a> ::windows::runtime::IntoParam<'a, PWSTR> for String {
+#[cfg(feature = "alloc")]
+impl<'a> ::windows::runtime::IntoParam<'a, PWSTR> for ::windows::runtime::alloc::string::String {
     fn into_param(self) -> ::windows::runtime::Param<'a, PWSTR> {
         ::windows::runtime::IntoParam::into_param(self.as_str())
     }
 }
-#[cfg(all(windows, feature = "std"))]
+#[cfg(feature = "std")]
 impl<'a> ::windows::runtime::IntoParam<'a, PWSTR> for &::std::ffi::OsStr {
     fn into_param(self) -> ::windows::runtime::Param<'a, PWSTR> {
         use std::os::windows::ffi::OsStrExt;
-        ::windows::runtime::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(self.encode_wide().chain(::core::iter::once(0)).collect::<std::vec::Vec<u16>>().into_boxed_slice()) as _))
+        ::windows::runtime::Param::Boxed(PWSTR(::windows::runtime::alloc::boxed::Box::<[u16]>::into_raw(self.encode_wide().chain(::core::iter::once(0)).collect::<::windows::runtime::alloc::vec::Vec<u16>>().into_boxed_slice()) as _))
     }
 }
-#[cfg(all(windows, feature = "std"))]
+#[cfg(feature = "std")]
 impl<'a> ::windows::runtime::IntoParam<'a, PWSTR> for ::std::ffi::OsString {
     fn into_param(self) -> ::windows::runtime::Param<'a, PWSTR> {
         ::windows::runtime::IntoParam::into_param(self.as_os_str())

--- a/src/runtime/bindings.rs
+++ b/src/runtime/bindings.rs
@@ -1353,37 +1353,32 @@ pub mod Windows {
                     Self::from_wide(self.as_wide())
                 }
             }
-            #[cfg(feature = "std")]
             impl ::core::convert::From<&str> for BSTR {
                 fn from(value: &str) -> Self {
-                    let value: ::std::vec::Vec<u16> = value.encode_utf16().collect();
+                    let value: ::windows::runtime::alloc::vec::Vec<u16> = value.encode_utf16().collect();
                     Self::from_wide(&value)
                 }
             }
-            #[cfg(feature = "std")]
-            impl ::core::convert::From<::std::string::String> for BSTR {
-                fn from(value: ::std::string::String) -> Self {
+            impl ::core::convert::From<::windows::runtime::alloc::string::String> for BSTR {
+                fn from(value: ::windows::runtime::alloc::string::String) -> Self {
                     value.as_str().into()
                 }
             }
-            #[cfg(feature = "std")]
-            impl ::core::convert::From<&::std::string::String> for BSTR {
-                fn from(value: &::std::string::String) -> Self {
+            impl ::core::convert::From<&::windows::runtime::alloc::string::String> for BSTR {
+                fn from(value: &::windows::runtime::alloc::string::String) -> Self {
                     value.as_str().into()
                 }
             }
-            #[cfg(feature = "std")]
-            impl<'a> ::core::convert::TryFrom<&'a BSTR> for ::std::string::String {
-                type Error = ::std::string::FromUtf16Error;
+            impl<'a> ::core::convert::TryFrom<&'a BSTR> for ::windows::runtime::alloc::string::String {
+                type Error = ::windows::runtime::alloc::string::FromUtf16Error;
                 fn try_from(value: &BSTR) -> ::core::result::Result<Self, Self::Error> {
-                    ::std::string::String::from_utf16(value.as_wide())
+                    ::windows::runtime::alloc::string::String::from_utf16(value.as_wide())
                 }
             }
-            #[cfg(feature = "std")]
-            impl ::core::convert::TryFrom<BSTR> for ::std::string::String {
-                type Error = ::std::string::FromUtf16Error;
+            impl ::core::convert::TryFrom<BSTR> for ::windows::runtime::alloc::string::String {
+                type Error = ::windows::runtime::alloc::string::FromUtf16Error;
                 fn try_from(value: BSTR) -> ::core::result::Result<Self, Self::Error> {
-                    ::std::string::String::try_from(&value)
+                    ::windows::runtime::alloc::string::String::try_from(&value)
                 }
             }
             impl ::core::default::Default for BSTR {
@@ -1410,9 +1405,8 @@ pub mod Windows {
                     self.as_wide() == other.as_wide()
                 }
             }
-            #[cfg(feature = "std")]
-            impl ::core::cmp::PartialEq<::std::string::String> for BSTR {
-                fn eq(&self, other: &::std::string::String) -> bool {
+            impl ::core::cmp::PartialEq<::windows::runtime::alloc::string::String> for BSTR {
+                fn eq(&self, other: &::windows::runtime::alloc::string::String) -> bool {
                     self == other.as_str()
                 }
             }
@@ -1442,14 +1436,14 @@ pub mod Windows {
                 type Abi = ::core::mem::ManuallyDrop<Self>;
             }
             pub type BSTR_abi = *mut u16;
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             impl<'a> ::windows::runtime::IntoParam<'a, BSTR> for &str {
                 fn into_param(self) -> ::windows::runtime::Param<'a, BSTR> {
                     ::windows::runtime::Param::Owned(self.into())
                 }
             }
-            #[cfg(feature = "std")]
-            impl<'a> ::windows::runtime::IntoParam<'a, BSTR> for ::std::string::String {
+            #[cfg(feature = "alloc")]
+            impl<'a> ::windows::runtime::IntoParam<'a, BSTR> for ::windows::runtime::alloc::string::String {
                 fn into_param(self) -> ::windows::runtime::Param<'a, BSTR> {
                     ::windows::runtime::Param::Owned(self.into())
                 }
@@ -1530,25 +1524,25 @@ pub mod Windows {
             }
             unsafe impl ::windows::runtime::Abi for PSTR {
                 type Abi = Self;
-                #[cfg(feature = "std")]
+                #[cfg(feature = "alloc")]
                 unsafe fn drop_param(param: &mut ::windows::runtime::Param<'_, Self>) {
                     if let ::windows::runtime::Param::Boxed(value) = param {
                         if !value.is_null() {
                             unsafe {
-                                ::std::boxed::Box::from_raw(value.0);
+                                ::windows::runtime::alloc::boxed::Box::from_raw(value.0);
                             }
                         }
                     }
                 }
             }
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             impl<'a> ::windows::runtime::IntoParam<'a, PSTR> for &str {
                 fn into_param(self) -> ::windows::runtime::Param<'a, PSTR> {
-                    ::windows::runtime::Param::Boxed(PSTR(::std::boxed::Box::<[u8]>::into_raw(self.bytes().chain(::std::iter::once(0)).collect::<std::vec::Vec<u8>>().into_boxed_slice()) as _))
+                    ::windows::runtime::Param::Boxed(PSTR(::windows::runtime::alloc::boxed::Box::<[u8]>::into_raw(self.bytes().chain(::core::iter::once(0)).collect::<::windows::runtime::alloc::vec::Vec<u8>>().into_boxed_slice()) as _))
                 }
             }
-            #[cfg(feature = "std")]
-            impl<'a> ::windows::runtime::IntoParam<'a, PSTR> for String {
+            #[cfg(feature = "alloc")]
+            impl<'a> ::windows::runtime::IntoParam<'a, PSTR> for ::windows::runtime::alloc::string::String {
                 fn into_param(self) -> ::windows::runtime::Param<'a, PSTR> {
                     ::windows::runtime::IntoParam::into_param(self.as_str())
                 }
@@ -1568,37 +1562,37 @@ pub mod Windows {
             }
             unsafe impl ::windows::runtime::Abi for PWSTR {
                 type Abi = Self;
-                #[cfg(feature = "std")]
+                #[cfg(feature = "alloc")]
                 unsafe fn drop_param(param: &mut ::windows::runtime::Param<'_, Self>) {
                     if let ::windows::runtime::Param::Boxed(value) = param {
                         if !value.is_null() {
                             unsafe {
-                                ::std::boxed::Box::from_raw(value.0);
+                                ::windows::runtime::alloc::boxed::Box::from_raw(value.0);
                             }
                         }
                     }
                 }
             }
-            #[cfg(feature = "std")]
+            #[cfg(feature = "alloc")]
             impl<'a> ::windows::runtime::IntoParam<'a, PWSTR> for &str {
                 fn into_param(self) -> ::windows::runtime::Param<'a, PWSTR> {
-                    ::windows::runtime::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(self.encode_utf16().chain(::core::iter::once(0)).collect::<std::vec::Vec<u16>>().into_boxed_slice()) as _))
+                    ::windows::runtime::Param::Boxed(PWSTR(::windows::runtime::alloc::boxed::Box::<[u16]>::into_raw(self.encode_utf16().chain(::core::iter::once(0)).collect::<::windows::runtime::alloc::vec::Vec<u16>>().into_boxed_slice()) as _))
                 }
             }
-            #[cfg(feature = "std")]
-            impl<'a> ::windows::runtime::IntoParam<'a, PWSTR> for String {
+            #[cfg(feature = "alloc")]
+            impl<'a> ::windows::runtime::IntoParam<'a, PWSTR> for ::windows::runtime::alloc::string::String {
                 fn into_param(self) -> ::windows::runtime::Param<'a, PWSTR> {
                     ::windows::runtime::IntoParam::into_param(self.as_str())
                 }
             }
-            #[cfg(all(windows, feature = "std"))]
+            #[cfg(feature = "std")]
             impl<'a> ::windows::runtime::IntoParam<'a, PWSTR> for &::std::ffi::OsStr {
                 fn into_param(self) -> ::windows::runtime::Param<'a, PWSTR> {
                     use std::os::windows::ffi::OsStrExt;
-                    ::windows::runtime::Param::Boxed(PWSTR(::std::boxed::Box::<[u16]>::into_raw(self.encode_wide().chain(::core::iter::once(0)).collect::<std::vec::Vec<u16>>().into_boxed_slice()) as _))
+                    ::windows::runtime::Param::Boxed(PWSTR(::windows::runtime::alloc::boxed::Box::<[u16]>::into_raw(self.encode_wide().chain(::core::iter::once(0)).collect::<::windows::runtime::alloc::vec::Vec<u16>>().into_boxed_slice()) as _))
                 }
             }
-            #[cfg(all(windows, feature = "std"))]
+            #[cfg(feature = "std")]
             impl<'a> ::windows::runtime::IntoParam<'a, PWSTR> for ::std::ffi::OsString {
                 fn into_param(self) -> ::windows::runtime::Param<'a, PWSTR> {
                     ::windows::runtime::IntoParam::into_param(self.as_os_str())

--- a/src/runtime/hstring.rs
+++ b/src/runtime/hstring.rs
@@ -46,9 +46,8 @@ impl HSTRING {
     }
 
     /// Get the contents of this `HSTRING` as a String lossily.
-    #[cfg(feature = "std")]
-    pub fn to_string_lossy(&self) -> String {
-        String::from_utf16_lossy(self.as_wide())
+    pub fn to_string_lossy(&self) -> alloc::string::String {
+        alloc::string::String::from_utf16_lossy(self.as_wide())
     }
 
     /// Clear the contents of the string and free the memory if `self` holds the
@@ -155,16 +154,14 @@ impl From<&str> for HSTRING {
     }
 }
 
-#[cfg(feature = "std")]
-impl From<String> for HSTRING {
-    fn from(value: String) -> Self {
+impl From<alloc::string::String> for HSTRING {
+    fn from(value: alloc::string::String) -> Self {
         value.as_str().into()
     }
 }
 
-#[cfg(feature = "std")]
-impl From<&String> for HSTRING {
-    fn from(value: &String) -> Self {
+impl From<&alloc::string::String> for HSTRING {
+    fn from(value: &alloc::string::String) -> Self {
         value.as_str().into()
     }
 }
@@ -175,23 +172,20 @@ impl PartialEq for HSTRING {
     }
 }
 
-#[cfg(feature = "std")]
-impl PartialEq<String> for HSTRING {
-    fn eq(&self, other: &String) -> bool {
+impl PartialEq<alloc::string::String> for HSTRING {
+    fn eq(&self, other: &alloc::string::String) -> bool {
         *self == **other
     }
 }
 
-#[cfg(feature = "std")]
-impl PartialEq<String> for &HSTRING {
-    fn eq(&self, other: &String) -> bool {
+impl PartialEq<alloc::string::String> for &HSTRING {
+    fn eq(&self, other: &alloc::string::String) -> bool {
         **self == **other
     }
 }
 
-#[cfg(feature = "std")]
-impl PartialEq<&String> for HSTRING {
-    fn eq(&self, other: &&String) -> bool {
+impl PartialEq<&alloc::string::String> for HSTRING {
+    fn eq(&self, other: &&alloc::string::String) -> bool {
         *self == ***other
     }
 }
@@ -232,42 +226,51 @@ impl PartialEq<&HSTRING> for str {
     }
 }
 
-#[cfg(feature = "std")]
-impl PartialEq<HSTRING> for String {
+impl PartialEq<HSTRING> for alloc::string::String {
     fn eq(&self, other: &HSTRING) -> bool {
         *other == **self
     }
 }
 
-#[cfg(feature = "std")]
-impl PartialEq<HSTRING> for &String {
+impl PartialEq<HSTRING> for &alloc::string::String {
     fn eq(&self, other: &HSTRING) -> bool {
         *other == ***self
     }
 }
 
-#[cfg(feature = "std")]
-impl PartialEq<&HSTRING> for String {
+impl PartialEq<&HSTRING> for alloc::string::String {
     fn eq(&self, other: &&HSTRING) -> bool {
         **other == **self
     }
 }
 
-#[cfg(feature = "std")]
-impl<'a> core::convert::TryFrom<&'a HSTRING> for String {
+impl<'a> core::convert::TryFrom<&'a HSTRING> for alloc::string::String {
     type Error = alloc::string::FromUtf16Error;
 
     fn try_from(hstring: &HSTRING) -> core::result::Result<Self, Self::Error> {
-        String::from_utf16(hstring.as_wide())
+        alloc::string::String::from_utf16(hstring.as_wide())
     }
 }
 
-#[cfg(feature = "std")]
-impl core::convert::TryFrom<HSTRING> for String {
+impl core::convert::TryFrom<HSTRING> for alloc::string::String {
     type Error = alloc::string::FromUtf16Error;
 
     fn try_from(hstring: HSTRING) -> core::result::Result<Self, Self::Error> {
-        String::try_from(&hstring)
+        alloc::string::String::try_from(&hstring)
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> IntoParam<'a, HSTRING> for &str {
+    fn into_param(self) -> Param<'a, HSTRING> {
+        Param::Owned(self.into())
+    }
+}
+
+#[cfg(feature = "alloc")]
+impl<'a> IntoParam<'a, HSTRING> for alloc::string::String {
+    fn into_param(self) -> Param<'a, HSTRING> {
+        Param::Owned(self.into())
     }
 }
 

--- a/src/runtime/into_param.rs
+++ b/src/runtime/into_param.rs
@@ -34,17 +34,3 @@ impl<'a, T: Abi> IntoParam<'a, T> for &'a Option<T> {
         }
     }
 }
-
-#[cfg(feature = "std")]
-impl<'a> IntoParam<'a, HSTRING> for &str {
-    fn into_param(self) -> Param<'a, HSTRING> {
-        Param::Owned(self.into())
-    }
-}
-
-#[cfg(feature = "std")]
-impl<'a> IntoParam<'a, HSTRING> for String {
-    fn into_param(self) -> Param<'a, HSTRING> {
-        Param::Owned(self.into())
-    }
-}


### PR DESCRIPTION
* Compiling with `no_std` no longer removes all of the string conversion operations.
* The `alloc` feature was added to enable implicit parameter allocations for strings. 