### PR TITLE
Version 0.28.0

### DIFF
--- a/.github/changelog.md
+++ b/.github/changelog.md
@@ -1,3 +1,8 @@
+# 0.28
+
+- Prefer type aliases for the `windows-sys` crate ([1331](https://github.com/microsoft/windows-rs/pull/1331))
+- Minor improvements to simplify `windows-sys` adoption ([1332](https://github.com/microsoft/windows-rs/pull/1332))
+
 # 0.27
 
 - Introduce `windows-sys` crate ([1310](https://github.com/microsoft/windows-rs/pull/1310)) - here's [a comparison](https://github.com/microsoft/windows-rs/pull/1314)

--- a/.github/readme.md
+++ b/.github/readme.md
@@ -78,12 +78,12 @@ use windows_sys::{Win32::Foundation::*, Win32::System::Threading::*, Win32::UI::
 
 fn main() {
     unsafe {
-        let event = CreateEventW(std::ptr::null_mut(), BOOL(1), BOOL(0), PWSTR(std::ptr::null_mut()));
+        let event = CreateEventW(std::ptr::null_mut(), 1, 0, std::ptr::null_mut());
         SetEvent(event);
         WaitForSingleObject(event, 0);
         CloseHandle(event);
 
-        MessageBoxA(HWND(0), PSTR(b"Text\0".as_ptr() as _), PSTR(b"Caption\0".as_ptr() as _), MB_OK);
+        MessageBoxA(0, b"Text\0".as_ptr() as _, b"Caption\0".as_ptr() as _, MB_OK);
     }
 }
 ```

--- a/.github/readme.md
+++ b/.github/readme.md
@@ -14,9 +14,9 @@ Start by adding the following to your Cargo.toml file:
 
 ```toml
 [dependencies.windows]
-version = "0.27.0"
+version = "0.28.0"
 features = [
-    "std",
+    "alloc",
     "Data_Xml_Dom",
     "Win32_Foundation",
     "Win32_Security",
@@ -29,7 +29,7 @@ Make use of any Windows APIs as needed.
 
 ```rust
 use windows::{
-    runtime::*, Data::Xml::Dom::*, Win32::Foundation::*, Win32::System::Threading::*,
+    core::*, Data::Xml::Dom::*, Win32::Foundation::*, Win32::System::Threading::*,
     Win32::UI::WindowsAndMessaging::*,
 };
 
@@ -62,14 +62,13 @@ Start by adding the following to your Cargo.toml file:
 
 ```toml
 [dependencies.windows-sys]
-version = "0.27.0"
+version = "0.28.0"
 features = [
     "Win32_Foundation",
     "Win32_Security",
     "Win32_System_Threading",
     "Win32_UI_WindowsAndMessaging",
 ]
-
 ```
 
 Make use of any Windows APIs as needed.

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "windows"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -30,10 +30,10 @@ default-target = "x86_64-pc-windows-msvc"
 targets = []
 
 [dependencies]
-windows-sys = { path = "crates/deps/sys",  version = "0.27.0" }
-windows_macros = { path = "crates/deps/macros",  version = "0.27.0", optional = true }
-windows_reader = { path = "crates/deps/reader", version = "0.27.0", optional = true }
-windows_gen = { path = "crates/deps/gen",  version = "0.27.0", optional = true }
+windows-sys = { path = "crates/deps/sys",  version = "0.28.0" }
+windows_macros = { path = "crates/deps/macros",  version = "0.28.0", optional = true }
+windows_reader = { path = "crates/deps/reader", version = "0.28.0", optional = true }
+windows_gen = { path = "crates/deps/gen",  version = "0.28.0", optional = true }
 
 [features]
 default = []

--- a/crates/deps/gen/Cargo.toml
+++ b/crates/deps/gen/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "windows_gen"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Code gen support for the windows crate"
 
 [dependencies]
-quote = { package = "windows_quote", path = "../quote", version = "0.27.0" }
-reader = { package = "windows_reader", path = "../reader", version = "0.27.0" }
+quote = { package = "windows_quote", path = "../quote", version = "0.28.0" }
+reader = { package = "windows_reader", path = "../reader", version = "0.28.0" }

--- a/crates/deps/macros/Cargo.toml
+++ b/crates/deps/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_macros"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -10,7 +10,7 @@ description = "Macros for the windows crate"
 proc-macro = true
 
 [dependencies]
-gen = { package = "windows_gen", path = "../gen", version = "0.27.0" }
-reader = { package = "windows_reader", path = "../reader", version = "0.27.0" }
+gen = { package = "windows_gen", path = "../gen", version = "0.28.0" }
+reader = { package = "windows_reader", path = "../reader", version = "0.28.0" }
 syn = { version = "1.0", default-features = false, features = ["parsing", "proc-macro", "printing", "full", "derive"] }
-quote = { package = "windows_quote", path = "../quote", version = "0.27.0" }
+quote = { package = "windows_quote", path = "../quote", version = "0.28.0" }

--- a/crates/deps/quote/Cargo.toml
+++ b/crates/deps/quote/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_quote"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/deps/reader/Cargo.toml
+++ b/crates/deps/reader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_reader"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/deps/sys/Cargo.toml
+++ b/crates/deps/sys/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "windows-sys"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -11,19 +11,19 @@ documentation = "https://microsoft.github.io/windows-docs-rs/"
 readme = "../../../.github/readme.md"
 
 [target.i686-pc-windows-msvc.dependencies]
-windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.27.0" }
+windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.28.0" }
 
 [target.x86_64-pc-windows-msvc.dependencies]
-windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.27.0" }
+windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.28.0" }
 
 [target.aarch64-pc-windows-msvc.dependencies]
-windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.27.0" }
+windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.28.0" }
 
 [target.i686-pc-windows-gnu.dependencies]
-windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.27.0" }
+windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.28.0" }
 
 [target.x86_64-pc-windows-gnu.dependencies]
-windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.27.0" }
+windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.28.0" }
 
 [features]
 default = []

--- a/crates/targets/aarch64_msvc/Cargo.toml
+++ b/crates/targets/aarch64_msvc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_aarch64_msvc"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/i686_gnu/Cargo.toml
+++ b/crates/targets/i686_gnu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_i686_gnu"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/i686_msvc/Cargo.toml
+++ b/crates/targets/i686_msvc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_i686_msvc"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/x86_64_gnu/Cargo.toml
+++ b/crates/targets/x86_64_gnu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_x86_64_gnu"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/x86_64_msvc/Cargo.toml
+++ b/crates/targets/x86_64_msvc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_x86_64_msvc"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/tools/api/Cargo.toml
+++ b/crates/tools/api/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2018"
 publish = false
 
 [dependencies]
-reader = { package = "windows_reader", path = "../../deps/reader", version = "0.27.0" }
-gen = { package = "windows_gen", path = "../../deps/gen", version = "0.27.0" }
+reader = { package = "windows_reader", path = "../../deps/reader", version = "0.28.0" }
+gen = { package = "windows_gen", path = "../../deps/gen", version = "0.28.0" }
 rayon = "1.5.1"

--- a/crates/tools/api/src/main.rs
+++ b/crates/tools/api/src/main.rs
@@ -31,7 +31,7 @@ fn write_toml(output: &std::path::Path, tree: &reader::TypeTree) {
         r#"
 [package]
 name = "windows"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -60,10 +60,10 @@ default-target = "x86_64-pc-windows-msvc"
 targets = []
 
 [dependencies]
-windows-sys = { path = "crates/deps/sys",  version = "0.27.0" }
-windows_macros = { path = "crates/deps/macros",  version = "0.27.0", optional = true }
-windows_reader = { path = "crates/deps/reader", version = "0.27.0", optional = true }
-windows_gen = { path = "crates/deps/gen",  version = "0.27.0", optional = true }
+windows-sys = { path = "crates/deps/sys",  version = "0.28.0" }
+windows_macros = { path = "crates/deps/macros",  version = "0.28.0", optional = true }
+windows_reader = { path = "crates/deps/reader", version = "0.28.0", optional = true }
+windows_gen = { path = "crates/deps/gen",  version = "0.28.0", optional = true }
 
 [features]
 default = []

--- a/crates/tools/bindings/Cargo.toml
+++ b/crates/tools/bindings/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2018"
 publish = false
 
 [dependencies]
-reader = { package = "windows_reader", path = "../../deps/reader", version = "0.27.0" }
-macros = { package = "windows_macros", path = "../../deps/macros", version = "0.27.0" }
+reader = { package = "windows_reader", path = "../../deps/reader", version = "0.28.0" }
+macros = { package = "windows_macros", path = "../../deps/macros", version = "0.28.0" }

--- a/crates/tools/fmt/Cargo.toml
+++ b/crates/tools/fmt/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2018"
 publish = false
 
 [dependencies]
-windows_reader = { path = "../../deps/reader", version = "0.27.0" }
+windows_reader = { path = "../../deps/reader", version = "0.28.0" }

--- a/crates/tools/gnu/Cargo.toml
+++ b/crates/tools/gnu/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2018"
 publish = false
 
 [dependencies]
-reader = { package = "windows_reader", path = "../../deps/reader", version = "0.27.0" }
+reader = { package = "windows_reader", path = "../../deps/reader", version = "0.28.0" }

--- a/crates/tools/msvc/Cargo.toml
+++ b/crates/tools/msvc/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2018"
 publish = false
 
 [dependencies]
-reader = { package = "windows_reader", path = "../../deps/reader", version = "0.27.0" }
+reader = { package = "windows_reader", path = "../../deps/reader", version = "0.28.0" }

--- a/crates/tools/sys/Cargo.toml
+++ b/crates/tools/sys/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2018"
 publish = false
 
 [dependencies]
-reader = { package = "windows_reader", path = "../../deps/reader", version = "0.27.0" }
-gen = { package = "windows_gen", path = "../../deps/gen", version = "0.27.0" }
+reader = { package = "windows_reader", path = "../../deps/reader", version = "0.28.0" }
+gen = { package = "windows_gen", path = "../../deps/gen", version = "0.28.0" }
 rayon = "1.5.1"

--- a/crates/tools/sys/src/main.rs
+++ b/crates/tools/sys/src/main.rs
@@ -31,7 +31,7 @@ fn write_toml(output: &std::path::Path, tree: &reader::TypeTree) {
         r#"
 [package]
 name = "windows-sys"
-version = "0.27.0"
+version = "0.28.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -41,19 +41,19 @@ documentation = "https://microsoft.github.io/windows-docs-rs/"
 readme = "../../../.github/readme.md"
 
 [target.i686-pc-windows-msvc.dependencies]
-windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.27.0" }
+windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.28.0" }
 
 [target.x86_64-pc-windows-msvc.dependencies]
-windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.27.0" }
+windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.28.0" }
 
 [target.aarch64-pc-windows-msvc.dependencies]
-windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.27.0" }
+windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.28.0" }
 
 [target.i686-pc-windows-gnu.dependencies]
-windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.27.0" }
+windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.28.0" }
 
 [target.x86_64-pc-windows-gnu.dependencies]
-windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.27.0" }
+windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.28.0" }
 
 [features]
 default = []


### PR DESCRIPTION
- Prefer type aliases for the `windows-sys` crate ([1331](https://github.com/microsoft/windows-rs/pull/1331))
- Minor improvements to simplify `windows-sys` adoption ([1332](https://github.com/microsoft/windows-rs/pull/1332))
- Fixes #1333