### PR TITLE
The `build` macro redirects to pre-packaged Windows APIs

### DIFF
--- a/crates/deps/gen/src/gen.rs
+++ b/crates/deps/gen/src/gen.rs
@@ -5,15 +5,26 @@ pub struct Gen {
     pub root: &'static str,
     pub ignore_windows_features: bool,
     pub docs: bool,
+    pub build: bool,
 }
 
 impl Gen {
     pub fn absolute() -> Self {
-        Gen { relative: "", root: "", ignore_windows_features: false, docs: false }
+        Gen { relative: "", root: "", ignore_windows_features: false, docs: false, build: false }
     }
 
     pub fn relative(namespace: &'static str) -> Self {
-        Gen { relative: namespace, root: "", ignore_windows_features: false, docs: false }
+        Gen { relative: namespace, root: "", ignore_windows_features: false, docs: false, build: false }
+    }
+
+    pub fn build(namespace: &'static str, redirect: bool) -> Self {
+        Gen {
+            relative: namespace,
+            root: "",
+            ignore_windows_features: false,
+            docs: false,
+            build: redirect,
+        }
     }
 
     pub fn namespace(&self, namespace: &str) -> TokenStream {
@@ -31,7 +42,7 @@ impl Gen {
                 return TokenStream::new();
             }
 
-            if !self.root.is_empty() && self.root != "Windows" && namespace.starts_with("Windows.") {
+            if (self.build || (!self.root.is_empty() && self.root != "Windows")) && namespace.starts_with("Windows.") {
                 let mut tokens: TokenStream = "::windows::".into();
 
                 for namespace in namespace.split('.').skip(1) {
@@ -236,13 +247,14 @@ mod tests {
     fn test_features() {
         let mut features = BTreeSet::new();
         features.insert("Windows.Foundation");
-        assert_eq!(Gen { root: "Microsoft", relative: "", ignore_windows_features: false, docs: false }.gen_cfg(&features).as_str(), r#"#[cfg(feature = "Windows_Foundation")]"#);
+        assert_eq!(Gen { root: "Microsoft", relative: "", ignore_windows_features: false, docs: false, build: false }.gen_cfg(&features).as_str(), r#"#[cfg(feature = "Windows_Foundation")]"#);
         assert_eq!(
             Gen {
                 root: "Microsoft",
                 relative: "Microsoft.UI.Composition.Diagnostics",
                 ignore_windows_features: false,
-                docs: true
+                docs: true,
+                build: false,
             }
             .gen_cfg_doc(&features)
             .as_str(),
@@ -251,13 +263,14 @@ mod tests {
 
         let mut features = BTreeSet::new();
         features.insert("Microsoft.Foundation");
-        assert_eq!(Gen { root: "Microsoft", relative: "", ignore_windows_features: false, docs: false }.gen_cfg(&features).as_str(), r#"#[cfg(feature = "Foundation")]"#);
+        assert_eq!(Gen { root: "Microsoft", relative: "", ignore_windows_features: false, docs: false, build: false }.gen_cfg(&features).as_str(), r#"#[cfg(feature = "Foundation")]"#);
         assert_eq!(
             Gen {
                 root: "Microsoft",
                 relative: "Microsoft.UI.Composition.Diagnostics",
                 ignore_windows_features: false,
-                docs: true
+                docs: true,
+                build: false,
             }
             .gen_cfg_doc(&features)
             .as_str(),

--- a/crates/deps/gen/src/tree.rs
+++ b/crates/deps/gen/src/tree.rs
@@ -1,7 +1,7 @@
 use super::*;
 
 pub fn gen_sys_file(root: &'static str, tree: &TypeTree, ignore_windows_features: bool) -> TokenStream {
-    let gen = Gen { relative: tree.namespace, root, ignore_windows_features, docs: false };
+    let gen = Gen { relative: tree.namespace, root, ignore_windows_features, docs: false, build: false };
     let types = gen_sys(tree, &gen);
 
     let namespaces = tree.namespaces.iter().filter_map(move |(name, tree)| {
@@ -24,7 +24,7 @@ pub fn gen_sys_file(root: &'static str, tree: &TypeTree, ignore_windows_features
 }
 
 pub fn gen_source_file(root: &'static str, tree: &TypeTree, ignore_windows_features: bool) -> TokenStream {
-    let gen = Gen { relative: tree.namespace, root, ignore_windows_features, docs: false };
+    let gen = Gen { relative: tree.namespace, root, ignore_windows_features, docs: false, build: false };
 
     let types = tree.types.values().map(move |t| gen_type_entry(t, &gen));
 
@@ -89,7 +89,7 @@ fn gen_namespaces<'a>(namespaces: &'a BTreeMap<&'static str, TypeTree>) -> impl 
     })
 }
 
-fn gen_type_entry(entry: &TypeEntry, gen: &Gen) -> TokenStream {
+pub fn gen_type_entry(entry: &TypeEntry, gen: &Gen) -> TokenStream {
     if entry.include == TypeInclude::None {
         return TokenStream::new();
     }

--- a/crates/deps/macros/src/lib.rs
+++ b/crates/deps/macros/src/lib.rs
@@ -38,6 +38,13 @@ pub fn build(stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
     gen_build().as_str().parse().unwrap()
 }
 
+#[doc(hidden)]
+#[proc_macro]
+pub fn build_legacy(stream: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    parse_macro_input!(stream as BuildMacro);
+    gen_build_legacy().as_str().parse().unwrap()
+}
+
 /// A macro for generating Windows API bindings ahead of time.
 #[proc_macro]
 pub fn generate(stream: proc_macro::TokenStream) -> proc_macro::TokenStream {

--- a/crates/tests/legacy/alternate_success_code/build.rs
+++ b/crates/tests/legacy/alternate_success_code/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    windows::core::build! {Windows::Win32::Foundation::CO_E_NOTINITIALIZED, Windows::Win32::System::Ole::DoDragDrop};
+    windows::core::build_legacy! {Windows::Win32::Foundation::CO_E_NOTINITIALIZED, Windows::Win32::System::Ole::DoDragDrop};
 }

--- a/crates/tests/legacy/build_groups/build.rs
+++ b/crates/tests/legacy/build_groups/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    windows::core::build! {
+    windows::core::build_legacy! {
         Windows::Foundation::{
             Collections::{IMap, IVector},
             IStringable,

--- a/crates/tests/legacy/build_wildcard/build.rs
+++ b/crates/tests/legacy/build_wildcard/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    windows::core::build! {
+    windows::core::build_legacy! {
         Windows::Foundation::*,
     };
 }

--- a/crates/tests/legacy/convertible/build.rs
+++ b/crates/tests/legacy/convertible/build.rs
@@ -1,7 +1,7 @@
 fn main() {
     // GetProcessHeap returns HeapHandle. So including GetProcessHeap
     // should also include HeapHandle.
-    windows::core::build! {
+    windows::core::build_legacy! {
         Windows::Win32::System::Memory::GetProcessHeap,
     };
     // Note: don't add anything else to this build macro!

--- a/crates/tests/legacy/data_object/build.rs
+++ b/crates/tests/legacy/data_object/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    windows::core::build! {
+    windows::core::build_legacy! {
         Windows::Win32::System::Com::IDataObject,
     };
 }

--- a/crates/tests/legacy/deprecated/build.rs
+++ b/crates/tests/legacy/deprecated/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    windows::core::build! {
+    windows::core::build_legacy! {
         Windows::ApplicationModel::Contacts::KnownContactField,
     };
 }

--- a/crates/tests/legacy/helpers/build.rs
+++ b/crates/tests/legacy/helpers/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    windows::core::build! {
+    windows::core::build_legacy! {
         Windows::Win32::Globalization::{SetThreadPreferredUILanguages, MUI_LANGUAGE_NAME},
     };
 }

--- a/crates/tests/legacy/implement/build.rs
+++ b/crates/tests/legacy/implement/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    windows::core::build! {
+    windows::core::build_legacy! {
         Windows::Foundation::Collections::{IIterable, IVectorView},
         Windows::Foundation::{IClosable, IStringable, Uri},
         Windows::Storage::Streams::Buffer,

--- a/crates/tests/legacy/implement_null_result/build.rs
+++ b/crates/tests/legacy/implement_null_result/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    windows::core::build! {Windows::Win32::Foundation::S_OK, Windows::UI::Xaml::Markup::IXamlType2};
+    windows::core::build_legacy! {Windows::Win32::Foundation::S_OK, Windows::UI::Xaml::Markup::IXamlType2};
 }

--- a/crates/tests/legacy/interfaces/build.rs
+++ b/crates/tests/legacy/interfaces/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    windows::core::build! {
+    windows::core::build_legacy! {
         // Test for https://github.com/microsoft/windows-rs/issues/1055
         Windows::Win32::Data::Xml::MsXml::IMXWriter,
 

--- a/crates/tests/legacy/interop/build.rs
+++ b/crates/tests/legacy/interop/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    windows::core::build! {Windows::Foundation::Collections::StringMap, Windows::Win32::System::Com::CoInitializeEx, Windows::Win32::System::WinRT::RoActivateInstance, Windows::Win32::UI::Input::Radial::IRadialControllerInterop};
+    windows::core::build_legacy! {Windows::Foundation::Collections::StringMap, Windows::Win32::System::Com::CoInitializeEx, Windows::Win32::System::WinRT::RoActivateInstance, Windows::Win32::UI::Input::Radial::IRadialControllerInterop};
 }

--- a/crates/tests/legacy/matrix3x2/build.rs
+++ b/crates/tests/legacy/matrix3x2/build.rs
@@ -1,7 +1,7 @@
 fn main() {
     // The Windows crate manually injects a functions needed to implement Matrix3x2.
     // This test validates this is included.
-    windows::core::build! {
+    windows::core::build_legacy! {
         Windows::Foundation::Numerics::Matrix3x2,
     };
 }

--- a/crates/tests/legacy/ntstatus/build.rs
+++ b/crates/tests/legacy/ntstatus/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    windows::core::build! {
+    windows::core::build_legacy! {
         Windows::Win32::Foundation::{STATUS_INVALID_SIGNATURE, STATUS_NOT_FOUND, STATUS_SUCCESS},
         Windows::Win32::Security::Cryptography::{BCryptGenRandom, BCryptOpenAlgorithmProvider},
     };

--- a/crates/tests/legacy/pwstr/build.rs
+++ b/crates/tests/legacy/pwstr/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    windows::core::build! {
+    windows::core::build_legacy! {
         Windows::Win32::Foundation::PWSTR
     }
 }

--- a/crates/tests/legacy/return_com_interface/build.rs
+++ b/crates/tests/legacy/return_com_interface/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    windows::core::build! {
+    windows::core::build_legacy! {
         Windows::Win32::Graphics::Direct3D12::ID3D12FunctionReflection,
     };
 }

--- a/crates/tests/legacy/return_struct/build.rs
+++ b/crates/tests/legacy/return_struct/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    windows::core::build! {
+    windows::core::build_legacy! {
         // Tests for SignatureKind::ReturnStruct
 
         // This free function returns a struct

--- a/crates/tests/legacy/structs/build.rs
+++ b/crates/tests/legacy/structs/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    windows::core::build! {
+    windows::core::build_legacy! {
         // Test to verify property key constants are generated
         // https://github.com/microsoft/win32metadata/issues/339
         Windows::Win32::Devices::Properties::DEVPKEY_Device_BiosDeviceName,

--- a/crates/tests/legacy/unions/build.rs
+++ b/crates/tests/legacy/unions/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    windows::core::build! {Windows::Win32::Graphics::Direct3D12::D3D12_INDIRECT_ARGUMENT_DESC, Windows::Win32::System::IO::OVERLAPPED};
+    windows::core::build_legacy! {Windows::Win32::Graphics::Direct3D12::D3D12_INDIRECT_ARGUMENT_DESC, Windows::Win32::System::IO::OVERLAPPED};
 }

--- a/crates/tests/legacy/win32/build.rs
+++ b/crates/tests/legacy/win32/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    windows::core::build! {
+    windows::core::build_legacy! {
         Windows::Win32::Foundation::{CloseHandle, GetLastError, BSTR, RECT, WIN32_ERROR},
         Windows::Win32::Gaming::HasExpandedResources,
         Windows::Win32::Graphics::Direct2D::CLSID_D2D1Shadow,

--- a/crates/tests/legacy/win32_arrays/build.rs
+++ b/crates/tests/legacy/win32_arrays/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    windows::core::build! {Windows::Win32::Graphics::Dxgi::DXGI_ADAPTER_DESC1, Windows::Win32::NetworkManagement::IpHelper::IPV6_ADDRESS_EX, Windows::Win32::System::Diagnostics::Debug::MINIDUMP_MEMORY_LIST, Windows::Win32::UI::WindowsAndMessaging::NCCALCSIZE_PARAMS};
+    windows::core::build_legacy! {Windows::Win32::Graphics::Dxgi::DXGI_ADAPTER_DESC1, Windows::Win32::NetworkManagement::IpHelper::IPV6_ADDRESS_EX, Windows::Win32::System::Diagnostics::Debug::MINIDUMP_MEMORY_LIST, Windows::Win32::UI::WindowsAndMessaging::NCCALCSIZE_PARAMS};
 }

--- a/crates/tests/legacy/winrt/build.rs
+++ b/crates/tests/legacy/winrt/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    windows::core::build! {
+    windows::core::build_legacy! {
         Windows::ApplicationModel::Activation::{BackgroundActivatedEventArgs, CachedFileUpdaterActivatedEventArgs, FileActivatedEventArgs, FileOpenPickerActivatedEventArgs, FileSavePickerActivatedEventArgs, IActivatedEventArgs, LaunchActivatedEventArgs, SearchActivatedEventArgs, ShareTargetActivatedEventArgs},
         Windows::ApplicationModel::Appointments::AppointmentDaysOfWeek,
         // Test for https://github.com/microsoft/windows-rs/issues/280

--- a/crates/tests/win32/arch/build.rs
+++ b/crates/tests/win32/arch/build.rs
@@ -2,7 +2,7 @@ fn main() {
     // This struct presents unique challenges to the type reader as it is both arch-specific
     // and one of those definitions has nested types. This combination is tricky because
     // traditional scope resolution is insufficient.
-    windows::core::build! {
+    windows::core::build_legacy! {
         Windows::Win32::System::Diagnostics::Debug::KNONVOLATILE_CONTEXT_POINTERS,
     };
 }

--- a/crates/tests/win32/bstr/build.rs
+++ b/crates/tests/win32/bstr/build.rs
@@ -1,7 +1,7 @@
 fn main() {
     // The Windows crate manually injects various functions needed to implement BSTR.
     // This test validates these are included.
-    windows::core::build! {
+    windows::core::build_legacy! {
         Windows::Win32::Foundation::BSTR,
     };
 }

--- a/crates/tests/win32/class_factory/build.rs
+++ b/crates/tests/win32/class_factory/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    windows::core::build!(
+    windows::core::build_legacy!(
         Windows::Foundation::{IClosable, IStringable},
         Windows::Win32::System::Com::IClassFactory
     );

--- a/crates/tests/win32/lib/build.rs
+++ b/crates/tests/win32/lib/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    windows::core::build! {
+    windows::core::build_legacy! {
         Windows::Win32::Graphics::Direct3D::Fxc::D3DCreateLinker,
     };
 }

--- a/crates/tests/win32/query/build.rs
+++ b/crates/tests/win32/query/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    windows::core::build! {Component::Win32::Query::*, Windows::Win32::Foundation::E_NOINTERFACE};
+    windows::core::build_legacy! {Component::Win32::Query::*, Windows::Win32::Foundation::E_NOINTERFACE};
 }

--- a/crates/tests/win32/return/build.rs
+++ b/crates/tests/win32/return/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    windows::core::build! {
+    windows::core::build_legacy! {
         Component::Win32::Return::*,
         Windows::Win32::Foundation::{E_APPLICATION_EXITING, STATUS_NOT_FOUND, STATUS_SUCCESS, S_OK},
     };

--- a/crates/tests/winrt/async/Cargo.toml
+++ b/crates/tests/winrt/async/Cargo.toml
@@ -4,8 +4,12 @@ version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 
-[dependencies]
-windows = { path = "../../../.." }
+[dependencies.windows]
+path = "../../../.."
+features = [
+    "std",
+    "Foundation",
+]
 
 [build-dependencies]
 windows = { path = "../../../..", features = ["build"] }

--- a/crates/tests/winrt/collections/Cargo.toml
+++ b/crates/tests/winrt/collections/Cargo.toml
@@ -4,8 +4,13 @@ version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 
-[dependencies]
-windows = { path = "../../../.." }
+[dependencies.windows]
+path = "../../../.."
+features = [
+    "std",
+    "alloc",
+    "Foundation_Collections",
+]
 
 [build-dependencies]
 windows = { path = "../../../..", features = ["build"] }

--- a/crates/tests/winrt/collections/tests/test.rs
+++ b/crates/tests/winrt/collections/tests/test.rs
@@ -1,8 +1,9 @@
 use test_winrt_collections::*;
 use windows::core::*;
 use Component::Collections::*;
-use Windows::Foundation::Collections::*;
-use Windows::Foundation::IStringable;
+use windows::Foundation::Collections::*;
+use windows::Foundation::IStringable;
+use windows as Windows;
 
 #[implement(Windows::Foundation::IStringable)]
 struct TestStringable(HSTRING);

--- a/crates/tests/winrt/collections/tests/test.rs
+++ b/crates/tests/winrt/collections/tests/test.rs
@@ -1,9 +1,9 @@
 use test_winrt_collections::*;
+use windows as Windows;
 use windows::core::*;
-use Component::Collections::*;
 use windows::Foundation::Collections::*;
 use windows::Foundation::IStringable;
-use windows as Windows;
+use Component::Collections::*;
 
 #[implement(Windows::Foundation::IStringable)]
 struct TestStringable(HSTRING);

--- a/crates/tests/winrt/dep_map/build.rs
+++ b/crates/tests/winrt/dep_map/build.rs
@@ -2,7 +2,7 @@ fn main() {
     // This test validates that IMap pulls in its dependencies including IIterator and IKeyValuePair.
     // This is a particularly interesting test because IMap only mentions IKeyValuePair indirectly
     // through its interface requirement on the specialization of IIterable.
-    windows::core::build! {
+    windows::core::build_legacy! {
         Windows::Foundation::Collections::IMap,
     };
 }

--- a/crates/tests/winrt/interfaces/build.rs
+++ b/crates/tests/winrt/interfaces/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    windows::core::build! {Component::Interfaces::*, Windows::Win32::Foundation::E_NOINTERFACE};
+    windows::core::build_legacy! {Component::Interfaces::*, Windows::Win32::Foundation::E_NOINTERFACE};
 }

--- a/crates/tests/winrt/method_names/Cargo.toml
+++ b/crates/tests/winrt/method_names/Cargo.toml
@@ -4,8 +4,11 @@ version = "0.0.0"
 authors = ["Microsoft"]
 edition = "2018"
 
-[dependencies]
-windows = { path = "../../../.." }
+[dependencies.windows]
+path = "../../../.."
+features = [
+    "Foundation",
+]
 
 [build-dependencies]
 windows = { path = "../../../..", features = ["build"] }

--- a/crates/tests/winrt/method_names/tests/test.rs
+++ b/crates/tests/winrt/method_names/tests/test.rs
@@ -1,7 +1,8 @@
 use test_winrt_method_names::*;
 use windows::core::*;
 use Component::MethodNames::*;
-use Windows::Foundation::*;
+use windows::Foundation::*;
+use windows as Windows;
 
 #[implement(Component::MethodNames::IMethodNames)]
 struct MethodNames(i64);

--- a/crates/tests/winrt/method_names/tests/test.rs
+++ b/crates/tests/winrt/method_names/tests/test.rs
@@ -1,8 +1,8 @@
 use test_winrt_method_names::*;
-use windows::core::*;
-use Component::MethodNames::*;
-use windows::Foundation::*;
 use windows as Windows;
+use windows::core::*;
+use windows::Foundation::*;
+use Component::MethodNames::*;
 
 #[implement(Component::MethodNames::IMethodNames)]
 struct MethodNames(i64);

--- a/crates/tests/winrt/signatures/build.rs
+++ b/crates/tests/winrt/signatures/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    windows::core::build! {
+    windows::core::build_legacy! {
         Component::Signatures::*,
         Component::Simple::Class,
         Windows::Foundation::PropertyValue,

--- a/crates/tests/winrt/structs/build.rs
+++ b/crates/tests/winrt/structs/build.rs
@@ -1,3 +1,3 @@
 fn main() {
-    windows::core::build! {Component::Structs::*, Windows::Foundation::IReference};
+    windows::core::build_legacy! {Component::Structs::*, Windows::Foundation::IReference};
 }

--- a/crates/tests/winrt/weak/build.rs
+++ b/crates/tests/winrt/weak/build.rs
@@ -1,5 +1,5 @@
 fn main() {
-    windows::core::build! {
+    windows::core::build_legacy! {
         Component::Classes::{Activatable, NoWeakRef},
         Windows::Foundation::IStringable,
         Windows::Win32::Foundation::E_NOINTERFACE,

--- a/src/core/mod.rs
+++ b/src/core/mod.rs
@@ -81,7 +81,7 @@ pub use bindings::Windows::Win32::System::Com::IAgileObject;
 pub type RawPtr = *mut core::ffi::c_void;
 
 #[cfg(feature = "build")]
-pub use windows_macros::{build, generate, implement, include_bindings};
+pub use windows_macros::{build, build_legacy, generate, implement, include_bindings};
 
 // TODO: remove this
 #[cfg(feature = "build")]


### PR DESCRIPTION
The `build` macro generates bindings for desired APIs from metadata. The need for this macro is substantially reduced with the introduction of [pre-packaged APIs in 0.22](https://github.com/microsoft/windows-rs/blob/master/.github/changelog.md) but is still useful if you have a 3rd party component. This update just ensures that any references to Windows APIs from such non-Windows APIs redirect to the `windows` crate rather than generating entirely new bindings for the Windows API. 

The `build_legacy` macro has been added temporarily to provide the old behavior but this macro will eventually be removed. 