### PR TITLE
Version 0.29.0

### DIFF
--- a/.github/changelog.md
+++ b/.github/changelog.md
@@ -1,3 +1,13 @@
+# 0.29
+
+- Update win32 metadata ([1387](https://github.com/microsoft/windows-rs/pull/1387))
+- Feature and doc generation for `windows-sys` ([1381](https://github.com/microsoft/windows-rs/pull/1381))
+- New `windows-bindgen` for simpler code generation ([1379](https://github.com/microsoft/windows-rs/pull/1379))
+- Simplify and unify underlying types ([1368](https://github.com/microsoft/windows-rs/pull/1368))
+- Callbacks now consistently use `Option` ([1344](https://github.com/microsoft/windows-rs/pull/1344))
+- Reduce crate size by limiting Xaml bindings ([1341](https://github.com/microsoft/windows-rs/pull/1341))
+- Other small improvements and fixes
+
 # 0.28
 
 - Prefer type aliases for the `windows-sys` crate ([1331](https://github.com/microsoft/windows-rs/pull/1331))

--- a/.github/readme.md
+++ b/.github/readme.md
@@ -14,7 +14,7 @@ Start by adding the following to your Cargo.toml file:
 
 ```toml
 [dependencies.windows]
-version = "0.28.0"
+version = "0.29.0"
 features = [
     "alloc",
     "Data_Xml_Dom",
@@ -62,7 +62,7 @@ Start by adding the following to your Cargo.toml file:
 
 ```toml
 [dependencies.windows-sys]
-version = "0.28.0"
+version = "0.29.0"
 features = [
     "Win32_Foundation",
     "Win32_Security",

--- a/crates/libs/bindgen/Cargo.toml
+++ b/crates/libs/bindgen/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "windows-bindgen"
-version = "0.28.0"
+version = "0.29.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Code gen support for the windows crate"
 
 [dependencies]
-quote = { package = "windows_quote", path = "../quote", version = "0.28.0" }
-reader = { package = "windows_reader", path = "../reader", version = "0.28.0" }
+quote = { package = "windows_quote", path = "../quote", version = "0.29.0" }
+reader = { package = "windows_reader", path = "../reader", version = "0.29.0" }

--- a/crates/libs/gen/Cargo.toml
+++ b/crates/libs/gen/Cargo.toml
@@ -1,11 +1,11 @@
 [package]
 name = "windows_gen"
-version = "0.28.0"
+version = "0.29.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Code gen support for the windows crate"
 
 [dependencies]
-quote = { package = "windows_quote", path = "../quote", version = "0.28.0" }
-reader = { package = "windows_reader", path = "../reader", version = "0.28.0" }
+quote = { package = "windows_quote", path = "../quote", version = "0.29.0" }
+reader = { package = "windows_reader", path = "../reader", version = "0.29.0" }

--- a/crates/libs/macros/Cargo.toml
+++ b/crates/libs/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_macros"
-version = "0.28.0"
+version = "0.29.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -10,7 +10,7 @@ description = "Macros for the windows crate"
 proc-macro = true
 
 [dependencies]
-gen = { package = "windows_gen", path = "../gen", version = "0.28.0" }
-reader = { package = "windows_reader", path = "../reader", version = "0.28.0" }
+gen = { package = "windows_gen", path = "../gen", version = "0.29.0" }
+reader = { package = "windows_reader", path = "../reader", version = "0.29.0" }
 syn = { version = "1.0", default-features = false, features = ["parsing", "proc-macro", "printing", "full", "derive"] }
-quote = { package = "windows_quote", path = "../quote", version = "0.28.0" }
+quote = { package = "windows_quote", path = "../quote", version = "0.29.0" }

--- a/crates/libs/quote/Cargo.toml
+++ b/crates/libs/quote/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 #TODO: rename to windows_tokens and rename quote! macro to tokens!
 name = "windows_quote"
-version = "0.28.0"
+version = "0.29.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/libs/reader/Cargo.toml
+++ b/crates/libs/reader/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_reader"
-version = "0.28.0"
+version = "0.29.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/libs/sys/Cargo.toml
+++ b/crates/libs/sys/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "windows-sys"
-version = "0.28.0"
+version = "0.29.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -14,19 +14,19 @@ default-target = "x86_64-pc-windows-msvc"
 all-features = true
 
 [target.i686-pc-windows-msvc.dependencies]
-windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.28.0" }
+windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.29.0" }
 
 [target.x86_64-pc-windows-msvc.dependencies]
-windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.28.0" }
+windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.29.0" }
 
 [target.aarch64-pc-windows-msvc.dependencies]
-windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.28.0" }
+windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.29.0" }
 
 [target.i686-pc-windows-gnu.dependencies]
-windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.28.0" }
+windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.29.0" }
 
 [target.x86_64-pc-windows-gnu.dependencies]
-windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.28.0" }
+windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.29.0" }
 
 [features]
 default = []

--- a/crates/libs/windows/Cargo.toml
+++ b/crates/libs/windows/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "windows"
-version = "0.28.0"
+version = "0.29.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -15,24 +15,24 @@ default-target = "x86_64-pc-windows-msvc"
 targets = []
 
 [target.i686-pc-windows-msvc.dependencies]
-windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.28.0" }
+windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.29.0" }
 
 [target.x86_64-pc-windows-msvc.dependencies]
-windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.28.0" }
+windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.29.0" }
 
 [target.aarch64-pc-windows-msvc.dependencies]
-windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.28.0" }
+windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.29.0" }
 
 [target.i686-pc-windows-gnu.dependencies]
-windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.28.0" }
+windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.29.0" }
 
 [target.x86_64-pc-windows-gnu.dependencies]
-windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.28.0" }
+windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.29.0" }
 
 [dependencies]
-windows_macros = { path = "../macros",  version = "0.28.0", optional = true }
-windows_reader = { path = "../reader", version = "0.28.0", optional = true }
-windows_gen = { path = "../gen",  version = "0.28.0", optional = true }
+windows_macros = { path = "../macros",  version = "0.29.0", optional = true }
+windows_reader = { path = "../reader", version = "0.29.0", optional = true }
+windows_gen = { path = "../gen",  version = "0.29.0", optional = true }
 
 [features]
 default = []

--- a/crates/targets/aarch64_msvc/Cargo.toml
+++ b/crates/targets/aarch64_msvc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_aarch64_msvc"
-version = "0.28.0"
+version = "0.29.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/i686_gnu/Cargo.toml
+++ b/crates/targets/i686_gnu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_i686_gnu"
-version = "0.28.0"
+version = "0.29.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/i686_msvc/Cargo.toml
+++ b/crates/targets/i686_msvc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_i686_msvc"
-version = "0.28.0"
+version = "0.29.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/x86_64_gnu/Cargo.toml
+++ b/crates/targets/x86_64_gnu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_x86_64_gnu"
-version = "0.28.0"
+version = "0.29.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/x86_64_msvc/Cargo.toml
+++ b/crates/targets/x86_64_msvc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_x86_64_msvc"
-version = "0.28.0"
+version = "0.29.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/tools/api/Cargo.toml
+++ b/crates/tools/api/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2018"
 publish = false
 
 [dependencies]
-reader = { package = "windows_reader", path = "../../libs/reader", version = "0.28.0" }
-bindgen = { package = "windows-bindgen", path = "../../libs/bindgen", version = "0.28.0" }
+reader = { package = "windows_reader", path = "../../libs/reader", version = "0.29.0" }
+bindgen = { package = "windows-bindgen", path = "../../libs/bindgen", version = "0.29.0" }
 rayon = "1.5.1"

--- a/crates/tools/api/src/main.rs
+++ b/crates/tools/api/src/main.rs
@@ -25,7 +25,7 @@ fn main() {
         r#"
 [package]
 name = "windows"
-version = "0.28.0"
+version = "0.29.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -39,24 +39,24 @@ default-target = "x86_64-pc-windows-msvc"
 targets = []
 
 [target.i686-pc-windows-msvc.dependencies]
-windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.28.0" }
+windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.29.0" }
 
 [target.x86_64-pc-windows-msvc.dependencies]
-windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.28.0" }
+windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.29.0" }
 
 [target.aarch64-pc-windows-msvc.dependencies]
-windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.28.0" }
+windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.29.0" }
 
 [target.i686-pc-windows-gnu.dependencies]
-windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.28.0" }
+windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.29.0" }
 
 [target.x86_64-pc-windows-gnu.dependencies]
-windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.28.0" }
+windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.29.0" }
 
 [dependencies]
-windows_macros = { path = "../macros",  version = "0.28.0", optional = true }
-windows_reader = { path = "../reader", version = "0.28.0", optional = true }
-windows_gen = { path = "../gen",  version = "0.28.0", optional = true }
+windows_macros = { path = "../macros",  version = "0.29.0", optional = true }
+windows_reader = { path = "../reader", version = "0.29.0", optional = true }
+windows_gen = { path = "../gen",  version = "0.29.0", optional = true }
 
 [features]
 default = []

--- a/crates/tools/bindings/Cargo.toml
+++ b/crates/tools/bindings/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2018"
 publish = false
 
 [dependencies]
-reader = { package = "windows_reader", path = "../../libs/reader", version = "0.28.0" }
-bindgen = { package = "windows-bindgen", path = "../../libs/bindgen", version = "0.28.0" }
+reader = { package = "windows_reader", path = "../../libs/reader", version = "0.29.0" }
+bindgen = { package = "windows-bindgen", path = "../../libs/bindgen", version = "0.29.0" }

--- a/crates/tools/fmt/Cargo.toml
+++ b/crates/tools/fmt/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2018"
 publish = false
 
 [dependencies]
-windows_reader = { path = "../../libs/reader", version = "0.28.0" }
+windows_reader = { path = "../../libs/reader", version = "0.29.0" }

--- a/crates/tools/gnu/Cargo.toml
+++ b/crates/tools/gnu/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2018"
 publish = false
 
 [dependencies]
-reader = { package = "windows_reader", path = "../../libs/reader", version = "0.28.0" }
+reader = { package = "windows_reader", path = "../../libs/reader", version = "0.29.0" }

--- a/crates/tools/msvc/Cargo.toml
+++ b/crates/tools/msvc/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2018"
 publish = false
 
 [dependencies]
-reader = { package = "windows_reader", path = "../../libs/reader", version = "0.28.0" }
+reader = { package = "windows_reader", path = "../../libs/reader", version = "0.29.0" }

--- a/crates/tools/sys/Cargo.toml
+++ b/crates/tools/sys/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2018"
 publish = false
 
 [dependencies]
-reader = { package = "windows_reader", path = "../../libs/reader", version = "0.28.0" }
-bindgen = { package = "windows-bindgen", path = "../../libs/bindgen", version = "0.28.0" }
+reader = { package = "windows_reader", path = "../../libs/reader", version = "0.29.0" }
+bindgen = { package = "windows-bindgen", path = "../../libs/bindgen", version = "0.29.0" }
 rayon = "1.5.1"

--- a/crates/tools/sys/src/main.rs
+++ b/crates/tools/sys/src/main.rs
@@ -25,7 +25,7 @@ fn main() {
         r#"
 [package]
 name = "windows-sys"
-version = "0.28.0"
+version = "0.29.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -38,19 +38,19 @@ default-target = "x86_64-pc-windows-msvc"
 all-features = true
 
 [target.i686-pc-windows-msvc.dependencies]
-windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.28.0" }
+windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.29.0" }
 
 [target.x86_64-pc-windows-msvc.dependencies]
-windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.28.0" }
+windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.29.0" }
 
 [target.aarch64-pc-windows-msvc.dependencies]
-windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.28.0" }
+windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.29.0" }
 
 [target.i686-pc-windows-gnu.dependencies]
-windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.28.0" }
+windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.29.0" }
 
 [target.x86_64-pc-windows-gnu.dependencies]
-windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.28.0" }
+windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.29.0" }
 
 [features]
 default = []


### PR DESCRIPTION
- Update win32 metadata ([1387](https://github.com/microsoft/windows-rs/pull/1387))
- Feature and doc generation for `windows-sys` ([1381](https://github.com/microsoft/windows-rs/pull/1381))
- New `windows-bindgen` for simpler code generation ([1379](https://github.com/microsoft/windows-rs/pull/1379))
- Simplify and unify underlying types ([1368](https://github.com/microsoft/windows-rs/pull/1368))
- Callbacks now consistently use `Option` ([1344](https://github.com/microsoft/windows-rs/pull/1344))
- Reduce crate size by limiting Xaml bindings ([1341](https://github.com/microsoft/windows-rs/pull/1341))
- Other small improvements and fixes