### PR TITLE
Add github issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/blank_issue.md
+++ b/.github/ISSUE_TEMPLATE/blank_issue.md
@@ -1,0 +1,4 @@
+---
+name: Blank Issue
+about: Create a blank issue.
+---

--- a/.github/ISSUE_TEMPLATE/blank_issue.md
+++ b/.github/ISSUE_TEMPLATE/blank_issue.md
@@ -1,4 +1,4 @@
 ---
 name: Blank Issue
-about: Create a blank issue.
+about: Create a blank issue
 ---

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,52 @@
+name: Bug report
+description: File a bug report
+title: 'Bug:'
+labels: [bug]
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: "Thank you for filing a bug report! 🐛"
+  - type: dropdown
+    attributes:
+      label: Which crate is this about?
+      multiple: true
+      options:
+        - "windows"
+        - "windows-sys"
+        - "other (please share in the comments)"
+  - type: input
+    attributes:
+      label: Crate version
+      description: What is the version of the crate you're using?
+      placeholder: You can find the exact crate version in your `Cargo.lock` file.
+  - type: textarea
+    attributes:
+      label: Summary
+      description: >
+        Please provide a short summary of the bug, along with any information
+        you feel relevant to replicating the bug.
+      value: |
+        ```rust
+        <code>
+        ```
+  - type: textarea
+    attributes:
+      label: Expected behavior
+      description: "I expected to see this happen:"
+      placeholder: "*explanation*"
+  - type: textarea
+    attributes:
+      label: Actual behavior
+      description: "Instead, this happened:"
+      placeholder: "*explanation*"
+  - type: textarea
+    attributes:
+      label: Additional comments
+      description: Is there anything else you'd like to share?
+      placeholder: "*additional comments*"
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: "Thank you! 🦀"

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -2,4 +2,4 @@ blank_issues_enabled: false
 contact_links:
   - name: Windows API question
     url: https://stackoverflow.com/questions/tagged/winapi
-    about: Please ask and answer questions about the Windows API on StackOverflow.
+    about: Please ask and answer questions about the Windows API on StackOverflow

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,5 @@
 blank_issues_enabled: false
 contact_links:
   - name: Windows API question
-    url: https://stackoverflow.com/questions/tagged/winapi
-    about: Please ask and answer questions about the Windows API on StackOverflow
+    url: https://docs.microsoft.com/en-us/answers/topics/windows-api.html
+    about: Please ask and answer questions about the Windows API on Microsoft Q&A

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,5 @@
+blank_issues_enabled: false
+contact_links:
+  - name: Windows API question
+    url: https://stackoverflow.com/questions/tagged/winapi
+    about: Please ask and answer questions about the Windows API on StackOverflow.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,51 @@
+name: Feature request
+description: Suggest an improvement for this project
+title: 'Feature request:'
+labels: ['enhancement']
+assignees: []
+body:
+  - type: markdown
+    attributes:
+      value: >
+        Thank you for submitting a feature request! 
+  - type: textarea
+    attributes:
+      label: Motivation
+      description: >
+        Why are we doing this? What use cases does it support?
+        What is the expected outcome?
+      placeholder: "Please list the motivation here."
+  - type: textarea
+    attributes:
+      label: Drawbacks
+      description: Why should we _not_ do this?
+      placeholder: "Please list the drawbacks you perceive here."
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Rationale and alternatives
+      description: >
+        Which alternative solutions or features have you considered?
+        What is the impact if we don't do this?
+      placeholder: |
+        - Why is this design the best in the space of possible designs?
+        - What other designs have been considered and what is the rationale for not choosing them?
+        - What is the impact of not doing this?
+    validations:
+      required: false
+  - type: textarea
+    attributes:
+      label: Additional context
+      description: >
+        Please share any additional context on the issue.
+      placeholder: |
+        - Is there prior art for this feature?
+        - Are there any unresolved questions?
+        - What possibilites do you think this feature will open up in the future?
+    validations:
+      required: false
+  - type: markdown
+    attributes:
+      value: "Thank you! 🦀"
+        

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,5 +1,5 @@
 name: Feature request
-description: Suggest an improvement for this project
+description: Suggest an improvement to windows-rs
 title: 'Feature request:'
 labels: ['enhancement']
 assignees: []
@@ -48,4 +48,3 @@ body:
   - type: markdown
     attributes:
       value: "Thank you! 🦀"
-        


### PR DESCRIPTION
This adds issue templates to better help guide customers to the resources they're looking for. You can find a live demo [here](https://github.com/yoshuawuyts/issue-forms-test/issues/new/choose). Thanks!

## Screenshots

![New-Issue-·-yoshuawuyts-issue-forms-test](https://user-images.githubusercontent.com/2467194/144637322-6c1d46b0-e9b1-47ea-be91-c1e124ccd723.png)

![New-Issue-·-yoshuawuyts-test](https://user-images.githubusercontent.com/2467194/144637758-e828acae-8d9d-4bdf-99e1-3687cdf414f5.png)

![New-Issue-·-yoshuawuyts-issue-forms-test (1)](https://user-images.githubusercontent.com/2467194/144637874-579880bc-7599-4edb-8a4a-705b6e8826c0.png)

