### PR TITLE
Guid hashmap

### DIFF
--- a/.github/readme.md
+++ b/.github/readme.md
@@ -88,3 +88,17 @@ fn main() {
     }
 }
 ```
+
+## guid_hashmap
+
+It's really common for Windows APIs to return GUID constants. If you need to convert a GUID to a 
+human readable name you can use the `guid_hashmap` feature to accomplish that. First, add `"guid_hashmap"`
+to your features list for `windows` in `Cargo.toml`. Then, you may call
+`windows::core::build_guid_hashmap()` in your code when you want to build this hashmap. The values in this
+hashmap are intended for consumption by programmers, not end users. A word of caution: This hashmap isn't
+cheap to build. Consider putting it in a [`lazy_static`](https://crates.io/crates/lazy_static) or using
+some other mechanism to avoid constructing it repeatedly. If Windows returns a GUID not contained in this
+HashMap that may be because the feature for generating that GUID constant wasn't enabled. Look over the
+feature list and consider which features might contain your unidentified GUID value.
+
+

--- a/crates/libs/bindgen/src/constants.rs
+++ b/crates/libs/bindgen/src/constants.rs
@@ -39,7 +39,16 @@ pub fn gen(def: &Field, gen: &Gen) -> TokenStream {
     } else if let Some(guid) = GUID::from_attributes(def.attributes()) {
         let value = gen_guid(&guid, gen);
         let guid = gen_element_name(&ElementType::GUID, gen);
-        quote! { pub const #name: #guid = #value; }
+        quote! {
+            pub const #name: #guid = #value;
+            #[cfg(feature = "guid_hashmap")]
+            inventory::submit! {
+                crate::core::GuidConst {
+                    name: stringify!(#name),
+                    guid: #value,
+                }
+            }
+        }
     } else if let Some((guid, id)) = get_property_key(def.attributes()) {
         let kind = gen_sig(&signature, gen);
         let guid = gen_guid(&guid, gen);
@@ -49,6 +58,13 @@ pub fn gen(def: &Field, gen: &Gen) -> TokenStream {
                 fmtid: #guid,
                 pid: #id,
             };
+            #[cfg(feature = "guid_hashmap")]
+            inventory::submit! {
+                crate::core::GuidConst {
+                    name: stringify!(#name),
+                    guid: #guid,
+                }
+            }
         }
     } else {
         quote! {}

--- a/crates/libs/windows/Cargo.toml
+++ b/crates/libs/windows/Cargo.toml
@@ -33,12 +33,14 @@ windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.29.0" }
 windows_macros = { path = "../macros",  version = "0.29.0", optional = true }
 windows_reader = { path = "../reader", version = "0.29.0", optional = true }
 windows_gen = { path = "../gen",  version = "0.29.0", optional = true }
+inventory = { version = "0.2.1", optional = true }
 
 [features]
 default = []
 deprecated = []
 std = []
 alloc = []
+guid_hashmap = ["inventory", "std"]
 build = ["windows_gen", "windows_macros", "windows_reader"]
 AI = []
 AI_MachineLearning = ["AI"]

--- a/crates/libs/windows/src/Windows/Win32/Data/HtmlHelp/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/HtmlHelp/mod.rs
@@ -1,18 +1,46 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 pub const CLSID_IITCmdInt: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4662daa2_d393_11d0_9a56_00c04fb68bf7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_IITCmdInt ) , guid : :: windows :: core :: GUID::from_u128(0x4662daa2_d393_11d0_9a56_00c04fb68bf7) , } }
 pub const CLSID_IITDatabase: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x66673452_8c23_11d0_a84e_00aa006c7d01);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_IITDatabase ) , guid : :: windows :: core :: GUID::from_u128(0x66673452_8c23_11d0_a84e_00aa006c7d01) , } }
 pub const CLSID_IITDatabaseLocal: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4662daa9_d393_11d0_9a56_00c04fb68bf7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_IITDatabaseLocal ) , guid : :: windows :: core :: GUID::from_u128(0x4662daa9_d393_11d0_9a56_00c04fb68bf7) , } }
 pub const CLSID_IITGroupUpdate: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4662daa4_d393_11d0_9a56_00c04fb68bf7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_IITGroupUpdate ) , guid : :: windows :: core :: GUID::from_u128(0x4662daa4_d393_11d0_9a56_00c04fb68bf7) , } }
 pub const CLSID_IITIndexBuild: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8fa0d5aa_dedf_11d0_9a61_00c04fb68bf7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_IITIndexBuild ) , guid : :: windows :: core :: GUID::from_u128(0x8fa0d5aa_dedf_11d0_9a61_00c04fb68bf7) , } }
 pub const CLSID_IITPropList: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4662daae_d393_11d0_9a56_00c04fb68bf7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_IITPropList ) , guid : :: windows :: core :: GUID::from_u128(0x4662daae_d393_11d0_9a56_00c04fb68bf7) , } }
 pub const CLSID_IITResultSet: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4662daa7_d393_11d0_9a56_00c04fb68bf7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_IITResultSet ) , guid : :: windows :: core :: GUID::from_u128(0x4662daa7_d393_11d0_9a56_00c04fb68bf7) , } }
 pub const CLSID_IITSvMgr: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4662daa3_d393_11d0_9a56_00c04fb68bf7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_IITSvMgr ) , guid : :: windows :: core :: GUID::from_u128(0x4662daa3_d393_11d0_9a56_00c04fb68bf7) , } }
 pub const CLSID_IITWWFilterBuild: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8fa0d5ab_dedf_11d0_9a61_00c04fb68bf7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_IITWWFilterBuild ) , guid : :: windows :: core :: GUID::from_u128(0x8fa0d5ab_dedf_11d0_9a61_00c04fb68bf7) , } }
 pub const CLSID_IITWordWheel: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd73725c2_8c12_11d0_a84e_00aa006c7d01);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_IITWordWheel ) , guid : :: windows :: core :: GUID::from_u128(0xd73725c2_8c12_11d0_a84e_00aa006c7d01) , } }
 pub const CLSID_IITWordWheelLocal: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4662daa8_d393_11d0_9a56_00c04fb68bf7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_IITWordWheelLocal ) , guid : :: windows :: core :: GUID::from_u128(0x4662daa8_d393_11d0_9a56_00c04fb68bf7) , } }
 pub const CLSID_IITWordWheelUpdate: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4662daa5_d393_11d0_9a56_00c04fb68bf7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_IITWordWheelUpdate ) , guid : :: windows :: core :: GUID::from_u128(0x4662daa5_d393_11d0_9a56_00c04fb68bf7) , } }
 pub const CLSID_ITEngStemmer: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8fa0d5a8_dedf_11d0_9a61_00c04fb68bf7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_ITEngStemmer ) , guid : :: windows :: core :: GUID::from_u128(0x8fa0d5a8_dedf_11d0_9a61_00c04fb68bf7) , } }
 pub const CLSID_ITStdBreaker: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4662daaf_d393_11d0_9a56_00c04fb68bf7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_ITStdBreaker ) , guid : :: windows :: core :: GUID::from_u128(0x4662daaf_d393_11d0_9a56_00c04fb68bf7) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Data_HtmlHelp'*"]
 pub struct COLUMNSTATUS {

--- a/crates/libs/windows/src/Windows/Win32/Data/Xml/XmlLite/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Data/Xml/XmlLite/mod.rs
@@ -1093,5 +1093,11 @@ pub const XmlWriterProperty_CompactEmptyElement: XmlWriterProperty = 5i32;
 #[doc = "*Required features: 'Win32_Data_Xml_XmlLite'*"]
 pub const _XmlWriterProperty_Last: XmlWriterProperty = 5i32;
 pub const _IID_IXmlReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7279fc81_709d_4095_b63d_69fe4b0d9030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( _IID_IXmlReader ) , guid : :: windows :: core :: GUID::from_u128(0x7279fc81_709d_4095_b63d_69fe4b0d9030) , } }
 pub const _IID_IXmlResolver: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7279fc82_709d_4095_b63d_69fe4b0d9030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( _IID_IXmlResolver ) , guid : :: windows :: core :: GUID::from_u128(0x7279fc82_709d_4095_b63d_69fe4b0d9030) , } }
 pub const _IID_IXmlWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7279fc88_709d_4095_b63d_69fe4b0d9030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( _IID_IXmlWriter ) , guid : :: windows :: core :: GUID::from_u128(0x7279fc88_709d_4095_b63d_69fe4b0d9030) , } }

--- a/crates/libs/windows/src/Windows/Win32/Devices/BiometricFramework/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/BiometricFramework/mod.rs
@@ -4,6 +4,8 @@ pub const FACILITY_NONE: u32 = 0u32;
 #[doc = "*Required features: 'Win32_Devices_BiometricFramework'*"]
 pub const FACILITY_WINBIO: u32 = 9u32;
 pub const GUID_DEVINTERFACE_BIOMETRIC_READER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe2b5183a_99ea_4cc3_ad6b_80ca8d715b80);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_BIOMETRIC_READER ) , guid : :: windows :: core :: GUID::from_u128(0xe2b5183a_99ea_4cc3_ad6b_80ca8d715b80) , } }
 #[doc = "*Required features: 'Win32_Devices_BiometricFramework'*"]
 pub const IOCTL_BIOMETRIC_VENDOR: u32 = 4464640u32;
 #[doc = "*Required features: 'Win32_Devices_BiometricFramework', 'Win32_Foundation', 'Win32_System_IO'*"]

--- a/crates/libs/windows/src/Windows/Win32/Devices/Bluetooth/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Bluetooth/mod.rs
@@ -1200,6 +1200,8 @@ impl ::core::default::Default for BTH_L2CAP_EVENT_INFO {
     }
 }
 pub const BTH_LE_ATT_BLUETOOTH_BASE_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x00000000_0000_1000_8000_00805f9b34fb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( BTH_LE_ATT_BLUETOOTH_BASE_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x00000000_0000_1000_8000_00805f9b34fb) , } }
 #[doc = "*Required features: 'Win32_Devices_Bluetooth'*"]
 pub const BTH_LE_ATT_CID: u32 = 4u32;
 #[doc = "*Required features: 'Win32_Devices_Bluetooth'*"]
@@ -2211,6 +2213,8 @@ pub unsafe fn BluetoothUpdateDeviceRecord(pbtdi: *const BLUETOOTH_DEVICE_INFO) -
     unimplemented!("Unsupported target OS");
 }
 pub const Bluetooth_Base_UUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x00000000_0000_1000_8000_00805f9b34fb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Bluetooth_Base_UUID ) , guid : :: windows :: core :: GUID::from_u128(0x00000000_0000_1000_8000_00805f9b34fb) , } }
 #[doc = "*Required features: 'Win32_Devices_Bluetooth'*"]
 pub const BrowseGroupDescriptorServiceClassID_UUID16: u32 = 4097u32;
 #[doc = "*Required features: 'Win32_Devices_Bluetooth'*"]
@@ -2470,16 +2474,38 @@ pub const GNSSServerServiceClassID_UUID16: u32 = 4406u32;
 #[doc = "*Required features: 'Win32_Devices_Bluetooth'*"]
 pub const GNServiceClassID_UUID16: u32 = 4375u32;
 pub const GUID_BLUETOOTHLE_DEVICE_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x781aee18_7733_4ce4_add0_91f41c67b592);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BLUETOOTHLE_DEVICE_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0x781aee18_7733_4ce4_add0_91f41c67b592) , } }
 pub const GUID_BLUETOOTH_AUTHENTICATION_REQUEST: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5dc9136d_996c_46db_84f5_32c0a3f47352);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BLUETOOTH_AUTHENTICATION_REQUEST ) , guid : :: windows :: core :: GUID::from_u128(0x5dc9136d_996c_46db_84f5_32c0a3f47352) , } }
 pub const GUID_BLUETOOTH_GATT_SERVICE_DEVICE_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6e3bb679_4372_40c8_9eaa_4509df260cd8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BLUETOOTH_GATT_SERVICE_DEVICE_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0x6e3bb679_4372_40c8_9eaa_4509df260cd8) , } }
 pub const GUID_BLUETOOTH_HCI_EVENT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfc240062_1541_49be_b463_84c4dcd7bf7f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BLUETOOTH_HCI_EVENT ) , guid : :: windows :: core :: GUID::from_u128(0xfc240062_1541_49be_b463_84c4dcd7bf7f) , } }
 pub const GUID_BLUETOOTH_HCI_VENDOR_EVENT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x547247e6_45bb_4c33_af8c_c00efe15a71d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BLUETOOTH_HCI_VENDOR_EVENT ) , guid : :: windows :: core :: GUID::from_u128(0x547247e6_45bb_4c33_af8c_c00efe15a71d) , } }
 pub const GUID_BLUETOOTH_KEYPRESS_EVENT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd668dfcd_0f4e_4efc_bfe0_392eeec5109c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BLUETOOTH_KEYPRESS_EVENT ) , guid : :: windows :: core :: GUID::from_u128(0xd668dfcd_0f4e_4efc_bfe0_392eeec5109c) , } }
 pub const GUID_BLUETOOTH_L2CAP_EVENT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7eae4030_b709_4aa8_ac55_e953829c9daa);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BLUETOOTH_L2CAP_EVENT ) , guid : :: windows :: core :: GUID::from_u128(0x7eae4030_b709_4aa8_ac55_e953829c9daa) , } }
 pub const GUID_BLUETOOTH_RADIO_IN_RANGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xea3b5b82_26ee_450e_b0d8_d26fe30a3869);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BLUETOOTH_RADIO_IN_RANGE ) , guid : :: windows :: core :: GUID::from_u128(0xea3b5b82_26ee_450e_b0d8_d26fe30a3869) , } }
 pub const GUID_BLUETOOTH_RADIO_OUT_OF_RANGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe28867c9_c2aa_4ced_b969_4570866037c4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BLUETOOTH_RADIO_OUT_OF_RANGE ) , guid : :: windows :: core :: GUID::from_u128(0xe28867c9_c2aa_4ced_b969_4570866037c4) , } }
 pub const GUID_BTHPORT_DEVICE_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0850302a_b344_4fda_9be9_90576b8d46f0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BTHPORT_DEVICE_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0x0850302a_b344_4fda_9be9_90576b8d46f0) , } }
 pub const GUID_BTH_RFCOMM_SERVICE_DEVICE_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb142fc3e_fa4e_460b_8abc_072b628b3c70);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BTH_RFCOMM_SERVICE_DEVICE_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0xb142fc3e_fa4e_460b_8abc_072b628b3c70) , } }
 #[doc = "*Required features: 'Win32_Devices_Bluetooth'*"]
 pub const GenericAudioServiceClassID_UUID16: u32 = 4611u32;
 #[doc = "*Required features: 'Win32_Devices_Bluetooth'*"]
@@ -3581,6 +3607,8 @@ pub const STRING_NAME_OFFSET: u32 = 0u32;
 #[doc = "*Required features: 'Win32_Devices_Bluetooth'*"]
 pub const STRING_PROVIDER_NAME_OFFSET: u32 = 2u32;
 pub const SVCID_BTH_PROVIDER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x06aa63e0_7d60_41ff_afb2_3ee6d2d9392d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SVCID_BTH_PROVIDER ) , guid : :: windows :: core :: GUID::from_u128(0x06aa63e0_7d60_41ff_afb2_3ee6d2d9392d) , } }
 #[doc = "*Required features: 'Win32_Devices_Bluetooth'*"]
 pub const SYNCH_DATA_STORE_CALENDAR: u32 = 3u32;
 #[doc = "*Required features: 'Win32_Devices_Bluetooth'*"]

--- a/crates/libs/windows/src/Windows/Win32/Devices/Communication/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Communication/mod.rs
@@ -990,6 +990,8 @@ pub unsafe fn PurgeComm<'a, Param0: ::windows::core::IntoParam<'a, super::super:
     unimplemented!("Unsupported target OS");
 }
 pub const SID_3GPP_SUPSVCMODEL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd7d08e07_d767_4478_b14a_eecc87ea12f7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SID_3GPP_SUPSVCMODEL ) , guid : :: windows :: core :: GUID::from_u128(0xd7d08e07_d767_4478_b14a_eecc87ea12f7) , } }
 #[doc = "*Required features: 'Win32_Devices_Communication', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]

--- a/crates/libs/windows/src/Windows/Win32/Devices/DeviceAccess/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/DeviceAccess/mod.rs
@@ -1,5 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 pub const CLSID_DeviceIoControl: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x12d3e372_874b_457d_9fdf_73977778686c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DeviceIoControl ) , guid : :: windows :: core :: GUID::from_u128(0x12d3e372_874b_457d_9fdf_73977778686c) , } }
 #[doc = "*Required features: 'Win32_Devices_DeviceAccess', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]

--- a/crates/libs/windows/src/Windows/Win32/Devices/DeviceAndDriverInstallation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/DeviceAndDriverInstallation/mod.rs
@@ -6534,189 +6534,557 @@ pub const FLG_REGSVR_DLLREGISTER: u32 = 1u32;
 #[doc = "*Required features: 'Win32_Devices_DeviceAndDriverInstallation'*"]
 pub const FORCED_LOG_CONF: u32 = 4u32;
 pub const GUID_ACPI_CMOS_INTERFACE_STANDARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3a8d0384_6505_40ca_bc39_56c15f8c5fed);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ACPI_CMOS_INTERFACE_STANDARD ) , guid : :: windows :: core :: GUID::from_u128(0x3a8d0384_6505_40ca_bc39_56c15f8c5fed) , } }
 pub const GUID_ACPI_INTERFACE_STANDARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb091a08a_ba97_11d0_bd14_00aa00b7b32a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ACPI_INTERFACE_STANDARD ) , guid : :: windows :: core :: GUID::from_u128(0xb091a08a_ba97_11d0_bd14_00aa00b7b32a) , } }
 pub const GUID_ACPI_INTERFACE_STANDARD2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe8695f63_1831_4870_a8cf_9c2f03f9dcb5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ACPI_INTERFACE_STANDARD2 ) , guid : :: windows :: core :: GUID::from_u128(0xe8695f63_1831_4870_a8cf_9c2f03f9dcb5) , } }
 pub const GUID_ACPI_PORT_RANGES_INTERFACE_STANDARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf14f609b_cbbd_4957_a674_bc00213f1c97);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ACPI_PORT_RANGES_INTERFACE_STANDARD ) , guid : :: windows :: core :: GUID::from_u128(0xf14f609b_cbbd_4957_a674_bc00213f1c97) , } }
 pub const GUID_ACPI_REGS_INTERFACE_STANDARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x06141966_7245_6369_462e_4e656c736f6e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ACPI_REGS_INTERFACE_STANDARD ) , guid : :: windows :: core :: GUID::from_u128(0x06141966_7245_6369_462e_4e656c736f6e) , } }
 pub const GUID_AGP_TARGET_BUS_INTERFACE_STANDARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb15cfce8_06d1_4d37_9d4c_bedde0c2a6ff);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_AGP_TARGET_BUS_INTERFACE_STANDARD ) , guid : :: windows :: core :: GUID::from_u128(0xb15cfce8_06d1_4d37_9d4c_bedde0c2a6ff) , } }
 pub const GUID_ARBITER_INTERFACE_STANDARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe644f185_8c0e_11d0_becf_08002be2092f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ARBITER_INTERFACE_STANDARD ) , guid : :: windows :: core :: GUID::from_u128(0xe644f185_8c0e_11d0_becf_08002be2092f) , } }
 pub const GUID_BUS_INTERFACE_STANDARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x496b8280_6f25_11d0_beaf_08002be2092f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BUS_INTERFACE_STANDARD ) , guid : :: windows :: core :: GUID::from_u128(0x496b8280_6f25_11d0_beaf_08002be2092f) , } }
 pub const GUID_BUS_RESOURCE_UPDATE_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x27d0102d_bfb2_4164_81dd_dbb82f968b48);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BUS_RESOURCE_UPDATE_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0x27d0102d_bfb2_4164_81dd_dbb82f968b48) , } }
 pub const GUID_BUS_TYPE_1394: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf74e73eb_9ac5_45eb_be4d_772cc71ddfb3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BUS_TYPE_1394 ) , guid : :: windows :: core :: GUID::from_u128(0xf74e73eb_9ac5_45eb_be4d_772cc71ddfb3) , } }
 pub const GUID_BUS_TYPE_ACPI: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd7b46895_001a_4942_891f_a7d46610a843);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BUS_TYPE_ACPI ) , guid : :: windows :: core :: GUID::from_u128(0xd7b46895_001a_4942_891f_a7d46610a843) , } }
 pub const GUID_BUS_TYPE_AVC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc06ff265_ae09_48f0_812c_16753d7cba83);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BUS_TYPE_AVC ) , guid : :: windows :: core :: GUID::from_u128(0xc06ff265_ae09_48f0_812c_16753d7cba83) , } }
 pub const GUID_BUS_TYPE_DOT4PRT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x441ee001_4342_11d5_a184_00c04f60524d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BUS_TYPE_DOT4PRT ) , guid : :: windows :: core :: GUID::from_u128(0x441ee001_4342_11d5_a184_00c04f60524d) , } }
 pub const GUID_BUS_TYPE_EISA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xddc35509_f3fc_11d0_a537_0000f8753ed1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BUS_TYPE_EISA ) , guid : :: windows :: core :: GUID::from_u128(0xddc35509_f3fc_11d0_a537_0000f8753ed1) , } }
 pub const GUID_BUS_TYPE_HID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xeeaf37d0_1963_47c4_aa48_72476db7cf49);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BUS_TYPE_HID ) , guid : :: windows :: core :: GUID::from_u128(0xeeaf37d0_1963_47c4_aa48_72476db7cf49) , } }
 pub const GUID_BUS_TYPE_INTERNAL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1530ea73_086b_11d1_a09f_00c04fc340b1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BUS_TYPE_INTERNAL ) , guid : :: windows :: core :: GUID::from_u128(0x1530ea73_086b_11d1_a09f_00c04fc340b1) , } }
 pub const GUID_BUS_TYPE_IRDA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7ae17dc1_c944_44d6_881f_4c2e61053bc1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BUS_TYPE_IRDA ) , guid : :: windows :: core :: GUID::from_u128(0x7ae17dc1_c944_44d6_881f_4c2e61053bc1) , } }
 pub const GUID_BUS_TYPE_ISAPNP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe676f854_d87d_11d0_92b2_00a0c9055fc5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BUS_TYPE_ISAPNP ) , guid : :: windows :: core :: GUID::from_u128(0xe676f854_d87d_11d0_92b2_00a0c9055fc5) , } }
 pub const GUID_BUS_TYPE_LPTENUM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc4ca1000_2ddc_11d5_a17a_00c04f60524d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BUS_TYPE_LPTENUM ) , guid : :: windows :: core :: GUID::from_u128(0xc4ca1000_2ddc_11d5_a17a_00c04f60524d) , } }
 pub const GUID_BUS_TYPE_MCA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1c75997a_dc33_11d0_92b2_00a0c9055fc5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BUS_TYPE_MCA ) , guid : :: windows :: core :: GUID::from_u128(0x1c75997a_dc33_11d0_92b2_00a0c9055fc5) , } }
 pub const GUID_BUS_TYPE_PCI: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc8ebdfb0_b510_11d0_80e5_00a0c92542e3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BUS_TYPE_PCI ) , guid : :: windows :: core :: GUID::from_u128(0xc8ebdfb0_b510_11d0_80e5_00a0c92542e3) , } }
 pub const GUID_BUS_TYPE_PCMCIA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x09343630_af9f_11d0_92e9_0000f81e1b30);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BUS_TYPE_PCMCIA ) , guid : :: windows :: core :: GUID::from_u128(0x09343630_af9f_11d0_92e9_0000f81e1b30) , } }
 pub const GUID_BUS_TYPE_SCM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x375a5912_804c_45aa_bdc2_fdd25a1d9512);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BUS_TYPE_SCM ) , guid : :: windows :: core :: GUID::from_u128(0x375a5912_804c_45aa_bdc2_fdd25a1d9512) , } }
 pub const GUID_BUS_TYPE_SD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe700cc04_4036_4e89_9579_89ebf45f00cd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BUS_TYPE_SD ) , guid : :: windows :: core :: GUID::from_u128(0xe700cc04_4036_4e89_9579_89ebf45f00cd) , } }
 pub const GUID_BUS_TYPE_SERENUM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x77114a87_8944_11d1_bd90_00a0c906be2d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BUS_TYPE_SERENUM ) , guid : :: windows :: core :: GUID::from_u128(0x77114a87_8944_11d1_bd90_00a0c906be2d) , } }
 pub const GUID_BUS_TYPE_SW_DEVICE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x06d10322_7de0_4cef_8e25_197d0e7442e2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BUS_TYPE_SW_DEVICE ) , guid : :: windows :: core :: GUID::from_u128(0x06d10322_7de0_4cef_8e25_197d0e7442e2) , } }
 pub const GUID_BUS_TYPE_USB: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9d7debbc_c85d_11d1_9eb4_006008c3a19a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BUS_TYPE_USB ) , guid : :: windows :: core :: GUID::from_u128(0x9d7debbc_c85d_11d1_9eb4_006008c3a19a) , } }
 pub const GUID_BUS_TYPE_USBPRINT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x441ee000_4342_11d5_a184_00c04f60524d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BUS_TYPE_USBPRINT ) , guid : :: windows :: core :: GUID::from_u128(0x441ee000_4342_11d5_a184_00c04f60524d) , } }
 pub const GUID_D3COLD_AUX_POWER_AND_TIMING_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0044d8aa_f664_4588_9ffc_2afeaf5950b9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_D3COLD_AUX_POWER_AND_TIMING_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0x0044d8aa_f664_4588_9ffc_2afeaf5950b9) , } }
 pub const GUID_D3COLD_SUPPORT_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb38290e5_3cd0_4f9d_9937_f5fe2b44d47a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_D3COLD_SUPPORT_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0xb38290e5_3cd0_4f9d_9937_f5fe2b44d47a) , } }
 pub const GUID_DEVCLASS_1394: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6bdd1fc1_810f_11d0_bec7_08002be2092f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_1394 ) , guid : :: windows :: core :: GUID::from_u128(0x6bdd1fc1_810f_11d0_bec7_08002be2092f) , } }
 pub const GUID_DEVCLASS_1394DEBUG: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x66f250d6_7801_4a64_b139_eea80a450b24);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_1394DEBUG ) , guid : :: windows :: core :: GUID::from_u128(0x66f250d6_7801_4a64_b139_eea80a450b24) , } }
 pub const GUID_DEVCLASS_61883: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7ebefbc0_3200_11d2_b4c2_00a0c9697d07);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_61883 ) , guid : :: windows :: core :: GUID::from_u128(0x7ebefbc0_3200_11d2_b4c2_00a0c9697d07) , } }
 pub const GUID_DEVCLASS_ADAPTER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e964_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_ADAPTER ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e964_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_DEVCLASS_APMSUPPORT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd45b1c18_c8fa_11d1_9f77_0000f805f530);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_APMSUPPORT ) , guid : :: windows :: core :: GUID::from_u128(0xd45b1c18_c8fa_11d1_9f77_0000f805f530) , } }
 pub const GUID_DEVCLASS_AVC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc06ff265_ae09_48f0_812c_16753d7cba83);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_AVC ) , guid : :: windows :: core :: GUID::from_u128(0xc06ff265_ae09_48f0_812c_16753d7cba83) , } }
 pub const GUID_DEVCLASS_BATTERY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x72631e54_78a4_11d0_bcf7_00aa00b7b32a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_BATTERY ) , guid : :: windows :: core :: GUID::from_u128(0x72631e54_78a4_11d0_bcf7_00aa00b7b32a) , } }
 pub const GUID_DEVCLASS_BIOMETRIC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x53d29ef7_377c_4d14_864b_eb3a85769359);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_BIOMETRIC ) , guid : :: windows :: core :: GUID::from_u128(0x53d29ef7_377c_4d14_864b_eb3a85769359) , } }
 pub const GUID_DEVCLASS_BLUETOOTH: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe0cbf06c_cd8b_4647_bb8a_263b43f0f974);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_BLUETOOTH ) , guid : :: windows :: core :: GUID::from_u128(0xe0cbf06c_cd8b_4647_bb8a_263b43f0f974) , } }
 pub const GUID_DEVCLASS_CAMERA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xca3e7ab9_b4c3_4ae6_8251_579ef933890f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_CAMERA ) , guid : :: windows :: core :: GUID::from_u128(0xca3e7ab9_b4c3_4ae6_8251_579ef933890f) , } }
 pub const GUID_DEVCLASS_CDROM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e965_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_CDROM ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e965_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_DEVCLASS_COMPUTEACCELERATOR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf01a9d53_3ff6_48d2_9f97_c8a7004be10c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_COMPUTEACCELERATOR ) , guid : :: windows :: core :: GUID::from_u128(0xf01a9d53_3ff6_48d2_9f97_c8a7004be10c) , } }
 pub const GUID_DEVCLASS_COMPUTER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e966_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_COMPUTER ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e966_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_DEVCLASS_DECODER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6bdd1fc2_810f_11d0_bec7_08002be2092f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_DECODER ) , guid : :: windows :: core :: GUID::from_u128(0x6bdd1fc2_810f_11d0_bec7_08002be2092f) , } }
 pub const GUID_DEVCLASS_DISKDRIVE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e967_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_DISKDRIVE ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e967_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_DEVCLASS_DISPLAY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e968_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_DISPLAY ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e968_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_DEVCLASS_DOT4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x48721b56_6795_11d2_b1a8_0080c72e74a2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_DOT4 ) , guid : :: windows :: core :: GUID::from_u128(0x48721b56_6795_11d2_b1a8_0080c72e74a2) , } }
 pub const GUID_DEVCLASS_DOT4PRINT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x49ce6ac8_6f86_11d2_b1e5_0080c72e74a2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_DOT4PRINT ) , guid : :: windows :: core :: GUID::from_u128(0x49ce6ac8_6f86_11d2_b1e5_0080c72e74a2) , } }
 pub const GUID_DEVCLASS_EHSTORAGESILO: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9da2b80f_f89f_4a49_a5c2_511b085b9e8a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_EHSTORAGESILO ) , guid : :: windows :: core :: GUID::from_u128(0x9da2b80f_f89f_4a49_a5c2_511b085b9e8a) , } }
 pub const GUID_DEVCLASS_ENUM1394: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc459df55_db08_11d1_b009_00a0c9081ff6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_ENUM1394 ) , guid : :: windows :: core :: GUID::from_u128(0xc459df55_db08_11d1_b009_00a0c9081ff6) , } }
 pub const GUID_DEVCLASS_EXTENSION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe2f84ce7_8efa_411c_aa69_97454ca4cb57);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_EXTENSION ) , guid : :: windows :: core :: GUID::from_u128(0xe2f84ce7_8efa_411c_aa69_97454ca4cb57) , } }
 pub const GUID_DEVCLASS_FDC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e969_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_FDC ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e969_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_DEVCLASS_FIRMWARE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf2e7dd72_6468_4e36_b6f1_6488f42c1b52);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_FIRMWARE ) , guid : :: windows :: core :: GUID::from_u128(0xf2e7dd72_6468_4e36_b6f1_6488f42c1b52) , } }
 pub const GUID_DEVCLASS_FLOPPYDISK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e980_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_FLOPPYDISK ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e980_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_DEVCLASS_FSFILTER_ACTIVITYMONITOR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb86dff51_a31e_4bac_b3cf_e8cfe75c9fc2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_FSFILTER_ACTIVITYMONITOR ) , guid : :: windows :: core :: GUID::from_u128(0xb86dff51_a31e_4bac_b3cf_e8cfe75c9fc2) , } }
 pub const GUID_DEVCLASS_FSFILTER_ANTIVIRUS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb1d1a169_c54f_4379_81db_bee7d88d7454);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_FSFILTER_ANTIVIRUS ) , guid : :: windows :: core :: GUID::from_u128(0xb1d1a169_c54f_4379_81db_bee7d88d7454) , } }
 pub const GUID_DEVCLASS_FSFILTER_BOTTOM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x37765ea0_5958_4fc9_b04b_2fdfef97e59e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_FSFILTER_BOTTOM ) , guid : :: windows :: core :: GUID::from_u128(0x37765ea0_5958_4fc9_b04b_2fdfef97e59e) , } }
 pub const GUID_DEVCLASS_FSFILTER_CFSMETADATASERVER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcdcf0939_b75b_4630_bf76_80f7ba655884);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_FSFILTER_CFSMETADATASERVER ) , guid : :: windows :: core :: GUID::from_u128(0xcdcf0939_b75b_4630_bf76_80f7ba655884) , } }
 pub const GUID_DEVCLASS_FSFILTER_COMPRESSION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf3586baf_b5aa_49b5_8d6c_0569284c639f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_FSFILTER_COMPRESSION ) , guid : :: windows :: core :: GUID::from_u128(0xf3586baf_b5aa_49b5_8d6c_0569284c639f) , } }
 pub const GUID_DEVCLASS_FSFILTER_CONTENTSCREENER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3e3f0674_c83c_4558_bb26_9820e1eba5c5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_FSFILTER_CONTENTSCREENER ) , guid : :: windows :: core :: GUID::from_u128(0x3e3f0674_c83c_4558_bb26_9820e1eba5c5) , } }
 pub const GUID_DEVCLASS_FSFILTER_CONTINUOUSBACKUP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x71aa14f8_6fad_4622_ad77_92bb9d7e6947);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_FSFILTER_CONTINUOUSBACKUP ) , guid : :: windows :: core :: GUID::from_u128(0x71aa14f8_6fad_4622_ad77_92bb9d7e6947) , } }
 pub const GUID_DEVCLASS_FSFILTER_COPYPROTECTION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x89786ff1_9c12_402f_9c9e_17753c7f4375);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_FSFILTER_COPYPROTECTION ) , guid : :: windows :: core :: GUID::from_u128(0x89786ff1_9c12_402f_9c9e_17753c7f4375) , } }
 pub const GUID_DEVCLASS_FSFILTER_ENCRYPTION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa0a701c0_a511_42ff_aa6c_06dc0395576f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_FSFILTER_ENCRYPTION ) , guid : :: windows :: core :: GUID::from_u128(0xa0a701c0_a511_42ff_aa6c_06dc0395576f) , } }
 pub const GUID_DEVCLASS_FSFILTER_HSM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd546500a_2aeb_45f6_9482_f4b1799c3177);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_FSFILTER_HSM ) , guid : :: windows :: core :: GUID::from_u128(0xd546500a_2aeb_45f6_9482_f4b1799c3177) , } }
 pub const GUID_DEVCLASS_FSFILTER_INFRASTRUCTURE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe55fa6f9_128c_4d04_abab_630c74b1453a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_FSFILTER_INFRASTRUCTURE ) , guid : :: windows :: core :: GUID::from_u128(0xe55fa6f9_128c_4d04_abab_630c74b1453a) , } }
 pub const GUID_DEVCLASS_FSFILTER_OPENFILEBACKUP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf8ecafa6_66d1_41a5_899b_66585d7216b7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_FSFILTER_OPENFILEBACKUP ) , guid : :: windows :: core :: GUID::from_u128(0xf8ecafa6_66d1_41a5_899b_66585d7216b7) , } }
 pub const GUID_DEVCLASS_FSFILTER_PHYSICALQUOTAMANAGEMENT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6a0a8e78_bba6_4fc4_a709_1e33cd09d67e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_FSFILTER_PHYSICALQUOTAMANAGEMENT ) , guid : :: windows :: core :: GUID::from_u128(0x6a0a8e78_bba6_4fc4_a709_1e33cd09d67e) , } }
 pub const GUID_DEVCLASS_FSFILTER_QUOTAMANAGEMENT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8503c911_a6c7_4919_8f79_5028f5866b0c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_FSFILTER_QUOTAMANAGEMENT ) , guid : :: windows :: core :: GUID::from_u128(0x8503c911_a6c7_4919_8f79_5028f5866b0c) , } }
 pub const GUID_DEVCLASS_FSFILTER_REPLICATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x48d3ebc4_4cf8_48ff_b869_9c68ad42eb9f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_FSFILTER_REPLICATION ) , guid : :: windows :: core :: GUID::from_u128(0x48d3ebc4_4cf8_48ff_b869_9c68ad42eb9f) , } }
 pub const GUID_DEVCLASS_FSFILTER_SECURITYENHANCER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd02bc3da_0c8e_4945_9bd5_f1883c226c8c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_FSFILTER_SECURITYENHANCER ) , guid : :: windows :: core :: GUID::from_u128(0xd02bc3da_0c8e_4945_9bd5_f1883c226c8c) , } }
 pub const GUID_DEVCLASS_FSFILTER_SYSTEM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5d1b9aaa_01e2_46af_849f_272b3f324c46);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_FSFILTER_SYSTEM ) , guid : :: windows :: core :: GUID::from_u128(0x5d1b9aaa_01e2_46af_849f_272b3f324c46) , } }
 pub const GUID_DEVCLASS_FSFILTER_SYSTEMRECOVERY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2db15374_706e_4131_a0c7_d7c78eb0289a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_FSFILTER_SYSTEMRECOVERY ) , guid : :: windows :: core :: GUID::from_u128(0x2db15374_706e_4131_a0c7_d7c78eb0289a) , } }
 pub const GUID_DEVCLASS_FSFILTER_TOP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb369baf4_5568_4e82_a87e_a93eb16bca87);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_FSFILTER_TOP ) , guid : :: windows :: core :: GUID::from_u128(0xb369baf4_5568_4e82_a87e_a93eb16bca87) , } }
 pub const GUID_DEVCLASS_FSFILTER_UNDELETE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfe8f1572_c67a_48c0_bbac_0b5c6d66cafb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_FSFILTER_UNDELETE ) , guid : :: windows :: core :: GUID::from_u128(0xfe8f1572_c67a_48c0_bbac_0b5c6d66cafb) , } }
 pub const GUID_DEVCLASS_FSFILTER_VIRTUALIZATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf75a86c0_10d8_4c3a_b233_ed60e4cdfaac);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_FSFILTER_VIRTUALIZATION ) , guid : :: windows :: core :: GUID::from_u128(0xf75a86c0_10d8_4c3a_b233_ed60e4cdfaac) , } }
 pub const GUID_DEVCLASS_GPS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6bdd1fc3_810f_11d0_bec7_08002be2092f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_GPS ) , guid : :: windows :: core :: GUID::from_u128(0x6bdd1fc3_810f_11d0_bec7_08002be2092f) , } }
 pub const GUID_DEVCLASS_HDC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e96a_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_HDC ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e96a_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_DEVCLASS_HIDCLASS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x745a17a0_74d3_11d0_b6fe_00a0c90f57da);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_HIDCLASS ) , guid : :: windows :: core :: GUID::from_u128(0x745a17a0_74d3_11d0_b6fe_00a0c90f57da) , } }
 pub const GUID_DEVCLASS_HOLOGRAPHIC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd612553d_06b1_49ca_8938_e39ef80eb16f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_HOLOGRAPHIC ) , guid : :: windows :: core :: GUID::from_u128(0xd612553d_06b1_49ca_8938_e39ef80eb16f) , } }
 pub const GUID_DEVCLASS_IMAGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6bdd1fc6_810f_11d0_bec7_08002be2092f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_IMAGE ) , guid : :: windows :: core :: GUID::from_u128(0x6bdd1fc6_810f_11d0_bec7_08002be2092f) , } }
 pub const GUID_DEVCLASS_INFINIBAND: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x30ef7132_d858_4a0c_ac24_b9028a5cca3f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_INFINIBAND ) , guid : :: windows :: core :: GUID::from_u128(0x30ef7132_d858_4a0c_ac24_b9028a5cca3f) , } }
 pub const GUID_DEVCLASS_INFRARED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6bdd1fc5_810f_11d0_bec7_08002be2092f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_INFRARED ) , guid : :: windows :: core :: GUID::from_u128(0x6bdd1fc5_810f_11d0_bec7_08002be2092f) , } }
 pub const GUID_DEVCLASS_KEYBOARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e96b_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_KEYBOARD ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e96b_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_DEVCLASS_LEGACYDRIVER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8ecc055d_047f_11d1_a537_0000f8753ed1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_LEGACYDRIVER ) , guid : :: windows :: core :: GUID::from_u128(0x8ecc055d_047f_11d1_a537_0000f8753ed1) , } }
 pub const GUID_DEVCLASS_MEDIA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e96c_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_MEDIA ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e96c_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_DEVCLASS_MEDIUM_CHANGER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xce5939ae_ebde_11d0_b181_0000f8753ec4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_MEDIUM_CHANGER ) , guid : :: windows :: core :: GUID::from_u128(0xce5939ae_ebde_11d0_b181_0000f8753ec4) , } }
 pub const GUID_DEVCLASS_MEMORY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5099944a_f6b9_4057_a056_8c550228544c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_MEMORY ) , guid : :: windows :: core :: GUID::from_u128(0x5099944a_f6b9_4057_a056_8c550228544c) , } }
 pub const GUID_DEVCLASS_MODEM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e96d_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_MODEM ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e96d_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_DEVCLASS_MONITOR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e96e_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_MONITOR ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e96e_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_DEVCLASS_MOUSE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e96f_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_MOUSE ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e96f_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_DEVCLASS_MTD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e970_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_MTD ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e970_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_DEVCLASS_MULTIFUNCTION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e971_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_MULTIFUNCTION ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e971_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_DEVCLASS_MULTIPORTSERIAL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x50906cb8_ba12_11d1_bf5d_0000f805f530);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_MULTIPORTSERIAL ) , guid : :: windows :: core :: GUID::from_u128(0x50906cb8_ba12_11d1_bf5d_0000f805f530) , } }
 pub const GUID_DEVCLASS_NET: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e972_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_NET ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e972_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_DEVCLASS_NETCLIENT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e973_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_NETCLIENT ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e973_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_DEVCLASS_NETDRIVER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x87ef9ad1_8f70_49ee_b215_ab1fcadcbe3c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_NETDRIVER ) , guid : :: windows :: core :: GUID::from_u128(0x87ef9ad1_8f70_49ee_b215_ab1fcadcbe3c) , } }
 pub const GUID_DEVCLASS_NETSERVICE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e974_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_NETSERVICE ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e974_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_DEVCLASS_NETTRANS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e975_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_NETTRANS ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e975_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_DEVCLASS_NETUIO: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x78912bc1_cb8e_4b28_a329_f322ebadbe0f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_NETUIO ) , guid : :: windows :: core :: GUID::from_u128(0x78912bc1_cb8e_4b28_a329_f322ebadbe0f) , } }
 pub const GUID_DEVCLASS_NODRIVER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e976_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_NODRIVER ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e976_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_DEVCLASS_PCMCIA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e977_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_PCMCIA ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e977_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_DEVCLASS_PNPPRINTERS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4658ee7e_f050_11d1_b6bd_00c04fa372a7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_PNPPRINTERS ) , guid : :: windows :: core :: GUID::from_u128(0x4658ee7e_f050_11d1_b6bd_00c04fa372a7) , } }
 pub const GUID_DEVCLASS_PORTS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e978_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_PORTS ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e978_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_DEVCLASS_PRINTER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e979_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_PRINTER ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e979_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_DEVCLASS_PRINTERUPGRADE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e97a_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_PRINTERUPGRADE ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e97a_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_DEVCLASS_PRINTQUEUE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1ed2bbf9_11f0_4084_b21f_ad83a8e6dcdc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_PRINTQUEUE ) , guid : :: windows :: core :: GUID::from_u128(0x1ed2bbf9_11f0_4084_b21f_ad83a8e6dcdc) , } }
 pub const GUID_DEVCLASS_PROCESSOR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x50127dc3_0f36_415e_a6cc_4cb3be910b65);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_PROCESSOR ) , guid : :: windows :: core :: GUID::from_u128(0x50127dc3_0f36_415e_a6cc_4cb3be910b65) , } }
 pub const GUID_DEVCLASS_SBP2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd48179be_ec20_11d1_b6b8_00c04fa372a7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_SBP2 ) , guid : :: windows :: core :: GUID::from_u128(0xd48179be_ec20_11d1_b6b8_00c04fa372a7) , } }
 pub const GUID_DEVCLASS_SCMDISK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x53966cb1_4d46_4166_bf23_c522403cd495);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_SCMDISK ) , guid : :: windows :: core :: GUID::from_u128(0x53966cb1_4d46_4166_bf23_c522403cd495) , } }
 pub const GUID_DEVCLASS_SCMVOLUME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x53ccb149_e543_4c84_b6e0_bce4f6b7e806);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_SCMVOLUME ) , guid : :: windows :: core :: GUID::from_u128(0x53ccb149_e543_4c84_b6e0_bce4f6b7e806) , } }
 pub const GUID_DEVCLASS_SCSIADAPTER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e97b_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_SCSIADAPTER ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e97b_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_DEVCLASS_SECURITYACCELERATOR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x268c95a1_edfe_11d3_95c3_0010dc4050a5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_SECURITYACCELERATOR ) , guid : :: windows :: core :: GUID::from_u128(0x268c95a1_edfe_11d3_95c3_0010dc4050a5) , } }
 pub const GUID_DEVCLASS_SENSOR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5175d334_c371_4806_b3ba_71fd53c9258d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_SENSOR ) , guid : :: windows :: core :: GUID::from_u128(0x5175d334_c371_4806_b3ba_71fd53c9258d) , } }
 pub const GUID_DEVCLASS_SIDESHOW: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x997b5d8d_c442_4f2e_baf3_9c8e671e9e21);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_SIDESHOW ) , guid : :: windows :: core :: GUID::from_u128(0x997b5d8d_c442_4f2e_baf3_9c8e671e9e21) , } }
 pub const GUID_DEVCLASS_SMARTCARDREADER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x50dd5230_ba8a_11d1_bf5d_0000f805f530);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_SMARTCARDREADER ) , guid : :: windows :: core :: GUID::from_u128(0x50dd5230_ba8a_11d1_bf5d_0000f805f530) , } }
 pub const GUID_DEVCLASS_SMRDISK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x53487c23_680f_4585_acc3_1f10d6777e82);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_SMRDISK ) , guid : :: windows :: core :: GUID::from_u128(0x53487c23_680f_4585_acc3_1f10d6777e82) , } }
 pub const GUID_DEVCLASS_SMRVOLUME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x53b3cf03_8f5a_4788_91b6_d19ed9fcccbf);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_SMRVOLUME ) , guid : :: windows :: core :: GUID::from_u128(0x53b3cf03_8f5a_4788_91b6_d19ed9fcccbf) , } }
 pub const GUID_DEVCLASS_SOFTWARECOMPONENT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5c4c3332_344d_483c_8739_259e934c9cc8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_SOFTWARECOMPONENT ) , guid : :: windows :: core :: GUID::from_u128(0x5c4c3332_344d_483c_8739_259e934c9cc8) , } }
 pub const GUID_DEVCLASS_SOUND: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e97c_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_SOUND ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e97c_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_DEVCLASS_SYSTEM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e97d_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_SYSTEM ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e97d_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_DEVCLASS_TAPEDRIVE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6d807884_7d21_11cf_801c_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_TAPEDRIVE ) , guid : :: windows :: core :: GUID::from_u128(0x6d807884_7d21_11cf_801c_08002be10318) , } }
 pub const GUID_DEVCLASS_UCM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe6f1aa1c_7f3b_4473_b2e8_c97d8ac71d53);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_UCM ) , guid : :: windows :: core :: GUID::from_u128(0xe6f1aa1c_7f3b_4473_b2e8_c97d8ac71d53) , } }
 pub const GUID_DEVCLASS_UNKNOWN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e97e_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_UNKNOWN ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e97e_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_DEVCLASS_USB: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x36fc9e60_c465_11cf_8056_444553540000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_USB ) , guid : :: windows :: core :: GUID::from_u128(0x36fc9e60_c465_11cf_8056_444553540000) , } }
 pub const GUID_DEVCLASS_VOLUME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x71a27cdd_812a_11d0_bec7_08002be2092f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_VOLUME ) , guid : :: windows :: core :: GUID::from_u128(0x71a27cdd_812a_11d0_bec7_08002be2092f) , } }
 pub const GUID_DEVCLASS_VOLUMESNAPSHOT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x533c5b84_ec70_11d2_9505_00c04f79deaf);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_VOLUMESNAPSHOT ) , guid : :: windows :: core :: GUID::from_u128(0x533c5b84_ec70_11d2_9505_00c04f79deaf) , } }
 pub const GUID_DEVCLASS_WCEUSBS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x25dbce51_6c8f_4a72_8a6d_b54c2b4fc835);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_WCEUSBS ) , guid : :: windows :: core :: GUID::from_u128(0x25dbce51_6c8f_4a72_8a6d_b54c2b4fc835) , } }
 pub const GUID_DEVCLASS_WPD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xeec5ad98_8080_425f_922a_dabf3de3f69a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVCLASS_WPD ) , guid : :: windows :: core :: GUID::from_u128(0xeec5ad98_8080_425f_922a_dabf3de3f69a) , } }
 pub const GUID_DEVICE_INTERFACE_ARRIVAL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcb3a4004_46f0_11d0_b08f_00609713053f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVICE_INTERFACE_ARRIVAL ) , guid : :: windows :: core :: GUID::from_u128(0xcb3a4004_46f0_11d0_b08f_00609713053f) , } }
 pub const GUID_DEVICE_INTERFACE_REMOVAL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcb3a4005_46f0_11d0_b08f_00609713053f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVICE_INTERFACE_REMOVAL ) , guid : :: windows :: core :: GUID::from_u128(0xcb3a4005_46f0_11d0_b08f_00609713053f) , } }
 pub const GUID_DEVICE_RESET_INTERFACE_STANDARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x649fdf26_3bc0_4813_ad24_7e0c1eda3fa3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVICE_RESET_INTERFACE_STANDARD ) , guid : :: windows :: core :: GUID::from_u128(0x649fdf26_3bc0_4813_ad24_7e0c1eda3fa3) , } }
 pub const GUID_DMA_CACHE_COHERENCY_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb520f7fa_8a5a_4e40_a3f6_6be1e162d935);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DMA_CACHE_COHERENCY_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0xb520f7fa_8a5a_4e40_a3f6_6be1e162d935) , } }
 pub const GUID_HWPROFILE_CHANGE_CANCELLED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcb3a4002_46f0_11d0_b08f_00609713053f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_HWPROFILE_CHANGE_CANCELLED ) , guid : :: windows :: core :: GUID::from_u128(0xcb3a4002_46f0_11d0_b08f_00609713053f) , } }
 pub const GUID_HWPROFILE_CHANGE_COMPLETE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcb3a4003_46f0_11d0_b08f_00609713053f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_HWPROFILE_CHANGE_COMPLETE ) , guid : :: windows :: core :: GUID::from_u128(0xcb3a4003_46f0_11d0_b08f_00609713053f) , } }
 pub const GUID_HWPROFILE_QUERY_CHANGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcb3a4001_46f0_11d0_b08f_00609713053f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_HWPROFILE_QUERY_CHANGE ) , guid : :: windows :: core :: GUID::from_u128(0xcb3a4001_46f0_11d0_b08f_00609713053f) , } }
 pub const GUID_INT_ROUTE_INTERFACE_STANDARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x70941bf4_0073_11d1_a09e_00c04fc340b1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_INT_ROUTE_INTERFACE_STANDARD ) , guid : :: windows :: core :: GUID::from_u128(0x70941bf4_0073_11d1_a09e_00c04fc340b1) , } }
 pub const GUID_IOMMU_BUS_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1efee0b2_d278_4ae4_bddc_1b34dd648043);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IOMMU_BUS_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0x1efee0b2_d278_4ae4_bddc_1b34dd648043) , } }
 pub const GUID_KERNEL_SOFT_RESTART_CANCEL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x31d737e7_8c0b_468a_956e_9f433ec358fb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_KERNEL_SOFT_RESTART_CANCEL ) , guid : :: windows :: core :: GUID::from_u128(0x31d737e7_8c0b_468a_956e_9f433ec358fb) , } }
 pub const GUID_KERNEL_SOFT_RESTART_FINALIZE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x20e91abd_350a_4d4f_8577_99c81507473a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_KERNEL_SOFT_RESTART_FINALIZE ) , guid : :: windows :: core :: GUID::from_u128(0x20e91abd_350a_4d4f_8577_99c81507473a) , } }
 pub const GUID_KERNEL_SOFT_RESTART_PREPARE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xde373def_a85c_4f76_8cbf_f96bea8bd10f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_KERNEL_SOFT_RESTART_PREPARE ) , guid : :: windows :: core :: GUID::from_u128(0xde373def_a85c_4f76_8cbf_f96bea8bd10f) , } }
 pub const GUID_LEGACY_DEVICE_DETECTION_STANDARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x50feb0de_596a_11d2_a5b8_0000f81a4619);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_LEGACY_DEVICE_DETECTION_STANDARD ) , guid : :: windows :: core :: GUID::from_u128(0x50feb0de_596a_11d2_a5b8_0000f81a4619) , } }
 pub const GUID_MF_ENUMERATION_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaeb895f0_5586_11d1_8d84_00a0c906b244);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MF_ENUMERATION_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0xaeb895f0_5586_11d1_8d84_00a0c906b244) , } }
 pub const GUID_MSIX_TABLE_CONFIG_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1a6a460b_194f_455d_b34b_b84c5b05712b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MSIX_TABLE_CONFIG_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0x1a6a460b_194f_455d_b34b_b84c5b05712b) , } }
 pub const GUID_NPEM_CONTROL_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d95573d_b774_488a_b120_4f284a9eff51);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NPEM_CONTROL_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0x4d95573d_b774_488a_b120_4f284a9eff51) , } }
 pub const GUID_PARTITION_UNIT_INTERFACE_STANDARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x52363f5b_d891_429b_8195_aec5fef6853c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PARTITION_UNIT_INTERFACE_STANDARD ) , guid : :: windows :: core :: GUID::from_u128(0x52363f5b_d891_429b_8195_aec5fef6853c) , } }
 pub const GUID_PCC_INTERFACE_INTERNAL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7cce62ce_c189_4814_a6a7_12112089e938);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PCC_INTERFACE_INTERNAL ) , guid : :: windows :: core :: GUID::from_u128(0x7cce62ce_c189_4814_a6a7_12112089e938) , } }
 pub const GUID_PCC_INTERFACE_STANDARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3ee8ba63_0f59_4a24_8a45_35808bdd1249);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PCC_INTERFACE_STANDARD ) , guid : :: windows :: core :: GUID::from_u128(0x3ee8ba63_0f59_4a24_8a45_35808bdd1249) , } }
 pub const GUID_PCI_ATS_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x010a7fe8_96f5_4943_bedf_95e651b93412);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PCI_ATS_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0x010a7fe8_96f5_4943_bedf_95e651b93412) , } }
 pub const GUID_PCI_BUS_INTERFACE_STANDARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x496b8281_6f25_11d0_beaf_08002be2092f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PCI_BUS_INTERFACE_STANDARD ) , guid : :: windows :: core :: GUID::from_u128(0x496b8281_6f25_11d0_beaf_08002be2092f) , } }
 pub const GUID_PCI_BUS_INTERFACE_STANDARD2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xde94e966_fdff_4c9c_9998_6747b150e74c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PCI_BUS_INTERFACE_STANDARD2 ) , guid : :: windows :: core :: GUID::from_u128(0xde94e966_fdff_4c9c_9998_6747b150e74c) , } }
 pub const GUID_PCI_DEVICE_PRESENT_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd1b82c26_bf49_45ef_b216_71cbd7889b57);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PCI_DEVICE_PRESENT_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0xd1b82c26_bf49_45ef_b216_71cbd7889b57) , } }
 pub const GUID_PCI_EXPRESS_LINK_QUIESCENT_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x146cd41c_dae3_4437_8aff_2af3f038099b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PCI_EXPRESS_LINK_QUIESCENT_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0x146cd41c_dae3_4437_8aff_2af3f038099b) , } }
 pub const GUID_PCI_EXPRESS_ROOT_PORT_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x83a7734a_84c7_4161_9a98_6000ed0c4a33);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PCI_EXPRESS_ROOT_PORT_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0x83a7734a_84c7_4161_9a98_6000ed0c4a33) , } }
 pub const GUID_PCI_FPGA_CONTROL_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2df3f7a8_b9b3_4063_9215_b5d14a0b266e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PCI_FPGA_CONTROL_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0x2df3f7a8_b9b3_4063_9215_b5d14a0b266e) , } }
 pub const GUID_PCI_PTM_CONTROL_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x348a5ebb_ba24_44b7_9916_285687735117);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PCI_PTM_CONTROL_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0x348a5ebb_ba24_44b7_9916_285687735117) , } }
 pub const GUID_PCI_SECURITY_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6e7f1451_199e_4acc_ba2d_762b4edf4674);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PCI_SECURITY_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0x6e7f1451_199e_4acc_ba2d_762b4edf4674) , } }
 pub const GUID_PCI_VIRTUALIZATION_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x64897b47_3a4a_4d75_bc74_89dd6c078293);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PCI_VIRTUALIZATION_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0x64897b47_3a4a_4d75_bc74_89dd6c078293) , } }
 pub const GUID_PCMCIA_BUS_INTERFACE_STANDARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x76173af0_c504_11d1_947f_00c04fb960ee);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PCMCIA_BUS_INTERFACE_STANDARD ) , guid : :: windows :: core :: GUID::from_u128(0x76173af0_c504_11d1_947f_00c04fb960ee) , } }
 pub const GUID_PNP_CUSTOM_NOTIFICATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaca73f8e_8d23_11d1_ac7d_0000f87571d0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PNP_CUSTOM_NOTIFICATION ) , guid : :: windows :: core :: GUID::from_u128(0xaca73f8e_8d23_11d1_ac7d_0000f87571d0) , } }
 pub const GUID_PNP_EXTENDED_ADDRESS_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb8e992ec_a797_4dc4_8846_84d041707446);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PNP_EXTENDED_ADDRESS_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0xb8e992ec_a797_4dc4_8846_84d041707446) , } }
 pub const GUID_PNP_LOCATION_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x70211b0e_0afb_47db_afc1_410bf842497a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PNP_LOCATION_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0x70211b0e_0afb_47db_afc1_410bf842497a) , } }
 pub const GUID_PNP_POWER_NOTIFICATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc2cf0660_eb7a_11d1_bd7f_0000f87571d0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PNP_POWER_NOTIFICATION ) , guid : :: windows :: core :: GUID::from_u128(0xc2cf0660_eb7a_11d1_bd7f_0000f87571d0) , } }
 pub const GUID_PNP_POWER_SETTING_CHANGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x29c69b3e_c79a_43bf_bbde_a932fa1bea7e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PNP_POWER_SETTING_CHANGE ) , guid : :: windows :: core :: GUID::from_u128(0x29c69b3e_c79a_43bf_bbde_a932fa1bea7e) , } }
 pub const GUID_POWER_DEVICE_ENABLE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x827c0a6f_feb0_11d0_bd26_00aa00b7b32a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_POWER_DEVICE_ENABLE ) , guid : :: windows :: core :: GUID::from_u128(0x827c0a6f_feb0_11d0_bd26_00aa00b7b32a) , } }
 pub const GUID_POWER_DEVICE_TIMEOUTS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa45da735_feb0_11d0_bd26_00aa00b7b32a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_POWER_DEVICE_TIMEOUTS ) , guid : :: windows :: core :: GUID::from_u128(0xa45da735_feb0_11d0_bd26_00aa00b7b32a) , } }
 pub const GUID_POWER_DEVICE_WAKE_ENABLE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa9546a82_feb0_11d0_bd26_00aa00b7b32a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_POWER_DEVICE_WAKE_ENABLE ) , guid : :: windows :: core :: GUID::from_u128(0xa9546a82_feb0_11d0_bd26_00aa00b7b32a) , } }
 pub const GUID_PROCESSOR_PCC_INTERFACE_STANDARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x37b17e9a_c21c_4296_972d_11c4b32b28f0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PCC_INTERFACE_STANDARD ) , guid : :: windows :: core :: GUID::from_u128(0x37b17e9a_c21c_4296_972d_11c4b32b28f0) , } }
 pub const GUID_QUERY_CRASHDUMP_FUNCTIONS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9cc6b8ff_32e2_4834_b1de_b32ef8880a4b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_QUERY_CRASHDUMP_FUNCTIONS ) , guid : :: windows :: core :: GUID::from_u128(0x9cc6b8ff_32e2_4834_b1de_b32ef8880a4b) , } }
 pub const GUID_RECOVERY_NVMED_PREPARE_SHUTDOWN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4b9770ea_bde7_400b_a9b9_4f684f54cc2a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_RECOVERY_NVMED_PREPARE_SHUTDOWN ) , guid : :: windows :: core :: GUID::from_u128(0x4b9770ea_bde7_400b_a9b9_4f684f54cc2a) , } }
 pub const GUID_RECOVERY_PCI_PREPARE_SHUTDOWN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x90d889de_8704_44cf_8115_ed8528d2b2da);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_RECOVERY_PCI_PREPARE_SHUTDOWN ) , guid : :: windows :: core :: GUID::from_u128(0x90d889de_8704_44cf_8115_ed8528d2b2da) , } }
 pub const GUID_REENUMERATE_SELF_INTERFACE_STANDARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2aeb0243_6a6e_486b_82fc_d815f6b97006);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_REENUMERATE_SELF_INTERFACE_STANDARD ) , guid : :: windows :: core :: GUID::from_u128(0x2aeb0243_6a6e_486b_82fc_d815f6b97006) , } }
 pub const GUID_SCM_BUS_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x25944783_ce79_4232_815e_4a30014e8eb4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SCM_BUS_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0x25944783_ce79_4232_815e_4a30014e8eb4) , } }
 pub const GUID_SCM_BUS_LD_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9b89307d_d76b_4f48_b186_54041ae92e8d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SCM_BUS_LD_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0x9b89307d_d76b_4f48_b186_54041ae92e8d) , } }
 pub const GUID_SCM_BUS_NVD_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8de064ff_b630_42e4_88ea_6f24c8641175);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SCM_BUS_NVD_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0x8de064ff_b630_42e4_88ea_6f24c8641175) , } }
 pub const GUID_SCM_PHYSICAL_NVDIMM_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0079c21b_917e_405e_a9ce_0732b5bbcebd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SCM_PHYSICAL_NVDIMM_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0x0079c21b_917e_405e_a9ce_0732b5bbcebd) , } }
 pub const GUID_SDEV_IDENTIFIER_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x49d67af8_916c_4ee8_9df1_889f17d21e91);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SDEV_IDENTIFIER_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0x49d67af8_916c_4ee8_9df1_889f17d21e91) , } }
 pub const GUID_SECURE_DRIVER_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x370f67e1_4ff5_4a94_9a35_06c5d9cc30e2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SECURE_DRIVER_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0x370f67e1_4ff5_4a94_9a35_06c5d9cc30e2) , } }
 pub const GUID_TARGET_DEVICE_QUERY_REMOVE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcb3a4006_46f0_11d0_b08f_00609713053f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TARGET_DEVICE_QUERY_REMOVE ) , guid : :: windows :: core :: GUID::from_u128(0xcb3a4006_46f0_11d0_b08f_00609713053f) , } }
 pub const GUID_TARGET_DEVICE_REMOVE_CANCELLED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcb3a4007_46f0_11d0_b08f_00609713053f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TARGET_DEVICE_REMOVE_CANCELLED ) , guid : :: windows :: core :: GUID::from_u128(0xcb3a4007_46f0_11d0_b08f_00609713053f) , } }
 pub const GUID_TARGET_DEVICE_REMOVE_COMPLETE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcb3a4008_46f0_11d0_b08f_00609713053f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TARGET_DEVICE_REMOVE_COMPLETE ) , guid : :: windows :: core :: GUID::from_u128(0xcb3a4008_46f0_11d0_b08f_00609713053f) , } }
 pub const GUID_TARGET_DEVICE_TRANSPORT_RELATIONS_CHANGED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfcf528f6_a82f_47b1_ad3a_8050594cad28);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TARGET_DEVICE_TRANSPORT_RELATIONS_CHANGED ) , guid : :: windows :: core :: GUID::from_u128(0xfcf528f6_a82f_47b1_ad3a_8050594cad28) , } }
 pub const GUID_THERMAL_COOLING_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xecbe47a8_c498_4bb9_bd70_e867e0940d22);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_THERMAL_COOLING_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0xecbe47a8_c498_4bb9_bd70_e867e0940d22) , } }
 pub const GUID_TRANSLATOR_INTERFACE_STANDARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6c154a92_aacf_11d0_8d2a_00a0c906b244);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TRANSLATOR_INTERFACE_STANDARD ) , guid : :: windows :: core :: GUID::from_u128(0x6c154a92_aacf_11d0_8d2a_00a0c906b244) , } }
 pub const GUID_WUDF_DEVICE_HOST_PROBLEM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc43d25bd_9346_40ee_a2d2_d70c15f8b75b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WUDF_DEVICE_HOST_PROBLEM ) , guid : :: windows :: core :: GUID::from_u128(0xc43d25bd_9346_40ee_a2d2_d70c15f8b75b) , } }
 pub type HCMNOTIFICATION = isize;
 #[repr(C, packed(1))]
 #[doc = "*Required features: 'Win32_Devices_DeviceAndDriverInstallation', 'Win32_Foundation'*"]

--- a/crates/libs/windows/src/Windows/Win32/Devices/Display/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Display/mod.rs
@@ -1409,15 +1409,23 @@ impl ::core::default::Default for DEVINFO {
 #[doc = "*Required features: 'Win32_Devices_Display', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_ActivityId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc50a3f10_aa5c_4247_b830_d6a6f8eaa310), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_ActivityId ) , guid : :: windows :: core :: GUID::from_u128(0xc50a3f10_aa5c_4247_b830_d6a6f8eaa310) , } }
 #[doc = "*Required features: 'Win32_Devices_Display', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_AdapterLuid: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc50a3f10_aa5c_4247_b830_d6a6f8eaa310), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_AdapterLuid ) , guid : :: windows :: core :: GUID::from_u128(0xc50a3f10_aa5c_4247_b830_d6a6f8eaa310) , } }
 #[doc = "*Required features: 'Win32_Devices_Display', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_TerminalLuid: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc50a3f10_aa5c_4247_b830_d6a6f8eaa310), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_TerminalLuid ) , guid : :: windows :: core :: GUID::from_u128(0xc50a3f10_aa5c_4247_b830_d6a6f8eaa310) , } }
 #[doc = "*Required features: 'Win32_Devices_Display', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_IndirectDisplay: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc50a3f10_aa5c_4247_b830_d6a6f8eaa310), pid: 1u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_IndirectDisplay ) , guid : :: windows :: core :: GUID::from_u128(0xc50a3f10_aa5c_4247_b830_d6a6f8eaa310) , } }
 pub type DHPDEV = isize;
 pub type DHSURF = isize;
 #[repr(C)]
@@ -6226,10 +6234,20 @@ pub const GS_8BIT_HANDLES: u32 = 2u32;
 #[doc = "*Required features: 'Win32_Devices_Display'*"]
 pub const GS_UNICODE_HANDLES: u32 = 1u32;
 pub const GUID_DEVINTERFACE_DISPLAY_ADAPTER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5b45201d_f2f2_4f3b_85bb_30ff1f953599);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_DISPLAY_ADAPTER ) , guid : :: windows :: core :: GUID::from_u128(0x5b45201d_f2f2_4f3b_85bb_30ff1f953599) , } }
 pub const GUID_DEVINTERFACE_MONITOR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe6f07b5f_ee97_4a90_b076_33f57bf4eaa7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_MONITOR ) , guid : :: windows :: core :: GUID::from_u128(0xe6f07b5f_ee97_4a90_b076_33f57bf4eaa7) , } }
 pub const GUID_DEVINTERFACE_VIDEO_OUTPUT_ARRIVAL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1ad9e4f0_f88d_4360_bab9_4c2d55e564cd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_VIDEO_OUTPUT_ARRIVAL ) , guid : :: windows :: core :: GUID::from_u128(0x1ad9e4f0_f88d_4360_bab9_4c2d55e564cd) , } }
 pub const GUID_DISPLAY_DEVICE_ARRIVAL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1ca05180_a699_450a_9a0c_de4fbe3ddd89);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DISPLAY_DEVICE_ARRIVAL ) , guid : :: windows :: core :: GUID::from_u128(0x1ca05180_a699_450a_9a0c_de4fbe3ddd89) , } }
 pub const GUID_MONITOR_OVERRIDE_PSEUDO_SPECIALIZED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf196c02f_f86f_4f9a_aa15_e9cebdfe3b96);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MONITOR_OVERRIDE_PSEUDO_SPECIALIZED ) , guid : :: windows :: core :: GUID::from_u128(0xf196c02f_f86f_4f9a_aa15_e9cebdfe3b96) , } }
 #[doc = "*Required features: 'Win32_Devices_Display'*"]
 pub const GX_GENERAL: i32 = 3i32;
 #[doc = "*Required features: 'Win32_Devices_Display'*"]

--- a/crates/libs/windows/src/Windows/Win32/Devices/Fax/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Fax/mod.rs
@@ -1,5 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 pub const CLSID_Sti: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb323f8e0_2e68_11d0_90ea_00aa0060f86c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_Sti ) , guid : :: windows :: core :: GUID::from_u128(0xb323f8e0_2e68_11d0_90ea_00aa0060f86c) , } }
 #[doc = "*Required features: 'Win32_Devices_Fax', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
@@ -18,9 +20,13 @@ pub unsafe fn CanSendToFaxRecipient() -> super::super::Foundation::BOOL {
 #[doc = "*Required features: 'Win32_Devices_Fax', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WIA_DeviceType: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6bdd1fc6_810f_11d0_bec7_08002be2092f), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WIA_DeviceType ) , guid : :: windows :: core :: GUID::from_u128(0x6bdd1fc6_810f_11d0_bec7_08002be2092f) , } }
 #[doc = "*Required features: 'Win32_Devices_Fax', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WIA_USDClassId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6bdd1fc6_810f_11d0_bec7_08002be2092f), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WIA_USDClassId ) , guid : :: windows :: core :: GUID::from_u128(0x6bdd1fc6_810f_11d0_bec7_08002be2092f) , } }
 #[doc = "*Required features: 'Win32_Devices_Fax'*"]
 pub const FAXDEVRECEIVE_SIZE: u32 = 4096u32;
 #[doc = "*Required features: 'Win32_Devices_Fax'*"]
@@ -3159,12 +3165,26 @@ pub unsafe fn FaxUnregisterServiceProviderW<'a, Param0: ::windows::core::IntoPar
     unimplemented!("Unsupported target OS");
 }
 pub const GUID_DeviceArrivedLaunch: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x740d9ee6_70f1_11d1_ad10_00a02438ad48);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DeviceArrivedLaunch ) , guid : :: windows :: core :: GUID::from_u128(0x740d9ee6_70f1_11d1_ad10_00a02438ad48) , } }
 pub const GUID_STIUserDefined1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc00eb795_8c6e_11d2_977a_0000f87a926f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_STIUserDefined1 ) , guid : :: windows :: core :: GUID::from_u128(0xc00eb795_8c6e_11d2_977a_0000f87a926f) , } }
 pub const GUID_STIUserDefined2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc77ae9c5_8c6e_11d2_977a_0000f87a926f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_STIUserDefined2 ) , guid : :: windows :: core :: GUID::from_u128(0xc77ae9c5_8c6e_11d2_977a_0000f87a926f) , } }
 pub const GUID_STIUserDefined3: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc77ae9c6_8c6e_11d2_977a_0000f87a926f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_STIUserDefined3 ) , guid : :: windows :: core :: GUID::from_u128(0xc77ae9c6_8c6e_11d2_977a_0000f87a926f) , } }
 pub const GUID_ScanFaxImage: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc00eb793_8c6e_11d2_977a_0000f87a926f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ScanFaxImage ) , guid : :: windows :: core :: GUID::from_u128(0xc00eb793_8c6e_11d2_977a_0000f87a926f) , } }
 pub const GUID_ScanImage: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa6c5a715_8c6e_11d2_977a_0000f87a926f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ScanImage ) , guid : :: windows :: core :: GUID::from_u128(0xa6c5a715_8c6e_11d2_977a_0000f87a926f) , } }
 pub const GUID_ScanPrintImage: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb441f425_8c6e_11d2_977a_0000f87a926f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ScanPrintImage ) , guid : :: windows :: core :: GUID::from_u128(0xb441f425_8c6e_11d2_977a_0000f87a926f) , } }
 #[doc = "*Required features: 'Win32_Devices_Fax'*"]
 #[repr(transparent)]
 pub struct IFaxAccount(::windows::core::IUnknown);

--- a/crates/libs/windows/src/Windows/Win32/Devices/FunctionDiscovery/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/FunctionDiscovery/mod.rs
@@ -36,12 +36,26 @@ pub const FD_Visibility_Default: u32 = 0u32;
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery'*"]
 pub const FD_Visibility_Hidden: u32 = 1u32;
 pub const FMTID_Device: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FMTID_Device ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 pub const FMTID_DeviceInterface: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x53808008_07bb_4661_bc3c_b5953e708560);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FMTID_DeviceInterface ) , guid : :: windows :: core :: GUID::from_u128(0x53808008_07bb_4661_bc3c_b5953e708560) , } }
 pub const FMTID_FD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x904b03a2_471d_423c_a584_f3483238a146);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FMTID_FD ) , guid : :: windows :: core :: GUID::from_u128(0x904b03a2_471d_423c_a584_f3483238a146) , } }
 pub const FMTID_PNPX: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FMTID_PNPX ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 pub const FMTID_PNPXDynamicProperty: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4fc5077e_b686_44be_93e3_86cafe368ccd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FMTID_PNPXDynamicProperty ) , guid : :: windows :: core :: GUID::from_u128(0x4fc5077e_b686_44be_93e3_86cafe368ccd) , } }
 pub const FMTID_Pairing: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8807cae6_7db6_4f10_8ee4_435eaa1392bc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FMTID_Pairing ) , guid : :: windows :: core :: GUID::from_u128(0x8807cae6_7db6_4f10_8ee4_435eaa1392bc) , } }
 pub const FMTID_WSD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x92506491_ff95_4724_a05a_5b81885a7c92);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FMTID_WSD ) , guid : :: windows :: core :: GUID::from_u128(0x92506491_ff95_4724_a05a_5b81885a7c92) , } }
 pub const FunctionDiscovery: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc72be2ec_8e90_452c_b29a_ab8ff1c071fc);
 pub const FunctionInstanceCollection: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xba818ce5_b55f_443f_ad39_2fe89be6191f);
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery'*"]
@@ -1419,717 +1433,1193 @@ pub const MAX_FDCONSTRAINTVALUE_LENGTH: u32 = 1000u32;
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceClass_Characteristics: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4321918b_f69e_470d_a5de_4d88c75ad24b), pid: 29u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceClass_Characteristics ) , guid : :: windows :: core :: GUID::from_u128(0x4321918b_f69e_470d_a5de_4d88c75ad24b) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceClass_ClassCoInstallers: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x713d1703_a2e2_49f5_9214_56472ef3da5c), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceClass_ClassCoInstallers ) , guid : :: windows :: core :: GUID::from_u128(0x713d1703_a2e2_49f5_9214_56472ef3da5c) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceClass_ClassInstaller: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceClass_ClassInstaller ) , guid : :: windows :: core :: GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceClass_ClassName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceClass_ClassName ) , guid : :: windows :: core :: GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceClass_DefaultService: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceClass_DefaultService ) , guid : :: windows :: core :: GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceClass_DevType: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4321918b_f69e_470d_a5de_4d88c75ad24b), pid: 27u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceClass_DevType ) , guid : :: windows :: core :: GUID::from_u128(0x4321918b_f69e_470d_a5de_4d88c75ad24b) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceClass_Exclusive: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4321918b_f69e_470d_a5de_4d88c75ad24b), pid: 28u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceClass_Exclusive ) , guid : :: windows :: core :: GUID::from_u128(0x4321918b_f69e_470d_a5de_4d88c75ad24b) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceClass_Icon: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceClass_Icon ) , guid : :: windows :: core :: GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceClass_IconPath: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceClass_IconPath ) , guid : :: windows :: core :: GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceClass_LowerFilters: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4321918b_f69e_470d_a5de_4d88c75ad24b), pid: 20u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceClass_LowerFilters ) , guid : :: windows :: core :: GUID::from_u128(0x4321918b_f69e_470d_a5de_4d88c75ad24b) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceClass_Name: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceClass_Name ) , guid : :: windows :: core :: GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceClass_NoDisplayClass: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceClass_NoDisplayClass ) , guid : :: windows :: core :: GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceClass_NoInstallClass: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceClass_NoInstallClass ) , guid : :: windows :: core :: GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceClass_NoUseClass: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceClass_NoUseClass ) , guid : :: windows :: core :: GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceClass_PropPageProvider: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceClass_PropPageProvider ) , guid : :: windows :: core :: GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceClass_Security: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4321918b_f69e_470d_a5de_4d88c75ad24b), pid: 25u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceClass_Security ) , guid : :: windows :: core :: GUID::from_u128(0x4321918b_f69e_470d_a5de_4d88c75ad24b) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceClass_SecuritySDS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4321918b_f69e_470d_a5de_4d88c75ad24b), pid: 26u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceClass_SecuritySDS ) , guid : :: windows :: core :: GUID::from_u128(0x4321918b_f69e_470d_a5de_4d88c75ad24b) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceClass_SilentInstall: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceClass_SilentInstall ) , guid : :: windows :: core :: GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceClass_UpperFilters: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4321918b_f69e_470d_a5de_4d88c75ad24b), pid: 19u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceClass_UpperFilters ) , guid : :: windows :: core :: GUID::from_u128(0x4321918b_f69e_470d_a5de_4d88c75ad24b) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_Address: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 51u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_Address ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_AlwaysShowDeviceAsConnected: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 101u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_AlwaysShowDeviceAsConnected ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_AssociationArray: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 80u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_AssociationArray ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_BaselineExperienceId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 78u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_BaselineExperienceId ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_Category: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 90u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_Category ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_CategoryGroup_Desc: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 94u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_CategoryGroup_Desc ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_CategoryGroup_Icon: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 95u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_CategoryGroup_Icon ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_Category_Desc_Plural: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 92u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_Category_Desc_Plural ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_Category_Desc_Singular: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 91u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_Category_Desc_Singular ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_Category_Icon: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 93u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_Category_Icon ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_DeviceDescription1: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 81u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_DeviceDescription1 ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_DeviceDescription2: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 82u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_DeviceDescription2 ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_DeviceFunctionSubRank: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_DeviceFunctionSubRank ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_DiscoveryMethod: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 52u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_DiscoveryMethod ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_ExperienceId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 89u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_ExperienceId ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_FriendlyName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 12288u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_FriendlyName ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_Icon: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 57u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_Icon ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_InstallInProgress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x83da6326_97a6_4088_9453_a1923f573b29), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_InstallInProgress ) , guid : :: windows :: core :: GUID::from_u128(0x83da6326_97a6_4088_9453_a1923f573b29) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_IsAuthenticated: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 54u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_IsAuthenticated ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_IsConnected: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 55u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_IsConnected ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_IsDefaultDevice: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 86u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_IsDefaultDevice ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_IsDeviceUniquelyIdentifiable: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 79u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_IsDeviceUniquelyIdentifiable ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_IsEncrypted: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 53u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_IsEncrypted ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_IsLocalMachine: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 70u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_IsLocalMachine ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_IsMetadataSearchInProgress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 72u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_IsMetadataSearchInProgress ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_IsNetworkDevice: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 85u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_IsNetworkDevice ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_IsNotInterestingForDisplay: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 74u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_IsNotInterestingForDisplay ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_IsNotWorkingProperly: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 83u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_IsNotWorkingProperly ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_IsPaired: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 56u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_IsPaired ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_IsSharedDevice: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 84u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_IsSharedDevice ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_IsShowInDisconnectedState: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 68u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_IsShowInDisconnectedState ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_Last_Connected: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 67u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_Last_Connected ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_Last_Seen: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 66u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_Last_Seen ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_LaunchDeviceStageFromExplorer: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 77u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_LaunchDeviceStageFromExplorer ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_LaunchDeviceStageOnDeviceConnect: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 76u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_LaunchDeviceStageOnDeviceConnect ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_Manufacturer: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 8192u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_Manufacturer ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_MetadataCabinet: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 87u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_MetadataCabinet ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_MetadataChecksum: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 73u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_MetadataChecksum ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_MetadataPath: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 71u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_MetadataPath ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_ModelName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 8194u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_ModelName ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_ModelNumber: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 8195u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_ModelNumber ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_PrimaryCategory: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 97u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_PrimaryCategory ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_RequiresPairingElevation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 88u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_RequiresPairingElevation ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_RequiresUninstallElevation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 99u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_RequiresUninstallElevation ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_UnpairUninstall: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 98u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_UnpairUninstall ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceDisplay_Version: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 65u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceDisplay_Version ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterfaceClass_DefaultInterface: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x14c83a99_0b3f_44b7_be4c_a178d3990564), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterfaceClass_DefaultInterface ) , guid : :: windows :: core :: GUID::from_u128(0x14c83a99_0b3f_44b7_be4c_a178d3990564) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_ClassGuid: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x026e516e_b814_414b_83cd_856d6fef4822), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_ClassGuid ) , guid : :: windows :: core :: GUID::from_u128(0x026e516e_b814_414b_83cd_856d6fef4822) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_Enabled: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x026e516e_b814_414b_83cd_856d6fef4822), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_Enabled ) , guid : :: windows :: core :: GUID::from_u128(0x026e516e_b814_414b_83cd_856d6fef4822) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_FriendlyName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x026e516e_b814_414b_83cd_856d6fef4822), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_FriendlyName ) , guid : :: windows :: core :: GUID::from_u128(0x026e516e_b814_414b_83cd_856d6fef4822) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_AdditionalSoftwareRequested: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 19u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_AdditionalSoftwareRequested ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_Address: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 30u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_Address ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_BIOSVersion: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xeaee7f1d_6a33_44d1_9441_5f46def23198), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_BIOSVersion ) , guid : :: windows :: core :: GUID::from_u128(0xeaee7f1d_6a33_44d1_9441_5f46def23198) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_BaseContainerId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 38u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_BaseContainerId ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_BusNumber: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 23u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_BusNumber ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_BusRelations: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_BusRelations ) , guid : :: windows :: core :: GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_BusReportedDeviceDesc: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_BusReportedDeviceDesc ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_BusTypeGuid: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 21u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_BusTypeGuid ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_Capabilities: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 17u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_Capabilities ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_Characteristics: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 29u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_Characteristics ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_Children: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_Children ) , guid : :: windows :: core :: GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_Class: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_Class ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_ClassGuid: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_ClassGuid ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_CompatibleIds: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_CompatibleIds ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_ConfigFlags: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_ConfigFlags ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_ContainerId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8c7ed206_3f8a_4827_b3ab_ae9e1faefc6c), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_ContainerId ) , guid : :: windows :: core :: GUID::from_u128(0x8c7ed206_3f8a_4827_b3ab_ae9e1faefc6c) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_DHP_Rebalance_Policy: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_DHP_Rebalance_Policy ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_DevNodeStatus: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_DevNodeStatus ) , guid : :: windows :: core :: GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_DevType: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 27u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_DevType ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_DeviceDesc: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_DeviceDesc ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_Driver: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_Driver ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_DriverCoInstallers: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_DriverCoInstallers ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_DriverDate: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_DriverDate ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_DriverDesc: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_DriverDesc ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_DriverInfPath: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_DriverInfPath ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_DriverInfSection: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_DriverInfSection ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_DriverInfSectionExt: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_DriverInfSectionExt ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_DriverLogoLevel: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 15u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_DriverLogoLevel ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_DriverPropPageProvider: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_DriverPropPageProvider ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_DriverProvider: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_DriverProvider ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_DriverRank: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_DriverRank ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_DriverVersion: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_DriverVersion ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_EjectionRelations: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_EjectionRelations ) , guid : :: windows :: core :: GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_EnumeratorName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 24u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_EnumeratorName ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_Exclusive: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 28u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_Exclusive ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_FriendlyName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_FriendlyName ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_FriendlyNameAttributes: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x80d81ea6_7473_4b0c_8216_efc11a2c4c8b), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_FriendlyNameAttributes ) , guid : :: windows :: core :: GUID::from_u128(0x80d81ea6_7473_4b0c_8216_efc11a2c4c8b) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_GenericDriverInstalled: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 18u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_GenericDriverInstalled ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_HardwareIds: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_HardwareIds ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_InstallInProgress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x83da6326_97a6_4088_9453_a1923f573b29), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_InstallInProgress ) , guid : :: windows :: core :: GUID::from_u128(0x83da6326_97a6_4088_9453_a1923f573b29) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_InstallState: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 36u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_InstallState ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_InstanceId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 256u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_InstanceId ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_IsAssociateableByUserAction: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x80d81ea6_7473_4b0c_8216_efc11a2c4c8b), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_IsAssociateableByUserAction ) , guid : :: windows :: core :: GUID::from_u128(0x80d81ea6_7473_4b0c_8216_efc11a2c4c8b) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_Legacy: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x80497100_8c73_48b9_aad9_ce387e19c56e), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_Legacy ) , guid : :: windows :: core :: GUID::from_u128(0x80497100_8c73_48b9_aad9_ce387e19c56e) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_LegacyBusType: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 22u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_LegacyBusType ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_LocationInfo: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 15u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_LocationInfo ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_LocationPaths: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 37u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_LocationPaths ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_LowerFilters: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 20u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_LowerFilters ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_Manufacturer: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_Manufacturer ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_ManufacturerAttributes: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x80d81ea6_7473_4b0c_8216_efc11a2c4c8b), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_ManufacturerAttributes ) , guid : :: windows :: core :: GUID::from_u128(0x80d81ea6_7473_4b0c_8216_efc11a2c4c8b) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_MatchingDeviceId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_MatchingDeviceId ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_ModelId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x80d81ea6_7473_4b0c_8216_efc11a2c4c8b), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_ModelId ) , guid : :: windows :: core :: GUID::from_u128(0x80d81ea6_7473_4b0c_8216_efc11a2c4c8b) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_NoConnectSound: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 17u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_NoConnectSound ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_Numa_Node: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_Numa_Node ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_PDOName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 16u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_PDOName ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_Parent: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_Parent ) , guid : :: windows :: core :: GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_PowerData: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 32u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_PowerData ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_PowerRelations: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_PowerRelations ) , guid : :: windows :: core :: GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_PresenceNotForDevice: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x80d81ea6_7473_4b0c_8216_efc11a2c4c8b), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_PresenceNotForDevice ) , guid : :: windows :: core :: GUID::from_u128(0x80d81ea6_7473_4b0c_8216_efc11a2c4c8b) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_ProblemCode: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_ProblemCode ) , guid : :: windows :: core :: GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_RemovalPolicy: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 33u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_RemovalPolicy ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_RemovalPolicyDefault: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 34u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_RemovalPolicyDefault ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_RemovalPolicyOverride: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 35u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_RemovalPolicyOverride ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_RemovalRelations: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_RemovalRelations ) , guid : :: windows :: core :: GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_Reported: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x80497100_8c73_48b9_aad9_ce387e19c56e), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_Reported ) , guid : :: windows :: core :: GUID::from_u128(0x80497100_8c73_48b9_aad9_ce387e19c56e) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_ResourcePickerExceptions: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_ResourcePickerExceptions ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_ResourcePickerTags: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_ResourcePickerTags ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_SafeRemovalRequired: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xafd97640_86a3_4210_b67c_289c41aabe55), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_SafeRemovalRequired ) , guid : :: windows :: core :: GUID::from_u128(0xafd97640_86a3_4210_b67c_289c41aabe55) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_SafeRemovalRequiredOverride: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xafd97640_86a3_4210_b67c_289c41aabe55), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_SafeRemovalRequiredOverride ) , guid : :: windows :: core :: GUID::from_u128(0xafd97640_86a3_4210_b67c_289c41aabe55) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_Security: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 25u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_Security ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_SecuritySDS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 26u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_SecuritySDS ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_Service: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_Service ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_Siblings: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_Siblings ) , guid : :: windows :: core :: GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_SignalStrength: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x80d81ea6_7473_4b0c_8216_efc11a2c4c8b), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_SignalStrength ) , guid : :: windows :: core :: GUID::from_u128(0x80d81ea6_7473_4b0c_8216_efc11a2c4c8b) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_TransportRelations: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_TransportRelations ) , guid : :: windows :: core :: GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_UINumber: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 18u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_UINumber ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_UINumberDescFormat: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 31u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_UINumberDescFormat ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_UpperFilters: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 19u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_UpperFilters ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DrvPkg_BrandingIcon: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcf73bb51_3abf_44a2_85e0_9a3dc7a12132), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DrvPkg_BrandingIcon ) , guid : :: windows :: core :: GUID::from_u128(0xcf73bb51_3abf_44a2_85e0_9a3dc7a12132) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DrvPkg_DetailedDescription: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcf73bb51_3abf_44a2_85e0_9a3dc7a12132), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DrvPkg_DetailedDescription ) , guid : :: windows :: core :: GUID::from_u128(0xcf73bb51_3abf_44a2_85e0_9a3dc7a12132) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DrvPkg_DocumentationLink: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcf73bb51_3abf_44a2_85e0_9a3dc7a12132), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DrvPkg_DocumentationLink ) , guid : :: windows :: core :: GUID::from_u128(0xcf73bb51_3abf_44a2_85e0_9a3dc7a12132) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DrvPkg_Icon: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcf73bb51_3abf_44a2_85e0_9a3dc7a12132), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DrvPkg_Icon ) , guid : :: windows :: core :: GUID::from_u128(0xcf73bb51_3abf_44a2_85e0_9a3dc7a12132) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DrvPkg_Model: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcf73bb51_3abf_44a2_85e0_9a3dc7a12132), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DrvPkg_Model ) , guid : :: windows :: core :: GUID::from_u128(0xcf73bb51_3abf_44a2_85e0_9a3dc7a12132) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DrvPkg_VendorWebSite: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcf73bb51_3abf_44a2_85e0_9a3dc7a12132), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DrvPkg_VendorWebSite ) , guid : :: windows :: core :: GUID::from_u128(0xcf73bb51_3abf_44a2_85e0_9a3dc7a12132) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FunctionInstance: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x08c0c253_a154_4746_9005_82de5317148b), pid: 1u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FunctionInstance ) , guid : :: windows :: core :: GUID::from_u128(0x08c0c253_a154_4746_9005_82de5317148b) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Hardware_Devinst: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5eaf3ef2_e0ca_4598_bf06_71ed1d9dd953), pid: 4097u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Hardware_Devinst ) , guid : :: windows :: core :: GUID::from_u128(0x5eaf3ef2_e0ca_4598_bf06_71ed1d9dd953) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Hardware_DisplayAttribute: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5eaf3ef2_e0ca_4598_bf06_71ed1d9dd953), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Hardware_DisplayAttribute ) , guid : :: windows :: core :: GUID::from_u128(0x5eaf3ef2_e0ca_4598_bf06_71ed1d9dd953) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Hardware_DriverDate: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5eaf3ef2_e0ca_4598_bf06_71ed1d9dd953), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Hardware_DriverDate ) , guid : :: windows :: core :: GUID::from_u128(0x5eaf3ef2_e0ca_4598_bf06_71ed1d9dd953) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Hardware_DriverProvider: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5eaf3ef2_e0ca_4598_bf06_71ed1d9dd953), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Hardware_DriverProvider ) , guid : :: windows :: core :: GUID::from_u128(0x5eaf3ef2_e0ca_4598_bf06_71ed1d9dd953) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Hardware_DriverVersion: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5eaf3ef2_e0ca_4598_bf06_71ed1d9dd953), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Hardware_DriverVersion ) , guid : :: windows :: core :: GUID::from_u128(0x5eaf3ef2_e0ca_4598_bf06_71ed1d9dd953) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Hardware_Function: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5eaf3ef2_e0ca_4598_bf06_71ed1d9dd953), pid: 4099u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Hardware_Function ) , guid : :: windows :: core :: GUID::from_u128(0x5eaf3ef2_e0ca_4598_bf06_71ed1d9dd953) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Hardware_Icon: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5eaf3ef2_e0ca_4598_bf06_71ed1d9dd953), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Hardware_Icon ) , guid : :: windows :: core :: GUID::from_u128(0x5eaf3ef2_e0ca_4598_bf06_71ed1d9dd953) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Hardware_Image: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5eaf3ef2_e0ca_4598_bf06_71ed1d9dd953), pid: 4098u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Hardware_Image ) , guid : :: windows :: core :: GUID::from_u128(0x5eaf3ef2_e0ca_4598_bf06_71ed1d9dd953) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Hardware_Manufacturer: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5eaf3ef2_e0ca_4598_bf06_71ed1d9dd953), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Hardware_Manufacturer ) , guid : :: windows :: core :: GUID::from_u128(0x5eaf3ef2_e0ca_4598_bf06_71ed1d9dd953) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Hardware_Model: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5eaf3ef2_e0ca_4598_bf06_71ed1d9dd953), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Hardware_Model ) , guid : :: windows :: core :: GUID::from_u128(0x5eaf3ef2_e0ca_4598_bf06_71ed1d9dd953) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Hardware_Name: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5eaf3ef2_e0ca_4598_bf06_71ed1d9dd953), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Hardware_Name ) , guid : :: windows :: core :: GUID::from_u128(0x5eaf3ef2_e0ca_4598_bf06_71ed1d9dd953) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Hardware_SerialNumber: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5eaf3ef2_e0ca_4598_bf06_71ed1d9dd953), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Hardware_SerialNumber ) , guid : :: windows :: core :: GUID::from_u128(0x5eaf3ef2_e0ca_4598_bf06_71ed1d9dd953) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Hardware_ShellAttributes: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5eaf3ef2_e0ca_4598_bf06_71ed1d9dd953), pid: 4100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Hardware_ShellAttributes ) , guid : :: windows :: core :: GUID::from_u128(0x5eaf3ef2_e0ca_4598_bf06_71ed1d9dd953) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Hardware_Status: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5eaf3ef2_e0ca_4598_bf06_71ed1d9dd953), pid: 4096u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Hardware_Status ) , guid : :: windows :: core :: GUID::from_u128(0x5eaf3ef2_e0ca_4598_bf06_71ed1d9dd953) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_NAME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_NAME ) , guid : :: windows :: core :: GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Numa_Proximity_Domain: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 1u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Numa_Proximity_Domain ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_Associated: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4fc5077e_b686_44be_93e3_86cafe368ccd), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_Associated ) , guid : :: windows :: core :: GUID::from_u128(0x4fc5077e_b686_44be_93e3_86cafe368ccd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_Category_Desc_NonPlural: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 12304u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_Category_Desc_NonPlural ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_CompactSignature: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 28674u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_CompactSignature ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_CompatibleTypes: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4fc5077e_b686_44be_93e3_86cafe368ccd), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_CompatibleTypes ) , guid : :: windows :: core :: GUID::from_u128(0x4fc5077e_b686_44be_93e3_86cafe368ccd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_DeviceCategory: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 12292u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_DeviceCategory ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_DeviceCategory_Desc: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 12293u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_DeviceCategory_Desc ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_DeviceCertHash: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 28675u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_DeviceCertHash ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_DomainName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 20480u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_DomainName ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_FirmwareVersion: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 12289u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_FirmwareVersion ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_GlobalIdentity: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 4096u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_GlobalIdentity ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 4101u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_ID ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_IPBusEnumerated: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 28688u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_IPBusEnumerated ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_InstallState: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4fc5077e_b686_44be_93e3_86cafe368ccd), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_InstallState ) , guid : :: windows :: core :: GUID::from_u128(0x4fc5077e_b686_44be_93e3_86cafe368ccd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_Installable: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4fc5077e_b686_44be_93e3_86cafe368ccd), pid: 1u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_Installable ) , guid : :: windows :: core :: GUID::from_u128(0x4fc5077e_b686_44be_93e3_86cafe368ccd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_IpAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 12297u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_IpAddress ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_ManufacturerUrl: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 8193u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_ManufacturerUrl ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_MetadataVersion: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 4100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_MetadataVersion ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_ModelUrl: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 8196u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_ModelUrl ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_NetworkInterfaceGuid: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 12296u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_NetworkInterfaceGuid ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_NetworkInterfaceLuid: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 12295u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_NetworkInterfaceLuid ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_PhysicalAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 12294u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_PhysicalAddress ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_PresentationUrl: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 8198u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_PresentationUrl ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_RemoteAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 4102u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_RemoteAddress ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_Removable: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 28672u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_Removable ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_RootProxy: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 4103u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_RootProxy ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_Scopes: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 4098u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_Scopes ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_SecureChannel: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 28673u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_SecureChannel ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_SerialNumber: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 12290u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_SerialNumber ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_ServiceAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 16384u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_ServiceAddress ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_ServiceControlUrl: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 16388u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_ServiceControlUrl ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_ServiceDescUrl: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 16389u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_ServiceDescUrl ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_ServiceEventSubUrl: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 16390u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_ServiceEventSubUrl ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_ServiceId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 16385u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_ServiceId ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_ServiceTypes: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 16386u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_ServiceTypes ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_ShareName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 20482u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_ShareName ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_Types: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 4097u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_Types ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_Upc: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 8197u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_Upc ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PNPX_XAddrs: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 4099u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PNPX_XAddrs ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Pairing_IsWifiOnlyDevice: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8807cae6_7db6_4f10_8ee4_435eaa1392bc), pid: 16u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Pairing_IsWifiOnlyDevice ) , guid : :: windows :: core :: GUID::from_u128(0x8807cae6_7db6_4f10_8ee4_435eaa1392bc) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Pairing_ListItemDefault: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8807cae6_7db6_4f10_8ee4_435eaa1392bc), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Pairing_ListItemDefault ) , guid : :: windows :: core :: GUID::from_u128(0x8807cae6_7db6_4f10_8ee4_435eaa1392bc) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Pairing_ListItemDescription: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8807cae6_7db6_4f10_8ee4_435eaa1392bc), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Pairing_ListItemDescription ) , guid : :: windows :: core :: GUID::from_u128(0x8807cae6_7db6_4f10_8ee4_435eaa1392bc) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Pairing_ListItemIcon: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8807cae6_7db6_4f10_8ee4_435eaa1392bc), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Pairing_ListItemIcon ) , guid : :: windows :: core :: GUID::from_u128(0x8807cae6_7db6_4f10_8ee4_435eaa1392bc) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Pairing_ListItemText: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8807cae6_7db6_4f10_8ee4_435eaa1392bc), pid: 1u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Pairing_ListItemText ) , guid : :: windows :: core :: GUID::from_u128(0x8807cae6_7db6_4f10_8ee4_435eaa1392bc) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_SSDP_AltLocationInfo: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 24576u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_SSDP_AltLocationInfo ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_SSDP_DevLifeTime: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 24577u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_SSDP_DevLifeTime ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_SSDP_NetworkInterface: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 24578u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_SSDP_NetworkInterface ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_WCN_AssocState: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x88190b88_4684_11da_a26a_0002b3988e81), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_WCN_AssocState ) , guid : :: windows :: core :: GUID::from_u128(0x88190b88_4684_11da_a26a_0002b3988e81) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_WCN_AuthType: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x88190b82_4684_11da_a26a_0002b3988e81), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_WCN_AuthType ) , guid : :: windows :: core :: GUID::from_u128(0x88190b82_4684_11da_a26a_0002b3988e81) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_WCN_ConfigError: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x88190b89_4684_11da_a26a_0002b3988e81), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_WCN_ConfigError ) , guid : :: windows :: core :: GUID::from_u128(0x88190b89_4684_11da_a26a_0002b3988e81) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_WCN_ConfigMethods: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x88190b85_4684_11da_a26a_0002b3988e81), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_WCN_ConfigMethods ) , guid : :: windows :: core :: GUID::from_u128(0x88190b85_4684_11da_a26a_0002b3988e81) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_WCN_ConfigState: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x88190b89_4684_11da_a26a_0002b3988e81), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_WCN_ConfigState ) , guid : :: windows :: core :: GUID::from_u128(0x88190b89_4684_11da_a26a_0002b3988e81) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_WCN_ConnType: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x88190b84_4684_11da_a26a_0002b3988e81), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_WCN_ConnType ) , guid : :: windows :: core :: GUID::from_u128(0x88190b84_4684_11da_a26a_0002b3988e81) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_WCN_DevicePasswordId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x88190b89_4684_11da_a26a_0002b3988e81), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_WCN_DevicePasswordId ) , guid : :: windows :: core :: GUID::from_u128(0x88190b89_4684_11da_a26a_0002b3988e81) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_WCN_EncryptType: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x88190b83_4684_11da_a26a_0002b3988e81), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_WCN_EncryptType ) , guid : :: windows :: core :: GUID::from_u128(0x88190b83_4684_11da_a26a_0002b3988e81) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_WCN_OSVersion: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x88190b89_4684_11da_a26a_0002b3988e81), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_WCN_OSVersion ) , guid : :: windows :: core :: GUID::from_u128(0x88190b89_4684_11da_a26a_0002b3988e81) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_WCN_RegistrarType: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x88190b8b_4684_11da_a26a_0002b3988e81), pid: 15u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_WCN_RegistrarType ) , guid : :: windows :: core :: GUID::from_u128(0x88190b8b_4684_11da_a26a_0002b3988e81) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_WCN_RequestType: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x88190b81_4684_11da_a26a_0002b3988e81), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_WCN_RequestType ) , guid : :: windows :: core :: GUID::from_u128(0x88190b81_4684_11da_a26a_0002b3988e81) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_WCN_RfBand: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x88190b87_4684_11da_a26a_0002b3988e81), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_WCN_RfBand ) , guid : :: windows :: core :: GUID::from_u128(0x88190b87_4684_11da_a26a_0002b3988e81) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_WCN_VendorExtension: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x88190b8a_4684_11da_a26a_0002b3988e81), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_WCN_VendorExtension ) , guid : :: windows :: core :: GUID::from_u128(0x88190b8a_4684_11da_a26a_0002b3988e81) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_WCN_Version: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x88190b80_4684_11da_a26a_0002b3988e81), pid: 1u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_WCN_Version ) , guid : :: windows :: core :: GUID::from_u128(0x88190b80_4684_11da_a26a_0002b3988e81) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_WNET_Comment: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xdebda43a_37b3_4383_91e7_4498da2995ab), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_WNET_Comment ) , guid : :: windows :: core :: GUID::from_u128(0xdebda43a_37b3_4383_91e7_4498da2995ab) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_WNET_DisplayType: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xdebda43a_37b3_4383_91e7_4498da2995ab), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_WNET_DisplayType ) , guid : :: windows :: core :: GUID::from_u128(0xdebda43a_37b3_4383_91e7_4498da2995ab) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_WNET_LocalName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xdebda43a_37b3_4383_91e7_4498da2995ab), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_WNET_LocalName ) , guid : :: windows :: core :: GUID::from_u128(0xdebda43a_37b3_4383_91e7_4498da2995ab) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_WNET_Provider: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xdebda43a_37b3_4383_91e7_4498da2995ab), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_WNET_Provider ) , guid : :: windows :: core :: GUID::from_u128(0xdebda43a_37b3_4383_91e7_4498da2995ab) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_WNET_RemoteName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xdebda43a_37b3_4383_91e7_4498da2995ab), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_WNET_RemoteName ) , guid : :: windows :: core :: GUID::from_u128(0xdebda43a_37b3_4383_91e7_4498da2995ab) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_WNET_Scope: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xdebda43a_37b3_4383_91e7_4498da2995ab), pid: 1u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_WNET_Scope ) , guid : :: windows :: core :: GUID::from_u128(0xdebda43a_37b3_4383_91e7_4498da2995ab) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_WNET_Type: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xdebda43a_37b3_4383_91e7_4498da2995ab), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_WNET_Type ) , guid : :: windows :: core :: GUID::from_u128(0xdebda43a_37b3_4383_91e7_4498da2995ab) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_WNET_Usage: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xdebda43a_37b3_4383_91e7_4498da2995ab), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_WNET_Usage ) , guid : :: windows :: core :: GUID::from_u128(0xdebda43a_37b3_4383_91e7_4498da2995ab) , } }
 pub const PNPXAssociation: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcee8ccc9_4f6b_4469_a235_5a22869eef03);
 pub const PNPXPairingHandler: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb8a27942_ade7_4085_aa6e_4fadc7ada1ef);
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery'*"]
@@ -2179,17 +2669,41 @@ pub const QUA_REMOVE: QueryUpdateAction = 1i32;
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery'*"]
 pub const QUA_CHANGE: QueryUpdateAction = 2i32;
 pub const SID_DeviceDisplayStatusManager: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf59aa553_8309_46ca_9736_1ac3c62d6031);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SID_DeviceDisplayStatusManager ) , guid : :: windows :: core :: GUID::from_u128(0xf59aa553_8309_46ca_9736_1ac3c62d6031) , } }
 pub const SID_EnumDeviceFunction: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x13e0e9e2_c3fa_4e3c_906e_64502fa4dc95);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SID_EnumDeviceFunction ) , guid : :: windows :: core :: GUID::from_u128(0x13e0e9e2_c3fa_4e3c_906e_64502fa4dc95) , } }
 pub const SID_EnumInterface: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x40eab0b9_4d7f_4b53_a334_1581dd9041f4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SID_EnumInterface ) , guid : :: windows :: core :: GUID::from_u128(0x40eab0b9_4d7f_4b53_a334_1581dd9041f4) , } }
 pub const SID_FDPairingHandler: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x383b69fa_5486_49da_91f5_d63c24c8e9d0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SID_FDPairingHandler ) , guid : :: windows :: core :: GUID::from_u128(0x383b69fa_5486_49da_91f5_d63c24c8e9d0) , } }
 pub const SID_FunctionDiscoveryProviderRefresh: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2b4cbdc9_31c4_40d4_a62d_772aa174ed52);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SID_FunctionDiscoveryProviderRefresh ) , guid : :: windows :: core :: GUID::from_u128(0x2b4cbdc9_31c4_40d4_a62d_772aa174ed52) , } }
 pub const SID_PNPXAssociation: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcee8ccc9_4f6b_4469_a235_5a22869eef03);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SID_PNPXAssociation ) , guid : :: windows :: core :: GUID::from_u128(0xcee8ccc9_4f6b_4469_a235_5a22869eef03) , } }
 pub const SID_PNPXPropertyStore: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa86530b1_542f_439f_b71c_b0756b13677a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SID_PNPXPropertyStore ) , guid : :: windows :: core :: GUID::from_u128(0xa86530b1_542f_439f_b71c_b0756b13677a) , } }
 pub const SID_PNPXServiceCollection: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x439e80ee_a217_4712_9fa6_deabd9c2a727);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SID_PNPXServiceCollection ) , guid : :: windows :: core :: GUID::from_u128(0x439e80ee_a217_4712_9fa6_deabd9c2a727) , } }
 pub const SID_PnpProvider: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8101368e_cabb_4426_acff_96c410812000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SID_PnpProvider ) , guid : :: windows :: core :: GUID::from_u128(0x8101368e_cabb_4426_acff_96c410812000) , } }
 pub const SID_UPnPActivator: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0d0d66eb_cf74_4164_b52f_08344672dd46);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SID_UPnPActivator ) , guid : :: windows :: core :: GUID::from_u128(0x0d0d66eb_cf74_4164_b52f_08344672dd46) , } }
 pub const SID_UninstallDeviceFunction: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc920566e_5671_4496_8025_bf0b89bd44cd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SID_UninstallDeviceFunction ) , guid : :: windows :: core :: GUID::from_u128(0xc920566e_5671_4496_8025_bf0b89bd44cd) , } }
 pub const SID_UnpairProvider: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x89a502fc_857b_4698_a0b7_027192002f9e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SID_UnpairProvider ) , guid : :: windows :: core :: GUID::from_u128(0x89a502fc_857b_4698_a0b7_027192002f9e) , } }
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery'*"]
 pub type SystemVisibilityFlags = i32;
 #[doc = "*Required features: 'Win32_Devices_FunctionDiscovery'*"]

--- a/crates/libs/windows/src/Windows/Win32/Devices/Geolocation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Geolocation/mod.rs
@@ -2491,6 +2491,8 @@ impl ::core::default::Default for GNSS_V2UPL_NI_INFO {
     }
 }
 pub const GUID_DEVINTERFACE_GNSS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3336e5e4_018a_4669_84c5_bd05f3bd368b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_GNSS ) , guid : :: windows :: core :: GUID::from_u128(0x3336e5e4_018a_4669_84c5_bd05f3bd368b) , } }
 #[doc = "*Required features: 'Win32_Devices_Geolocation'*"]
 #[repr(transparent)]
 pub struct ICivicAddressReport(::windows::core::IUnknown);

--- a/crates/libs/windows/src/Windows/Win32/Devices/HumanInterfaceDevice/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/HumanInterfaceDevice/mod.rs
@@ -38,9 +38,17 @@ pub const BUTTON_BIT_VOLUMEUP: u32 = 4u32;
 #[doc = "*Required features: 'Win32_Devices_HumanInterfaceDevice'*"]
 pub const BUTTON_BIT_WINDOWS: u32 = 2u32;
 pub const CLSID_DirectInput: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x25e609e0_b259_11cf_bfc7_444553540000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DirectInput ) , guid : :: windows :: core :: GUID::from_u128(0x25e609e0_b259_11cf_bfc7_444553540000) , } }
 pub const CLSID_DirectInput8: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x25e609e4_b259_11cf_bfc7_444553540000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DirectInput8 ) , guid : :: windows :: core :: GUID::from_u128(0x25e609e4_b259_11cf_bfc7_444553540000) , } }
 pub const CLSID_DirectInputDevice: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x25e609e1_b259_11cf_bfc7_444553540000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DirectInputDevice ) , guid : :: windows :: core :: GUID::from_u128(0x25e609e1_b259_11cf_bfc7_444553540000) , } }
 pub const CLSID_DirectInputDevice8: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x25e609e5_b259_11cf_bfc7_444553540000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DirectInputDevice8 ) , guid : :: windows :: core :: GUID::from_u128(0x25e609e5_b259_11cf_bfc7_444553540000) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Devices_HumanInterfaceDevice'*"]
 pub struct CPOINT {
@@ -75,27 +83,43 @@ impl ::core::default::Default for CPOINT {
 #[doc = "*Required features: 'Win32_Devices_HumanInterfaceDevice', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceInterface_HID_BackgroundAccess: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcbf38310_4a17_4310_a1eb_247f0b67593b), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceInterface_HID_BackgroundAccess ) , guid : :: windows :: core :: GUID::from_u128(0xcbf38310_4a17_4310_a1eb_247f0b67593b) , } }
 #[doc = "*Required features: 'Win32_Devices_HumanInterfaceDevice', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceInterface_HID_IsReadOnly: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcbf38310_4a17_4310_a1eb_247f0b67593b), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceInterface_HID_IsReadOnly ) , guid : :: windows :: core :: GUID::from_u128(0xcbf38310_4a17_4310_a1eb_247f0b67593b) , } }
 #[doc = "*Required features: 'Win32_Devices_HumanInterfaceDevice', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceInterface_HID_ProductId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcbf38310_4a17_4310_a1eb_247f0b67593b), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceInterface_HID_ProductId ) , guid : :: windows :: core :: GUID::from_u128(0xcbf38310_4a17_4310_a1eb_247f0b67593b) , } }
 #[doc = "*Required features: 'Win32_Devices_HumanInterfaceDevice', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceInterface_HID_UsageId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcbf38310_4a17_4310_a1eb_247f0b67593b), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceInterface_HID_UsageId ) , guid : :: windows :: core :: GUID::from_u128(0xcbf38310_4a17_4310_a1eb_247f0b67593b) , } }
 #[doc = "*Required features: 'Win32_Devices_HumanInterfaceDevice', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceInterface_HID_UsagePage: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcbf38310_4a17_4310_a1eb_247f0b67593b), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceInterface_HID_UsagePage ) , guid : :: windows :: core :: GUID::from_u128(0xcbf38310_4a17_4310_a1eb_247f0b67593b) , } }
 #[doc = "*Required features: 'Win32_Devices_HumanInterfaceDevice', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceInterface_HID_VendorId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcbf38310_4a17_4310_a1eb_247f0b67593b), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceInterface_HID_VendorId ) , guid : :: windows :: core :: GUID::from_u128(0xcbf38310_4a17_4310_a1eb_247f0b67593b) , } }
 #[doc = "*Required features: 'Win32_Devices_HumanInterfaceDevice', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceInterface_HID_VersionNumber: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcbf38310_4a17_4310_a1eb_247f0b67593b), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceInterface_HID_VersionNumber ) , guid : :: windows :: core :: GUID::from_u128(0xcbf38310_4a17_4310_a1eb_247f0b67593b) , } }
 #[doc = "*Required features: 'Win32_Devices_HumanInterfaceDevice', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceInterface_HID_WakeScreenOnInputCapable: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcbf38310_4a17_4310_a1eb_247f0b67593b), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceInterface_HID_WakeScreenOnInputCapable ) , guid : :: windows :: core :: GUID::from_u128(0xcbf38310_4a17_4310_a1eb_247f0b67593b) , } }
 #[doc = "*Required features: 'Win32_Devices_HumanInterfaceDevice'*"]
 pub const DI8DEVCLASS_ALL: u32 = 0u32;
 #[doc = "*Required features: 'Win32_Devices_HumanInterfaceDevice'*"]
@@ -5938,44 +5962,122 @@ pub const GPIO_BUTTON_COUNT_MIN: GPIOBUTTONS_BUTTON_TYPE = 5i32;
 #[doc = "*Required features: 'Win32_Devices_HumanInterfaceDevice'*"]
 pub const GPIO_BUTTON_COUNT: GPIOBUTTONS_BUTTON_TYPE = 16i32;
 pub const GUID_Button: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa36d02f0_c9f3_11cf_bfc7_444553540000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_Button ) , guid : :: windows :: core :: GUID::from_u128(0xa36d02f0_c9f3_11cf_bfc7_444553540000) , } }
 pub const GUID_ConstantForce: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x13541c20_8e33_11d0_9ad0_00a0c9a06e35);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ConstantForce ) , guid : :: windows :: core :: GUID::from_u128(0x13541c20_8e33_11d0_9ad0_00a0c9a06e35) , } }
 pub const GUID_CustomForce: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x13541c2b_8e33_11d0_9ad0_00a0c9a06e35);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_CustomForce ) , guid : :: windows :: core :: GUID::from_u128(0x13541c2b_8e33_11d0_9ad0_00a0c9a06e35) , } }
 pub const GUID_DEVINTERFACE_HID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d1e55b2_f16f_11cf_88cb_001111000030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_HID ) , guid : :: windows :: core :: GUID::from_u128(0x4d1e55b2_f16f_11cf_88cb_001111000030) , } }
 pub const GUID_DEVINTERFACE_KEYBOARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x884b96c3_56ef_11d1_bc8c_00a0c91405dd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_KEYBOARD ) , guid : :: windows :: core :: GUID::from_u128(0x884b96c3_56ef_11d1_bc8c_00a0c91405dd) , } }
 pub const GUID_DEVINTERFACE_MOUSE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x378de44c_56ef_11d1_bc8c_00a0c91405dd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_MOUSE ) , guid : :: windows :: core :: GUID::from_u128(0x378de44c_56ef_11d1_bc8c_00a0c91405dd) , } }
 pub const GUID_Damper: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x13541c28_8e33_11d0_9ad0_00a0c9a06e35);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_Damper ) , guid : :: windows :: core :: GUID::from_u128(0x13541c28_8e33_11d0_9ad0_00a0c9a06e35) , } }
 pub const GUID_Friction: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x13541c2a_8e33_11d0_9ad0_00a0c9a06e35);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_Friction ) , guid : :: windows :: core :: GUID::from_u128(0x13541c2a_8e33_11d0_9ad0_00a0c9a06e35) , } }
 pub const GUID_HIDClass: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x745a17a0_74d3_11d0_b6fe_00a0c90f57da);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_HIDClass ) , guid : :: windows :: core :: GUID::from_u128(0x745a17a0_74d3_11d0_b6fe_00a0c90f57da) , } }
 pub const GUID_HID_INTERFACE_HIDPARSE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf5c315a5_69ac_4bc2_9279_d0b64576f44b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_HID_INTERFACE_HIDPARSE ) , guid : :: windows :: core :: GUID::from_u128(0xf5c315a5_69ac_4bc2_9279_d0b64576f44b) , } }
 pub const GUID_HID_INTERFACE_NOTIFY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2c4e2e88_25e6_4c33_882f_3d82e6073681);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_HID_INTERFACE_NOTIFY ) , guid : :: windows :: core :: GUID::from_u128(0x2c4e2e88_25e6_4c33_882f_3d82e6073681) , } }
 pub const GUID_Inertia: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x13541c29_8e33_11d0_9ad0_00a0c9a06e35);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_Inertia ) , guid : :: windows :: core :: GUID::from_u128(0x13541c29_8e33_11d0_9ad0_00a0c9a06e35) , } }
 pub const GUID_Joystick: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6f1d2b70_d5a0_11cf_bfc7_444553540000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_Joystick ) , guid : :: windows :: core :: GUID::from_u128(0x6f1d2b70_d5a0_11cf_bfc7_444553540000) , } }
 pub const GUID_Key: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x55728220_d33c_11cf_bfc7_444553540000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_Key ) , guid : :: windows :: core :: GUID::from_u128(0x55728220_d33c_11cf_bfc7_444553540000) , } }
 pub const GUID_KeyboardClass: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e96b_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_KeyboardClass ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e96b_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_MediaClass: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e96c_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MediaClass ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e96c_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_MouseClass: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e96f_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MouseClass ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e96f_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_POV: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa36d02f2_c9f3_11cf_bfc7_444553540000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_POV ) , guid : :: windows :: core :: GUID::from_u128(0xa36d02f2_c9f3_11cf_bfc7_444553540000) , } }
 pub const GUID_RampForce: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x13541c21_8e33_11d0_9ad0_00a0c9a06e35);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_RampForce ) , guid : :: windows :: core :: GUID::from_u128(0x13541c21_8e33_11d0_9ad0_00a0c9a06e35) , } }
 pub const GUID_RxAxis: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa36d02f4_c9f3_11cf_bfc7_444553540000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_RxAxis ) , guid : :: windows :: core :: GUID::from_u128(0xa36d02f4_c9f3_11cf_bfc7_444553540000) , } }
 pub const GUID_RyAxis: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa36d02f5_c9f3_11cf_bfc7_444553540000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_RyAxis ) , guid : :: windows :: core :: GUID::from_u128(0xa36d02f5_c9f3_11cf_bfc7_444553540000) , } }
 pub const GUID_RzAxis: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa36d02e3_c9f3_11cf_bfc7_444553540000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_RzAxis ) , guid : :: windows :: core :: GUID::from_u128(0xa36d02e3_c9f3_11cf_bfc7_444553540000) , } }
 pub const GUID_SawtoothDown: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x13541c26_8e33_11d0_9ad0_00a0c9a06e35);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SawtoothDown ) , guid : :: windows :: core :: GUID::from_u128(0x13541c26_8e33_11d0_9ad0_00a0c9a06e35) , } }
 pub const GUID_SawtoothUp: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x13541c25_8e33_11d0_9ad0_00a0c9a06e35);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SawtoothUp ) , guid : :: windows :: core :: GUID::from_u128(0x13541c25_8e33_11d0_9ad0_00a0c9a06e35) , } }
 pub const GUID_Sine: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x13541c23_8e33_11d0_9ad0_00a0c9a06e35);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_Sine ) , guid : :: windows :: core :: GUID::from_u128(0x13541c23_8e33_11d0_9ad0_00a0c9a06e35) , } }
 pub const GUID_Slider: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa36d02e4_c9f3_11cf_bfc7_444553540000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_Slider ) , guid : :: windows :: core :: GUID::from_u128(0xa36d02e4_c9f3_11cf_bfc7_444553540000) , } }
 pub const GUID_Spring: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x13541c27_8e33_11d0_9ad0_00a0c9a06e35);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_Spring ) , guid : :: windows :: core :: GUID::from_u128(0x13541c27_8e33_11d0_9ad0_00a0c9a06e35) , } }
 pub const GUID_Square: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x13541c22_8e33_11d0_9ad0_00a0c9a06e35);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_Square ) , guid : :: windows :: core :: GUID::from_u128(0x13541c22_8e33_11d0_9ad0_00a0c9a06e35) , } }
 pub const GUID_SysKeyboard: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6f1d2b61_d5a0_11cf_bfc7_444553540000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SysKeyboard ) , guid : :: windows :: core :: GUID::from_u128(0x6f1d2b61_d5a0_11cf_bfc7_444553540000) , } }
 pub const GUID_SysKeyboardEm: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6f1d2b82_d5a0_11cf_bfc7_444553540000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SysKeyboardEm ) , guid : :: windows :: core :: GUID::from_u128(0x6f1d2b82_d5a0_11cf_bfc7_444553540000) , } }
 pub const GUID_SysKeyboardEm2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6f1d2b83_d5a0_11cf_bfc7_444553540000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SysKeyboardEm2 ) , guid : :: windows :: core :: GUID::from_u128(0x6f1d2b83_d5a0_11cf_bfc7_444553540000) , } }
 pub const GUID_SysMouse: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6f1d2b60_d5a0_11cf_bfc7_444553540000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SysMouse ) , guid : :: windows :: core :: GUID::from_u128(0x6f1d2b60_d5a0_11cf_bfc7_444553540000) , } }
 pub const GUID_SysMouseEm: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6f1d2b80_d5a0_11cf_bfc7_444553540000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SysMouseEm ) , guid : :: windows :: core :: GUID::from_u128(0x6f1d2b80_d5a0_11cf_bfc7_444553540000) , } }
 pub const GUID_SysMouseEm2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6f1d2b81_d5a0_11cf_bfc7_444553540000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SysMouseEm2 ) , guid : :: windows :: core :: GUID::from_u128(0x6f1d2b81_d5a0_11cf_bfc7_444553540000) , } }
 pub const GUID_Triangle: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x13541c24_8e33_11d0_9ad0_00a0c9a06e35);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_Triangle ) , guid : :: windows :: core :: GUID::from_u128(0x13541c24_8e33_11d0_9ad0_00a0c9a06e35) , } }
 pub const GUID_Unknown: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa36d02f3_c9f3_11cf_bfc7_444553540000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_Unknown ) , guid : :: windows :: core :: GUID::from_u128(0xa36d02f3_c9f3_11cf_bfc7_444553540000) , } }
 pub const GUID_XAxis: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa36d02e0_c9f3_11cf_bfc7_444553540000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_XAxis ) , guid : :: windows :: core :: GUID::from_u128(0xa36d02e0_c9f3_11cf_bfc7_444553540000) , } }
 pub const GUID_YAxis: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa36d02e1_c9f3_11cf_bfc7_444553540000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_YAxis ) , guid : :: windows :: core :: GUID::from_u128(0xa36d02e1_c9f3_11cf_bfc7_444553540000) , } }
 pub const GUID_ZAxis: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa36d02e2_c9f3_11cf_bfc7_444553540000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ZAxis ) , guid : :: windows :: core :: GUID::from_u128(0xa36d02e2_c9f3_11cf_bfc7_444553540000) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Devices_HumanInterfaceDevice'*"]
 pub struct HIDD_ATTRIBUTES {

--- a/crates/libs/windows/src/Windows/Win32/Devices/ImageAcquisition/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/ImageAcquisition/mod.rs
@@ -40,6 +40,8 @@ pub const CAPTUREMODE_TIMELAPSE: u32 = 3u32;
 #[doc = "*Required features: 'Win32_Devices_ImageAcquisition'*"]
 pub const CENTERED: u32 = 1u32;
 pub const CLSID_WiaDefaultSegFilter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd4f4d30b_0b29_4508_8922_0c5797d42765);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WiaDefaultSegFilter ) , guid : :: windows :: core :: GUID::from_u128(0xd4f4d30b_0b29_4508_8922_0c5797d42765) , } }
 #[doc = "*Required features: 'Win32_Devices_ImageAcquisition'*"]
 pub const CMD_GETADFAVAILABLE: u32 = 117u32;
 #[doc = "*Required features: 'Win32_Devices_ImageAcquisition'*"]
@@ -334,6 +336,8 @@ pub const FRONT_FIRST: u32 = 8u32;
 #[doc = "*Required features: 'Win32_Devices_ImageAcquisition'*"]
 pub const FRONT_ONLY: u32 = 32u32;
 pub const GUID_DEVINTERFACE_IMAGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6bdd1fc6_810f_11d0_bec7_08002be2092f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_IMAGE ) , guid : :: windows :: core :: GUID::from_u128(0x6bdd1fc6_810f_11d0_bec7_08002be2092f) , } }
 #[doc = "*Required features: 'Win32_Devices_ImageAcquisition'*"]
 #[repr(transparent)]
 pub struct IEnumWIA_DEV_CAPS(::windows::core::IUnknown);
@@ -4087,31 +4091,83 @@ pub const WIA_BLANK_PAGE_DISCARD: u32 = 1u32;
 #[doc = "*Required features: 'Win32_Devices_ImageAcquisition'*"]
 pub const WIA_BLANK_PAGE_JOB_SEPARATOR: u32 = 2u32;
 pub const WIA_CATEGORY_AUTO: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdefe5fd8_6c97_4dde_b11e_cb509b270e11);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_CATEGORY_AUTO ) , guid : :: windows :: core :: GUID::from_u128(0xdefe5fd8_6c97_4dde_b11e_cb509b270e11) , } }
 pub const WIA_CATEGORY_BARCODE_READER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x36e178a0_473f_494b_af8f_6c3f6d7486fc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_CATEGORY_BARCODE_READER ) , guid : :: windows :: core :: GUID::from_u128(0x36e178a0_473f_494b_af8f_6c3f6d7486fc) , } }
 pub const WIA_CATEGORY_ENDORSER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x47102cc3_127f_4771_adfc_991ab8ee1e97);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_CATEGORY_ENDORSER ) , guid : :: windows :: core :: GUID::from_u128(0x47102cc3_127f_4771_adfc_991ab8ee1e97) , } }
 pub const WIA_CATEGORY_FEEDER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfe131934_f84c_42ad_8da4_6129cddd7288);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_CATEGORY_FEEDER ) , guid : :: windows :: core :: GUID::from_u128(0xfe131934_f84c_42ad_8da4_6129cddd7288) , } }
 pub const WIA_CATEGORY_FEEDER_BACK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x61ca74d4_39db_42aa_89b1_8c19c9cd4c23);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_CATEGORY_FEEDER_BACK ) , guid : :: windows :: core :: GUID::from_u128(0x61ca74d4_39db_42aa_89b1_8c19c9cd4c23) , } }
 pub const WIA_CATEGORY_FEEDER_FRONT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4823175c_3b28_487b_a7e6_eebc17614fd1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_CATEGORY_FEEDER_FRONT ) , guid : :: windows :: core :: GUID::from_u128(0x4823175c_3b28_487b_a7e6_eebc17614fd1) , } }
 pub const WIA_CATEGORY_FILM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfcf65be7_3ce3_4473_af85_f5d37d21b68a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_CATEGORY_FILM ) , guid : :: windows :: core :: GUID::from_u128(0xfcf65be7_3ce3_4473_af85_f5d37d21b68a) , } }
 pub const WIA_CATEGORY_FINISHED_FILE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xff2b77ca_cf84_432b_a735_3a130dde2a88);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_CATEGORY_FINISHED_FILE ) , guid : :: windows :: core :: GUID::from_u128(0xff2b77ca_cf84_432b_a735_3a130dde2a88) , } }
 pub const WIA_CATEGORY_FLATBED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfb607b1f_43f3_488b_855b_fb703ec342a6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_CATEGORY_FLATBED ) , guid : :: windows :: core :: GUID::from_u128(0xfb607b1f_43f3_488b_855b_fb703ec342a6) , } }
 pub const WIA_CATEGORY_FOLDER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc692a446_6f5a_481d_85bb_92e2e86fd30a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_CATEGORY_FOLDER ) , guid : :: windows :: core :: GUID::from_u128(0xc692a446_6f5a_481d_85bb_92e2e86fd30a) , } }
 pub const WIA_CATEGORY_IMPRINTER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfc65016d_9202_43dd_91a7_64c2954cfb8b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_CATEGORY_IMPRINTER ) , guid : :: windows :: core :: GUID::from_u128(0xfc65016d_9202_43dd_91a7_64c2954cfb8b) , } }
 pub const WIA_CATEGORY_MICR_READER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3b86c1ec_71bc_4645_b4d5_1b19da2be978);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_CATEGORY_MICR_READER ) , guid : :: windows :: core :: GUID::from_u128(0x3b86c1ec_71bc_4645_b4d5_1b19da2be978) , } }
 pub const WIA_CATEGORY_PATCH_CODE_READER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8faa1a6d_9c8a_42cd_98b3_ee9700cbc74f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_CATEGORY_PATCH_CODE_READER ) , guid : :: windows :: core :: GUID::from_u128(0x8faa1a6d_9c8a_42cd_98b3_ee9700cbc74f) , } }
 pub const WIA_CATEGORY_ROOT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf193526f_59b8_4a26_9888_e16e4f97ce10);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_CATEGORY_ROOT ) , guid : :: windows :: core :: GUID::from_u128(0xf193526f_59b8_4a26_9888_e16e4f97ce10) , } }
 pub const WIA_CMD_BUILD_DEVICE_TREE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9cba5ce0_dbea_11d2_8416_00c04fa36145);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_CMD_BUILD_DEVICE_TREE ) , guid : :: windows :: core :: GUID::from_u128(0x9cba5ce0_dbea_11d2_8416_00c04fa36145) , } }
 pub const WIA_CMD_CHANGE_DOCUMENT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x04e725b0_acae_11d2_a093_00c04f72dc3c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_CMD_CHANGE_DOCUMENT ) , guid : :: windows :: core :: GUID::from_u128(0x04e725b0_acae_11d2_a093_00c04f72dc3c) , } }
 pub const WIA_CMD_DELETE_ALL_ITEMS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe208c170_acad_11d2_a093_00c04f72dc3c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_CMD_DELETE_ALL_ITEMS ) , guid : :: windows :: core :: GUID::from_u128(0xe208c170_acad_11d2_a093_00c04f72dc3c) , } }
 pub const WIA_CMD_DELETE_DEVICE_TREE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x73815942_dbea_11d2_8416_00c04fa36145);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_CMD_DELETE_DEVICE_TREE ) , guid : :: windows :: core :: GUID::from_u128(0x73815942_dbea_11d2_8416_00c04fa36145) , } }
 pub const WIA_CMD_DIAGNOSTIC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x10ff52f5_de04_4cf0_a5ad_691f8dce0141);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_CMD_DIAGNOSTIC ) , guid : :: windows :: core :: GUID::from_u128(0x10ff52f5_de04_4cf0_a5ad_691f8dce0141) , } }
 pub const WIA_CMD_FORMAT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc3a693aa_f788_4d34_a5b0_be7190759a24);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_CMD_FORMAT ) , guid : :: windows :: core :: GUID::from_u128(0xc3a693aa_f788_4d34_a5b0_be7190759a24) , } }
 pub const WIA_CMD_PAUSE_FEEDER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x50985e4d_a5b2_4b71_9c95_6d7d7c469a43);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_CMD_PAUSE_FEEDER ) , guid : :: windows :: core :: GUID::from_u128(0x50985e4d_a5b2_4b71_9c95_6d7d7c469a43) , } }
 pub const WIA_CMD_START_FEEDER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5a9df6c9_5f2d_4a39_9d6c_00456d047f00);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_CMD_START_FEEDER ) , guid : :: windows :: core :: GUID::from_u128(0x5a9df6c9_5f2d_4a39_9d6c_00456d047f00) , } }
 pub const WIA_CMD_STOP_FEEDER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd847b06d_3905_459c_9509_9b29cdb691e7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_CMD_STOP_FEEDER ) , guid : :: windows :: core :: GUID::from_u128(0xd847b06d_3905_459c_9509_9b29cdb691e7) , } }
 pub const WIA_CMD_SYNCHRONIZE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9b26b7b2_acad_11d2_a093_00c04f72dc3c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_CMD_SYNCHRONIZE ) , guid : :: windows :: core :: GUID::from_u128(0x9b26b7b2_acad_11d2_a093_00c04f72dc3c) , } }
 pub const WIA_CMD_TAKE_PICTURE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaf933cac_acad_11d2_a093_00c04f72dc3c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_CMD_TAKE_PICTURE ) , guid : :: windows :: core :: GUID::from_u128(0xaf933cac_acad_11d2_a093_00c04f72dc3c) , } }
 pub const WIA_CMD_UNLOAD_DOCUMENT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1f3b3d8e_acae_11d2_a093_00c04f72dc3c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_CMD_UNLOAD_DOCUMENT ) , guid : :: windows :: core :: GUID::from_u128(0x1f3b3d8e_acae_11d2_a093_00c04f72dc3c) , } }
 #[doc = "*Required features: 'Win32_Devices_ImageAcquisition'*"]
 pub const WIA_COLOR_DROP_BLUE: u32 = 3u32;
 #[doc = "*Required features: 'Win32_Devices_ImageAcquisition'*"]
@@ -4664,36 +4720,98 @@ pub const WIA_ERROR_USER_INTERVENTION: ::windows::core::HRESULT = ::windows::cor
 #[doc = "*Required features: 'Win32_Devices_ImageAcquisition'*"]
 pub const WIA_ERROR_WARMING_UP: ::windows::core::HRESULT = ::windows::core::HRESULT(-2145320953i32);
 pub const WIA_EVENT_CANCEL_IO: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc860f7b8_9ccd_41ea_bbbf_4dd09c5b1795);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_CANCEL_IO ) , guid : :: windows :: core :: GUID::from_u128(0xc860f7b8_9ccd_41ea_bbbf_4dd09c5b1795) , } }
 pub const WIA_EVENT_COVER_CLOSED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6714a1e6_e285_468c_9b8c_da7dc4cbaa05);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_COVER_CLOSED ) , guid : :: windows :: core :: GUID::from_u128(0x6714a1e6_e285_468c_9b8c_da7dc4cbaa05) , } }
 pub const WIA_EVENT_COVER_OPEN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x19a12136_fa1c_4f66_900f_8f914ec74ec9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_COVER_OPEN ) , guid : :: windows :: core :: GUID::from_u128(0x19a12136_fa1c_4f66_900f_8f914ec74ec9) , } }
 pub const WIA_EVENT_DEVICE_CONNECTED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa28bbade_64b6_11d2_a231_00c04fa31809);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_DEVICE_CONNECTED ) , guid : :: windows :: core :: GUID::from_u128(0xa28bbade_64b6_11d2_a231_00c04fa31809) , } }
 pub const WIA_EVENT_DEVICE_DISCONNECTED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x143e4e83_6497_11d2_a231_00c04fa31809);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_DEVICE_DISCONNECTED ) , guid : :: windows :: core :: GUID::from_u128(0x143e4e83_6497_11d2_a231_00c04fa31809) , } }
 pub const WIA_EVENT_DEVICE_NOT_READY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd8962d7e_e4dc_4b4d_ba29_668a87f42e6f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_DEVICE_NOT_READY ) , guid : :: windows :: core :: GUID::from_u128(0xd8962d7e_e4dc_4b4d_ba29_668a87f42e6f) , } }
 pub const WIA_EVENT_DEVICE_READY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7523ec6c_988b_419e_9a0a_425ac31b37dc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_DEVICE_READY ) , guid : :: windows :: core :: GUID::from_u128(0x7523ec6c_988b_419e_9a0a_425ac31b37dc) , } }
 pub const WIA_EVENT_FEEDER_EMPTIED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe70b4b82_6dda_46bb_8ff9_53ceb1a03e35);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_FEEDER_EMPTIED ) , guid : :: windows :: core :: GUID::from_u128(0xe70b4b82_6dda_46bb_8ff9_53ceb1a03e35) , } }
 pub const WIA_EVENT_FEEDER_LOADED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcc8d701e_9aba_481d_bf74_78f763dc342a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_FEEDER_LOADED ) , guid : :: windows :: core :: GUID::from_u128(0xcc8d701e_9aba_481d_bf74_78f763dc342a) , } }
 pub const WIA_EVENT_FLATBED_LID_CLOSED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf879af0f_9b29_4283_ad95_d412164d39a9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_FLATBED_LID_CLOSED ) , guid : :: windows :: core :: GUID::from_u128(0xf879af0f_9b29_4283_ad95_d412164d39a9) , } }
 pub const WIA_EVENT_FLATBED_LID_OPEN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xba0a0623_437d_4f03_a97d_7793b123113c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_FLATBED_LID_OPEN ) , guid : :: windows :: core :: GUID::from_u128(0xba0a0623_437d_4f03_a97d_7793b123113c) , } }
 pub const WIA_EVENT_HANDLER_NO_ACTION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe0372b7d_e115_4525_bc55_b629e68c745a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_HANDLER_NO_ACTION ) , guid : :: windows :: core :: GUID::from_u128(0xe0372b7d_e115_4525_bc55_b629e68c745a) , } }
 pub const WIA_EVENT_HANDLER_PROMPT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5f4baad0_4d59_4fcd_b213_783ce7a92f22);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_HANDLER_PROMPT ) , guid : :: windows :: core :: GUID::from_u128(0x5f4baad0_4d59_4fcd_b213_783ce7a92f22) , } }
 pub const WIA_EVENT_ITEM_CREATED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4c8f4ef5_e14f_11d2_b326_00c04f68ce61);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_ITEM_CREATED ) , guid : :: windows :: core :: GUID::from_u128(0x4c8f4ef5_e14f_11d2_b326_00c04f68ce61) , } }
 pub const WIA_EVENT_ITEM_DELETED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1d22a559_e14f_11d2_b326_00c04f68ce61);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_ITEM_DELETED ) , guid : :: windows :: core :: GUID::from_u128(0x1d22a559_e14f_11d2_b326_00c04f68ce61) , } }
 pub const WIA_EVENT_POWER_RESUME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x618f153e_f686_4350_9634_4115a304830c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_POWER_RESUME ) , guid : :: windows :: core :: GUID::from_u128(0x618f153e_f686_4350_9634_4115a304830c) , } }
 pub const WIA_EVENT_POWER_SUSPEND: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa0922ff9_c3b4_411c_9e29_03a66993d2be);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_POWER_SUSPEND ) , guid : :: windows :: core :: GUID::from_u128(0xa0922ff9_c3b4_411c_9e29_03a66993d2be) , } }
 pub const WIA_EVENT_SCAN_EMAIL_IMAGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc686dcee_54f2_419e_9a27_2fc7f2e98f9e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_SCAN_EMAIL_IMAGE ) , guid : :: windows :: core :: GUID::from_u128(0xc686dcee_54f2_419e_9a27_2fc7f2e98f9e) , } }
 pub const WIA_EVENT_SCAN_FAX_IMAGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc00eb793_8c6e_11d2_977a_0000f87a926f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_SCAN_FAX_IMAGE ) , guid : :: windows :: core :: GUID::from_u128(0xc00eb793_8c6e_11d2_977a_0000f87a926f) , } }
 pub const WIA_EVENT_SCAN_FILM_IMAGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9b2b662c_6185_438c_b68b_e39ee25e71cb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_SCAN_FILM_IMAGE ) , guid : :: windows :: core :: GUID::from_u128(0x9b2b662c_6185_438c_b68b_e39ee25e71cb) , } }
 pub const WIA_EVENT_SCAN_IMAGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa6c5a715_8c6e_11d2_977a_0000f87a926f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_SCAN_IMAGE ) , guid : :: windows :: core :: GUID::from_u128(0xa6c5a715_8c6e_11d2_977a_0000f87a926f) , } }
 pub const WIA_EVENT_SCAN_IMAGE2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfc4767c1_c8b3_48a2_9cfa_2e90cb3d3590);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_SCAN_IMAGE2 ) , guid : :: windows :: core :: GUID::from_u128(0xfc4767c1_c8b3_48a2_9cfa_2e90cb3d3590) , } }
 pub const WIA_EVENT_SCAN_IMAGE3: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x154e27be_b617_4653_acc5_0fd7bd4c65ce);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_SCAN_IMAGE3 ) , guid : :: windows :: core :: GUID::from_u128(0x154e27be_b617_4653_acc5_0fd7bd4c65ce) , } }
 pub const WIA_EVENT_SCAN_IMAGE4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa65b704a_7f3c_4447_a75d_8a26dfca1fdf);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_SCAN_IMAGE4 ) , guid : :: windows :: core :: GUID::from_u128(0xa65b704a_7f3c_4447_a75d_8a26dfca1fdf) , } }
 pub const WIA_EVENT_SCAN_OCR_IMAGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9d095b89_37d6_4877_afed_62a297dc6dbe);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_SCAN_OCR_IMAGE ) , guid : :: windows :: core :: GUID::from_u128(0x9d095b89_37d6_4877_afed_62a297dc6dbe) , } }
 pub const WIA_EVENT_SCAN_PRINT_IMAGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb441f425_8c6e_11d2_977a_0000f87a926f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_SCAN_PRINT_IMAGE ) , guid : :: windows :: core :: GUID::from_u128(0xb441f425_8c6e_11d2_977a_0000f87a926f) , } }
 pub const WIA_EVENT_STI_PROXY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd711f81f_1f0d_422d_8641_927d1b93e5e5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_STI_PROXY ) , guid : :: windows :: core :: GUID::from_u128(0xd711f81f_1f0d_422d_8641_927d1b93e5e5) , } }
 pub const WIA_EVENT_STORAGE_CREATED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x353308b2_fe73_46c8_895e_fa4551ccc85a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_STORAGE_CREATED ) , guid : :: windows :: core :: GUID::from_u128(0x353308b2_fe73_46c8_895e_fa4551ccc85a) , } }
 pub const WIA_EVENT_STORAGE_DELETED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5e41e75e_9390_44c5_9a51_e47019e390cf);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_STORAGE_DELETED ) , guid : :: windows :: core :: GUID::from_u128(0x5e41e75e_9390_44c5_9a51_e47019e390cf) , } }
 pub const WIA_EVENT_TREE_UPDATED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc9859b91_4ab2_4cd6_a1fc_582eec55e585);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_TREE_UPDATED ) , guid : :: windows :: core :: GUID::from_u128(0xc9859b91_4ab2_4cd6_a1fc_582eec55e585) , } }
 pub const WIA_EVENT_VOLUME_INSERT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9638bbfd_d1bd_11d2_b31f_00c04f68ce61);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WIA_EVENT_VOLUME_INSERT ) , guid : :: windows :: core :: GUID::from_u128(0x9638bbfd_d1bd_11d2_b31f_00c04f68ce61) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Devices_ImageAcquisition'*"]
 pub struct WIA_EXTENDED_TRANSFER_INFO {
@@ -6242,53 +6360,145 @@ pub const WIA_WSD_SCAN_AVAILABLE_ITEM: u32 = 38922u32;
 #[doc = "*Required features: 'Win32_Devices_ImageAcquisition'*"]
 pub const WIA_WSD_SERIAL_NUMBER: u32 = 38921u32;
 pub const WiaAudFmt_AIFF: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x66e2bf4f_b6fc_443f_94c8_2f33c8a65aaf);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaAudFmt_AIFF ) , guid : :: windows :: core :: GUID::from_u128(0x66e2bf4f_b6fc_443f_94c8_2f33c8a65aaf) , } }
 pub const WiaAudFmt_MP3: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0fbc71fb_43bf_49f2_9190_e6fecff37e54);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaAudFmt_MP3 ) , guid : :: windows :: core :: GUID::from_u128(0x0fbc71fb_43bf_49f2_9190_e6fecff37e54) , } }
 pub const WiaAudFmt_WAV: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf818e146_07af_40ff_ae55_be8f2c065dbe);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaAudFmt_WAV ) , guid : :: windows :: core :: GUID::from_u128(0xf818e146_07af_40ff_ae55_be8f2c065dbe) , } }
 pub const WiaAudFmt_WMA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd61d6413_8bc2_438f_93ad_21bd484db6a1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaAudFmt_WMA ) , guid : :: windows :: core :: GUID::from_u128(0xd61d6413_8bc2_438f_93ad_21bd484db6a1) , } }
 pub const WiaDevMgr: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa1f4e726_8cf1_11d1_bf92_0060081ed811);
 pub const WiaDevMgr2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb6c292bc_7c88_41ee_8b54_8ec92617e599);
 pub const WiaImgFmt_ASF: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8d948ee9_d0aa_4a12_9d9a_9cc5de36199b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_ASF ) , guid : :: windows :: core :: GUID::from_u128(0x8d948ee9_d0aa_4a12_9d9a_9cc5de36199b) , } }
 pub const WiaImgFmt_AVI: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x32f8ca14_087c_4908_b7c4_6757fe7e90ab);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_AVI ) , guid : :: windows :: core :: GUID::from_u128(0x32f8ca14_087c_4908_b7c4_6757fe7e90ab) , } }
 pub const WiaImgFmt_BMP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb96b3cab_0728_11d3_9d7b_0000f81ef32e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_BMP ) , guid : :: windows :: core :: GUID::from_u128(0xb96b3cab_0728_11d3_9d7b_0000f81ef32e) , } }
 pub const WiaImgFmt_CIFF: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9821a8ab_3a7e_4215_94e0_d27a460c03b2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_CIFF ) , guid : :: windows :: core :: GUID::from_u128(0x9821a8ab_3a7e_4215_94e0_d27a460c03b2) , } }
 pub const WiaImgFmt_CSV: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x355bda24_5a9f_4494_80dc_be752cecbc8c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_CSV ) , guid : :: windows :: core :: GUID::from_u128(0x355bda24_5a9f_4494_80dc_be752cecbc8c) , } }
 pub const WiaImgFmt_DPOF: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x369eeeab_a0e8_45ca_86a6_a83ce5697e28);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_DPOF ) , guid : :: windows :: core :: GUID::from_u128(0x369eeeab_a0e8_45ca_86a6_a83ce5697e28) , } }
 pub const WiaImgFmt_EMF: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb96b3cac_0728_11d3_9d7b_0000f81ef32e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_EMF ) , guid : :: windows :: core :: GUID::from_u128(0xb96b3cac_0728_11d3_9d7b_0000f81ef32e) , } }
 pub const WiaImgFmt_EXEC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x485da097_141e_4aa5_bb3b_a5618d95d02b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_EXEC ) , guid : :: windows :: core :: GUID::from_u128(0x485da097_141e_4aa5_bb3b_a5618d95d02b) , } }
 pub const WiaImgFmt_EXIF: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb96b3cb2_0728_11d3_9d7b_0000f81ef32e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_EXIF ) , guid : :: windows :: core :: GUID::from_u128(0xb96b3cb2_0728_11d3_9d7b_0000f81ef32e) , } }
 pub const WiaImgFmt_FLASHPIX: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb96b3cb4_0728_11d3_9d7b_0000f81ef32e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_FLASHPIX ) , guid : :: windows :: core :: GUID::from_u128(0xb96b3cb4_0728_11d3_9d7b_0000f81ef32e) , } }
 pub const WiaImgFmt_GIF: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb96b3cb0_0728_11d3_9d7b_0000f81ef32e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_GIF ) , guid : :: windows :: core :: GUID::from_u128(0xb96b3cb0_0728_11d3_9d7b_0000f81ef32e) , } }
 pub const WiaImgFmt_HTML: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc99a4e62_99de_4a94_acca_71956ac2977d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_HTML ) , guid : :: windows :: core :: GUID::from_u128(0xc99a4e62_99de_4a94_acca_71956ac2977d) , } }
 pub const WiaImgFmt_ICO: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb96b3cb5_0728_11d3_9d7b_0000f81ef32e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_ICO ) , guid : :: windows :: core :: GUID::from_u128(0xb96b3cb5_0728_11d3_9d7b_0000f81ef32e) , } }
 pub const WiaImgFmt_JBIG: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x41e8dd92_2f0a_43d4_8636_f1614ba11e46);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_JBIG ) , guid : :: windows :: core :: GUID::from_u128(0x41e8dd92_2f0a_43d4_8636_f1614ba11e46) , } }
 pub const WiaImgFmt_JBIG2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbb8e7e67_283c_4235_9e59_0b9bf94ca687);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_JBIG2 ) , guid : :: windows :: core :: GUID::from_u128(0xbb8e7e67_283c_4235_9e59_0b9bf94ca687) , } }
 pub const WiaImgFmt_JPEG: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb96b3cae_0728_11d3_9d7b_0000f81ef32e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_JPEG ) , guid : :: windows :: core :: GUID::from_u128(0xb96b3cae_0728_11d3_9d7b_0000f81ef32e) , } }
 pub const WiaImgFmt_JPEG2K: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x344ee2b2_39db_4dde_8173_c4b75f8f1e49);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_JPEG2K ) , guid : :: windows :: core :: GUID::from_u128(0x344ee2b2_39db_4dde_8173_c4b75f8f1e49) , } }
 pub const WiaImgFmt_JPEG2KX: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x43e14614_c80a_4850_baf3_4b152dc8da27);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_JPEG2KX ) , guid : :: windows :: core :: GUID::from_u128(0x43e14614_c80a_4850_baf3_4b152dc8da27) , } }
 pub const WiaImgFmt_MEMORYBMP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb96b3caa_0728_11d3_9d7b_0000f81ef32e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_MEMORYBMP ) , guid : :: windows :: core :: GUID::from_u128(0xb96b3caa_0728_11d3_9d7b_0000f81ef32e) , } }
 pub const WiaImgFmt_MPG: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xecd757e4_d2ec_4f57_955d_bcf8a97c4e52);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_MPG ) , guid : :: windows :: core :: GUID::from_u128(0xecd757e4_d2ec_4f57_955d_bcf8a97c4e52) , } }
 pub const WiaImgFmt_OXPS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2c7b1240_c14d_4109_9755_04b89025153a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_OXPS ) , guid : :: windows :: core :: GUID::from_u128(0x2c7b1240_c14d_4109_9755_04b89025153a) , } }
 pub const WiaImgFmt_PDFA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9980bd5b_3463_43c7_bdca_3caa146f229f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_PDFA ) , guid : :: windows :: core :: GUID::from_u128(0x9980bd5b_3463_43c7_bdca_3caa146f229f) , } }
 pub const WiaImgFmt_PHOTOCD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb96b3cb3_0728_11d3_9d7b_0000f81ef32e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_PHOTOCD ) , guid : :: windows :: core :: GUID::from_u128(0xb96b3cb3_0728_11d3_9d7b_0000f81ef32e) , } }
 pub const WiaImgFmt_PICT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa6bc85d8_6b3e_40ee_a95c_25d482e41adc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_PICT ) , guid : :: windows :: core :: GUID::from_u128(0xa6bc85d8_6b3e_40ee_a95c_25d482e41adc) , } }
 pub const WiaImgFmt_PNG: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb96b3caf_0728_11d3_9d7b_0000f81ef32e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_PNG ) , guid : :: windows :: core :: GUID::from_u128(0xb96b3caf_0728_11d3_9d7b_0000f81ef32e) , } }
 pub const WiaImgFmt_RAW: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6f120719_f1a8_4e07_9ade_9b64c63a3dcc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_RAW ) , guid : :: windows :: core :: GUID::from_u128(0x6f120719_f1a8_4e07_9ade_9b64c63a3dcc) , } }
 pub const WiaImgFmt_RAWBAR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xda63f833_d26e_451e_90d2_ea55a1365d62);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_RAWBAR ) , guid : :: windows :: core :: GUID::from_u128(0xda63f833_d26e_451e_90d2_ea55a1365d62) , } }
 pub const WiaImgFmt_RAWMIC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x22c4f058_0d88_409c_ac1c_eec12b0ea680);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_RAWMIC ) , guid : :: windows :: core :: GUID::from_u128(0x22c4f058_0d88_409c_ac1c_eec12b0ea680) , } }
 pub const WiaImgFmt_RAWPAT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7760507c_5064_400c_9a17_575624d8824b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_RAWPAT ) , guid : :: windows :: core :: GUID::from_u128(0x7760507c_5064_400c_9a17_575624d8824b) , } }
 pub const WiaImgFmt_RAWRGB: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbca48b55_f272_4371_b0f1_4a150d057bb4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_RAWRGB ) , guid : :: windows :: core :: GUID::from_u128(0xbca48b55_f272_4371_b0f1_4a150d057bb4) , } }
 pub const WiaImgFmt_RTF: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x573dd6a3_4834_432d_a9b5_e198dd9e890d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_RTF ) , guid : :: windows :: core :: GUID::from_u128(0x573dd6a3_4834_432d_a9b5_e198dd9e890d) , } }
 pub const WiaImgFmt_SCRIPT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfe7d6c53_2dac_446a_b0bd_d73e21e924c9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_SCRIPT ) , guid : :: windows :: core :: GUID::from_u128(0xfe7d6c53_2dac_446a_b0bd_d73e21e924c9) , } }
 pub const WiaImgFmt_TIFF: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb96b3cb1_0728_11d3_9d7b_0000f81ef32e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_TIFF ) , guid : :: windows :: core :: GUID::from_u128(0xb96b3cb1_0728_11d3_9d7b_0000f81ef32e) , } }
 pub const WiaImgFmt_TXT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfafd4d82_723f_421f_9318_30501ac44b59);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_TXT ) , guid : :: windows :: core :: GUID::from_u128(0xfafd4d82_723f_421f_9318_30501ac44b59) , } }
 pub const WiaImgFmt_UNDEFINED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb96b3ca9_0728_11d3_9d7b_0000f81ef32e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_UNDEFINED ) , guid : :: windows :: core :: GUID::from_u128(0xb96b3ca9_0728_11d3_9d7b_0000f81ef32e) , } }
 pub const WiaImgFmt_UNICODE16: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1b7639b6_6357_47d1_9a07_12452dc073e9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_UNICODE16 ) , guid : :: windows :: core :: GUID::from_u128(0x1b7639b6_6357_47d1_9a07_12452dc073e9) , } }
 pub const WiaImgFmt_WMF: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb96b3cad_0728_11d3_9d7b_0000f81ef32e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_WMF ) , guid : :: windows :: core :: GUID::from_u128(0xb96b3cad_0728_11d3_9d7b_0000f81ef32e) , } }
 pub const WiaImgFmt_XML: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb9171457_dac8_4884_b393_15b471d5f07e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_XML ) , guid : :: windows :: core :: GUID::from_u128(0xb9171457_dac8_4884_b393_15b471d5f07e) , } }
 pub const WiaImgFmt_XMLBAR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6235701c_3a98_484c_b2a8_fdffd87e6b16);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_XMLBAR ) , guid : :: windows :: core :: GUID::from_u128(0x6235701c_3a98_484c_b2a8_fdffd87e6b16) , } }
 pub const WiaImgFmt_XMLMIC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2d164c61_b9ae_4b23_8973_c7067e1fbd31);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_XMLMIC ) , guid : :: windows :: core :: GUID::from_u128(0x2d164c61_b9ae_4b23_8973_c7067e1fbd31) , } }
 pub const WiaImgFmt_XMLPAT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf8986f55_f052_460d_9523_3a7dfedbb33c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_XMLPAT ) , guid : :: windows :: core :: GUID::from_u128(0xf8986f55_f052_460d_9523_3a7dfedbb33c) , } }
 pub const WiaImgFmt_XPS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x700b4a0f_2011_411c_b430_d1e0b2e10b28);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WiaImgFmt_XPS ) , guid : :: windows :: core :: GUID::from_u128(0x700b4a0f_2011_411c_b430_d1e0b2e10b28) , } }
 #[doc = "*Required features: 'Win32_Devices_ImageAcquisition'*"]
 pub const WiaItemTypeAnalyze: u32 = 16u32;
 #[doc = "*Required features: 'Win32_Devices_ImageAcquisition'*"]

--- a/crates/libs/windows/src/Windows/Win32/Devices/PortableDevices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/PortableDevices/mod.rs
@@ -1,5 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 pub const CLSID_WPD_NAMESPACE_EXTENSION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x35786d3c_b075_49b9_88dd_029876e11c01);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WPD_NAMESPACE_EXTENSION ) , guid : :: windows :: core :: GUID::from_u128(0x35786d3c_b075_49b9_88dd_029876e11c01) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
 pub type DELETE_OBJECT_OPTIONS = i32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
@@ -27,6 +29,8 @@ pub const DRS_RADIO_MAX: DEVICE_RADIO_STATE = 6i32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_MTPBTH_IsConnected: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xea1237fa_589d_4472_84e4_0abe36fd62ef), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_MTPBTH_IsConnected ) , guid : :: windows :: core :: GUID::from_u128(0xea1237fa_589d_4472_84e4_0abe36fd62ef) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
 pub const DEVSVCTYPE_ABSTRACT: u32 = 1u32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
@@ -175,8 +179,14 @@ pub const FLAG_MessageObj_DayOfWeekTuesday: u32 = 4u32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
 pub const FLAG_MessageObj_DayOfWeekWednesday: u32 = 8u32;
 pub const GUID_DEVINTERFACE_WPD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6ac27878_a6fa_4155_ba85_f98f491d4f33);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_WPD ) , guid : :: windows :: core :: GUID::from_u128(0x6ac27878_a6fa_4155_ba85_f98f491d4f33) , } }
 pub const GUID_DEVINTERFACE_WPD_PRIVATE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xba0c718f_4ded_49b7_bdd3_fabe28661211);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_WPD_PRIVATE ) , guid : :: windows :: core :: GUID::from_u128(0xba0c718f_4ded_49b7_bdd3_fabe28661211) , } }
 pub const GUID_DEVINTERFACE_WPD_SERVICE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9ef44f80_3d64_4246_a6aa_206f328d1edc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_WPD_SERVICE ) , guid : :: windows :: core :: GUID::from_u128(0x9ef44f80_3d64_4246_a6aa_206f328d1edc) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
 #[repr(transparent)]
 pub struct IConnectionRequestCallback(::windows::core::IUnknown);
@@ -3527,22 +3537,36 @@ pub const TYPE_TasksSvc: u32 = 0u32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPDNSE_OBJECT_HAS_ALBUM_ART: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x34d71409_4b47_4d80_aaac_3a28a4a3b3e6), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPDNSE_OBJECT_HAS_ALBUM_ART ) , guid : :: windows :: core :: GUID::from_u128(0x34d71409_4b47_4d80_aaac_3a28a4a3b3e6) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPDNSE_OBJECT_HAS_AUDIO_CLIP: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x34d71409_4b47_4d80_aaac_3a28a4a3b3e6), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPDNSE_OBJECT_HAS_AUDIO_CLIP ) , guid : :: windows :: core :: GUID::from_u128(0x34d71409_4b47_4d80_aaac_3a28a4a3b3e6) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPDNSE_OBJECT_HAS_CONTACT_PHOTO: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x34d71409_4b47_4d80_aaac_3a28a4a3b3e6), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPDNSE_OBJECT_HAS_CONTACT_PHOTO ) , guid : :: windows :: core :: GUID::from_u128(0x34d71409_4b47_4d80_aaac_3a28a4a3b3e6) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPDNSE_OBJECT_HAS_ICON: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x34d71409_4b47_4d80_aaac_3a28a4a3b3e6), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPDNSE_OBJECT_HAS_ICON ) , guid : :: windows :: core :: GUID::from_u128(0x34d71409_4b47_4d80_aaac_3a28a4a3b3e6) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPDNSE_OBJECT_HAS_THUMBNAIL: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x34d71409_4b47_4d80_aaac_3a28a4a3b3e6), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPDNSE_OBJECT_HAS_THUMBNAIL ) , guid : :: windows :: core :: GUID::from_u128(0x34d71409_4b47_4d80_aaac_3a28a4a3b3e6) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPDNSE_OBJECT_OPTIMAL_READ_BLOCK_SIZE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x34d71409_4b47_4d80_aaac_3a28a4a3b3e6), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPDNSE_OBJECT_OPTIMAL_READ_BLOCK_SIZE ) , guid : :: windows :: core :: GUID::from_u128(0x34d71409_4b47_4d80_aaac_3a28a4a3b3e6) , } }
 pub const WPDNSE_OBJECT_PROPERTIES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x34d71409_4b47_4d80_aaac_3a28a4a3b3e6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPDNSE_OBJECT_PROPERTIES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0x34d71409_4b47_4d80_aaac_3a28a4a3b3e6) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
 pub const WPDNSE_PROPSHEET_CONTENT_DETAILS: u32 = 32u32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
@@ -3556,52 +3580,86 @@ pub const WPDNSE_PROPSHEET_DEVICE_GENERAL: u32 = 1u32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
 pub const WPDNSE_PROPSHEET_STORAGE_GENERAL: u32 = 2u32;
 pub const WPD_API_OPTIONS_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x10e54a3e_052d_4777_a13c_de7614be2bc4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_API_OPTIONS_V1 ) , guid : :: windows :: core :: GUID::from_u128(0x10e54a3e_052d_4777_a13c_de7614be2bc4) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_API_OPTION_IOCTL_ACCESS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x10e54a3e_052d_4777_a13c_de7614be2bc4), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_API_OPTION_IOCTL_ACCESS ) , guid : :: windows :: core :: GUID::from_u128(0x10e54a3e_052d_4777_a13c_de7614be2bc4) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_API_OPTION_USE_CLEAR_DATA_STREAM: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x10e54a3e_052d_4777_a13c_de7614be2bc4), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_API_OPTION_USE_CLEAR_DATA_STREAM ) , guid : :: windows :: core :: GUID::from_u128(0x10e54a3e_052d_4777_a13c_de7614be2bc4) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_APPOINTMENT_ACCEPTED_ATTENDEES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf99efd03_431d_40d8_a1c9_4e220d9c88d3), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_APPOINTMENT_ACCEPTED_ATTENDEES ) , guid : :: windows :: core :: GUID::from_u128(0xf99efd03_431d_40d8_a1c9_4e220d9c88d3) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_APPOINTMENT_DECLINED_ATTENDEES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf99efd03_431d_40d8_a1c9_4e220d9c88d3), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_APPOINTMENT_DECLINED_ATTENDEES ) , guid : :: windows :: core :: GUID::from_u128(0xf99efd03_431d_40d8_a1c9_4e220d9c88d3) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_APPOINTMENT_LOCATION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf99efd03_431d_40d8_a1c9_4e220d9c88d3), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_APPOINTMENT_LOCATION ) , guid : :: windows :: core :: GUID::from_u128(0xf99efd03_431d_40d8_a1c9_4e220d9c88d3) , } }
 pub const WPD_APPOINTMENT_OBJECT_PROPERTIES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf99efd03_431d_40d8_a1c9_4e220d9c88d3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_APPOINTMENT_OBJECT_PROPERTIES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0xf99efd03_431d_40d8_a1c9_4e220d9c88d3) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_APPOINTMENT_OPTIONAL_ATTENDEES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf99efd03_431d_40d8_a1c9_4e220d9c88d3), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_APPOINTMENT_OPTIONAL_ATTENDEES ) , guid : :: windows :: core :: GUID::from_u128(0xf99efd03_431d_40d8_a1c9_4e220d9c88d3) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_APPOINTMENT_REQUIRED_ATTENDEES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf99efd03_431d_40d8_a1c9_4e220d9c88d3), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_APPOINTMENT_REQUIRED_ATTENDEES ) , guid : :: windows :: core :: GUID::from_u128(0xf99efd03_431d_40d8_a1c9_4e220d9c88d3) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_APPOINTMENT_RESOURCES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf99efd03_431d_40d8_a1c9_4e220d9c88d3), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_APPOINTMENT_RESOURCES ) , guid : :: windows :: core :: GUID::from_u128(0xf99efd03_431d_40d8_a1c9_4e220d9c88d3) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_APPOINTMENT_TENTATIVE_ATTENDEES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf99efd03_431d_40d8_a1c9_4e220d9c88d3), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_APPOINTMENT_TENTATIVE_ATTENDEES ) , guid : :: windows :: core :: GUID::from_u128(0xf99efd03_431d_40d8_a1c9_4e220d9c88d3) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_APPOINTMENT_TYPE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf99efd03_431d_40d8_a1c9_4e220d9c88d3), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_APPOINTMENT_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0xf99efd03_431d_40d8_a1c9_4e220d9c88d3) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_AUDIO_BITRATE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb324f56a_dc5d_46e5_b6df_d2ea414888c6), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_AUDIO_BITRATE ) , guid : :: windows :: core :: GUID::from_u128(0xb324f56a_dc5d_46e5_b6df_d2ea414888c6) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_AUDIO_BIT_DEPTH: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb324f56a_dc5d_46e5_b6df_d2ea414888c6), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_AUDIO_BIT_DEPTH ) , guid : :: windows :: core :: GUID::from_u128(0xb324f56a_dc5d_46e5_b6df_d2ea414888c6) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_AUDIO_BLOCK_ALIGNMENT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb324f56a_dc5d_46e5_b6df_d2ea414888c6), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_AUDIO_BLOCK_ALIGNMENT ) , guid : :: windows :: core :: GUID::from_u128(0xb324f56a_dc5d_46e5_b6df_d2ea414888c6) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_AUDIO_CHANNEL_COUNT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb324f56a_dc5d_46e5_b6df_d2ea414888c6), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_AUDIO_CHANNEL_COUNT ) , guid : :: windows :: core :: GUID::from_u128(0xb324f56a_dc5d_46e5_b6df_d2ea414888c6) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_AUDIO_FORMAT_CODE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb324f56a_dc5d_46e5_b6df_d2ea414888c6), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_AUDIO_FORMAT_CODE ) , guid : :: windows :: core :: GUID::from_u128(0xb324f56a_dc5d_46e5_b6df_d2ea414888c6) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
 pub type WPD_BITRATE_TYPES = i32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
@@ -3623,86 +3681,172 @@ pub const WPD_CAPTURE_MODE_BURST: WPD_CAPTURE_MODES = 2i32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
 pub const WPD_CAPTURE_MODE_TIMELAPSE: WPD_CAPTURE_MODES = 3i32;
 pub const WPD_CATEGORY_CAPABILITIES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CATEGORY_CAPABILITIES ) , guid : :: windows :: core :: GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356) , } }
 pub const WPD_CATEGORY_COMMON: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CATEGORY_COMMON ) , guid : :: windows :: core :: GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a) , } }
 pub const WPD_CATEGORY_DEVICE_HINTS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0d5fb92b_cb46_4c4f_8343_0bc3d3f17c84);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CATEGORY_DEVICE_HINTS ) , guid : :: windows :: core :: GUID::from_u128(0x0d5fb92b_cb46_4c4f_8343_0bc3d3f17c84) , } }
 pub const WPD_CATEGORY_MEDIA_CAPTURE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x59b433ba_fe44_4d8d_808c_6bcb9b0f15e8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CATEGORY_MEDIA_CAPTURE ) , guid : :: windows :: core :: GUID::from_u128(0x59b433ba_fe44_4d8d_808c_6bcb9b0f15e8) , } }
 pub const WPD_CATEGORY_MTP_EXT_VENDOR_OPERATIONS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CATEGORY_MTP_EXT_VENDOR_OPERATIONS ) , guid : :: windows :: core :: GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56) , } }
 pub const WPD_CATEGORY_NETWORK_CONFIGURATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x78f9c6fc_79b8_473c_9060_6bd23dd072c4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CATEGORY_NETWORK_CONFIGURATION ) , guid : :: windows :: core :: GUID::from_u128(0x78f9c6fc_79b8_473c_9060_6bd23dd072c4) , } }
 pub const WPD_CATEGORY_NULL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x00000000_0000_0000_0000_000000000000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CATEGORY_NULL ) , guid : :: windows :: core :: GUID::from_u128(0x00000000_0000_0000_0000_000000000000) , } }
 pub const WPD_CATEGORY_OBJECT_ENUMERATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb7474e91_e7f8_4ad9_b400_ad1a4b58eeec);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CATEGORY_OBJECT_ENUMERATION ) , guid : :: windows :: core :: GUID::from_u128(0xb7474e91_e7f8_4ad9_b400_ad1a4b58eeec) , } }
 pub const WPD_CATEGORY_OBJECT_MANAGEMENT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CATEGORY_OBJECT_MANAGEMENT ) , guid : :: windows :: core :: GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089) , } }
 pub const WPD_CATEGORY_OBJECT_PROPERTIES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9e5582e4_0814_44e6_981a_b2998d583804);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CATEGORY_OBJECT_PROPERTIES ) , guid : :: windows :: core :: GUID::from_u128(0x9e5582e4_0814_44e6_981a_b2998d583804) , } }
 pub const WPD_CATEGORY_OBJECT_PROPERTIES_BULK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CATEGORY_OBJECT_PROPERTIES_BULK ) , guid : :: windows :: core :: GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e) , } }
 pub const WPD_CATEGORY_OBJECT_RESOURCES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CATEGORY_OBJECT_RESOURCES ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 pub const WPD_CATEGORY_SERVICE_CAPABILITIES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CATEGORY_SERVICE_CAPABILITIES ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 pub const WPD_CATEGORY_SERVICE_COMMON: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x322f071d_36ef_477f_b4b5_6f52d734baee);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CATEGORY_SERVICE_COMMON ) , guid : :: windows :: core :: GUID::from_u128(0x322f071d_36ef_477f_b4b5_6f52d734baee) , } }
 pub const WPD_CATEGORY_SERVICE_METHODS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2d521ca8_c1b0_4268_a342_cf19321569bc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CATEGORY_SERVICE_METHODS ) , guid : :: windows :: core :: GUID::from_u128(0x2d521ca8_c1b0_4268_a342_cf19321569bc) , } }
 pub const WPD_CATEGORY_SMS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xafc25d66_fe0d_4114_9097_970c93e920d1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CATEGORY_SMS ) , guid : :: windows :: core :: GUID::from_u128(0xafc25d66_fe0d_4114_9097_970c93e920d1) , } }
 pub const WPD_CATEGORY_STILL_IMAGE_CAPTURE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4fcd6982_22a2_4b05_a48b_62d38bf27b32);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CATEGORY_STILL_IMAGE_CAPTURE ) , guid : :: windows :: core :: GUID::from_u128(0x4fcd6982_22a2_4b05_a48b_62d38bf27b32) , } }
 pub const WPD_CATEGORY_STORAGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd8f907a6_34cc_45fa_97fb_d007fa47ec94);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CATEGORY_STORAGE ) , guid : :: windows :: core :: GUID::from_u128(0xd8f907a6_34cc_45fa_97fb_d007fa47ec94) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CLASS_EXTENSION_OPTIONS_DEVICE_IDENTIFICATION_VALUES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x3e3595da_4d71_49fe_a0b4_d4406c3ae93f), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CLASS_EXTENSION_OPTIONS_DEVICE_IDENTIFICATION_VALUES ) , guid : :: windows :: core :: GUID::from_u128(0x3e3595da_4d71_49fe_a0b4_d4406c3ae93f) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CLASS_EXTENSION_OPTIONS_DONT_REGISTER_WPD_DEVICE_INTERFACE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6309ffef_a87c_4ca7_8434_797576e40a96), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CLASS_EXTENSION_OPTIONS_DONT_REGISTER_WPD_DEVICE_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0x6309ffef_a87c_4ca7_8434_797576e40a96) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CLASS_EXTENSION_OPTIONS_MULTITRANSPORT_MODE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x3e3595da_4d71_49fe_a0b4_d4406c3ae93f), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CLASS_EXTENSION_OPTIONS_MULTITRANSPORT_MODE ) , guid : :: windows :: core :: GUID::from_u128(0x3e3595da_4d71_49fe_a0b4_d4406c3ae93f) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CLASS_EXTENSION_OPTIONS_REGISTER_WPD_PRIVATE_DEVICE_INTERFACE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6309ffef_a87c_4ca7_8434_797576e40a96), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CLASS_EXTENSION_OPTIONS_REGISTER_WPD_PRIVATE_DEVICE_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0x6309ffef_a87c_4ca7_8434_797576e40a96) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CLASS_EXTENSION_OPTIONS_SILENCE_AUTOPLAY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x65c160f8_1367_4ce2_939d_8310839f0d30), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CLASS_EXTENSION_OPTIONS_SILENCE_AUTOPLAY ) , guid : :: windows :: core :: GUID::from_u128(0x65c160f8_1367_4ce2_939d_8310839f0d30) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CLASS_EXTENSION_OPTIONS_SUPPORTED_CONTENT_TYPES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6309ffef_a87c_4ca7_8434_797576e40a96), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CLASS_EXTENSION_OPTIONS_SUPPORTED_CONTENT_TYPES ) , guid : :: windows :: core :: GUID::from_u128(0x6309ffef_a87c_4ca7_8434_797576e40a96) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CLASS_EXTENSION_OPTIONS_TRANSPORT_BANDWIDTH: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x3e3595da_4d71_49fe_a0b4_d4406c3ae93f), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CLASS_EXTENSION_OPTIONS_TRANSPORT_BANDWIDTH ) , guid : :: windows :: core :: GUID::from_u128(0x3e3595da_4d71_49fe_a0b4_d4406c3ae93f) , } }
 pub const WPD_CLASS_EXTENSION_OPTIONS_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6309ffef_a87c_4ca7_8434_797576e40a96);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CLASS_EXTENSION_OPTIONS_V1 ) , guid : :: windows :: core :: GUID::from_u128(0x6309ffef_a87c_4ca7_8434_797576e40a96) , } }
 pub const WPD_CLASS_EXTENSION_OPTIONS_V2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3e3595da_4d71_49fe_a0b4_d4406c3ae93f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CLASS_EXTENSION_OPTIONS_V2 ) , guid : :: windows :: core :: GUID::from_u128(0x3e3595da_4d71_49fe_a0b4_d4406c3ae93f) , } }
 pub const WPD_CLASS_EXTENSION_OPTIONS_V3: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x65c160f8_1367_4ce2_939d_8310839f0d30);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CLASS_EXTENSION_OPTIONS_V3 ) , guid : :: windows :: core :: GUID::from_u128(0x65c160f8_1367_4ce2_939d_8310839f0d30) , } }
 pub const WPD_CLASS_EXTENSION_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x33fb0d11_64a3_4fac_b4c7_3dfeaa99b051);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CLASS_EXTENSION_V1 ) , guid : :: windows :: core :: GUID::from_u128(0x33fb0d11_64a3_4fac_b4c7_3dfeaa99b051) , } }
 pub const WPD_CLASS_EXTENSION_V2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7f0779b5_fa2b_4766_9cb2_f73ba30b6758);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CLASS_EXTENSION_V2 ) , guid : :: windows :: core :: GUID::from_u128(0x7f0779b5_fa2b_4766_9cb2_f73ba30b6758) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CLIENT_DESIRED_ACCESS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x204d9f0c_2292_4080_9f42_40664e70f859), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CLIENT_DESIRED_ACCESS ) , guid : :: windows :: core :: GUID::from_u128(0x204d9f0c_2292_4080_9f42_40664e70f859) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CLIENT_EVENT_COOKIE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x204d9f0c_2292_4080_9f42_40664e70f859), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CLIENT_EVENT_COOKIE ) , guid : :: windows :: core :: GUID::from_u128(0x204d9f0c_2292_4080_9f42_40664e70f859) , } }
 pub const WPD_CLIENT_INFORMATION_PROPERTIES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x204d9f0c_2292_4080_9f42_40664e70f859);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CLIENT_INFORMATION_PROPERTIES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0x204d9f0c_2292_4080_9f42_40664e70f859) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CLIENT_MAJOR_VERSION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x204d9f0c_2292_4080_9f42_40664e70f859), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CLIENT_MAJOR_VERSION ) , guid : :: windows :: core :: GUID::from_u128(0x204d9f0c_2292_4080_9f42_40664e70f859) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CLIENT_MANUAL_CLOSE_ON_DISCONNECT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x204d9f0c_2292_4080_9f42_40664e70f859), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CLIENT_MANUAL_CLOSE_ON_DISCONNECT ) , guid : :: windows :: core :: GUID::from_u128(0x204d9f0c_2292_4080_9f42_40664e70f859) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CLIENT_MINIMUM_RESULTS_BUFFER_SIZE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x204d9f0c_2292_4080_9f42_40664e70f859), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CLIENT_MINIMUM_RESULTS_BUFFER_SIZE ) , guid : :: windows :: core :: GUID::from_u128(0x204d9f0c_2292_4080_9f42_40664e70f859) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CLIENT_MINOR_VERSION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x204d9f0c_2292_4080_9f42_40664e70f859), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CLIENT_MINOR_VERSION ) , guid : :: windows :: core :: GUID::from_u128(0x204d9f0c_2292_4080_9f42_40664e70f859) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CLIENT_NAME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x204d9f0c_2292_4080_9f42_40664e70f859), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CLIENT_NAME ) , guid : :: windows :: core :: GUID::from_u128(0x204d9f0c_2292_4080_9f42_40664e70f859) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CLIENT_REVISION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x204d9f0c_2292_4080_9f42_40664e70f859), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CLIENT_REVISION ) , guid : :: windows :: core :: GUID::from_u128(0x204d9f0c_2292_4080_9f42_40664e70f859) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CLIENT_SECURITY_QUALITY_OF_SERVICE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x204d9f0c_2292_4080_9f42_40664e70f859), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CLIENT_SECURITY_QUALITY_OF_SERVICE ) , guid : :: windows :: core :: GUID::from_u128(0x204d9f0c_2292_4080_9f42_40664e70f859) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CLIENT_SHARE_MODE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x204d9f0c_2292_4080_9f42_40664e70f859), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CLIENT_SHARE_MODE ) , guid : :: windows :: core :: GUID::from_u128(0x204d9f0c_2292_4080_9f42_40664e70f859) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CLIENT_WMDRM_APPLICATION_CERTIFICATE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x204d9f0c_2292_4080_9f42_40664e70f859), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CLIENT_WMDRM_APPLICATION_CERTIFICATE ) , guid : :: windows :: core :: GUID::from_u128(0x204d9f0c_2292_4080_9f42_40664e70f859) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CLIENT_WMDRM_APPLICATION_PRIVATE_KEY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x204d9f0c_2292_4080_9f42_40664e70f859), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CLIENT_WMDRM_APPLICATION_PRIVATE_KEY ) , guid : :: windows :: core :: GUID::from_u128(0x204d9f0c_2292_4080_9f42_40664e70f859) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
 pub type WPD_COLOR_CORRECTED_STATUS_VALUES = i32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
@@ -3766,517 +3910,901 @@ pub const WPD_COMMAND_ACCESS_FROM_ATTRIBUTE_WITH_METHOD_ACCESS: WPD_COMMAND_ACCE
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_CAPABILITIES_GET_COMMAND_OPTIONS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_CAPABILITIES_GET_COMMAND_OPTIONS ) , guid : :: windows :: core :: GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_CAPABILITIES_GET_EVENT_OPTIONS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_CAPABILITIES_GET_EVENT_OPTIONS ) , guid : :: windows :: core :: GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_CAPABILITIES_GET_FIXED_PROPERTY_ATTRIBUTES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_CAPABILITIES_GET_FIXED_PROPERTY_ATTRIBUTES ) , guid : :: windows :: core :: GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_CAPABILITIES_GET_FUNCTIONAL_OBJECTS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_CAPABILITIES_GET_FUNCTIONAL_OBJECTS ) , guid : :: windows :: core :: GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_CAPABILITIES_GET_SUPPORTED_COMMANDS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_CAPABILITIES_GET_SUPPORTED_COMMANDS ) , guid : :: windows :: core :: GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_CAPABILITIES_GET_SUPPORTED_CONTENT_TYPES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_CAPABILITIES_GET_SUPPORTED_CONTENT_TYPES ) , guid : :: windows :: core :: GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_CAPABILITIES_GET_SUPPORTED_EVENTS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_CAPABILITIES_GET_SUPPORTED_EVENTS ) , guid : :: windows :: core :: GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_CAPABILITIES_GET_SUPPORTED_FORMATS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_CAPABILITIES_GET_SUPPORTED_FORMATS ) , guid : :: windows :: core :: GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_CAPABILITIES_GET_SUPPORTED_FORMAT_PROPERTIES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_CAPABILITIES_GET_SUPPORTED_FORMAT_PROPERTIES ) , guid : :: windows :: core :: GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_CAPABILITIES_GET_SUPPORTED_FUNCTIONAL_CATEGORIES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_CAPABILITIES_GET_SUPPORTED_FUNCTIONAL_CATEGORIES ) , guid : :: windows :: core :: GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_CLASS_EXTENSION_REGISTER_SERVICE_INTERFACES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7f0779b5_fa2b_4766_9cb2_f73ba30b6758), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_CLASS_EXTENSION_REGISTER_SERVICE_INTERFACES ) , guid : :: windows :: core :: GUID::from_u128(0x7f0779b5_fa2b_4766_9cb2_f73ba30b6758) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_CLASS_EXTENSION_UNREGISTER_SERVICE_INTERFACES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7f0779b5_fa2b_4766_9cb2_f73ba30b6758), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_CLASS_EXTENSION_UNREGISTER_SERVICE_INTERFACES ) , guid : :: windows :: core :: GUID::from_u128(0x7f0779b5_fa2b_4766_9cb2_f73ba30b6758) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_CLASS_EXTENSION_WRITE_DEVICE_INFORMATION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x33fb0d11_64a3_4fac_b4c7_3dfeaa99b051), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_CLASS_EXTENSION_WRITE_DEVICE_INFORMATION ) , guid : :: windows :: core :: GUID::from_u128(0x33fb0d11_64a3_4fac_b4c7_3dfeaa99b051) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_COMMIT_KEYPAIR: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78f9c6fc_79b8_473c_9060_6bd23dd072c4), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_COMMIT_KEYPAIR ) , guid : :: windows :: core :: GUID::from_u128(0x78f9c6fc_79b8_473c_9060_6bd23dd072c4) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_COMMON_GET_OBJECT_IDS_FROM_PERSISTENT_UNIQUE_IDS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_COMMON_GET_OBJECT_IDS_FROM_PERSISTENT_UNIQUE_IDS ) , guid : :: windows :: core :: GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_COMMON_RESET_DEVICE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_COMMON_RESET_DEVICE ) , guid : :: windows :: core :: GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_COMMON_SAVE_CLIENT_INFORMATION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_COMMON_SAVE_CLIENT_INFORMATION ) , guid : :: windows :: core :: GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_DEVICE_HINTS_GET_CONTENT_LOCATION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0d5fb92b_cb46_4c4f_8343_0bc3d3f17c84), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_DEVICE_HINTS_GET_CONTENT_LOCATION ) , guid : :: windows :: core :: GUID::from_u128(0x0d5fb92b_cb46_4c4f_8343_0bc3d3f17c84) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_GENERATE_KEYPAIR: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78f9c6fc_79b8_473c_9060_6bd23dd072c4), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_GENERATE_KEYPAIR ) , guid : :: windows :: core :: GUID::from_u128(0x78f9c6fc_79b8_473c_9060_6bd23dd072c4) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_MEDIA_CAPTURE_PAUSE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x59b433ba_fe44_4d8d_808c_6bcb9b0f15e8), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_MEDIA_CAPTURE_PAUSE ) , guid : :: windows :: core :: GUID::from_u128(0x59b433ba_fe44_4d8d_808c_6bcb9b0f15e8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_MEDIA_CAPTURE_START: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x59b433ba_fe44_4d8d_808c_6bcb9b0f15e8), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_MEDIA_CAPTURE_START ) , guid : :: windows :: core :: GUID::from_u128(0x59b433ba_fe44_4d8d_808c_6bcb9b0f15e8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_MEDIA_CAPTURE_STOP: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x59b433ba_fe44_4d8d_808c_6bcb9b0f15e8), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_MEDIA_CAPTURE_STOP ) , guid : :: windows :: core :: GUID::from_u128(0x59b433ba_fe44_4d8d_808c_6bcb9b0f15e8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_MTP_EXT_END_DATA_TRANSFER: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56), pid: 17u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_MTP_EXT_END_DATA_TRANSFER ) , guid : :: windows :: core :: GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_MTP_EXT_EXECUTE_COMMAND_WITHOUT_DATA_PHASE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_MTP_EXT_EXECUTE_COMMAND_WITHOUT_DATA_PHASE ) , guid : :: windows :: core :: GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_MTP_EXT_EXECUTE_COMMAND_WITH_DATA_TO_READ: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_MTP_EXT_EXECUTE_COMMAND_WITH_DATA_TO_READ ) , guid : :: windows :: core :: GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_MTP_EXT_EXECUTE_COMMAND_WITH_DATA_TO_WRITE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_MTP_EXT_EXECUTE_COMMAND_WITH_DATA_TO_WRITE ) , guid : :: windows :: core :: GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_MTP_EXT_GET_SUPPORTED_VENDOR_OPCODES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_MTP_EXT_GET_SUPPORTED_VENDOR_OPCODES ) , guid : :: windows :: core :: GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_MTP_EXT_GET_VENDOR_EXTENSION_DESCRIPTION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56), pid: 18u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_MTP_EXT_GET_VENDOR_EXTENSION_DESCRIPTION ) , guid : :: windows :: core :: GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_MTP_EXT_READ_DATA: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56), pid: 15u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_MTP_EXT_READ_DATA ) , guid : :: windows :: core :: GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_MTP_EXT_WRITE_DATA: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56), pid: 16u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_MTP_EXT_WRITE_DATA ) , guid : :: windows :: core :: GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_ENUMERATION_END_FIND: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb7474e91_e7f8_4ad9_b400_ad1a4b58eeec), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_ENUMERATION_END_FIND ) , guid : :: windows :: core :: GUID::from_u128(0xb7474e91_e7f8_4ad9_b400_ad1a4b58eeec) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_ENUMERATION_FIND_NEXT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb7474e91_e7f8_4ad9_b400_ad1a4b58eeec), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_ENUMERATION_FIND_NEXT ) , guid : :: windows :: core :: GUID::from_u128(0xb7474e91_e7f8_4ad9_b400_ad1a4b58eeec) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_ENUMERATION_START_FIND: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb7474e91_e7f8_4ad9_b400_ad1a4b58eeec), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_ENUMERATION_START_FIND ) , guid : :: windows :: core :: GUID::from_u128(0xb7474e91_e7f8_4ad9_b400_ad1a4b58eeec) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_MANAGEMENT_COMMIT_OBJECT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_MANAGEMENT_COMMIT_OBJECT ) , guid : :: windows :: core :: GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_MANAGEMENT_COPY_OBJECTS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_MANAGEMENT_COPY_OBJECTS ) , guid : :: windows :: core :: GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_MANAGEMENT_CREATE_OBJECT_WITH_PROPERTIES_AND_DATA: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_MANAGEMENT_CREATE_OBJECT_WITH_PROPERTIES_AND_DATA ) , guid : :: windows :: core :: GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_MANAGEMENT_CREATE_OBJECT_WITH_PROPERTIES_ONLY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_MANAGEMENT_CREATE_OBJECT_WITH_PROPERTIES_ONLY ) , guid : :: windows :: core :: GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_MANAGEMENT_DELETE_OBJECTS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_MANAGEMENT_DELETE_OBJECTS ) , guid : :: windows :: core :: GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_MANAGEMENT_MOVE_OBJECTS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_MANAGEMENT_MOVE_OBJECTS ) , guid : :: windows :: core :: GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_MANAGEMENT_REVERT_OBJECT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_MANAGEMENT_REVERT_OBJECT ) , guid : :: windows :: core :: GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_MANAGEMENT_UPDATE_OBJECT_WITH_PROPERTIES_AND_DATA: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_MANAGEMENT_UPDATE_OBJECT_WITH_PROPERTIES_AND_DATA ) , guid : :: windows :: core :: GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_MANAGEMENT_WRITE_OBJECT_DATA: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_MANAGEMENT_WRITE_OBJECT_DATA ) , guid : :: windows :: core :: GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_PROPERTIES_BULK_GET_VALUES_BY_OBJECT_FORMAT_END: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_PROPERTIES_BULK_GET_VALUES_BY_OBJECT_FORMAT_END ) , guid : :: windows :: core :: GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_PROPERTIES_BULK_GET_VALUES_BY_OBJECT_FORMAT_NEXT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_PROPERTIES_BULK_GET_VALUES_BY_OBJECT_FORMAT_NEXT ) , guid : :: windows :: core :: GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_PROPERTIES_BULK_GET_VALUES_BY_OBJECT_FORMAT_START: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_PROPERTIES_BULK_GET_VALUES_BY_OBJECT_FORMAT_START ) , guid : :: windows :: core :: GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_PROPERTIES_BULK_GET_VALUES_BY_OBJECT_LIST_END: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_PROPERTIES_BULK_GET_VALUES_BY_OBJECT_LIST_END ) , guid : :: windows :: core :: GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_PROPERTIES_BULK_GET_VALUES_BY_OBJECT_LIST_NEXT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_PROPERTIES_BULK_GET_VALUES_BY_OBJECT_LIST_NEXT ) , guid : :: windows :: core :: GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_PROPERTIES_BULK_GET_VALUES_BY_OBJECT_LIST_START: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_PROPERTIES_BULK_GET_VALUES_BY_OBJECT_LIST_START ) , guid : :: windows :: core :: GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_PROPERTIES_BULK_SET_VALUES_BY_OBJECT_LIST_END: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_PROPERTIES_BULK_SET_VALUES_BY_OBJECT_LIST_END ) , guid : :: windows :: core :: GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_PROPERTIES_BULK_SET_VALUES_BY_OBJECT_LIST_NEXT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_PROPERTIES_BULK_SET_VALUES_BY_OBJECT_LIST_NEXT ) , guid : :: windows :: core :: GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_PROPERTIES_BULK_SET_VALUES_BY_OBJECT_LIST_START: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_PROPERTIES_BULK_SET_VALUES_BY_OBJECT_LIST_START ) , guid : :: windows :: core :: GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_PROPERTIES_DELETE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9e5582e4_0814_44e6_981a_b2998d583804), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_PROPERTIES_DELETE ) , guid : :: windows :: core :: GUID::from_u128(0x9e5582e4_0814_44e6_981a_b2998d583804) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_PROPERTIES_GET: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9e5582e4_0814_44e6_981a_b2998d583804), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_PROPERTIES_GET ) , guid : :: windows :: core :: GUID::from_u128(0x9e5582e4_0814_44e6_981a_b2998d583804) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_PROPERTIES_GET_ALL: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9e5582e4_0814_44e6_981a_b2998d583804), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_PROPERTIES_GET_ALL ) , guid : :: windows :: core :: GUID::from_u128(0x9e5582e4_0814_44e6_981a_b2998d583804) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_PROPERTIES_GET_ATTRIBUTES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9e5582e4_0814_44e6_981a_b2998d583804), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_PROPERTIES_GET_ATTRIBUTES ) , guid : :: windows :: core :: GUID::from_u128(0x9e5582e4_0814_44e6_981a_b2998d583804) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_PROPERTIES_GET_SUPPORTED: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9e5582e4_0814_44e6_981a_b2998d583804), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_PROPERTIES_GET_SUPPORTED ) , guid : :: windows :: core :: GUID::from_u128(0x9e5582e4_0814_44e6_981a_b2998d583804) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_PROPERTIES_SET: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9e5582e4_0814_44e6_981a_b2998d583804), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_PROPERTIES_SET ) , guid : :: windows :: core :: GUID::from_u128(0x9e5582e4_0814_44e6_981a_b2998d583804) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_RESOURCES_CLOSE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_RESOURCES_CLOSE ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_RESOURCES_COMMIT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_RESOURCES_COMMIT ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_RESOURCES_CREATE_RESOURCE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_RESOURCES_CREATE_RESOURCE ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_RESOURCES_DELETE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_RESOURCES_DELETE ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_RESOURCES_GET_ATTRIBUTES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_RESOURCES_GET_ATTRIBUTES ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_RESOURCES_GET_SUPPORTED: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_RESOURCES_GET_SUPPORTED ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_RESOURCES_OPEN: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_RESOURCES_OPEN ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_RESOURCES_READ: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_RESOURCES_READ ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_RESOURCES_REVERT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_RESOURCES_REVERT ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_RESOURCES_SEEK: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_RESOURCES_SEEK ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_RESOURCES_SEEK_IN_UNITS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_RESOURCES_SEEK_IN_UNITS ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_OBJECT_RESOURCES_WRITE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_OBJECT_RESOURCES_WRITE ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_PROCESS_WIRELESS_PROFILE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78f9c6fc_79b8_473c_9060_6bd23dd072c4), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_PROCESS_WIRELESS_PROFILE ) , guid : :: windows :: core :: GUID::from_u128(0x78f9c6fc_79b8_473c_9060_6bd23dd072c4) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_SERVICE_CAPABILITIES_GET_COMMAND_OPTIONS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 16u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_SERVICE_CAPABILITIES_GET_COMMAND_OPTIONS ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_SERVICE_CAPABILITIES_GET_EVENT_ATTRIBUTES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_SERVICE_CAPABILITIES_GET_EVENT_ATTRIBUTES ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_SERVICE_CAPABILITIES_GET_EVENT_PARAMETER_ATTRIBUTES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_SERVICE_CAPABILITIES_GET_EVENT_PARAMETER_ATTRIBUTES ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_SERVICE_CAPABILITIES_GET_FORMAT_ATTRIBUTES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_SERVICE_CAPABILITIES_GET_FORMAT_ATTRIBUTES ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_SERVICE_CAPABILITIES_GET_FORMAT_PROPERTY_ATTRIBUTES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_SERVICE_CAPABILITIES_GET_FORMAT_PROPERTY_ATTRIBUTES ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_SERVICE_CAPABILITIES_GET_FORMAT_RENDERING_PROFILES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_SERVICE_CAPABILITIES_GET_FORMAT_RENDERING_PROFILES ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_SERVICE_CAPABILITIES_GET_INHERITED_SERVICES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_SERVICE_CAPABILITIES_GET_INHERITED_SERVICES ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_SERVICE_CAPABILITIES_GET_METHOD_ATTRIBUTES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_SERVICE_CAPABILITIES_GET_METHOD_ATTRIBUTES ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_SERVICE_CAPABILITIES_GET_METHOD_PARAMETER_ATTRIBUTES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_SERVICE_CAPABILITIES_GET_METHOD_PARAMETER_ATTRIBUTES ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_SERVICE_CAPABILITIES_GET_SUPPORTED_COMMANDS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 15u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_SERVICE_CAPABILITIES_GET_SUPPORTED_COMMANDS ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_SERVICE_CAPABILITIES_GET_SUPPORTED_EVENTS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_SERVICE_CAPABILITIES_GET_SUPPORTED_EVENTS ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_SERVICE_CAPABILITIES_GET_SUPPORTED_FORMATS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_SERVICE_CAPABILITIES_GET_SUPPORTED_FORMATS ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_SERVICE_CAPABILITIES_GET_SUPPORTED_FORMAT_PROPERTIES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_SERVICE_CAPABILITIES_GET_SUPPORTED_FORMAT_PROPERTIES ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_SERVICE_CAPABILITIES_GET_SUPPORTED_METHODS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_SERVICE_CAPABILITIES_GET_SUPPORTED_METHODS ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_SERVICE_CAPABILITIES_GET_SUPPORTED_METHODS_BY_FORMAT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_SERVICE_CAPABILITIES_GET_SUPPORTED_METHODS_BY_FORMAT ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_SERVICE_COMMON_GET_SERVICE_OBJECT_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x322f071d_36ef_477f_b4b5_6f52d734baee), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_SERVICE_COMMON_GET_SERVICE_OBJECT_ID ) , guid : :: windows :: core :: GUID::from_u128(0x322f071d_36ef_477f_b4b5_6f52d734baee) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_SERVICE_METHODS_CANCEL_INVOKE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2d521ca8_c1b0_4268_a342_cf19321569bc), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_SERVICE_METHODS_CANCEL_INVOKE ) , guid : :: windows :: core :: GUID::from_u128(0x2d521ca8_c1b0_4268_a342_cf19321569bc) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_SERVICE_METHODS_END_INVOKE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2d521ca8_c1b0_4268_a342_cf19321569bc), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_SERVICE_METHODS_END_INVOKE ) , guid : :: windows :: core :: GUID::from_u128(0x2d521ca8_c1b0_4268_a342_cf19321569bc) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_SERVICE_METHODS_START_INVOKE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2d521ca8_c1b0_4268_a342_cf19321569bc), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_SERVICE_METHODS_START_INVOKE ) , guid : :: windows :: core :: GUID::from_u128(0x2d521ca8_c1b0_4268_a342_cf19321569bc) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_SMS_SEND: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xafc25d66_fe0d_4114_9097_970c93e920d1), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_SMS_SEND ) , guid : :: windows :: core :: GUID::from_u128(0xafc25d66_fe0d_4114_9097_970c93e920d1) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_STILL_IMAGE_CAPTURE_INITIATE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4fcd6982_22a2_4b05_a48b_62d38bf27b32), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_STILL_IMAGE_CAPTURE_INITIATE ) , guid : :: windows :: core :: GUID::from_u128(0x4fcd6982_22a2_4b05_a48b_62d38bf27b32) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_STORAGE_EJECT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd8f907a6_34cc_45fa_97fb_d007fa47ec94), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_STORAGE_EJECT ) , guid : :: windows :: core :: GUID::from_u128(0xd8f907a6_34cc_45fa_97fb_d007fa47ec94) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMAND_STORAGE_FORMAT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd8f907a6_34cc_45fa_97fb_d007fa47ec94), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMAND_STORAGE_FORMAT ) , guid : :: windows :: core :: GUID::from_u128(0xd8f907a6_34cc_45fa_97fb_d007fa47ec94) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMON_INFORMATION_BODY_TEXT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb28ae94b_05a4_4e8e_be01_72cc7e099d8f), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMON_INFORMATION_BODY_TEXT ) , guid : :: windows :: core :: GUID::from_u128(0xb28ae94b_05a4_4e8e_be01_72cc7e099d8f) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMON_INFORMATION_END_DATETIME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb28ae94b_05a4_4e8e_be01_72cc7e099d8f), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMON_INFORMATION_END_DATETIME ) , guid : :: windows :: core :: GUID::from_u128(0xb28ae94b_05a4_4e8e_be01_72cc7e099d8f) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMON_INFORMATION_NOTES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb28ae94b_05a4_4e8e_be01_72cc7e099d8f), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMON_INFORMATION_NOTES ) , guid : :: windows :: core :: GUID::from_u128(0xb28ae94b_05a4_4e8e_be01_72cc7e099d8f) , } }
 pub const WPD_COMMON_INFORMATION_OBJECT_PROPERTIES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb28ae94b_05a4_4e8e_be01_72cc7e099d8f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMON_INFORMATION_OBJECT_PROPERTIES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0xb28ae94b_05a4_4e8e_be01_72cc7e099d8f) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMON_INFORMATION_PRIORITY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb28ae94b_05a4_4e8e_be01_72cc7e099d8f), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMON_INFORMATION_PRIORITY ) , guid : :: windows :: core :: GUID::from_u128(0xb28ae94b_05a4_4e8e_be01_72cc7e099d8f) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMON_INFORMATION_START_DATETIME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb28ae94b_05a4_4e8e_be01_72cc7e099d8f), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMON_INFORMATION_START_DATETIME ) , guid : :: windows :: core :: GUID::from_u128(0xb28ae94b_05a4_4e8e_be01_72cc7e099d8f) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_COMMON_INFORMATION_SUBJECT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb28ae94b_05a4_4e8e_be01_72cc7e099d8f), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_COMMON_INFORMATION_SUBJECT ) , guid : :: windows :: core :: GUID::from_u128(0xb28ae94b_05a4_4e8e_be01_72cc7e099d8f) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_ANNIVERSARY_DATE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 62u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_ANNIVERSARY_DATE ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_ASSISTANT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 61u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_ASSISTANT ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_BIRTHDATE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 57u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_BIRTHDATE ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_BUSINESS_EMAIL: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 34u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_BUSINESS_EMAIL ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_BUSINESS_EMAIL2: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 35u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_BUSINESS_EMAIL2 ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_BUSINESS_FAX: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 45u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_BUSINESS_FAX ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_BUSINESS_FULL_POSTAL_ADDRESS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 17u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_BUSINESS_FULL_POSTAL_ADDRESS ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_BUSINESS_PHONE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 40u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_BUSINESS_PHONE ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_BUSINESS_PHONE2: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 41u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_BUSINESS_PHONE2 ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_BUSINESS_POSTAL_ADDRESS_CITY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 20u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_BUSINESS_POSTAL_ADDRESS_CITY ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_BUSINESS_POSTAL_ADDRESS_COUNTRY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 23u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_BUSINESS_POSTAL_ADDRESS_COUNTRY ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_BUSINESS_POSTAL_ADDRESS_LINE1: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 18u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_BUSINESS_POSTAL_ADDRESS_LINE1 ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_BUSINESS_POSTAL_ADDRESS_LINE2: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 19u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_BUSINESS_POSTAL_ADDRESS_LINE2 ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_BUSINESS_POSTAL_ADDRESS_POSTAL_CODE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 22u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_BUSINESS_POSTAL_ADDRESS_POSTAL_CODE ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_BUSINESS_POSTAL_ADDRESS_REGION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 21u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_BUSINESS_POSTAL_ADDRESS_REGION ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_BUSINESS_WEB_ADDRESS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 50u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_BUSINESS_WEB_ADDRESS ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_CHILDREN: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 60u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_CHILDREN ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_COMPANY_NAME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 54u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_COMPANY_NAME ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_DISPLAY_NAME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_DISPLAY_NAME ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_FIRST_NAME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_FIRST_NAME ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_INSTANT_MESSENGER: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 51u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_INSTANT_MESSENGER ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_INSTANT_MESSENGER2: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 52u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_INSTANT_MESSENGER2 ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_INSTANT_MESSENGER3: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 53u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_INSTANT_MESSENGER3 ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_LAST_NAME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_LAST_NAME ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_MIDDLE_NAMES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_MIDDLE_NAMES ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_MOBILE_PHONE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 42u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_MOBILE_PHONE ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_MOBILE_PHONE2: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 43u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_MOBILE_PHONE2 ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 pub const WPD_CONTACT_OBJECT_PROPERTIES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_OBJECT_PROPERTIES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_OTHER_EMAILS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 36u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_OTHER_EMAILS ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_OTHER_FULL_POSTAL_ADDRESS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 24u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_OTHER_FULL_POSTAL_ADDRESS ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_OTHER_PHONES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 47u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_OTHER_PHONES ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_OTHER_POSTAL_ADDRESS_CITY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 27u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_OTHER_POSTAL_ADDRESS_CITY ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_OTHER_POSTAL_ADDRESS_LINE1: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 25u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_OTHER_POSTAL_ADDRESS_LINE1 ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_OTHER_POSTAL_ADDRESS_LINE2: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 26u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_OTHER_POSTAL_ADDRESS_LINE2 ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_OTHER_POSTAL_ADDRESS_POSTAL_CODE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 29u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_OTHER_POSTAL_ADDRESS_POSTAL_CODE ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_OTHER_POSTAL_ADDRESS_POSTAL_COUNTRY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 30u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_OTHER_POSTAL_ADDRESS_POSTAL_COUNTRY ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_OTHER_POSTAL_ADDRESS_REGION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 28u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_OTHER_POSTAL_ADDRESS_REGION ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_PAGER: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 46u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_PAGER ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_PERSONAL_EMAIL: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 32u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_PERSONAL_EMAIL ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_PERSONAL_EMAIL2: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 33u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_PERSONAL_EMAIL2 ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_PERSONAL_FAX: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 44u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_PERSONAL_FAX ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_PERSONAL_FULL_POSTAL_ADDRESS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_PERSONAL_FULL_POSTAL_ADDRESS ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_PERSONAL_PHONE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 38u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_PERSONAL_PHONE ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_PERSONAL_PHONE2: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 39u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_PERSONAL_PHONE2 ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_PERSONAL_POSTAL_ADDRESS_CITY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_PERSONAL_POSTAL_ADDRESS_CITY ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_PERSONAL_POSTAL_ADDRESS_COUNTRY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 16u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_PERSONAL_POSTAL_ADDRESS_COUNTRY ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_PERSONAL_POSTAL_ADDRESS_LINE1: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_PERSONAL_POSTAL_ADDRESS_LINE1 ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_PERSONAL_POSTAL_ADDRESS_LINE2: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_PERSONAL_POSTAL_ADDRESS_LINE2 ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_PERSONAL_POSTAL_ADDRESS_POSTAL_CODE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 15u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_PERSONAL_POSTAL_ADDRESS_POSTAL_CODE ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_PERSONAL_POSTAL_ADDRESS_REGION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_PERSONAL_POSTAL_ADDRESS_REGION ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_PERSONAL_WEB_ADDRESS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 49u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_PERSONAL_WEB_ADDRESS ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_PHONETIC_COMPANY_NAME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 55u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_PHONETIC_COMPANY_NAME ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_PHONETIC_FIRST_NAME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_PHONETIC_FIRST_NAME ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_PHONETIC_LAST_NAME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_PHONETIC_LAST_NAME ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_PREFIX: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_PREFIX ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_PRIMARY_EMAIL_ADDRESS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 31u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_PRIMARY_EMAIL_ADDRESS ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_PRIMARY_FAX: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 58u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_PRIMARY_FAX ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_PRIMARY_PHONE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 37u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_PRIMARY_PHONE ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_PRIMARY_WEB_ADDRESS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 48u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_PRIMARY_WEB_ADDRESS ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_RINGTONE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 63u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_RINGTONE ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_ROLE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 56u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_ROLE ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_SPOUSE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 59u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_SPOUSE ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_CONTACT_SUFFIX: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTACT_SUFFIX ) , guid : :: windows :: core :: GUID::from_u128(0xfbd4fdab_987d_4777_b3f9_726185a9312b) , } }
 pub const WPD_CONTENT_TYPE_ALL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x80e170d2_1055_4a3e_b952_82cc4f8a8689);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTENT_TYPE_ALL ) , guid : :: windows :: core :: GUID::from_u128(0x80e170d2_1055_4a3e_b952_82cc4f8a8689) , } }
 pub const WPD_CONTENT_TYPE_APPOINTMENT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0fed060e_8793_4b1e_90c9_48ac389ac631);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTENT_TYPE_APPOINTMENT ) , guid : :: windows :: core :: GUID::from_u128(0x0fed060e_8793_4b1e_90c9_48ac389ac631) , } }
 pub const WPD_CONTENT_TYPE_AUDIO: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4ad2c85e_5e2d_45e5_8864_4f229e3c6cf0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTENT_TYPE_AUDIO ) , guid : :: windows :: core :: GUID::from_u128(0x4ad2c85e_5e2d_45e5_8864_4f229e3c6cf0) , } }
 pub const WPD_CONTENT_TYPE_AUDIO_ALBUM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaa18737e_5009_48fa_ae21_85f24383b4e6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTENT_TYPE_AUDIO_ALBUM ) , guid : :: windows :: core :: GUID::from_u128(0xaa18737e_5009_48fa_ae21_85f24383b4e6) , } }
 pub const WPD_CONTENT_TYPE_CALENDAR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa1fd5967_6023_49a0_9df1_f8060be751b0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTENT_TYPE_CALENDAR ) , guid : :: windows :: core :: GUID::from_u128(0xa1fd5967_6023_49a0_9df1_f8060be751b0) , } }
 pub const WPD_CONTENT_TYPE_CERTIFICATE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdc3876e8_a948_4060_9050_cbd77e8a3d87);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTENT_TYPE_CERTIFICATE ) , guid : :: windows :: core :: GUID::from_u128(0xdc3876e8_a948_4060_9050_cbd77e8a3d87) , } }
 pub const WPD_CONTENT_TYPE_CONTACT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xeaba8313_4525_4707_9f0e_87c6808e9435);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTENT_TYPE_CONTACT ) , guid : :: windows :: core :: GUID::from_u128(0xeaba8313_4525_4707_9f0e_87c6808e9435) , } }
 pub const WPD_CONTENT_TYPE_CONTACT_GROUP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x346b8932_4c36_40d8_9415_1828291f9de9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTENT_TYPE_CONTACT_GROUP ) , guid : :: windows :: core :: GUID::from_u128(0x346b8932_4c36_40d8_9415_1828291f9de9) , } }
 pub const WPD_CONTENT_TYPE_DOCUMENT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x680adf52_950a_4041_9b41_65e393648155);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTENT_TYPE_DOCUMENT ) , guid : :: windows :: core :: GUID::from_u128(0x680adf52_950a_4041_9b41_65e393648155) , } }
 pub const WPD_CONTENT_TYPE_EMAIL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8038044a_7e51_4f8f_883d_1d0623d14533);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTENT_TYPE_EMAIL ) , guid : :: windows :: core :: GUID::from_u128(0x8038044a_7e51_4f8f_883d_1d0623d14533) , } }
 pub const WPD_CONTENT_TYPE_FOLDER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x27e2e392_a111_48e0_ab0c_e17705a05f85);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTENT_TYPE_FOLDER ) , guid : :: windows :: core :: GUID::from_u128(0x27e2e392_a111_48e0_ab0c_e17705a05f85) , } }
 pub const WPD_CONTENT_TYPE_FUNCTIONAL_OBJECT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x99ed0160_17ff_4c44_9d98_1d7a6f941921);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTENT_TYPE_FUNCTIONAL_OBJECT ) , guid : :: windows :: core :: GUID::from_u128(0x99ed0160_17ff_4c44_9d98_1d7a6f941921) , } }
 pub const WPD_CONTENT_TYPE_GENERIC_FILE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0085e0a6_8d34_45d7_bc5c_447e59c73d48);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTENT_TYPE_GENERIC_FILE ) , guid : :: windows :: core :: GUID::from_u128(0x0085e0a6_8d34_45d7_bc5c_447e59c73d48) , } }
 pub const WPD_CONTENT_TYPE_GENERIC_MESSAGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe80eaaf8_b2db_4133_b67e_1bef4b4a6e5f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTENT_TYPE_GENERIC_MESSAGE ) , guid : :: windows :: core :: GUID::from_u128(0xe80eaaf8_b2db_4133_b67e_1bef4b4a6e5f) , } }
 pub const WPD_CONTENT_TYPE_IMAGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xef2107d5_a52a_4243_a26b_62d4176d7603);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTENT_TYPE_IMAGE ) , guid : :: windows :: core :: GUID::from_u128(0xef2107d5_a52a_4243_a26b_62d4176d7603) , } }
 pub const WPD_CONTENT_TYPE_IMAGE_ALBUM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x75793148_15f5_4a30_a813_54ed8a37e226);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTENT_TYPE_IMAGE_ALBUM ) , guid : :: windows :: core :: GUID::from_u128(0x75793148_15f5_4a30_a813_54ed8a37e226) , } }
 pub const WPD_CONTENT_TYPE_MEDIA_CAST: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5e88b3cc_3e65_4e62_bfff_229495253ab0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTENT_TYPE_MEDIA_CAST ) , guid : :: windows :: core :: GUID::from_u128(0x5e88b3cc_3e65_4e62_bfff_229495253ab0) , } }
 pub const WPD_CONTENT_TYPE_MEMO: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9cd20ecf_3b50_414f_a641_e473ffe45751);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTENT_TYPE_MEMO ) , guid : :: windows :: core :: GUID::from_u128(0x9cd20ecf_3b50_414f_a641_e473ffe45751) , } }
 pub const WPD_CONTENT_TYPE_MIXED_CONTENT_ALBUM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x00f0c3ac_a593_49ac_9219_24abca5a2563);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTENT_TYPE_MIXED_CONTENT_ALBUM ) , guid : :: windows :: core :: GUID::from_u128(0x00f0c3ac_a593_49ac_9219_24abca5a2563) , } }
 pub const WPD_CONTENT_TYPE_NETWORK_ASSOCIATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x031da7ee_18c8_4205_847e_89a11261d0f3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTENT_TYPE_NETWORK_ASSOCIATION ) , guid : :: windows :: core :: GUID::from_u128(0x031da7ee_18c8_4205_847e_89a11261d0f3) , } }
 pub const WPD_CONTENT_TYPE_PLAYLIST: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1a33f7e4_af13_48f5_994e_77369dfe04a3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTENT_TYPE_PLAYLIST ) , guid : :: windows :: core :: GUID::from_u128(0x1a33f7e4_af13_48f5_994e_77369dfe04a3) , } }
 pub const WPD_CONTENT_TYPE_PROGRAM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd269f96a_247c_4bff_98fb_97f3c49220e6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTENT_TYPE_PROGRAM ) , guid : :: windows :: core :: GUID::from_u128(0xd269f96a_247c_4bff_98fb_97f3c49220e6) , } }
 pub const WPD_CONTENT_TYPE_SECTION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x821089f5_1d91_4dc9_be3c_bbb1b35b18ce);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTENT_TYPE_SECTION ) , guid : :: windows :: core :: GUID::from_u128(0x821089f5_1d91_4dc9_be3c_bbb1b35b18ce) , } }
 pub const WPD_CONTENT_TYPE_TASK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x63252f2c_887f_4cb6_b1ac_d29855dcef6c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTENT_TYPE_TASK ) , guid : :: windows :: core :: GUID::from_u128(0x63252f2c_887f_4cb6_b1ac_d29855dcef6c) , } }
 pub const WPD_CONTENT_TYPE_TELEVISION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x60a169cf_f2ae_4e21_9375_9677f11c1c6e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTENT_TYPE_TELEVISION ) , guid : :: windows :: core :: GUID::from_u128(0x60a169cf_f2ae_4e21_9375_9677f11c1c6e) , } }
 pub const WPD_CONTENT_TYPE_UNSPECIFIED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x28d8d31e_249c_454e_aabc_34883168e634);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTENT_TYPE_UNSPECIFIED ) , guid : :: windows :: core :: GUID::from_u128(0x28d8d31e_249c_454e_aabc_34883168e634) , } }
 pub const WPD_CONTENT_TYPE_VIDEO: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9261b03c_3d78_4519_85e3_02c5e1f50bb9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTENT_TYPE_VIDEO ) , guid : :: windows :: core :: GUID::from_u128(0x9261b03c_3d78_4519_85e3_02c5e1f50bb9) , } }
 pub const WPD_CONTENT_TYPE_VIDEO_ALBUM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x012b0db7_d4c1_45d6_b081_94b87779614f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTENT_TYPE_VIDEO_ALBUM ) , guid : :: windows :: core :: GUID::from_u128(0x012b0db7_d4c1_45d6_b081_94b87779614f) , } }
 pub const WPD_CONTENT_TYPE_WIRELESS_PROFILE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0bac070a_9f5f_4da4_a8f6_3de44d68fd6c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CONTENT_TYPE_WIRELESS_PROFILE ) , guid : :: windows :: core :: GUID::from_u128(0x0bac070a_9f5f_4da4_a8f6_3de44d68fd6c) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
 pub const WPD_CONTROL_FUNCTION_GENERIC_MESSAGE: u32 = 66u32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
@@ -4290,60 +4818,102 @@ pub const WPD_CROPPED_STATUS_SHOULD_NOT_BE_CROPPED: WPD_CROPPED_STATUS_VALUES = 
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_DEVICE_DATETIME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_DEVICE_DATETIME ) , guid : :: windows :: core :: GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_DEVICE_EDP_IDENTITY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6c2b878c_c2ec_490d_b425_d7a75e23e5ed), pid: 1u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_DEVICE_EDP_IDENTITY ) , guid : :: windows :: core :: GUID::from_u128(0x6c2b878c_c2ec_490d_b425_d7a75e23e5ed) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_DEVICE_FIRMWARE_VERSION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_DEVICE_FIRMWARE_VERSION ) , guid : :: windows :: core :: GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_DEVICE_FRIENDLY_NAME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_DEVICE_FRIENDLY_NAME ) , guid : :: windows :: core :: GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_DEVICE_FUNCTIONAL_UNIQUE_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x463dd662_7fc4_4291_911c_7f4c9cca9799), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_DEVICE_FUNCTIONAL_UNIQUE_ID ) , guid : :: windows :: core :: GUID::from_u128(0x463dd662_7fc4_4291_911c_7f4c9cca9799) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_DEVICE_MANUFACTURER: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_DEVICE_MANUFACTURER ) , guid : :: windows :: core :: GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_DEVICE_MODEL: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_DEVICE_MODEL ) , guid : :: windows :: core :: GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_DEVICE_MODEL_UNIQUE_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x463dd662_7fc4_4291_911c_7f4c9cca9799), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_DEVICE_MODEL_UNIQUE_ID ) , guid : :: windows :: core :: GUID::from_u128(0x463dd662_7fc4_4291_911c_7f4c9cca9799) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_DEVICE_NETWORK_IDENTIFIER: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc), pid: 16u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_DEVICE_NETWORK_IDENTIFIER ) , guid : :: windows :: core :: GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_DEVICE_POWER_LEVEL: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_DEVICE_POWER_LEVEL ) , guid : :: windows :: core :: GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_DEVICE_POWER_SOURCE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_DEVICE_POWER_SOURCE ) , guid : :: windows :: core :: GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc) , } }
 pub const WPD_DEVICE_PROPERTIES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_DEVICE_PROPERTIES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc) , } }
 pub const WPD_DEVICE_PROPERTIES_V2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x463dd662_7fc4_4291_911c_7f4c9cca9799);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_DEVICE_PROPERTIES_V2 ) , guid : :: windows :: core :: GUID::from_u128(0x463dd662_7fc4_4291_911c_7f4c9cca9799) , } }
 pub const WPD_DEVICE_PROPERTIES_V3: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6c2b878c_c2ec_490d_b425_d7a75e23e5ed);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_DEVICE_PROPERTIES_V3 ) , guid : :: windows :: core :: GUID::from_u128(0x6c2b878c_c2ec_490d_b425_d7a75e23e5ed) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_DEVICE_PROTOCOL: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_DEVICE_PROTOCOL ) , guid : :: windows :: core :: GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_DEVICE_SERIAL_NUMBER: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_DEVICE_SERIAL_NUMBER ) , guid : :: windows :: core :: GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_DEVICE_SUPPORTED_DRM_SCHEMES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_DEVICE_SUPPORTED_DRM_SCHEMES ) , guid : :: windows :: core :: GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_DEVICE_SUPPORTED_FORMATS_ARE_ORDERED: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_DEVICE_SUPPORTED_FORMATS_ARE_ORDERED ) , guid : :: windows :: core :: GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_DEVICE_SUPPORTS_NON_CONSUMABLE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_DEVICE_SUPPORTS_NON_CONSUMABLE ) , guid : :: windows :: core :: GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_DEVICE_SYNC_PARTNER: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_DEVICE_SYNC_PARTNER ) , guid : :: windows :: core :: GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_DEVICE_TRANSPORT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x463dd662_7fc4_4291_911c_7f4c9cca9799), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_DEVICE_TRANSPORT ) , guid : :: windows :: core :: GUID::from_u128(0x463dd662_7fc4_4291_911c_7f4c9cca9799) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
 pub type WPD_DEVICE_TRANSPORTS = i32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
@@ -4357,6 +4927,8 @@ pub const WPD_DEVICE_TRANSPORT_BLUETOOTH: WPD_DEVICE_TRANSPORTS = 3i32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_DEVICE_TYPE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc), pid: 15u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_DEVICE_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x26d4979a_e643_4626_9e2b_736dc0c92fdc) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
 pub type WPD_DEVICE_TYPES = i32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
@@ -4376,7 +4948,11 @@ pub const WPD_DEVICE_TYPE_AUDIO_RECORDER: WPD_DEVICE_TYPES = 6i32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_DEVICE_USE_DEVICE_STAGE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x463dd662_7fc4_4291_911c_7f4c9cca9799), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_DEVICE_USE_DEVICE_STAGE ) , guid : :: windows :: core :: GUID::from_u128(0x463dd662_7fc4_4291_911c_7f4c9cca9799) , } }
 pub const WPD_DOCUMENT_OBJECT_PROPERTIES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0b110203_eb95_4f02_93e0_97c631493ad5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_DOCUMENT_OBJECT_PROPERTIES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0x0b110203_eb95_4f02_93e0_97c631493ad5) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
 pub type WPD_EFFECT_MODES = i32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
@@ -4390,79 +4966,151 @@ pub const WPD_EFFECT_MODE_SEPIA: WPD_EFFECT_MODES = 3i32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_EMAIL_BCC_LINE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x41f8f65a_5484_4782_b13d_4740dd7c37c5), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EMAIL_BCC_LINE ) , guid : :: windows :: core :: GUID::from_u128(0x41f8f65a_5484_4782_b13d_4740dd7c37c5) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_EMAIL_CC_LINE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x41f8f65a_5484_4782_b13d_4740dd7c37c5), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EMAIL_CC_LINE ) , guid : :: windows :: core :: GUID::from_u128(0x41f8f65a_5484_4782_b13d_4740dd7c37c5) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_EMAIL_HAS_ATTACHMENTS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x41f8f65a_5484_4782_b13d_4740dd7c37c5), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EMAIL_HAS_ATTACHMENTS ) , guid : :: windows :: core :: GUID::from_u128(0x41f8f65a_5484_4782_b13d_4740dd7c37c5) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_EMAIL_HAS_BEEN_READ: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x41f8f65a_5484_4782_b13d_4740dd7c37c5), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EMAIL_HAS_BEEN_READ ) , guid : :: windows :: core :: GUID::from_u128(0x41f8f65a_5484_4782_b13d_4740dd7c37c5) , } }
 pub const WPD_EMAIL_OBJECT_PROPERTIES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x41f8f65a_5484_4782_b13d_4740dd7c37c5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EMAIL_OBJECT_PROPERTIES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0x41f8f65a_5484_4782_b13d_4740dd7c37c5) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_EMAIL_RECEIVED_TIME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x41f8f65a_5484_4782_b13d_4740dd7c37c5), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EMAIL_RECEIVED_TIME ) , guid : :: windows :: core :: GUID::from_u128(0x41f8f65a_5484_4782_b13d_4740dd7c37c5) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_EMAIL_SENDER_ADDRESS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x41f8f65a_5484_4782_b13d_4740dd7c37c5), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EMAIL_SENDER_ADDRESS ) , guid : :: windows :: core :: GUID::from_u128(0x41f8f65a_5484_4782_b13d_4740dd7c37c5) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_EMAIL_TO_LINE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x41f8f65a_5484_4782_b13d_4740dd7c37c5), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EMAIL_TO_LINE ) , guid : :: windows :: core :: GUID::from_u128(0x41f8f65a_5484_4782_b13d_4740dd7c37c5) , } }
 pub const WPD_EVENT_ATTRIBUTES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x10c96578_2e81_4111_adde_e08ca6138f6d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EVENT_ATTRIBUTES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0x10c96578_2e81_4111_adde_e08ca6138f6d) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_EVENT_ATTRIBUTE_NAME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x10c96578_2e81_4111_adde_e08ca6138f6d), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EVENT_ATTRIBUTE_NAME ) , guid : :: windows :: core :: GUID::from_u128(0x10c96578_2e81_4111_adde_e08ca6138f6d) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_EVENT_ATTRIBUTE_OPTIONS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x10c96578_2e81_4111_adde_e08ca6138f6d), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EVENT_ATTRIBUTE_OPTIONS ) , guid : :: windows :: core :: GUID::from_u128(0x10c96578_2e81_4111_adde_e08ca6138f6d) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_EVENT_ATTRIBUTE_PARAMETERS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x10c96578_2e81_4111_adde_e08ca6138f6d), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EVENT_ATTRIBUTE_PARAMETERS ) , guid : :: windows :: core :: GUID::from_u128(0x10c96578_2e81_4111_adde_e08ca6138f6d) , } }
 pub const WPD_EVENT_DEVICE_CAPABILITIES_UPDATED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x36885aa1_cd54_4daa_b3d0_afb3e03f5999);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EVENT_DEVICE_CAPABILITIES_UPDATED ) , guid : :: windows :: core :: GUID::from_u128(0x36885aa1_cd54_4daa_b3d0_afb3e03f5999) , } }
 pub const WPD_EVENT_DEVICE_REMOVED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe4cbca1b_6918_48b9_85ee_02be7c850af9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EVENT_DEVICE_REMOVED ) , guid : :: windows :: core :: GUID::from_u128(0xe4cbca1b_6918_48b9_85ee_02be7c850af9) , } }
 pub const WPD_EVENT_DEVICE_RESET: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7755cf53_c1ed_44f3_b5a2_451e2c376b27);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EVENT_DEVICE_RESET ) , guid : :: windows :: core :: GUID::from_u128(0x7755cf53_c1ed_44f3_b5a2_451e2c376b27) , } }
 pub const WPD_EVENT_MTP_VENDOR_EXTENDED_EVENTS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x00000000_5738_4ff2_8445_be3126691059);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EVENT_MTP_VENDOR_EXTENDED_EVENTS ) , guid : :: windows :: core :: GUID::from_u128(0x00000000_5738_4ff2_8445_be3126691059) , } }
 pub const WPD_EVENT_NOTIFICATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2ba2e40a_6b4c_4295_bb43_26322b99aeb2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EVENT_NOTIFICATION ) , guid : :: windows :: core :: GUID::from_u128(0x2ba2e40a_6b4c_4295_bb43_26322b99aeb2) , } }
 pub const WPD_EVENT_OBJECT_ADDED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa726da95_e207_4b02_8d44_bef2e86cbffc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EVENT_OBJECT_ADDED ) , guid : :: windows :: core :: GUID::from_u128(0xa726da95_e207_4b02_8d44_bef2e86cbffc) , } }
 pub const WPD_EVENT_OBJECT_REMOVED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbe82ab88_a52c_4823_96e5_d0272671fc38);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EVENT_OBJECT_REMOVED ) , guid : :: windows :: core :: GUID::from_u128(0xbe82ab88_a52c_4823_96e5_d0272671fc38) , } }
 pub const WPD_EVENT_OBJECT_TRANSFER_REQUESTED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8d16a0a1_f2c6_41da_8f19_5e53721adbf2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EVENT_OBJECT_TRANSFER_REQUESTED ) , guid : :: windows :: core :: GUID::from_u128(0x8d16a0a1_f2c6_41da_8f19_5e53721adbf2) , } }
 pub const WPD_EVENT_OBJECT_UPDATED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1445a759_2e01_485d_9f27_ff07dae697ab);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EVENT_OBJECT_UPDATED ) , guid : :: windows :: core :: GUID::from_u128(0x1445a759_2e01_485d_9f27_ff07dae697ab) , } }
 pub const WPD_EVENT_OPTIONS_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb3d8dad7_a361_4b83_8a48_5b02ce10713b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EVENT_OPTIONS_V1 ) , guid : :: windows :: core :: GUID::from_u128(0xb3d8dad7_a361_4b83_8a48_5b02ce10713b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_EVENT_OPTION_IS_AUTOPLAY_EVENT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3d8dad7_a361_4b83_8a48_5b02ce10713b), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EVENT_OPTION_IS_AUTOPLAY_EVENT ) , guid : :: windows :: core :: GUID::from_u128(0xb3d8dad7_a361_4b83_8a48_5b02ce10713b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_EVENT_OPTION_IS_BROADCAST_EVENT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3d8dad7_a361_4b83_8a48_5b02ce10713b), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EVENT_OPTION_IS_BROADCAST_EVENT ) , guid : :: windows :: core :: GUID::from_u128(0xb3d8dad7_a361_4b83_8a48_5b02ce10713b) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_EVENT_PARAMETER_CHILD_HIERARCHY_CHANGED: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x15ab1953_f817_4fef_a921_5676e838f6e0), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EVENT_PARAMETER_CHILD_HIERARCHY_CHANGED ) , guid : :: windows :: core :: GUID::from_u128(0x15ab1953_f817_4fef_a921_5676e838f6e0) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_EVENT_PARAMETER_EVENT_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x15ab1953_f817_4fef_a921_5676e838f6e0), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EVENT_PARAMETER_EVENT_ID ) , guid : :: windows :: core :: GUID::from_u128(0x15ab1953_f817_4fef_a921_5676e838f6e0) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_EVENT_PARAMETER_OBJECT_CREATION_COOKIE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x15ab1953_f817_4fef_a921_5676e838f6e0), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EVENT_PARAMETER_OBJECT_CREATION_COOKIE ) , guid : :: windows :: core :: GUID::from_u128(0x15ab1953_f817_4fef_a921_5676e838f6e0) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_EVENT_PARAMETER_OBJECT_PARENT_PERSISTENT_UNIQUE_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x15ab1953_f817_4fef_a921_5676e838f6e0), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EVENT_PARAMETER_OBJECT_PARENT_PERSISTENT_UNIQUE_ID ) , guid : :: windows :: core :: GUID::from_u128(0x15ab1953_f817_4fef_a921_5676e838f6e0) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_EVENT_PARAMETER_OPERATION_PROGRESS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x15ab1953_f817_4fef_a921_5676e838f6e0), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EVENT_PARAMETER_OPERATION_PROGRESS ) , guid : :: windows :: core :: GUID::from_u128(0x15ab1953_f817_4fef_a921_5676e838f6e0) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_EVENT_PARAMETER_OPERATION_STATE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x15ab1953_f817_4fef_a921_5676e838f6e0), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EVENT_PARAMETER_OPERATION_STATE ) , guid : :: windows :: core :: GUID::from_u128(0x15ab1953_f817_4fef_a921_5676e838f6e0) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_EVENT_PARAMETER_PNP_DEVICE_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x15ab1953_f817_4fef_a921_5676e838f6e0), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EVENT_PARAMETER_PNP_DEVICE_ID ) , guid : :: windows :: core :: GUID::from_u128(0x15ab1953_f817_4fef_a921_5676e838f6e0) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_EVENT_PARAMETER_SERVICE_METHOD_CONTEXT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x52807b8a_4914_4323_9b9a_74f654b2b846), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EVENT_PARAMETER_SERVICE_METHOD_CONTEXT ) , guid : :: windows :: core :: GUID::from_u128(0x52807b8a_4914_4323_9b9a_74f654b2b846) , } }
 pub const WPD_EVENT_PROPERTIES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x15ab1953_f817_4fef_a921_5676e838f6e0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EVENT_PROPERTIES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0x15ab1953_f817_4fef_a921_5676e838f6e0) , } }
 pub const WPD_EVENT_PROPERTIES_V2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x52807b8a_4914_4323_9b9a_74f654b2b846);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EVENT_PROPERTIES_V2 ) , guid : :: windows :: core :: GUID::from_u128(0x52807b8a_4914_4323_9b9a_74f654b2b846) , } }
 pub const WPD_EVENT_SERVICE_METHOD_COMPLETE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8a33f5f8_0acc_4d9b_9cc4_112d353b86ca);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EVENT_SERVICE_METHOD_COMPLETE ) , guid : :: windows :: core :: GUID::from_u128(0x8a33f5f8_0acc_4d9b_9cc4_112d353b86ca) , } }
 pub const WPD_EVENT_STORAGE_FORMAT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3782616b_22bc_4474_a251_3070f8d38857);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_EVENT_STORAGE_FORMAT ) , guid : :: windows :: core :: GUID::from_u128(0x3782616b_22bc_4474_a251_3070f8d38857) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
 pub type WPD_EXPOSURE_METERING_MODES = i32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
@@ -4530,171 +5178,303 @@ pub const WPD_FOCUS_AUTOMATIC_MACRO: WPD_FOCUS_MODES = 3i32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_FOLDER_CONTENT_TYPES_ALLOWED: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7e9a7abf_e568_4b34_aa2f_13bb12ab177d), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_FOLDER_CONTENT_TYPES_ALLOWED ) , guid : :: windows :: core :: GUID::from_u128(0x7e9a7abf_e568_4b34_aa2f_13bb12ab177d) , } }
 pub const WPD_FOLDER_OBJECT_PROPERTIES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7e9a7abf_e568_4b34_aa2f_13bb12ab177d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_FOLDER_OBJECT_PROPERTIES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0x7e9a7abf_e568_4b34_aa2f_13bb12ab177d) , } }
 pub const WPD_FORMAT_ATTRIBUTES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa0a02000_bcaf_4be8_b3f5_233f231cf58f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_FORMAT_ATTRIBUTES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0xa0a02000_bcaf_4be8_b3f5_233f231cf58f) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_FORMAT_ATTRIBUTE_MIMETYPE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa0a02000_bcaf_4be8_b3f5_233f231cf58f), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_FORMAT_ATTRIBUTE_MIMETYPE ) , guid : :: windows :: core :: GUID::from_u128(0xa0a02000_bcaf_4be8_b3f5_233f231cf58f) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_FORMAT_ATTRIBUTE_NAME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa0a02000_bcaf_4be8_b3f5_233f231cf58f), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_FORMAT_ATTRIBUTE_NAME ) , guid : :: windows :: core :: GUID::from_u128(0xa0a02000_bcaf_4be8_b3f5_233f231cf58f) , } }
 pub const WPD_FUNCTIONAL_CATEGORY_ALL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2d8a6512_a74c_448e_ba8a_f4ac07c49399);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_FUNCTIONAL_CATEGORY_ALL ) , guid : :: windows :: core :: GUID::from_u128(0x2d8a6512_a74c_448e_ba8a_f4ac07c49399) , } }
 pub const WPD_FUNCTIONAL_CATEGORY_AUDIO_CAPTURE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3f2a1919_c7c2_4a00_855d_f57cf06debbb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_FUNCTIONAL_CATEGORY_AUDIO_CAPTURE ) , guid : :: windows :: core :: GUID::from_u128(0x3f2a1919_c7c2_4a00_855d_f57cf06debbb) , } }
 pub const WPD_FUNCTIONAL_CATEGORY_DEVICE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x08ea466b_e3a4_4336_a1f3_a44d2b5c438c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_FUNCTIONAL_CATEGORY_DEVICE ) , guid : :: windows :: core :: GUID::from_u128(0x08ea466b_e3a4_4336_a1f3_a44d2b5c438c) , } }
 pub const WPD_FUNCTIONAL_CATEGORY_NETWORK_CONFIGURATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x48f4db72_7c6a_4ab0_9e1a_470e3cdbf26a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_FUNCTIONAL_CATEGORY_NETWORK_CONFIGURATION ) , guid : :: windows :: core :: GUID::from_u128(0x48f4db72_7c6a_4ab0_9e1a_470e3cdbf26a) , } }
 pub const WPD_FUNCTIONAL_CATEGORY_RENDERING_INFORMATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x08600ba4_a7ba_4a01_ab0e_0065d0a356d3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_FUNCTIONAL_CATEGORY_RENDERING_INFORMATION ) , guid : :: windows :: core :: GUID::from_u128(0x08600ba4_a7ba_4a01_ab0e_0065d0a356d3) , } }
 pub const WPD_FUNCTIONAL_CATEGORY_SMS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0044a0b1_c1e9_4afd_b358_a62c6117c9cf);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_FUNCTIONAL_CATEGORY_SMS ) , guid : :: windows :: core :: GUID::from_u128(0x0044a0b1_c1e9_4afd_b358_a62c6117c9cf) , } }
 pub const WPD_FUNCTIONAL_CATEGORY_STILL_IMAGE_CAPTURE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x613ca327_ab93_4900_b4fa_895bb5874b79);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_FUNCTIONAL_CATEGORY_STILL_IMAGE_CAPTURE ) , guid : :: windows :: core :: GUID::from_u128(0x613ca327_ab93_4900_b4fa_895bb5874b79) , } }
 pub const WPD_FUNCTIONAL_CATEGORY_STORAGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x23f05bbc_15de_4c2a_a55b_a9af5ce412ef);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_FUNCTIONAL_CATEGORY_STORAGE ) , guid : :: windows :: core :: GUID::from_u128(0x23f05bbc_15de_4c2a_a55b_a9af5ce412ef) , } }
 pub const WPD_FUNCTIONAL_CATEGORY_VIDEO_CAPTURE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe23e5f6b_7243_43aa_8df1_0eb3d968a918);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_FUNCTIONAL_CATEGORY_VIDEO_CAPTURE ) , guid : :: windows :: core :: GUID::from_u128(0xe23e5f6b_7243_43aa_8df1_0eb3d968a918) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_FUNCTIONAL_OBJECT_CATEGORY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8f052d93_abca_4fc5_a5ac_b01df4dbe598), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_FUNCTIONAL_OBJECT_CATEGORY ) , guid : :: windows :: core :: GUID::from_u128(0x8f052d93_abca_4fc5_a5ac_b01df4dbe598) , } }
 pub const WPD_FUNCTIONAL_OBJECT_PROPERTIES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8f052d93_abca_4fc5_a5ac_b01df4dbe598);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_FUNCTIONAL_OBJECT_PROPERTIES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0x8f052d93_abca_4fc5_a5ac_b01df4dbe598) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_IMAGE_BITDEPTH: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x63d64908_9fa1_479f_85ba_9952216447db), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_IMAGE_BITDEPTH ) , guid : :: windows :: core :: GUID::from_u128(0x63d64908_9fa1_479f_85ba_9952216447db) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_IMAGE_COLOR_CORRECTED_STATUS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x63d64908_9fa1_479f_85ba_9952216447db), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_IMAGE_COLOR_CORRECTED_STATUS ) , guid : :: windows :: core :: GUID::from_u128(0x63d64908_9fa1_479f_85ba_9952216447db) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_IMAGE_CROPPED_STATUS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x63d64908_9fa1_479f_85ba_9952216447db), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_IMAGE_CROPPED_STATUS ) , guid : :: windows :: core :: GUID::from_u128(0x63d64908_9fa1_479f_85ba_9952216447db) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_IMAGE_EXPOSURE_INDEX: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x63d64908_9fa1_479f_85ba_9952216447db), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_IMAGE_EXPOSURE_INDEX ) , guid : :: windows :: core :: GUID::from_u128(0x63d64908_9fa1_479f_85ba_9952216447db) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_IMAGE_EXPOSURE_TIME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x63d64908_9fa1_479f_85ba_9952216447db), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_IMAGE_EXPOSURE_TIME ) , guid : :: windows :: core :: GUID::from_u128(0x63d64908_9fa1_479f_85ba_9952216447db) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_IMAGE_FNUMBER: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x63d64908_9fa1_479f_85ba_9952216447db), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_IMAGE_FNUMBER ) , guid : :: windows :: core :: GUID::from_u128(0x63d64908_9fa1_479f_85ba_9952216447db) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_IMAGE_HORIZONTAL_RESOLUTION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x63d64908_9fa1_479f_85ba_9952216447db), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_IMAGE_HORIZONTAL_RESOLUTION ) , guid : :: windows :: core :: GUID::from_u128(0x63d64908_9fa1_479f_85ba_9952216447db) , } }
 pub const WPD_IMAGE_OBJECT_PROPERTIES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x63d64908_9fa1_479f_85ba_9952216447db);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_IMAGE_OBJECT_PROPERTIES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0x63d64908_9fa1_479f_85ba_9952216447db) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_IMAGE_VERTICAL_RESOLUTION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x63d64908_9fa1_479f_85ba_9952216447db), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_IMAGE_VERTICAL_RESOLUTION ) , guid : :: windows :: core :: GUID::from_u128(0x63d64908_9fa1_479f_85ba_9952216447db) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_ALBUM_ARTIST: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 25u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_ALBUM_ARTIST ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_ARTIST: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 24u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_ARTIST ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_AUDIO_ENCODING_PROFILE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 49u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_AUDIO_ENCODING_PROFILE ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_BITRATE_TYPE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_BITRATE_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_BUY_NOW: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 20u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_BUY_NOW ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_BYTE_BOOKMARK: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 36u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_BYTE_BOOKMARK ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_COMPOSER: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_COMPOSER ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_COPYRIGHT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_COPYRIGHT ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_DESCRIPTION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 31u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_DESCRIPTION ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_DESTINATION_URL: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 30u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_DESTINATION_URL ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_DURATION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 19u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_DURATION ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_EFFECTIVE_RATING: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_EFFECTIVE_RATING ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_ENCODING_PROFILE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 21u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_ENCODING_PROFILE ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_GENRE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 32u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_GENRE ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_GUID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 38u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_HEIGHT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 23u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_HEIGHT ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_LAST_ACCESSED_TIME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_LAST_ACCESSED_TIME ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_LAST_BUILD_DATE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 35u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_LAST_BUILD_DATE ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_MANAGING_EDITOR: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 27u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_MANAGING_EDITOR ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_META_GENRE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_META_GENRE ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_OBJECT_BOOKMARK: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 34u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_OBJECT_BOOKMARK ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_OWNER: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 26u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_OWNER ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_PARENTAL_RATING: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_PARENTAL_RATING ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 pub const WPD_MEDIA_PROPERTIES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_PROPERTIES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_RELEASE_DATE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_RELEASE_DATE ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_SAMPLE_RATE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 15u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_SAMPLE_RATE ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_SKIP_COUNT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_SKIP_COUNT ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_SOURCE_URL: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 29u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_SOURCE_URL ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_STAR_RATING: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 16u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_STAR_RATING ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_SUBSCRIPTION_CONTENT_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_SUBSCRIPTION_CONTENT_ID ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_SUB_DESCRIPTION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 39u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_SUB_DESCRIPTION ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_SUB_TITLE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_SUB_TITLE ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_TIME_BOOKMARK: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 33u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_TIME_BOOKMARK ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_TIME_TO_LIVE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 37u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_TIME_TO_LIVE ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_TITLE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 18u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_TITLE ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_TOTAL_BITRATE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_TOTAL_BITRATE ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_USER_EFFECTIVE_RATING: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 17u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_USER_EFFECTIVE_RATING ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_USE_COUNT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_USE_COUNT ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_WEBMASTER: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 28u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_WEBMASTER ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MEDIA_WIDTH: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8), pid: 22u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEDIA_WIDTH ) , guid : :: windows :: core :: GUID::from_u128(0x2ed8ba05_0ad3_42dc_b0d0_bc95ac396ac8) , } }
 pub const WPD_MEMO_OBJECT_PROPERTIES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5ffbfc7b_7483_41ad_afb9_da3f4e592b8d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MEMO_OBJECT_PROPERTIES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0x5ffbfc7b_7483_41ad_afb9_da3f4e592b8d) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
 pub type WPD_META_GENRES = i32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
@@ -4736,186 +5516,408 @@ pub const WPD_META_GENRE_VIDEO_PODCAST: WPD_META_GENRES = 65i32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
 pub const WPD_META_GENRE_MIXED_PODCAST: WPD_META_GENRES = 66i32;
 pub const WPD_METHOD_ATTRIBUTES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf17a5071_f039_44af_8efe_432cf32e432a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_METHOD_ATTRIBUTES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0xf17a5071_f039_44af_8efe_432cf32e432a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_METHOD_ATTRIBUTE_ACCESS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf17a5071_f039_44af_8efe_432cf32e432a), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_METHOD_ATTRIBUTE_ACCESS ) , guid : :: windows :: core :: GUID::from_u128(0xf17a5071_f039_44af_8efe_432cf32e432a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_METHOD_ATTRIBUTE_ASSOCIATED_FORMAT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf17a5071_f039_44af_8efe_432cf32e432a), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_METHOD_ATTRIBUTE_ASSOCIATED_FORMAT ) , guid : :: windows :: core :: GUID::from_u128(0xf17a5071_f039_44af_8efe_432cf32e432a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_METHOD_ATTRIBUTE_NAME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf17a5071_f039_44af_8efe_432cf32e432a), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_METHOD_ATTRIBUTE_NAME ) , guid : :: windows :: core :: GUID::from_u128(0xf17a5071_f039_44af_8efe_432cf32e432a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_METHOD_ATTRIBUTE_PARAMETERS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf17a5071_f039_44af_8efe_432cf32e432a), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_METHOD_ATTRIBUTE_PARAMETERS ) , guid : :: windows :: core :: GUID::from_u128(0xf17a5071_f039_44af_8efe_432cf32e432a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MUSIC_ALBUM: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb324f56a_dc5d_46e5_b6df_d2ea414888c6), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MUSIC_ALBUM ) , guid : :: windows :: core :: GUID::from_u128(0xb324f56a_dc5d_46e5_b6df_d2ea414888c6) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MUSIC_LYRICS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb324f56a_dc5d_46e5_b6df_d2ea414888c6), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MUSIC_LYRICS ) , guid : :: windows :: core :: GUID::from_u128(0xb324f56a_dc5d_46e5_b6df_d2ea414888c6) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MUSIC_MOOD: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb324f56a_dc5d_46e5_b6df_d2ea414888c6), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MUSIC_MOOD ) , guid : :: windows :: core :: GUID::from_u128(0xb324f56a_dc5d_46e5_b6df_d2ea414888c6) , } }
 pub const WPD_MUSIC_OBJECT_PROPERTIES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb324f56a_dc5d_46e5_b6df_d2ea414888c6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MUSIC_OBJECT_PROPERTIES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0xb324f56a_dc5d_46e5_b6df_d2ea414888c6) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_MUSIC_TRACK: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb324f56a_dc5d_46e5_b6df_d2ea414888c6), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_MUSIC_TRACK ) , guid : :: windows :: core :: GUID::from_u128(0xb324f56a_dc5d_46e5_b6df_d2ea414888c6) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_NETWORK_ASSOCIATION_HOST_NETWORK_IDENTIFIERS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe4c93c1f_b203_43f1_a100_5a07d11b0274), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_NETWORK_ASSOCIATION_HOST_NETWORK_IDENTIFIERS ) , guid : :: windows :: core :: GUID::from_u128(0xe4c93c1f_b203_43f1_a100_5a07d11b0274) , } }
 pub const WPD_NETWORK_ASSOCIATION_PROPERTIES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe4c93c1f_b203_43f1_a100_5a07d11b0274);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_NETWORK_ASSOCIATION_PROPERTIES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0xe4c93c1f_b203_43f1_a100_5a07d11b0274) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_NETWORK_ASSOCIATION_X509V3SEQUENCE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe4c93c1f_b203_43f1_a100_5a07d11b0274), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_NETWORK_ASSOCIATION_X509V3SEQUENCE ) , guid : :: windows :: core :: GUID::from_u128(0xe4c93c1f_b203_43f1_a100_5a07d11b0274) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OBJECT_BACK_REFERENCES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c), pid: 21u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_BACK_REFERENCES ) , guid : :: windows :: core :: GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OBJECT_CAN_DELETE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c), pid: 26u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_CAN_DELETE ) , guid : :: windows :: core :: GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OBJECT_CONTAINER_FUNCTIONAL_OBJECT_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c), pid: 23u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_CONTAINER_FUNCTIONAL_OBJECT_ID ) , guid : :: windows :: core :: GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OBJECT_CONTENT_TYPE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_CONTENT_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OBJECT_DATE_AUTHORED: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c), pid: 20u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_DATE_AUTHORED ) , guid : :: windows :: core :: GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OBJECT_DATE_CREATED: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c), pid: 18u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_DATE_CREATED ) , guid : :: windows :: core :: GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OBJECT_DATE_MODIFIED: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c), pid: 19u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_DATE_MODIFIED ) , guid : :: windows :: core :: GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OBJECT_FORMAT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT ) , guid : :: windows :: core :: GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c) , } }
 pub const WPD_OBJECT_FORMAT_3G2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb9850000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_3G2 ) , guid : :: windows :: core :: GUID::from_u128(0xb9850000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_3G2A: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1a11202d_8759_4e34_ba5e_b1211087eee4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_3G2A ) , guid : :: windows :: core :: GUID::from_u128(0x1a11202d_8759_4e34_ba5e_b1211087eee4) , } }
 pub const WPD_OBJECT_FORMAT_3GP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb9840000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_3GP ) , guid : :: windows :: core :: GUID::from_u128(0xb9840000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_3GPA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe5172730_f971_41ef_a10b_2271a0019d7a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_3GPA ) , guid : :: windows :: core :: GUID::from_u128(0xe5172730_f971_41ef_a10b_2271a0019d7a) , } }
 pub const WPD_OBJECT_FORMAT_AAC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb9030000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_AAC ) , guid : :: windows :: core :: GUID::from_u128(0xb9030000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_ABSTRACT_CONTACT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbb810000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_ABSTRACT_CONTACT ) , guid : :: windows :: core :: GUID::from_u128(0xbb810000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_ABSTRACT_CONTACT_GROUP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xba060000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_ABSTRACT_CONTACT_GROUP ) , guid : :: windows :: core :: GUID::from_u128(0xba060000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_ABSTRACT_MEDIA_CAST: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xba0b0000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_ABSTRACT_MEDIA_CAST ) , guid : :: windows :: core :: GUID::from_u128(0xba0b0000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_AIFF: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x30070000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_AIFF ) , guid : :: windows :: core :: GUID::from_u128(0x30070000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_ALL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc1f62eb2_4bb3_479c_9cfa_05b5f3a57b22);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_ALL ) , guid : :: windows :: core :: GUID::from_u128(0xc1f62eb2_4bb3_479c_9cfa_05b5f3a57b22) , } }
 pub const WPD_OBJECT_FORMAT_AMR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb9080000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_AMR ) , guid : :: windows :: core :: GUID::from_u128(0xb9080000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_ASF: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x300c0000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_ASF ) , guid : :: windows :: core :: GUID::from_u128(0x300c0000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_ASXPLAYLIST: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xba130000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_ASXPLAYLIST ) , guid : :: windows :: core :: GUID::from_u128(0xba130000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_ATSCTS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb9870000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_ATSCTS ) , guid : :: windows :: core :: GUID::from_u128(0xb9870000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_AUDIBLE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb9040000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_AUDIBLE ) , guid : :: windows :: core :: GUID::from_u128(0xb9040000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_AVCHD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb9860000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_AVCHD ) , guid : :: windows :: core :: GUID::from_u128(0xb9860000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_AVI: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x300a0000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_AVI ) , guid : :: windows :: core :: GUID::from_u128(0x300a0000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_BMP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x38040000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_BMP ) , guid : :: windows :: core :: GUID::from_u128(0x38040000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_CIFF: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x38050000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_CIFF ) , guid : :: windows :: core :: GUID::from_u128(0x38050000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_DPOF: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x30060000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_DPOF ) , guid : :: windows :: core :: GUID::from_u128(0x30060000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_DVBTS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb9880000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_DVBTS ) , guid : :: windows :: core :: GUID::from_u128(0xb9880000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_EXECUTABLE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x30030000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_EXECUTABLE ) , guid : :: windows :: core :: GUID::from_u128(0x30030000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_EXIF: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x38010000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_EXIF ) , guid : :: windows :: core :: GUID::from_u128(0x38010000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_FLAC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb9060000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_FLAC ) , guid : :: windows :: core :: GUID::from_u128(0xb9060000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_FLASHPIX: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x38030000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_FLASHPIX ) , guid : :: windows :: core :: GUID::from_u128(0x38030000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_GIF: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x38070000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_GIF ) , guid : :: windows :: core :: GUID::from_u128(0x38070000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_HTML: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x30050000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_HTML ) , guid : :: windows :: core :: GUID::from_u128(0x30050000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_ICALENDAR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbe030000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_ICALENDAR ) , guid : :: windows :: core :: GUID::from_u128(0xbe030000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_ICON: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x077232ed_102c_4638_9c22_83f142bfc822);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_ICON ) , guid : :: windows :: core :: GUID::from_u128(0x077232ed_102c_4638_9c22_83f142bfc822) , } }
 pub const WPD_OBJECT_FORMAT_JFIF: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x38080000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_JFIF ) , guid : :: windows :: core :: GUID::from_u128(0x38080000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_JP2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x380f0000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_JP2 ) , guid : :: windows :: core :: GUID::from_u128(0x380f0000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_JPEGXR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb8040000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_JPEGXR ) , guid : :: windows :: core :: GUID::from_u128(0xb8040000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_JPX: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x38100000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_JPX ) , guid : :: windows :: core :: GUID::from_u128(0x38100000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_M3UPLAYLIST: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xba110000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_M3UPLAYLIST ) , guid : :: windows :: core :: GUID::from_u128(0xba110000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_M4A: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x30aba7ac_6ffd_4c23_a359_3e9b52f3f1c8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_M4A ) , guid : :: windows :: core :: GUID::from_u128(0x30aba7ac_6ffd_4c23_a359_3e9b52f3f1c8) , } }
 pub const WPD_OBJECT_FORMAT_MHT_COMPILED_HTML: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xba840000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_MHT_COMPILED_HTML ) , guid : :: windows :: core :: GUID::from_u128(0xba840000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_MICROSOFT_EXCEL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xba850000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_MICROSOFT_EXCEL ) , guid : :: windows :: core :: GUID::from_u128(0xba850000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_MICROSOFT_POWERPOINT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xba860000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_MICROSOFT_POWERPOINT ) , guid : :: windows :: core :: GUID::from_u128(0xba860000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_MICROSOFT_WFC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb1040000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_MICROSOFT_WFC ) , guid : :: windows :: core :: GUID::from_u128(0xb1040000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_MICROSOFT_WORD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xba830000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_MICROSOFT_WORD ) , guid : :: windows :: core :: GUID::from_u128(0xba830000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_MKV: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb9900000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_MKV ) , guid : :: windows :: core :: GUID::from_u128(0xb9900000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_MP2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb9830000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_MP2 ) , guid : :: windows :: core :: GUID::from_u128(0xb9830000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_MP3: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x30090000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_MP3 ) , guid : :: windows :: core :: GUID::from_u128(0x30090000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_MP4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb9820000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_MP4 ) , guid : :: windows :: core :: GUID::from_u128(0xb9820000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_MPEG: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x300b0000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_MPEG ) , guid : :: windows :: core :: GUID::from_u128(0x300b0000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_MPLPLAYLIST: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xba120000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_MPLPLAYLIST ) , guid : :: windows :: core :: GUID::from_u128(0xba120000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_NETWORK_ASSOCIATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb1020000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_NETWORK_ASSOCIATION ) , guid : :: windows :: core :: GUID::from_u128(0xb1020000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_OGG: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb9020000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_OGG ) , guid : :: windows :: core :: GUID::from_u128(0xb9020000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_PCD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x38090000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_PCD ) , guid : :: windows :: core :: GUID::from_u128(0x38090000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_PICT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x380a0000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_PICT ) , guid : :: windows :: core :: GUID::from_u128(0x380a0000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_PLSPLAYLIST: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xba140000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_PLSPLAYLIST ) , guid : :: windows :: core :: GUID::from_u128(0xba140000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_PNG: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x380b0000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_PNG ) , guid : :: windows :: core :: GUID::from_u128(0x380b0000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_PROPERTIES_ONLY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x30010000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_PROPERTIES_ONLY ) , guid : :: windows :: core :: GUID::from_u128(0x30010000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_QCELP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb9070000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_QCELP ) , guid : :: windows :: core :: GUID::from_u128(0xb9070000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_SCRIPT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x30020000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_SCRIPT ) , guid : :: windows :: core :: GUID::from_u128(0x30020000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_TEXT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x30040000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_TEXT ) , guid : :: windows :: core :: GUID::from_u128(0x30040000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_TIFF: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x380d0000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_TIFF ) , guid : :: windows :: core :: GUID::from_u128(0x380d0000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_TIFFEP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x38020000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_TIFFEP ) , guid : :: windows :: core :: GUID::from_u128(0x38020000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_TIFFIT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x380e0000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_TIFFIT ) , guid : :: windows :: core :: GUID::from_u128(0x380e0000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_UNSPECIFIED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x30000000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_UNSPECIFIED ) , guid : :: windows :: core :: GUID::from_u128(0x30000000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_VCALENDAR1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbe020000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_VCALENDAR1 ) , guid : :: windows :: core :: GUID::from_u128(0xbe020000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_VCARD2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbb820000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_VCARD2 ) , guid : :: windows :: core :: GUID::from_u128(0xbb820000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_VCARD3: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbb830000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_VCARD3 ) , guid : :: windows :: core :: GUID::from_u128(0xbb830000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_WAVE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x30080000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_WAVE ) , guid : :: windows :: core :: GUID::from_u128(0x30080000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_WBMP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb8030000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_WBMP ) , guid : :: windows :: core :: GUID::from_u128(0xb8030000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_WINDOWSIMAGEFORMAT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb8810000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_WINDOWSIMAGEFORMAT ) , guid : :: windows :: core :: GUID::from_u128(0xb8810000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_WMA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb9010000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_WMA ) , guid : :: windows :: core :: GUID::from_u128(0xb9010000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_WMV: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb9810000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_WMV ) , guid : :: windows :: core :: GUID::from_u128(0xb9810000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_WPLPLAYLIST: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xba100000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_WPLPLAYLIST ) , guid : :: windows :: core :: GUID::from_u128(0xba100000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_X509V3CERTIFICATE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb1030000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_X509V3CERTIFICATE ) , guid : :: windows :: core :: GUID::from_u128(0xb1030000_ae6c_4804_98ba_c57b46965fe7) , } }
 pub const WPD_OBJECT_FORMAT_XML: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xba820000_ae6c_4804_98ba_c57b46965fe7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_FORMAT_XML ) , guid : :: windows :: core :: GUID::from_u128(0xba820000_ae6c_4804_98ba_c57b46965fe7) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OBJECT_GENERATE_THUMBNAIL_FROM_RESOURCE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c), pid: 24u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_GENERATE_THUMBNAIL_FROM_RESOURCE ) , guid : :: windows :: core :: GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OBJECT_HINT_LOCATION_DISPLAY_NAME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c), pid: 25u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_HINT_LOCATION_DISPLAY_NAME ) , guid : :: windows :: core :: GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OBJECT_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_ID ) , guid : :: windows :: core :: GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OBJECT_ISHIDDEN: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_ISHIDDEN ) , guid : :: windows :: core :: GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OBJECT_ISSYSTEM: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_ISSYSTEM ) , guid : :: windows :: core :: GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OBJECT_IS_DRM_PROTECTED: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c), pid: 17u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_IS_DRM_PROTECTED ) , guid : :: windows :: core :: GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OBJECT_KEYWORDS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c), pid: 15u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_KEYWORDS ) , guid : :: windows :: core :: GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OBJECT_LANGUAGE_LOCALE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c), pid: 27u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_LANGUAGE_LOCALE ) , guid : :: windows :: core :: GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OBJECT_NAME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_NAME ) , guid : :: windows :: core :: GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OBJECT_NON_CONSUMABLE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_NON_CONSUMABLE ) , guid : :: windows :: core :: GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OBJECT_ORIGINAL_FILE_NAME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_ORIGINAL_FILE_NAME ) , guid : :: windows :: core :: GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OBJECT_PARENT_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_PARENT_ID ) , guid : :: windows :: core :: GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OBJECT_PERSISTENT_UNIQUE_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_PERSISTENT_UNIQUE_ID ) , guid : :: windows :: core :: GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c) , } }
 pub const WPD_OBJECT_PROPERTIES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_PROPERTIES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c) , } }
 pub const WPD_OBJECT_PROPERTIES_V2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0373cd3d_4a46_40d7_b4d8_73e8da74e775);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_PROPERTIES_V2 ) , guid : :: windows :: core :: GUID::from_u128(0x0373cd3d_4a46_40d7_b4d8_73e8da74e775) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OBJECT_REFERENCES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_REFERENCES ) , guid : :: windows :: core :: GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OBJECT_SIZE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_SIZE ) , guid : :: windows :: core :: GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OBJECT_SUPPORTED_UNITS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0373cd3d_4a46_40d7_b4d8_73e8da74e775), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_SUPPORTED_UNITS ) , guid : :: windows :: core :: GUID::from_u128(0x0373cd3d_4a46_40d7_b4d8_73e8da74e775) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OBJECT_SYNC_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c), pid: 16u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OBJECT_SYNC_ID ) , guid : :: windows :: core :: GUID::from_u128(0xef6b490d_5cd8_437a_affc_da8b60ee4a3c) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
 pub type WPD_OPERATION_STATES = i32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
@@ -4935,58 +5937,96 @@ pub const WPD_OPERATION_STATE_ABORTED: WPD_OPERATION_STATES = 6i32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OPTION_OBJECT_MANAGEMENT_RECURSIVE_DELETE_SUPPORTED: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089), pid: 5001u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OPTION_OBJECT_MANAGEMENT_RECURSIVE_DELETE_SUPPORTED ) , guid : :: windows :: core :: GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OPTION_OBJECT_RESOURCES_NO_INPUT_BUFFER_ON_READ: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 5003u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OPTION_OBJECT_RESOURCES_NO_INPUT_BUFFER_ON_READ ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OPTION_OBJECT_RESOURCES_SEEK_ON_READ_SUPPORTED: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 5001u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OPTION_OBJECT_RESOURCES_SEEK_ON_READ_SUPPORTED ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OPTION_OBJECT_RESOURCES_SEEK_ON_WRITE_SUPPORTED: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 5002u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OPTION_OBJECT_RESOURCES_SEEK_ON_WRITE_SUPPORTED ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OPTION_SMS_BINARY_MESSAGE_SUPPORTED: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xafc25d66_fe0d_4114_9097_970c93e920d1), pid: 5001u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OPTION_SMS_BINARY_MESSAGE_SUPPORTED ) , guid : :: windows :: core :: GUID::from_u128(0xafc25d66_fe0d_4114_9097_970c93e920d1) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_OPTION_VALID_OBJECT_IDS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a), pid: 5001u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_OPTION_VALID_OBJECT_IDS ) , guid : :: windows :: core :: GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a) , } }
 pub const WPD_PARAMETER_ATTRIBUTES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe6864dd7_f325_45ea_a1d5_97cf73b6ca58);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PARAMETER_ATTRIBUTES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0xe6864dd7_f325_45ea_a1d5_97cf73b6ca58) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PARAMETER_ATTRIBUTE_DEFAULT_VALUE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe6864dd7_f325_45ea_a1d5_97cf73b6ca58), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PARAMETER_ATTRIBUTE_DEFAULT_VALUE ) , guid : :: windows :: core :: GUID::from_u128(0xe6864dd7_f325_45ea_a1d5_97cf73b6ca58) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PARAMETER_ATTRIBUTE_ENUMERATION_ELEMENTS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe6864dd7_f325_45ea_a1d5_97cf73b6ca58), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PARAMETER_ATTRIBUTE_ENUMERATION_ELEMENTS ) , guid : :: windows :: core :: GUID::from_u128(0xe6864dd7_f325_45ea_a1d5_97cf73b6ca58) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PARAMETER_ATTRIBUTE_FORM: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe6864dd7_f325_45ea_a1d5_97cf73b6ca58), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PARAMETER_ATTRIBUTE_FORM ) , guid : :: windows :: core :: GUID::from_u128(0xe6864dd7_f325_45ea_a1d5_97cf73b6ca58) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PARAMETER_ATTRIBUTE_MAX_SIZE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe6864dd7_f325_45ea_a1d5_97cf73b6ca58), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PARAMETER_ATTRIBUTE_MAX_SIZE ) , guid : :: windows :: core :: GUID::from_u128(0xe6864dd7_f325_45ea_a1d5_97cf73b6ca58) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PARAMETER_ATTRIBUTE_NAME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe6864dd7_f325_45ea_a1d5_97cf73b6ca58), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PARAMETER_ATTRIBUTE_NAME ) , guid : :: windows :: core :: GUID::from_u128(0xe6864dd7_f325_45ea_a1d5_97cf73b6ca58) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PARAMETER_ATTRIBUTE_ORDER: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe6864dd7_f325_45ea_a1d5_97cf73b6ca58), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PARAMETER_ATTRIBUTE_ORDER ) , guid : :: windows :: core :: GUID::from_u128(0xe6864dd7_f325_45ea_a1d5_97cf73b6ca58) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PARAMETER_ATTRIBUTE_RANGE_MAX: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe6864dd7_f325_45ea_a1d5_97cf73b6ca58), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PARAMETER_ATTRIBUTE_RANGE_MAX ) , guid : :: windows :: core :: GUID::from_u128(0xe6864dd7_f325_45ea_a1d5_97cf73b6ca58) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PARAMETER_ATTRIBUTE_RANGE_MIN: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe6864dd7_f325_45ea_a1d5_97cf73b6ca58), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PARAMETER_ATTRIBUTE_RANGE_MIN ) , guid : :: windows :: core :: GUID::from_u128(0xe6864dd7_f325_45ea_a1d5_97cf73b6ca58) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PARAMETER_ATTRIBUTE_RANGE_STEP: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe6864dd7_f325_45ea_a1d5_97cf73b6ca58), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PARAMETER_ATTRIBUTE_RANGE_STEP ) , guid : :: windows :: core :: GUID::from_u128(0xe6864dd7_f325_45ea_a1d5_97cf73b6ca58) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PARAMETER_ATTRIBUTE_REGULAR_EXPRESSION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe6864dd7_f325_45ea_a1d5_97cf73b6ca58), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PARAMETER_ATTRIBUTE_REGULAR_EXPRESSION ) , guid : :: windows :: core :: GUID::from_u128(0xe6864dd7_f325_45ea_a1d5_97cf73b6ca58) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PARAMETER_ATTRIBUTE_USAGE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe6864dd7_f325_45ea_a1d5_97cf73b6ca58), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PARAMETER_ATTRIBUTE_USAGE ) , guid : :: windows :: core :: GUID::from_u128(0xe6864dd7_f325_45ea_a1d5_97cf73b6ca58) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PARAMETER_ATTRIBUTE_VARTYPE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe6864dd7_f325_45ea_a1d5_97cf73b6ca58), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PARAMETER_ATTRIBUTE_VARTYPE ) , guid : :: windows :: core :: GUID::from_u128(0xe6864dd7_f325_45ea_a1d5_97cf73b6ca58) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
 pub type WPD_PARAMETER_USAGE_TYPES = i32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
@@ -5004,454 +6044,760 @@ pub const WPD_POWER_SOURCE_BATTERY: WPD_POWER_SOURCES = 0i32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
 pub const WPD_POWER_SOURCE_EXTERNAL: WPD_POWER_SOURCES = 1i32;
 pub const WPD_PROPERTIES_MTP_VENDOR_EXTENDED_DEVICE_PROPS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d545058_8900_40b3_8f1d_dc246e1e8370);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTIES_MTP_VENDOR_EXTENDED_DEVICE_PROPS ) , guid : :: windows :: core :: GUID::from_u128(0x4d545058_8900_40b3_8f1d_dc246e1e8370) , } }
 pub const WPD_PROPERTIES_MTP_VENDOR_EXTENDED_OBJECT_PROPS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d545058_4fce_4578_95c8_8698a9bc0f49);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTIES_MTP_VENDOR_EXTENDED_OBJECT_PROPS ) , guid : :: windows :: core :: GUID::from_u128(0x4d545058_4fce_4578_95c8_8698a9bc0f49) , } }
 pub const WPD_PROPERTY_ATTRIBUTES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xab7943d8_6332_445f_a00d_8d5ef1e96f37);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_ATTRIBUTES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0xab7943d8_6332_445f_a00d_8d5ef1e96f37) , } }
 pub const WPD_PROPERTY_ATTRIBUTES_V2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5d9da160_74ae_43cc_85a9_fe555a80798e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_ATTRIBUTES_V2 ) , guid : :: windows :: core :: GUID::from_u128(0x5d9da160_74ae_43cc_85a9_fe555a80798e) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_ATTRIBUTE_CAN_DELETE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xab7943d8_6332_445f_a00d_8d5ef1e96f37), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_ATTRIBUTE_CAN_DELETE ) , guid : :: windows :: core :: GUID::from_u128(0xab7943d8_6332_445f_a00d_8d5ef1e96f37) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_ATTRIBUTE_CAN_READ: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xab7943d8_6332_445f_a00d_8d5ef1e96f37), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_ATTRIBUTE_CAN_READ ) , guid : :: windows :: core :: GUID::from_u128(0xab7943d8_6332_445f_a00d_8d5ef1e96f37) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_ATTRIBUTE_CAN_WRITE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xab7943d8_6332_445f_a00d_8d5ef1e96f37), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_ATTRIBUTE_CAN_WRITE ) , guid : :: windows :: core :: GUID::from_u128(0xab7943d8_6332_445f_a00d_8d5ef1e96f37) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_ATTRIBUTE_DEFAULT_VALUE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xab7943d8_6332_445f_a00d_8d5ef1e96f37), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_ATTRIBUTE_DEFAULT_VALUE ) , guid : :: windows :: core :: GUID::from_u128(0xab7943d8_6332_445f_a00d_8d5ef1e96f37) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_ATTRIBUTE_ENUMERATION_ELEMENTS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xab7943d8_6332_445f_a00d_8d5ef1e96f37), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_ATTRIBUTE_ENUMERATION_ELEMENTS ) , guid : :: windows :: core :: GUID::from_u128(0xab7943d8_6332_445f_a00d_8d5ef1e96f37) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_ATTRIBUTE_FAST_PROPERTY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xab7943d8_6332_445f_a00d_8d5ef1e96f37), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_ATTRIBUTE_FAST_PROPERTY ) , guid : :: windows :: core :: GUID::from_u128(0xab7943d8_6332_445f_a00d_8d5ef1e96f37) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_ATTRIBUTE_FORM: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xab7943d8_6332_445f_a00d_8d5ef1e96f37), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_ATTRIBUTE_FORM ) , guid : :: windows :: core :: GUID::from_u128(0xab7943d8_6332_445f_a00d_8d5ef1e96f37) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_ATTRIBUTE_MAX_SIZE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xab7943d8_6332_445f_a00d_8d5ef1e96f37), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_ATTRIBUTE_MAX_SIZE ) , guid : :: windows :: core :: GUID::from_u128(0xab7943d8_6332_445f_a00d_8d5ef1e96f37) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_ATTRIBUTE_NAME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5d9da160_74ae_43cc_85a9_fe555a80798e), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_ATTRIBUTE_NAME ) , guid : :: windows :: core :: GUID::from_u128(0x5d9da160_74ae_43cc_85a9_fe555a80798e) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_ATTRIBUTE_RANGE_MAX: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xab7943d8_6332_445f_a00d_8d5ef1e96f37), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_ATTRIBUTE_RANGE_MAX ) , guid : :: windows :: core :: GUID::from_u128(0xab7943d8_6332_445f_a00d_8d5ef1e96f37) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_ATTRIBUTE_RANGE_MIN: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xab7943d8_6332_445f_a00d_8d5ef1e96f37), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_ATTRIBUTE_RANGE_MIN ) , guid : :: windows :: core :: GUID::from_u128(0xab7943d8_6332_445f_a00d_8d5ef1e96f37) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_ATTRIBUTE_RANGE_STEP: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xab7943d8_6332_445f_a00d_8d5ef1e96f37), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_ATTRIBUTE_RANGE_STEP ) , guid : :: windows :: core :: GUID::from_u128(0xab7943d8_6332_445f_a00d_8d5ef1e96f37) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_ATTRIBUTE_REGULAR_EXPRESSION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xab7943d8_6332_445f_a00d_8d5ef1e96f37), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_ATTRIBUTE_REGULAR_EXPRESSION ) , guid : :: windows :: core :: GUID::from_u128(0xab7943d8_6332_445f_a00d_8d5ef1e96f37) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_ATTRIBUTE_VARTYPE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5d9da160_74ae_43cc_85a9_fe555a80798e), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_ATTRIBUTE_VARTYPE ) , guid : :: windows :: core :: GUID::from_u128(0x5d9da160_74ae_43cc_85a9_fe555a80798e) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_CAPABILITIES_COMMAND: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356), pid: 1002u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_CAPABILITIES_COMMAND ) , guid : :: windows :: core :: GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_CAPABILITIES_COMMAND_OPTIONS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356), pid: 1003u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_CAPABILITIES_COMMAND_OPTIONS ) , guid : :: windows :: core :: GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_CAPABILITIES_CONTENT_TYPE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356), pid: 1008u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_CAPABILITIES_CONTENT_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_CAPABILITIES_CONTENT_TYPES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356), pid: 1007u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_CAPABILITIES_CONTENT_TYPES ) , guid : :: windows :: core :: GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_CAPABILITIES_EVENT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356), pid: 1014u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_CAPABILITIES_EVENT ) , guid : :: windows :: core :: GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_CAPABILITIES_EVENT_OPTIONS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356), pid: 1015u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_CAPABILITIES_EVENT_OPTIONS ) , guid : :: windows :: core :: GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_CAPABILITIES_FORMAT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356), pid: 1010u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_CAPABILITIES_FORMAT ) , guid : :: windows :: core :: GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_CAPABILITIES_FORMATS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356), pid: 1009u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_CAPABILITIES_FORMATS ) , guid : :: windows :: core :: GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_CAPABILITIES_FUNCTIONAL_CATEGORIES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356), pid: 1004u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_CAPABILITIES_FUNCTIONAL_CATEGORIES ) , guid : :: windows :: core :: GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_CAPABILITIES_FUNCTIONAL_CATEGORY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356), pid: 1005u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_CAPABILITIES_FUNCTIONAL_CATEGORY ) , guid : :: windows :: core :: GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_CAPABILITIES_FUNCTIONAL_OBJECTS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356), pid: 1006u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_CAPABILITIES_FUNCTIONAL_OBJECTS ) , guid : :: windows :: core :: GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_CAPABILITIES_PROPERTY_ATTRIBUTES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356), pid: 1012u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_CAPABILITIES_PROPERTY_ATTRIBUTES ) , guid : :: windows :: core :: GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_CAPABILITIES_PROPERTY_KEYS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356), pid: 1011u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_CAPABILITIES_PROPERTY_KEYS ) , guid : :: windows :: core :: GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_CAPABILITIES_SUPPORTED_COMMANDS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356), pid: 1001u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_CAPABILITIES_SUPPORTED_COMMANDS ) , guid : :: windows :: core :: GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_CAPABILITIES_SUPPORTED_EVENTS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356), pid: 1013u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_CAPABILITIES_SUPPORTED_EVENTS ) , guid : :: windows :: core :: GUID::from_u128(0x0cabec78_6b74_41c6_9216_2639d1fce356) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_CLASS_EXTENSION_DEVICE_INFORMATION_VALUES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x33fb0d11_64a3_4fac_b4c7_3dfeaa99b051), pid: 1001u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_CLASS_EXTENSION_DEVICE_INFORMATION_VALUES ) , guid : :: windows :: core :: GUID::from_u128(0x33fb0d11_64a3_4fac_b4c7_3dfeaa99b051) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_CLASS_EXTENSION_DEVICE_INFORMATION_WRITE_RESULTS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x33fb0d11_64a3_4fac_b4c7_3dfeaa99b051), pid: 1002u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_CLASS_EXTENSION_DEVICE_INFORMATION_WRITE_RESULTS ) , guid : :: windows :: core :: GUID::from_u128(0x33fb0d11_64a3_4fac_b4c7_3dfeaa99b051) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_CLASS_EXTENSION_SERVICE_INTERFACES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7f0779b5_fa2b_4766_9cb2_f73ba30b6758), pid: 1002u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_CLASS_EXTENSION_SERVICE_INTERFACES ) , guid : :: windows :: core :: GUID::from_u128(0x7f0779b5_fa2b_4766_9cb2_f73ba30b6758) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_CLASS_EXTENSION_SERVICE_OBJECT_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7f0779b5_fa2b_4766_9cb2_f73ba30b6758), pid: 1001u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_CLASS_EXTENSION_SERVICE_OBJECT_ID ) , guid : :: windows :: core :: GUID::from_u128(0x7f0779b5_fa2b_4766_9cb2_f73ba30b6758) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_CLASS_EXTENSION_SERVICE_REGISTRATION_RESULTS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7f0779b5_fa2b_4766_9cb2_f73ba30b6758), pid: 1003u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_CLASS_EXTENSION_SERVICE_REGISTRATION_RESULTS ) , guid : :: windows :: core :: GUID::from_u128(0x7f0779b5_fa2b_4766_9cb2_f73ba30b6758) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_COMMON_ACTIVITY_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a), pid: 1011u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_COMMON_ACTIVITY_ID ) , guid : :: windows :: core :: GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_COMMON_CLIENT_INFORMATION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a), pid: 1009u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_COMMON_CLIENT_INFORMATION ) , guid : :: windows :: core :: GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_COMMON_CLIENT_INFORMATION_CONTEXT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a), pid: 1010u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_COMMON_CLIENT_INFORMATION_CONTEXT ) , guid : :: windows :: core :: GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_COMMON_COMMAND_CATEGORY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a), pid: 1001u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_COMMON_COMMAND_CATEGORY ) , guid : :: windows :: core :: GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_COMMON_COMMAND_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a), pid: 1002u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_COMMON_COMMAND_ID ) , guid : :: windows :: core :: GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_COMMON_COMMAND_TARGET: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a), pid: 1006u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_COMMON_COMMAND_TARGET ) , guid : :: windows :: core :: GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_COMMON_DRIVER_ERROR_CODE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a), pid: 1004u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_COMMON_DRIVER_ERROR_CODE ) , guid : :: windows :: core :: GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_COMMON_HRESULT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a), pid: 1003u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_COMMON_HRESULT ) , guid : :: windows :: core :: GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_COMMON_OBJECT_IDS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a), pid: 1008u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_COMMON_OBJECT_IDS ) , guid : :: windows :: core :: GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_COMMON_PERSISTENT_UNIQUE_IDS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a), pid: 1007u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_COMMON_PERSISTENT_UNIQUE_IDS ) , guid : :: windows :: core :: GUID::from_u128(0xf0422a9c_5dc8_4440_b5bd_5df28835658a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_DEVICE_HINTS_CONTENT_LOCATIONS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0d5fb92b_cb46_4c4f_8343_0bc3d3f17c84), pid: 1002u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_DEVICE_HINTS_CONTENT_LOCATIONS ) , guid : :: windows :: core :: GUID::from_u128(0x0d5fb92b_cb46_4c4f_8343_0bc3d3f17c84) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_DEVICE_HINTS_CONTENT_TYPE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0d5fb92b_cb46_4c4f_8343_0bc3d3f17c84), pid: 1001u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_DEVICE_HINTS_CONTENT_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x0d5fb92b_cb46_4c4f_8343_0bc3d3f17c84) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_MTP_EXT_EVENT_PARAMS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d545058_ef88_4e4d_95c3_4f327f728a96), pid: 1011u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_MTP_EXT_EVENT_PARAMS ) , guid : :: windows :: core :: GUID::from_u128(0x4d545058_ef88_4e4d_95c3_4f327f728a96) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_MTP_EXT_OPERATION_CODE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56), pid: 1001u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_MTP_EXT_OPERATION_CODE ) , guid : :: windows :: core :: GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_MTP_EXT_OPERATION_PARAMS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56), pid: 1002u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_MTP_EXT_OPERATION_PARAMS ) , guid : :: windows :: core :: GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_MTP_EXT_OPTIMAL_TRANSFER_BUFFER_SIZE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56), pid: 1013u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_MTP_EXT_OPTIMAL_TRANSFER_BUFFER_SIZE ) , guid : :: windows :: core :: GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_MTP_EXT_RESPONSE_CODE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56), pid: 1003u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_MTP_EXT_RESPONSE_CODE ) , guid : :: windows :: core :: GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_MTP_EXT_RESPONSE_PARAMS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56), pid: 1004u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_MTP_EXT_RESPONSE_PARAMS ) , guid : :: windows :: core :: GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_MTP_EXT_TRANSFER_CONTEXT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56), pid: 1006u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_MTP_EXT_TRANSFER_CONTEXT ) , guid : :: windows :: core :: GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_MTP_EXT_TRANSFER_DATA: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56), pid: 1012u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_MTP_EXT_TRANSFER_DATA ) , guid : :: windows :: core :: GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_MTP_EXT_TRANSFER_NUM_BYTES_READ: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56), pid: 1009u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_MTP_EXT_TRANSFER_NUM_BYTES_READ ) , guid : :: windows :: core :: GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_MTP_EXT_TRANSFER_NUM_BYTES_TO_READ: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56), pid: 1008u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_MTP_EXT_TRANSFER_NUM_BYTES_TO_READ ) , guid : :: windows :: core :: GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_MTP_EXT_TRANSFER_NUM_BYTES_TO_WRITE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56), pid: 1010u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_MTP_EXT_TRANSFER_NUM_BYTES_TO_WRITE ) , guid : :: windows :: core :: GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_MTP_EXT_TRANSFER_NUM_BYTES_WRITTEN: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56), pid: 1011u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_MTP_EXT_TRANSFER_NUM_BYTES_WRITTEN ) , guid : :: windows :: core :: GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_MTP_EXT_TRANSFER_TOTAL_DATA_SIZE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56), pid: 1007u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_MTP_EXT_TRANSFER_TOTAL_DATA_SIZE ) , guid : :: windows :: core :: GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_MTP_EXT_VENDOR_EXTENSION_DESCRIPTION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56), pid: 1014u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_MTP_EXT_VENDOR_EXTENSION_DESCRIPTION ) , guid : :: windows :: core :: GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_MTP_EXT_VENDOR_OPERATION_CODES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56), pid: 1005u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_MTP_EXT_VENDOR_OPERATION_CODES ) , guid : :: windows :: core :: GUID::from_u128(0x4d545058_1a2e_4106_a357_771e0819fc56) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_NULL: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00000000_0000_0000_0000_000000000000), pid: 0u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_NULL ) , guid : :: windows :: core :: GUID::from_u128(0x00000000_0000_0000_0000_000000000000) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_ENUMERATION_CONTEXT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb7474e91_e7f8_4ad9_b400_ad1a4b58eeec), pid: 1004u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_ENUMERATION_CONTEXT ) , guid : :: windows :: core :: GUID::from_u128(0xb7474e91_e7f8_4ad9_b400_ad1a4b58eeec) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_ENUMERATION_FILTER: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb7474e91_e7f8_4ad9_b400_ad1a4b58eeec), pid: 1002u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_ENUMERATION_FILTER ) , guid : :: windows :: core :: GUID::from_u128(0xb7474e91_e7f8_4ad9_b400_ad1a4b58eeec) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_ENUMERATION_NUM_OBJECTS_REQUESTED: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb7474e91_e7f8_4ad9_b400_ad1a4b58eeec), pid: 1005u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_ENUMERATION_NUM_OBJECTS_REQUESTED ) , guid : :: windows :: core :: GUID::from_u128(0xb7474e91_e7f8_4ad9_b400_ad1a4b58eeec) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_ENUMERATION_OBJECT_IDS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb7474e91_e7f8_4ad9_b400_ad1a4b58eeec), pid: 1003u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_ENUMERATION_OBJECT_IDS ) , guid : :: windows :: core :: GUID::from_u128(0xb7474e91_e7f8_4ad9_b400_ad1a4b58eeec) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_ENUMERATION_PARENT_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb7474e91_e7f8_4ad9_b400_ad1a4b58eeec), pid: 1001u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_ENUMERATION_PARENT_ID ) , guid : :: windows :: core :: GUID::from_u128(0xb7474e91_e7f8_4ad9_b400_ad1a4b58eeec) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_MANAGEMENT_CONTEXT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089), pid: 1002u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_MANAGEMENT_CONTEXT ) , guid : :: windows :: core :: GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_MANAGEMENT_COPY_RESULTS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089), pid: 1013u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_MANAGEMENT_COPY_RESULTS ) , guid : :: windows :: core :: GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_MANAGEMENT_CREATION_PROPERTIES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089), pid: 1001u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_MANAGEMENT_CREATION_PROPERTIES ) , guid : :: windows :: core :: GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_MANAGEMENT_DATA: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089), pid: 1005u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_MANAGEMENT_DATA ) , guid : :: windows :: core :: GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_MANAGEMENT_DELETE_OPTIONS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089), pid: 1007u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_MANAGEMENT_DELETE_OPTIONS ) , guid : :: windows :: core :: GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_MANAGEMENT_DELETE_RESULTS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089), pid: 1010u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_MANAGEMENT_DELETE_RESULTS ) , guid : :: windows :: core :: GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_MANAGEMENT_DESTINATION_FOLDER_OBJECT_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089), pid: 1011u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_MANAGEMENT_DESTINATION_FOLDER_OBJECT_ID ) , guid : :: windows :: core :: GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_MANAGEMENT_MOVE_RESULTS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089), pid: 1012u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_MANAGEMENT_MOVE_RESULTS ) , guid : :: windows :: core :: GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_MANAGEMENT_NUM_BYTES_TO_WRITE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089), pid: 1003u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_MANAGEMENT_NUM_BYTES_TO_WRITE ) , guid : :: windows :: core :: GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_MANAGEMENT_NUM_BYTES_WRITTEN: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089), pid: 1004u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_MANAGEMENT_NUM_BYTES_WRITTEN ) , guid : :: windows :: core :: GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_MANAGEMENT_OBJECT_FORMAT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089), pid: 1016u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_MANAGEMENT_OBJECT_FORMAT ) , guid : :: windows :: core :: GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_MANAGEMENT_OBJECT_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089), pid: 1006u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_MANAGEMENT_OBJECT_ID ) , guid : :: windows :: core :: GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_MANAGEMENT_OBJECT_IDS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089), pid: 1009u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_MANAGEMENT_OBJECT_IDS ) , guid : :: windows :: core :: GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_MANAGEMENT_OPTIMAL_TRANSFER_BUFFER_SIZE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089), pid: 1008u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_MANAGEMENT_OPTIMAL_TRANSFER_BUFFER_SIZE ) , guid : :: windows :: core :: GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_MANAGEMENT_PROPERTY_KEYS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089), pid: 1015u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_MANAGEMENT_PROPERTY_KEYS ) , guid : :: windows :: core :: GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_MANAGEMENT_UPDATE_PROPERTIES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089), pid: 1014u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_MANAGEMENT_UPDATE_PROPERTIES ) , guid : :: windows :: core :: GUID::from_u128(0xef1e43dd_a9ed_4341_8bcc_186192aea089) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_PROPERTIES_BULK_CONTEXT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e), pid: 1002u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_PROPERTIES_BULK_CONTEXT ) , guid : :: windows :: core :: GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_PROPERTIES_BULK_DEPTH: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e), pid: 1005u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_PROPERTIES_BULK_DEPTH ) , guid : :: windows :: core :: GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_PROPERTIES_BULK_OBJECT_FORMAT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e), pid: 1007u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_PROPERTIES_BULK_OBJECT_FORMAT ) , guid : :: windows :: core :: GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_PROPERTIES_BULK_OBJECT_IDS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e), pid: 1001u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_PROPERTIES_BULK_OBJECT_IDS ) , guid : :: windows :: core :: GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_PROPERTIES_BULK_PARENT_OBJECT_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e), pid: 1006u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_PROPERTIES_BULK_PARENT_OBJECT_ID ) , guid : :: windows :: core :: GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_PROPERTIES_BULK_PROPERTY_KEYS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e), pid: 1004u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_PROPERTIES_BULK_PROPERTY_KEYS ) , guid : :: windows :: core :: GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_PROPERTIES_BULK_VALUES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e), pid: 1003u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_PROPERTIES_BULK_VALUES ) , guid : :: windows :: core :: GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_PROPERTIES_BULK_WRITE_RESULTS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e), pid: 1008u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_PROPERTIES_BULK_WRITE_RESULTS ) , guid : :: windows :: core :: GUID::from_u128(0x11c824dd_04cd_4e4e_8c7b_f6efb794d84e) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_PROPERTIES_OBJECT_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9e5582e4_0814_44e6_981a_b2998d583804), pid: 1001u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_PROPERTIES_OBJECT_ID ) , guid : :: windows :: core :: GUID::from_u128(0x9e5582e4_0814_44e6_981a_b2998d583804) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_PROPERTIES_PROPERTY_ATTRIBUTES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9e5582e4_0814_44e6_981a_b2998d583804), pid: 1003u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_PROPERTIES_PROPERTY_ATTRIBUTES ) , guid : :: windows :: core :: GUID::from_u128(0x9e5582e4_0814_44e6_981a_b2998d583804) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_PROPERTIES_PROPERTY_DELETE_RESULTS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9e5582e4_0814_44e6_981a_b2998d583804), pid: 1006u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_PROPERTIES_PROPERTY_DELETE_RESULTS ) , guid : :: windows :: core :: GUID::from_u128(0x9e5582e4_0814_44e6_981a_b2998d583804) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_PROPERTIES_PROPERTY_KEYS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9e5582e4_0814_44e6_981a_b2998d583804), pid: 1002u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_PROPERTIES_PROPERTY_KEYS ) , guid : :: windows :: core :: GUID::from_u128(0x9e5582e4_0814_44e6_981a_b2998d583804) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_PROPERTIES_PROPERTY_VALUES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9e5582e4_0814_44e6_981a_b2998d583804), pid: 1004u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_PROPERTIES_PROPERTY_VALUES ) , guid : :: windows :: core :: GUID::from_u128(0x9e5582e4_0814_44e6_981a_b2998d583804) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_PROPERTIES_PROPERTY_WRITE_RESULTS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9e5582e4_0814_44e6_981a_b2998d583804), pid: 1005u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_PROPERTIES_PROPERTY_WRITE_RESULTS ) , guid : :: windows :: core :: GUID::from_u128(0x9e5582e4_0814_44e6_981a_b2998d583804) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_RESOURCES_ACCESS_MODE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 1002u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_RESOURCES_ACCESS_MODE ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_RESOURCES_CONTEXT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 1005u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_RESOURCES_CONTEXT ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_RESOURCES_DATA: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 1010u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_RESOURCES_DATA ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_RESOURCES_NUM_BYTES_READ: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 1007u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_RESOURCES_NUM_BYTES_READ ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_RESOURCES_NUM_BYTES_TO_READ: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 1006u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_RESOURCES_NUM_BYTES_TO_READ ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_RESOURCES_NUM_BYTES_TO_WRITE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 1008u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_RESOURCES_NUM_BYTES_TO_WRITE ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_RESOURCES_NUM_BYTES_WRITTEN: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 1009u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_RESOURCES_NUM_BYTES_WRITTEN ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_RESOURCES_OBJECT_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 1001u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_RESOURCES_OBJECT_ID ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_RESOURCES_OPTIMAL_TRANSFER_BUFFER_SIZE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 1011u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_RESOURCES_OPTIMAL_TRANSFER_BUFFER_SIZE ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_RESOURCES_POSITION_FROM_START: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 1014u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_RESOURCES_POSITION_FROM_START ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_RESOURCES_RESOURCE_ATTRIBUTES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 1004u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_RESOURCES_RESOURCE_ATTRIBUTES ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_RESOURCES_RESOURCE_KEYS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 1003u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_RESOURCES_RESOURCE_KEYS ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_RESOURCES_SEEK_OFFSET: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 1012u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_RESOURCES_SEEK_OFFSET ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_RESOURCES_SEEK_ORIGIN_FLAG: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 1013u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_RESOURCES_SEEK_ORIGIN_FLAG ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_RESOURCES_STREAM_UNITS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 1016u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_RESOURCES_STREAM_UNITS ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_OBJECT_RESOURCES_SUPPORTS_UNITS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a), pid: 1015u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_OBJECT_RESOURCES_SUPPORTS_UNITS ) , guid : :: windows :: core :: GUID::from_u128(0xb3a2b22d_a595_4108_be0a_fc3c965f3d4a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_PUBLIC_KEY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78f9c6fc_79b8_473c_9060_6bd23dd072c4), pid: 1001u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_PUBLIC_KEY ) , guid : :: windows :: core :: GUID::from_u128(0x78f9c6fc_79b8_473c_9060_6bd23dd072c4) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_SERVICE_CAPABILITIES_COMMAND: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 1018u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_SERVICE_CAPABILITIES_COMMAND ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_SERVICE_CAPABILITIES_COMMAND_OPTIONS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 1019u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_SERVICE_CAPABILITIES_COMMAND_OPTIONS ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_SERVICE_CAPABILITIES_EVENT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 1012u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_SERVICE_CAPABILITIES_EVENT ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_SERVICE_CAPABILITIES_EVENT_ATTRIBUTES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 1013u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_SERVICE_CAPABILITIES_EVENT_ATTRIBUTES ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_SERVICE_CAPABILITIES_FORMAT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 1002u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_SERVICE_CAPABILITIES_FORMAT ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_SERVICE_CAPABILITIES_FORMATS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 1007u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_SERVICE_CAPABILITIES_FORMATS ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_SERVICE_CAPABILITIES_FORMAT_ATTRIBUTES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 1008u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_SERVICE_CAPABILITIES_FORMAT_ATTRIBUTES ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_SERVICE_CAPABILITIES_INHERITANCE_TYPE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 1014u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_SERVICE_CAPABILITIES_INHERITANCE_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_SERVICE_CAPABILITIES_INHERITED_SERVICES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 1015u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_SERVICE_CAPABILITIES_INHERITED_SERVICES ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_SERVICE_CAPABILITIES_METHOD: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 1003u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_SERVICE_CAPABILITIES_METHOD ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_SERVICE_CAPABILITIES_METHOD_ATTRIBUTES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 1004u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_SERVICE_CAPABILITIES_METHOD_ATTRIBUTES ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_SERVICE_CAPABILITIES_PARAMETER: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 1005u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_SERVICE_CAPABILITIES_PARAMETER ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_SERVICE_CAPABILITIES_PARAMETER_ATTRIBUTES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 1006u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_SERVICE_CAPABILITIES_PARAMETER_ATTRIBUTES ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_SERVICE_CAPABILITIES_PROPERTY_ATTRIBUTES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 1010u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_SERVICE_CAPABILITIES_PROPERTY_ATTRIBUTES ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_SERVICE_CAPABILITIES_PROPERTY_KEYS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 1009u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_SERVICE_CAPABILITIES_PROPERTY_KEYS ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_SERVICE_CAPABILITIES_RENDERING_PROFILES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 1016u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_SERVICE_CAPABILITIES_RENDERING_PROFILES ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_SERVICE_CAPABILITIES_SUPPORTED_COMMANDS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 1017u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_SERVICE_CAPABILITIES_SUPPORTED_COMMANDS ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_SERVICE_CAPABILITIES_SUPPORTED_EVENTS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 1011u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_SERVICE_CAPABILITIES_SUPPORTED_EVENTS ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_SERVICE_CAPABILITIES_SUPPORTED_METHODS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89), pid: 1001u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_SERVICE_CAPABILITIES_SUPPORTED_METHODS ) , guid : :: windows :: core :: GUID::from_u128(0x24457e74_2e9f_44f9_8c57_1d1bcb170b89) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_SERVICE_METHOD: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2d521ca8_c1b0_4268_a342_cf19321569bc), pid: 1001u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_SERVICE_METHOD ) , guid : :: windows :: core :: GUID::from_u128(0x2d521ca8_c1b0_4268_a342_cf19321569bc) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_SERVICE_METHOD_CONTEXT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2d521ca8_c1b0_4268_a342_cf19321569bc), pid: 1004u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_SERVICE_METHOD_CONTEXT ) , guid : :: windows :: core :: GUID::from_u128(0x2d521ca8_c1b0_4268_a342_cf19321569bc) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_SERVICE_METHOD_HRESULT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2d521ca8_c1b0_4268_a342_cf19321569bc), pid: 1005u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_SERVICE_METHOD_HRESULT ) , guid : :: windows :: core :: GUID::from_u128(0x2d521ca8_c1b0_4268_a342_cf19321569bc) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_SERVICE_METHOD_PARAMETER_VALUES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2d521ca8_c1b0_4268_a342_cf19321569bc), pid: 1002u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_SERVICE_METHOD_PARAMETER_VALUES ) , guid : :: windows :: core :: GUID::from_u128(0x2d521ca8_c1b0_4268_a342_cf19321569bc) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_SERVICE_METHOD_RESULT_VALUES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2d521ca8_c1b0_4268_a342_cf19321569bc), pid: 1003u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_SERVICE_METHOD_RESULT_VALUES ) , guid : :: windows :: core :: GUID::from_u128(0x2d521ca8_c1b0_4268_a342_cf19321569bc) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_SERVICE_OBJECT_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x322f071d_36ef_477f_b4b5_6f52d734baee), pid: 1001u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_SERVICE_OBJECT_ID ) , guid : :: windows :: core :: GUID::from_u128(0x322f071d_36ef_477f_b4b5_6f52d734baee) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_SMS_BINARY_MESSAGE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xafc25d66_fe0d_4114_9097_970c93e920d1), pid: 1004u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_SMS_BINARY_MESSAGE ) , guid : :: windows :: core :: GUID::from_u128(0xafc25d66_fe0d_4114_9097_970c93e920d1) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_SMS_MESSAGE_TYPE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xafc25d66_fe0d_4114_9097_970c93e920d1), pid: 1002u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_SMS_MESSAGE_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0xafc25d66_fe0d_4114_9097_970c93e920d1) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_SMS_RECIPIENT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xafc25d66_fe0d_4114_9097_970c93e920d1), pid: 1001u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_SMS_RECIPIENT ) , guid : :: windows :: core :: GUID::from_u128(0xafc25d66_fe0d_4114_9097_970c93e920d1) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_SMS_TEXT_MESSAGE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xafc25d66_fe0d_4114_9097_970c93e920d1), pid: 1003u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_SMS_TEXT_MESSAGE ) , guid : :: windows :: core :: GUID::from_u128(0xafc25d66_fe0d_4114_9097_970c93e920d1) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_STORAGE_DESTINATION_OBJECT_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd8f907a6_34cc_45fa_97fb_d007fa47ec94), pid: 1002u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_STORAGE_DESTINATION_OBJECT_ID ) , guid : :: windows :: core :: GUID::from_u128(0xd8f907a6_34cc_45fa_97fb_d007fa47ec94) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_PROPERTY_STORAGE_OBJECT_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd8f907a6_34cc_45fa_97fb_d007fa47ec94), pid: 1001u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_PROPERTY_STORAGE_OBJECT_ID ) , guid : :: windows :: core :: GUID::from_u128(0xd8f907a6_34cc_45fa_97fb_d007fa47ec94) , } }
 pub const WPD_RENDERING_INFORMATION_OBJECT_PROPERTIES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc53d039f_ee23_4a31_8590_7639879870b4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_RENDERING_INFORMATION_OBJECT_PROPERTIES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0xc53d039f_ee23_4a31_8590_7639879870b4) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_RENDERING_INFORMATION_PROFILES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc53d039f_ee23_4a31_8590_7639879870b4), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_RENDERING_INFORMATION_PROFILES ) , guid : :: windows :: core :: GUID::from_u128(0xc53d039f_ee23_4a31_8590_7639879870b4) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_RENDERING_INFORMATION_PROFILE_ENTRY_CREATABLE_RESOURCES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc53d039f_ee23_4a31_8590_7639879870b4), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_RENDERING_INFORMATION_PROFILE_ENTRY_CREATABLE_RESOURCES ) , guid : :: windows :: core :: GUID::from_u128(0xc53d039f_ee23_4a31_8590_7639879870b4) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_RENDERING_INFORMATION_PROFILE_ENTRY_TYPE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc53d039f_ee23_4a31_8590_7639879870b4), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_RENDERING_INFORMATION_PROFILE_ENTRY_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0xc53d039f_ee23_4a31_8590_7639879870b4) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
 pub type WPD_RENDERING_INFORMATION_PROFILE_ENTRY_TYPES = i32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
@@ -5461,67 +6807,111 @@ pub const WPD_RENDERING_INFORMATION_PROFILE_ENTRY_TYPE_RESOURCE: WPD_RENDERING_I
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_RESOURCE_ALBUM_ART: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf02aa354_2300_4e2d_a1b9_3b6730f7fa21), pid: 0u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_RESOURCE_ALBUM_ART ) , guid : :: windows :: core :: GUID::from_u128(0xf02aa354_2300_4e2d_a1b9_3b6730f7fa21) , } }
 pub const WPD_RESOURCE_ATTRIBUTES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1eb6f604_9278_429f_93cc_5bb8c06656b6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_RESOURCE_ATTRIBUTES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0x1eb6f604_9278_429f_93cc_5bb8c06656b6) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_RESOURCE_ATTRIBUTE_CAN_DELETE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1eb6f604_9278_429f_93cc_5bb8c06656b6), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_RESOURCE_ATTRIBUTE_CAN_DELETE ) , guid : :: windows :: core :: GUID::from_u128(0x1eb6f604_9278_429f_93cc_5bb8c06656b6) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_RESOURCE_ATTRIBUTE_CAN_READ: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1eb6f604_9278_429f_93cc_5bb8c06656b6), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_RESOURCE_ATTRIBUTE_CAN_READ ) , guid : :: windows :: core :: GUID::from_u128(0x1eb6f604_9278_429f_93cc_5bb8c06656b6) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_RESOURCE_ATTRIBUTE_CAN_WRITE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1eb6f604_9278_429f_93cc_5bb8c06656b6), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_RESOURCE_ATTRIBUTE_CAN_WRITE ) , guid : :: windows :: core :: GUID::from_u128(0x1eb6f604_9278_429f_93cc_5bb8c06656b6) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_RESOURCE_ATTRIBUTE_FORMAT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1eb6f604_9278_429f_93cc_5bb8c06656b6), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_RESOURCE_ATTRIBUTE_FORMAT ) , guid : :: windows :: core :: GUID::from_u128(0x1eb6f604_9278_429f_93cc_5bb8c06656b6) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_RESOURCE_ATTRIBUTE_OPTIMAL_READ_BUFFER_SIZE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1eb6f604_9278_429f_93cc_5bb8c06656b6), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_RESOURCE_ATTRIBUTE_OPTIMAL_READ_BUFFER_SIZE ) , guid : :: windows :: core :: GUID::from_u128(0x1eb6f604_9278_429f_93cc_5bb8c06656b6) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_RESOURCE_ATTRIBUTE_OPTIMAL_WRITE_BUFFER_SIZE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1eb6f604_9278_429f_93cc_5bb8c06656b6), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_RESOURCE_ATTRIBUTE_OPTIMAL_WRITE_BUFFER_SIZE ) , guid : :: windows :: core :: GUID::from_u128(0x1eb6f604_9278_429f_93cc_5bb8c06656b6) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_RESOURCE_ATTRIBUTE_RESOURCE_KEY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1eb6f604_9278_429f_93cc_5bb8c06656b6), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_RESOURCE_ATTRIBUTE_RESOURCE_KEY ) , guid : :: windows :: core :: GUID::from_u128(0x1eb6f604_9278_429f_93cc_5bb8c06656b6) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_RESOURCE_ATTRIBUTE_TOTAL_SIZE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1eb6f604_9278_429f_93cc_5bb8c06656b6), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_RESOURCE_ATTRIBUTE_TOTAL_SIZE ) , guid : :: windows :: core :: GUID::from_u128(0x1eb6f604_9278_429f_93cc_5bb8c06656b6) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_RESOURCE_AUDIO_CLIP: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x3bc13982_85b1_48e0_95a6_8d3ad06be117), pid: 0u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_RESOURCE_AUDIO_CLIP ) , guid : :: windows :: core :: GUID::from_u128(0x3bc13982_85b1_48e0_95a6_8d3ad06be117) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_RESOURCE_BRANDING_ART: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb633b1ae_6caf_4a87_9589_22ded6dd5899), pid: 0u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_RESOURCE_BRANDING_ART ) , guid : :: windows :: core :: GUID::from_u128(0xb633b1ae_6caf_4a87_9589_22ded6dd5899) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_RESOURCE_CONTACT_PHOTO: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2c4d6803_80ea_4580_af9a_5be1a23eddcb), pid: 0u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_RESOURCE_CONTACT_PHOTO ) , guid : :: windows :: core :: GUID::from_u128(0x2c4d6803_80ea_4580_af9a_5be1a23eddcb) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_RESOURCE_DEFAULT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe81e79be_34f0_41bf_b53f_f1a06ae87842), pid: 0u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_RESOURCE_DEFAULT ) , guid : :: windows :: core :: GUID::from_u128(0xe81e79be_34f0_41bf_b53f_f1a06ae87842) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_RESOURCE_GENERIC: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb9b9f515_ba70_4647_94dc_fa4925e95a07), pid: 0u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_RESOURCE_GENERIC ) , guid : :: windows :: core :: GUID::from_u128(0xb9b9f515_ba70_4647_94dc_fa4925e95a07) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_RESOURCE_ICON: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf195fed8_aa28_4ee3_b153_e182dd5edc39), pid: 0u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_RESOURCE_ICON ) , guid : :: windows :: core :: GUID::from_u128(0xf195fed8_aa28_4ee3_b153_e182dd5edc39) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_RESOURCE_THUMBNAIL: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc7c407ba_98fa_46b5_9960_23fec124cfde), pid: 0u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_RESOURCE_THUMBNAIL ) , guid : :: windows :: core :: GUID::from_u128(0xc7c407ba_98fa_46b5_9960_23fec124cfde) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_RESOURCE_VIDEO_CLIP: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb566ee42_6368_4290_8662_70182fb79f20), pid: 0u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_RESOURCE_VIDEO_CLIP ) , guid : :: windows :: core :: GUID::from_u128(0xb566ee42_6368_4290_8662_70182fb79f20) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_SECTION_DATA_LENGTH: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x516afd2b_c64e_44f0_98dc_bee1c88f7d66), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_SECTION_DATA_LENGTH ) , guid : :: windows :: core :: GUID::from_u128(0x516afd2b_c64e_44f0_98dc_bee1c88f7d66) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_SECTION_DATA_OFFSET: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x516afd2b_c64e_44f0_98dc_bee1c88f7d66), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_SECTION_DATA_OFFSET ) , guid : :: windows :: core :: GUID::from_u128(0x516afd2b_c64e_44f0_98dc_bee1c88f7d66) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_SECTION_DATA_REFERENCED_OBJECT_RESOURCE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x516afd2b_c64e_44f0_98dc_bee1c88f7d66), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_SECTION_DATA_REFERENCED_OBJECT_RESOURCE ) , guid : :: windows :: core :: GUID::from_u128(0x516afd2b_c64e_44f0_98dc_bee1c88f7d66) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_SECTION_DATA_UNITS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x516afd2b_c64e_44f0_98dc_bee1c88f7d66), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_SECTION_DATA_UNITS ) , guid : :: windows :: core :: GUID::from_u128(0x516afd2b_c64e_44f0_98dc_bee1c88f7d66) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
 pub type WPD_SECTION_DATA_UNITS_VALUES = i32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
@@ -5529,17 +6919,25 @@ pub const WPD_SECTION_DATA_UNITS_BYTES: WPD_SECTION_DATA_UNITS_VALUES = 0i32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
 pub const WPD_SECTION_DATA_UNITS_MILLISECONDS: WPD_SECTION_DATA_UNITS_VALUES = 1i32;
 pub const WPD_SECTION_OBJECT_PROPERTIES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x516afd2b_c64e_44f0_98dc_bee1c88f7d66);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_SECTION_OBJECT_PROPERTIES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0x516afd2b_c64e_44f0_98dc_bee1c88f7d66) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
 pub type WPD_SERVICE_INHERITANCE_TYPES = i32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
 pub const WPD_SERVICE_INHERITANCE_IMPLEMENTATION: WPD_SERVICE_INHERITANCE_TYPES = 0i32;
 pub const WPD_SERVICE_PROPERTIES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7510698a_cb54_481c_b8db_0d75c93f1c06);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_SERVICE_PROPERTIES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0x7510698a_cb54_481c_b8db_0d75c93f1c06) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_SERVICE_VERSION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7510698a_cb54_481c_b8db_0d75c93f1c06), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_SERVICE_VERSION ) , guid : :: windows :: core :: GUID::from_u128(0x7510698a_cb54_481c_b8db_0d75c93f1c06) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_SMS_ENCODING: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7e1074cc_50ff_4dd1_a742_53be6f093a0d), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_SMS_ENCODING ) , guid : :: windows :: core :: GUID::from_u128(0x7e1074cc_50ff_4dd1_a742_53be6f093a0d) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
 pub type WPD_SMS_ENCODING_TYPES = i32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
@@ -5551,107 +6949,179 @@ pub const SMS_ENCODING_UTF_16: WPD_SMS_ENCODING_TYPES = 2i32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_SMS_MAX_PAYLOAD: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7e1074cc_50ff_4dd1_a742_53be6f093a0d), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_SMS_MAX_PAYLOAD ) , guid : :: windows :: core :: GUID::from_u128(0x7e1074cc_50ff_4dd1_a742_53be6f093a0d) , } }
 pub const WPD_SMS_OBJECT_PROPERTIES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7e1074cc_50ff_4dd1_a742_53be6f093a0d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_SMS_OBJECT_PROPERTIES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0x7e1074cc_50ff_4dd1_a742_53be6f093a0d) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_SMS_PROVIDER: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7e1074cc_50ff_4dd1_a742_53be6f093a0d), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_SMS_PROVIDER ) , guid : :: windows :: core :: GUID::from_u128(0x7e1074cc_50ff_4dd1_a742_53be6f093a0d) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_SMS_TIMEOUT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7e1074cc_50ff_4dd1_a742_53be6f093a0d), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_SMS_TIMEOUT ) , guid : :: windows :: core :: GUID::from_u128(0x7e1074cc_50ff_4dd1_a742_53be6f093a0d) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_ARTIST: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 29u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_ARTIST ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_BURST_INTERVAL: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 24u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_BURST_INTERVAL ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_BURST_NUMBER: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 23u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_BURST_NUMBER ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_CAMERA_MANUFACTURER: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 31u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_CAMERA_MANUFACTURER ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_CAMERA_MODEL: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 30u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_CAMERA_MODEL ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_CAPTURE_DELAY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 17u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_CAPTURE_DELAY ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_CAPTURE_FORMAT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_CAPTURE_FORMAT ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_CAPTURE_MODE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 18u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_CAPTURE_MODE ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 pub const WPD_STILL_IMAGE_CAPTURE_OBJECT_PROPERTIES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_CAPTURE_OBJECT_PROPERTIES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_CAPTURE_RESOLUTION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_CAPTURE_RESOLUTION ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_COMPRESSION_SETTING: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_COMPRESSION_SETTING ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_CONTRAST: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 19u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_CONTRAST ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_DIGITAL_ZOOM: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 21u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_DIGITAL_ZOOM ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_EFFECT_MODE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 22u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_EFFECT_MODE ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_EXPOSURE_BIAS_COMPENSATION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 16u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_EXPOSURE_BIAS_COMPENSATION ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_EXPOSURE_INDEX: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 15u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_EXPOSURE_INDEX ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_EXPOSURE_METERING_MODE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_EXPOSURE_METERING_MODE ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_EXPOSURE_PROGRAM_MODE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_EXPOSURE_PROGRAM_MODE ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_EXPOSURE_TIME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_EXPOSURE_TIME ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_FLASH_MODE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_FLASH_MODE ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_FNUMBER: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_FNUMBER ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_FOCAL_LENGTH: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_FOCAL_LENGTH ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_FOCUS_DISTANCE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_FOCUS_DISTANCE ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_FOCUS_METERING_MODE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 27u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_FOCUS_METERING_MODE ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_FOCUS_MODE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_FOCUS_MODE ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_RGB_GAIN: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_RGB_GAIN ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_SHARPNESS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 20u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_SHARPNESS ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_TIMELAPSE_INTERVAL: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 26u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_TIMELAPSE_INTERVAL ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_TIMELAPSE_NUMBER: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 25u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_TIMELAPSE_NUMBER ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_UPLOAD_URL: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 28u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_UPLOAD_URL ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STILL_IMAGE_WHITE_BALANCE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STILL_IMAGE_WHITE_BALANCE ) , guid : :: windows :: core :: GUID::from_u128(0x58c571ec_1bcb_42a7_8ac5_bb291573a260) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STORAGE_ACCESS_CAPABILITY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x01a3057a_74d6_4e80_bea7_dc4c212ce50a), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STORAGE_ACCESS_CAPABILITY ) , guid : :: windows :: core :: GUID::from_u128(0x01a3057a_74d6_4e80_bea7_dc4c212ce50a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
 pub type WPD_STORAGE_ACCESS_CAPABILITY_VALUES = i32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
@@ -5663,31 +7133,51 @@ pub const WPD_STORAGE_ACCESS_CAPABILITY_READ_ONLY_WITH_OBJECT_DELETION: WPD_STOR
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STORAGE_CAPACITY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x01a3057a_74d6_4e80_bea7_dc4c212ce50a), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STORAGE_CAPACITY ) , guid : :: windows :: core :: GUID::from_u128(0x01a3057a_74d6_4e80_bea7_dc4c212ce50a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STORAGE_CAPACITY_IN_OBJECTS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x01a3057a_74d6_4e80_bea7_dc4c212ce50a), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STORAGE_CAPACITY_IN_OBJECTS ) , guid : :: windows :: core :: GUID::from_u128(0x01a3057a_74d6_4e80_bea7_dc4c212ce50a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STORAGE_DESCRIPTION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x01a3057a_74d6_4e80_bea7_dc4c212ce50a), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STORAGE_DESCRIPTION ) , guid : :: windows :: core :: GUID::from_u128(0x01a3057a_74d6_4e80_bea7_dc4c212ce50a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STORAGE_FILE_SYSTEM_TYPE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x01a3057a_74d6_4e80_bea7_dc4c212ce50a), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STORAGE_FILE_SYSTEM_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x01a3057a_74d6_4e80_bea7_dc4c212ce50a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STORAGE_FREE_SPACE_IN_BYTES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x01a3057a_74d6_4e80_bea7_dc4c212ce50a), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STORAGE_FREE_SPACE_IN_BYTES ) , guid : :: windows :: core :: GUID::from_u128(0x01a3057a_74d6_4e80_bea7_dc4c212ce50a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STORAGE_FREE_SPACE_IN_OBJECTS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x01a3057a_74d6_4e80_bea7_dc4c212ce50a), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STORAGE_FREE_SPACE_IN_OBJECTS ) , guid : :: windows :: core :: GUID::from_u128(0x01a3057a_74d6_4e80_bea7_dc4c212ce50a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STORAGE_MAX_OBJECT_SIZE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x01a3057a_74d6_4e80_bea7_dc4c212ce50a), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STORAGE_MAX_OBJECT_SIZE ) , guid : :: windows :: core :: GUID::from_u128(0x01a3057a_74d6_4e80_bea7_dc4c212ce50a) , } }
 pub const WPD_STORAGE_OBJECT_PROPERTIES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x01a3057a_74d6_4e80_bea7_dc4c212ce50a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STORAGE_OBJECT_PROPERTIES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0x01a3057a_74d6_4e80_bea7_dc4c212ce50a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STORAGE_SERIAL_NUMBER: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x01a3057a_74d6_4e80_bea7_dc4c212ce50a), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STORAGE_SERIAL_NUMBER ) , guid : :: windows :: core :: GUID::from_u128(0x01a3057a_74d6_4e80_bea7_dc4c212ce50a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_STORAGE_TYPE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x01a3057a_74d6_4e80_bea7_dc4c212ce50a), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_STORAGE_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x01a3057a_74d6_4e80_bea7_dc4c212ce50a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
 pub type WPD_STORAGE_TYPE_VALUES = i32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
@@ -5713,55 +7203,91 @@ pub const WPD_STREAM_UNITS_MILLISECONDS: WPD_STREAM_UNITS = 4i32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
 pub const WPD_STREAM_UNITS_MICROSECONDS: WPD_STREAM_UNITS = 8i32;
 pub const WPD_TASK_OBJECT_PROPERTIES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe354e95e_d8a0_4637_a03a_0cb26838dbc7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_TASK_OBJECT_PROPERTIES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0xe354e95e_d8a0_4637_a03a_0cb26838dbc7) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_TASK_OWNER: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe354e95e_d8a0_4637_a03a_0cb26838dbc7), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_TASK_OWNER ) , guid : :: windows :: core :: GUID::from_u128(0xe354e95e_d8a0_4637_a03a_0cb26838dbc7) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_TASK_PERCENT_COMPLETE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe354e95e_d8a0_4637_a03a_0cb26838dbc7), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_TASK_PERCENT_COMPLETE ) , guid : :: windows :: core :: GUID::from_u128(0xe354e95e_d8a0_4637_a03a_0cb26838dbc7) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_TASK_REMINDER_DATE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe354e95e_d8a0_4637_a03a_0cb26838dbc7), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_TASK_REMINDER_DATE ) , guid : :: windows :: core :: GUID::from_u128(0xe354e95e_d8a0_4637_a03a_0cb26838dbc7) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_TASK_STATUS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe354e95e_d8a0_4637_a03a_0cb26838dbc7), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_TASK_STATUS ) , guid : :: windows :: core :: GUID::from_u128(0xe354e95e_d8a0_4637_a03a_0cb26838dbc7) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_VIDEO_AUTHOR: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x346f2163_f998_4146_8b01_d19b4c00de9a), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_VIDEO_AUTHOR ) , guid : :: windows :: core :: GUID::from_u128(0x346f2163_f998_4146_8b01_d19b4c00de9a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_VIDEO_BITRATE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x346f2163_f998_4146_8b01_d19b4c00de9a), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_VIDEO_BITRATE ) , guid : :: windows :: core :: GUID::from_u128(0x346f2163_f998_4146_8b01_d19b4c00de9a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_VIDEO_BUFFER_SIZE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x346f2163_f998_4146_8b01_d19b4c00de9a), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_VIDEO_BUFFER_SIZE ) , guid : :: windows :: core :: GUID::from_u128(0x346f2163_f998_4146_8b01_d19b4c00de9a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_VIDEO_CREDITS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x346f2163_f998_4146_8b01_d19b4c00de9a), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_VIDEO_CREDITS ) , guid : :: windows :: core :: GUID::from_u128(0x346f2163_f998_4146_8b01_d19b4c00de9a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_VIDEO_FOURCC_CODE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x346f2163_f998_4146_8b01_d19b4c00de9a), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_VIDEO_FOURCC_CODE ) , guid : :: windows :: core :: GUID::from_u128(0x346f2163_f998_4146_8b01_d19b4c00de9a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_VIDEO_FRAMERATE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x346f2163_f998_4146_8b01_d19b4c00de9a), pid: 15u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_VIDEO_FRAMERATE ) , guid : :: windows :: core :: GUID::from_u128(0x346f2163_f998_4146_8b01_d19b4c00de9a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_VIDEO_KEY_FRAME_DISTANCE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x346f2163_f998_4146_8b01_d19b4c00de9a), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_VIDEO_KEY_FRAME_DISTANCE ) , guid : :: windows :: core :: GUID::from_u128(0x346f2163_f998_4146_8b01_d19b4c00de9a) , } }
 pub const WPD_VIDEO_OBJECT_PROPERTIES_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x346f2163_f998_4146_8b01_d19b4c00de9a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_VIDEO_OBJECT_PROPERTIES_V1 ) , guid : :: windows :: core :: GUID::from_u128(0x346f2163_f998_4146_8b01_d19b4c00de9a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_VIDEO_QUALITY_SETTING: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x346f2163_f998_4146_8b01_d19b4c00de9a), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_VIDEO_QUALITY_SETTING ) , guid : :: windows :: core :: GUID::from_u128(0x346f2163_f998_4146_8b01_d19b4c00de9a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_VIDEO_RECORDEDTV_CHANNEL_NUMBER: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x346f2163_f998_4146_8b01_d19b4c00de9a), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_VIDEO_RECORDEDTV_CHANNEL_NUMBER ) , guid : :: windows :: core :: GUID::from_u128(0x346f2163_f998_4146_8b01_d19b4c00de9a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_VIDEO_RECORDEDTV_REPEAT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x346f2163_f998_4146_8b01_d19b4c00de9a), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_VIDEO_RECORDEDTV_REPEAT ) , guid : :: windows :: core :: GUID::from_u128(0x346f2163_f998_4146_8b01_d19b4c00de9a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_VIDEO_RECORDEDTV_STATION_NAME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x346f2163_f998_4146_8b01_d19b4c00de9a), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_VIDEO_RECORDEDTV_STATION_NAME ) , guid : :: windows :: core :: GUID::from_u128(0x346f2163_f998_4146_8b01_d19b4c00de9a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const WPD_VIDEO_SCAN_TYPE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x346f2163_f998_4146_8b01_d19b4c00de9a), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_VIDEO_SCAN_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x346f2163_f998_4146_8b01_d19b4c00de9a) , } }
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]
 pub type WPD_VIDEO_SCAN_TYPES = i32;
 #[doc = "*Required features: 'Win32_Devices_PortableDevices'*"]

--- a/crates/libs/windows/src/Windows/Win32/Devices/Properties/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Properties/mod.rs
@@ -2,588 +2,978 @@
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DevQuery_ObjectType: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x13673f42_a3d6_49f6_b4da_ae46e0c5237c), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DevQuery_ObjectType ) , guid : :: windows :: core :: GUID::from_u128(0x13673f42_a3d6_49f6_b4da_ae46e0c5237c) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceClass_Characteristics: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4321918b_f69e_470d_a5de_4d88c75ad24b), pid: 29u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceClass_Characteristics ) , guid : :: windows :: core :: GUID::from_u128(0x4321918b_f69e_470d_a5de_4d88c75ad24b) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceClass_ClassCoInstallers: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x713d1703_a2e2_49f5_9214_56472ef3da5c), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceClass_ClassCoInstallers ) , guid : :: windows :: core :: GUID::from_u128(0x713d1703_a2e2_49f5_9214_56472ef3da5c) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceClass_ClassInstaller: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceClass_ClassInstaller ) , guid : :: windows :: core :: GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceClass_ClassName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceClass_ClassName ) , guid : :: windows :: core :: GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceClass_DHPRebalanceOptOut: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd14d3ef3_66cf_4ba2_9d38_0ddb37ab4701), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceClass_DHPRebalanceOptOut ) , guid : :: windows :: core :: GUID::from_u128(0xd14d3ef3_66cf_4ba2_9d38_0ddb37ab4701) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceClass_DefaultService: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceClass_DefaultService ) , guid : :: windows :: core :: GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceClass_DevType: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4321918b_f69e_470d_a5de_4d88c75ad24b), pid: 27u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceClass_DevType ) , guid : :: windows :: core :: GUID::from_u128(0x4321918b_f69e_470d_a5de_4d88c75ad24b) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceClass_Exclusive: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4321918b_f69e_470d_a5de_4d88c75ad24b), pid: 28u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceClass_Exclusive ) , guid : :: windows :: core :: GUID::from_u128(0x4321918b_f69e_470d_a5de_4d88c75ad24b) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceClass_Icon: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceClass_Icon ) , guid : :: windows :: core :: GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceClass_IconPath: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceClass_IconPath ) , guid : :: windows :: core :: GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceClass_LowerFilters: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4321918b_f69e_470d_a5de_4d88c75ad24b), pid: 20u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceClass_LowerFilters ) , guid : :: windows :: core :: GUID::from_u128(0x4321918b_f69e_470d_a5de_4d88c75ad24b) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceClass_Name: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceClass_Name ) , guid : :: windows :: core :: GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceClass_NoDisplayClass: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceClass_NoDisplayClass ) , guid : :: windows :: core :: GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceClass_NoInstallClass: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceClass_NoInstallClass ) , guid : :: windows :: core :: GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceClass_NoUseClass: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceClass_NoUseClass ) , guid : :: windows :: core :: GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceClass_PropPageProvider: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceClass_PropPageProvider ) , guid : :: windows :: core :: GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceClass_Security: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4321918b_f69e_470d_a5de_4d88c75ad24b), pid: 25u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceClass_Security ) , guid : :: windows :: core :: GUID::from_u128(0x4321918b_f69e_470d_a5de_4d88c75ad24b) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceClass_SecuritySDS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4321918b_f69e_470d_a5de_4d88c75ad24b), pid: 26u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceClass_SecuritySDS ) , guid : :: windows :: core :: GUID::from_u128(0x4321918b_f69e_470d_a5de_4d88c75ad24b) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceClass_SilentInstall: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceClass_SilentInstall ) , guid : :: windows :: core :: GUID::from_u128(0x259abffc_50a7_47ce_af08_68c9a7d73366) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceClass_UpperFilters: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4321918b_f69e_470d_a5de_4d88c75ad24b), pid: 19u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceClass_UpperFilters ) , guid : :: windows :: core :: GUID::from_u128(0x4321918b_f69e_470d_a5de_4d88c75ad24b) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_Address: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 51u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_Address ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_AlwaysShowDeviceAsConnected: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 101u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_AlwaysShowDeviceAsConnected ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_AssociationArray: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 80u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_AssociationArray ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_BaselineExperienceId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 78u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_BaselineExperienceId ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_Category: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 90u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_Category ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_CategoryGroup_Desc: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 94u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_CategoryGroup_Desc ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_CategoryGroup_Icon: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 95u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_CategoryGroup_Icon ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_Category_Desc_Plural: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 92u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_Category_Desc_Plural ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_Category_Desc_Singular: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 91u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_Category_Desc_Singular ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_Category_Icon: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 93u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_Category_Icon ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_ConfigFlags: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 105u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_ConfigFlags ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_CustomPrivilegedPackageFamilyNames: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 107u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_CustomPrivilegedPackageFamilyNames ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_DeviceDescription1: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 81u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_DeviceDescription1 ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_DeviceDescription2: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 82u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_DeviceDescription2 ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_DeviceFunctionSubRank: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_DeviceFunctionSubRank ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_DiscoveryMethod: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 52u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_DiscoveryMethod ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_ExperienceId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 89u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_ExperienceId ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_FriendlyName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 12288u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_FriendlyName ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_HasProblem: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 83u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_HasProblem ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_Icon: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 57u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_Icon ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_InstallInProgress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x83da6326_97a6_4088_9453_a1923f573b29), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_InstallInProgress ) , guid : :: windows :: core :: GUID::from_u128(0x83da6326_97a6_4088_9453_a1923f573b29) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_IsAuthenticated: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 54u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_IsAuthenticated ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_IsConnected: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 55u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_IsConnected ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_IsDefaultDevice: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 86u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_IsDefaultDevice ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_IsDeviceUniquelyIdentifiable: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 79u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_IsDeviceUniquelyIdentifiable ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_IsEncrypted: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 53u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_IsEncrypted ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_IsLocalMachine: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 70u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_IsLocalMachine ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_IsMetadataSearchInProgress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 72u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_IsMetadataSearchInProgress ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_IsNetworkDevice: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 85u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_IsNetworkDevice ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_IsNotInterestingForDisplay: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 74u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_IsNotInterestingForDisplay ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_IsPaired: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 56u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_IsPaired ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_IsRebootRequired: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 108u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_IsRebootRequired ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_IsSharedDevice: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 84u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_IsSharedDevice ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_IsShowInDisconnectedState: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 68u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_IsShowInDisconnectedState ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_Last_Connected: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 67u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_Last_Connected ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_Last_Seen: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 66u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_Last_Seen ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_LaunchDeviceStageFromExplorer: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 77u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_LaunchDeviceStageFromExplorer ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_LaunchDeviceStageOnDeviceConnect: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 76u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_LaunchDeviceStageOnDeviceConnect ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_Manufacturer: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 8192u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_Manufacturer ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_MetadataCabinet: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 87u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_MetadataCabinet ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_MetadataChecksum: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 73u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_MetadataChecksum ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_MetadataPath: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 71u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_MetadataPath ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_ModelName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 8194u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_ModelName ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_ModelNumber: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 8195u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_ModelNumber ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_PrimaryCategory: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 97u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_PrimaryCategory ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_PrivilegedPackageFamilyNames: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 106u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_PrivilegedPackageFamilyNames ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_RequiresPairingElevation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 88u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_RequiresPairingElevation ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_RequiresUninstallElevation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 99u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_RequiresUninstallElevation ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_UnpairUninstall: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 98u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_UnpairUninstall ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceContainer_Version: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 65u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceContainer_Version ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceInterfaceClass_DefaultInterface: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x14c83a99_0b3f_44b7_be4c_a178d3990564), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceInterfaceClass_DefaultInterface ) , guid : :: windows :: core :: GUID::from_u128(0x14c83a99_0b3f_44b7_be4c_a178d3990564) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceInterfaceClass_Name: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x14c83a99_0b3f_44b7_be4c_a178d3990564), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceInterfaceClass_Name ) , guid : :: windows :: core :: GUID::from_u128(0x14c83a99_0b3f_44b7_be4c_a178d3990564) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceInterface_Autoplay_Silent: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x434dd28f_9e75_450a_9ab9_ff61e618bad0), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceInterface_Autoplay_Silent ) , guid : :: windows :: core :: GUID::from_u128(0x434dd28f_9e75_450a_9ab9_ff61e618bad0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceInterface_ClassGuid: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x026e516e_b814_414b_83cd_856d6fef4822), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceInterface_ClassGuid ) , guid : :: windows :: core :: GUID::from_u128(0x026e516e_b814_414b_83cd_856d6fef4822) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceInterface_Enabled: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x026e516e_b814_414b_83cd_856d6fef4822), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceInterface_Enabled ) , guid : :: windows :: core :: GUID::from_u128(0x026e516e_b814_414b_83cd_856d6fef4822) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceInterface_FriendlyName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x026e516e_b814_414b_83cd_856d6fef4822), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceInterface_FriendlyName ) , guid : :: windows :: core :: GUID::from_u128(0x026e516e_b814_414b_83cd_856d6fef4822) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceInterface_ReferenceString: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x026e516e_b814_414b_83cd_856d6fef4822), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceInterface_ReferenceString ) , guid : :: windows :: core :: GUID::from_u128(0x026e516e_b814_414b_83cd_856d6fef4822) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceInterface_Restricted: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x026e516e_b814_414b_83cd_856d6fef4822), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceInterface_Restricted ) , guid : :: windows :: core :: GUID::from_u128(0x026e516e_b814_414b_83cd_856d6fef4822) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceInterface_SchematicName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x026e516e_b814_414b_83cd_856d6fef4822), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceInterface_SchematicName ) , guid : :: windows :: core :: GUID::from_u128(0x026e516e_b814_414b_83cd_856d6fef4822) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DeviceInterface_UnrestrictedAppCapabilities: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x026e516e_b814_414b_83cd_856d6fef4822), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DeviceInterface_UnrestrictedAppCapabilities ) , guid : :: windows :: core :: GUID::from_u128(0x026e516e_b814_414b_83cd_856d6fef4822) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_AdditionalSoftwareRequested: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 19u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_AdditionalSoftwareRequested ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_Address: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 30u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_Address ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_AssignedToGuest: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 24u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_AssignedToGuest ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_BaseContainerId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 38u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_BaseContainerId ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_BiosDeviceName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_BiosDeviceName ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_BusNumber: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 23u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_BusNumber ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_BusRelations: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_BusRelations ) , guid : :: windows :: core :: GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_BusReportedDeviceDesc: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_BusReportedDeviceDesc ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_BusTypeGuid: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 21u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_BusTypeGuid ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_Capabilities: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 17u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_Capabilities ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_Characteristics: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 29u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_Characteristics ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_Children: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_Children ) , guid : :: windows :: core :: GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_Class: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_Class ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_ClassGuid: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_ClassGuid ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_CompatibleIds: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_CompatibleIds ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_ConfigFlags: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_ConfigFlags ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_ConfigurationId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_ConfigurationId ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_ContainerId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8c7ed206_3f8a_4827_b3ab_ae9e1faefc6c), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_ContainerId ) , guid : :: windows :: core :: GUID::from_u128(0x8c7ed206_3f8a_4827_b3ab_ae9e1faefc6c) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_CreatorProcessId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 25u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_CreatorProcessId ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_DHP_Rebalance_Policy: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_DHP_Rebalance_Policy ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_DebuggerSafe: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_DebuggerSafe ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_DependencyDependents: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 21u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_DependencyDependents ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_DependencyProviders: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 20u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_DependencyProviders ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_DevNodeStatus: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_DevNodeStatus ) , guid : :: windows :: core :: GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_DevType: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 27u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_DevType ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_DeviceDesc: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_DeviceDesc ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_Driver: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_Driver ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_DriverCoInstallers: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_DriverCoInstallers ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_DriverDate: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_DriverDate ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_DriverDesc: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_DriverDesc ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_DriverInfPath: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_DriverInfPath ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_DriverInfSection: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_DriverInfSection ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_DriverInfSectionExt: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_DriverInfSectionExt ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_DriverLogoLevel: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 15u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_DriverLogoLevel ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_DriverProblemDesc: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_DriverProblemDesc ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_DriverPropPageProvider: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_DriverPropPageProvider ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_DriverProvider: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_DriverProvider ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_DriverRank: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_DriverRank ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_DriverVersion: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_DriverVersion ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_EjectionRelations: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_EjectionRelations ) , guid : :: windows :: core :: GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_EnumeratorName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 24u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_EnumeratorName ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_Exclusive: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 28u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_Exclusive ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_ExtendedAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 23u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_ExtendedAddress ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_ExtendedConfigurationIds: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 15u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_ExtendedConfigurationIds ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_FirmwareDate: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 17u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_FirmwareDate ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_FirmwareRevision: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 19u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_FirmwareRevision ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_FirmwareVersion: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 18u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_FirmwareVersion ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_FirstInstallDate: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x83da6326_97a6_4088_9453_a1923f573b29), pid: 101u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_FirstInstallDate ) , guid : :: windows :: core :: GUID::from_u128(0x83da6326_97a6_4088_9453_a1923f573b29) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_FriendlyName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_FriendlyName ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_FriendlyNameAttributes: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x80d81ea6_7473_4b0c_8216_efc11a2c4c8b), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_FriendlyNameAttributes ) , guid : :: windows :: core :: GUID::from_u128(0x80d81ea6_7473_4b0c_8216_efc11a2c4c8b) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_GenericDriverInstalled: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 18u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_GenericDriverInstalled ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_HardwareIds: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_HardwareIds ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_HasProblem: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_HasProblem ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_InLocalMachineContainer: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8c7ed206_3f8a_4827_b3ab_ae9e1faefc6c), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_InLocalMachineContainer ) , guid : :: windows :: core :: GUID::from_u128(0x8c7ed206_3f8a_4827_b3ab_ae9e1faefc6c) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_InstallDate: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x83da6326_97a6_4088_9453_a1923f573b29), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_InstallDate ) , guid : :: windows :: core :: GUID::from_u128(0x83da6326_97a6_4088_9453_a1923f573b29) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_InstallState: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 36u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_InstallState ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_InstanceId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 256u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_InstanceId ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_IsAssociateableByUserAction: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x80d81ea6_7473_4b0c_8216_efc11a2c4c8b), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_IsAssociateableByUserAction ) , guid : :: windows :: core :: GUID::from_u128(0x80d81ea6_7473_4b0c_8216_efc11a2c4c8b) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_IsPresent: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_IsPresent ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_IsRebootRequired: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 16u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_IsRebootRequired ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_LastArrivalDate: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x83da6326_97a6_4088_9453_a1923f573b29), pid: 102u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_LastArrivalDate ) , guid : :: windows :: core :: GUID::from_u128(0x83da6326_97a6_4088_9453_a1923f573b29) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_LastRemovalDate: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x83da6326_97a6_4088_9453_a1923f573b29), pid: 103u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_LastRemovalDate ) , guid : :: windows :: core :: GUID::from_u128(0x83da6326_97a6_4088_9453_a1923f573b29) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_Legacy: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x80497100_8c73_48b9_aad9_ce387e19c56e), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_Legacy ) , guid : :: windows :: core :: GUID::from_u128(0x80497100_8c73_48b9_aad9_ce387e19c56e) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_LegacyBusType: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 22u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_LegacyBusType ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_LocationInfo: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 15u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_LocationInfo ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_LocationPaths: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 37u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_LocationPaths ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_LowerFilters: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 20u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_LowerFilters ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_Manufacturer: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_Manufacturer ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_ManufacturerAttributes: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x80d81ea6_7473_4b0c_8216_efc11a2c4c8b), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_ManufacturerAttributes ) , guid : :: windows :: core :: GUID::from_u128(0x80d81ea6_7473_4b0c_8216_efc11a2c4c8b) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_MatchingDeviceId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_MatchingDeviceId ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_Model: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 39u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_Model ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_ModelId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x80d81ea6_7473_4b0c_8216_efc11a2c4c8b), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_ModelId ) , guid : :: windows :: core :: GUID::from_u128(0x80d81ea6_7473_4b0c_8216_efc11a2c4c8b) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_NoConnectSound: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 17u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_NoConnectSound ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_Numa_Node: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_Numa_Node ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_Numa_Proximity_Domain: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 1u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_Numa_Proximity_Domain ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_PDOName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 16u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_PDOName ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_Parent: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_Parent ) , guid : :: windows :: core :: GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_PhysicalDeviceLocation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_PhysicalDeviceLocation ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_PostInstallInProgress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_PostInstallInProgress ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_PowerData: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 32u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_PowerData ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_PowerRelations: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_PowerRelations ) , guid : :: windows :: core :: GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_PresenceNotForDevice: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x80d81ea6_7473_4b0c_8216_efc11a2c4c8b), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_PresenceNotForDevice ) , guid : :: windows :: core :: GUID::from_u128(0x80d81ea6_7473_4b0c_8216_efc11a2c4c8b) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_ProblemCode: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_ProblemCode ) , guid : :: windows :: core :: GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_ProblemStatus: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_ProblemStatus ) , guid : :: windows :: core :: GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_RemovalPolicy: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 33u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_RemovalPolicy ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_RemovalPolicyDefault: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 34u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_RemovalPolicyDefault ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_RemovalPolicyOverride: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 35u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_RemovalPolicyOverride ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_RemovalRelations: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_RemovalRelations ) , guid : :: windows :: core :: GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_Reported: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x80497100_8c73_48b9_aad9_ce387e19c56e), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_Reported ) , guid : :: windows :: core :: GUID::from_u128(0x80497100_8c73_48b9_aad9_ce387e19c56e) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_ReportedDeviceIdsHash: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_ReportedDeviceIdsHash ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_ResourcePickerExceptions: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_ResourcePickerExceptions ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_ResourcePickerTags: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_ResourcePickerTags ) , guid : :: windows :: core :: GUID::from_u128(0xa8b865dd_2e3d_4094_ad97_e593a70c75d6) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_SafeRemovalRequired: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xafd97640_86a3_4210_b67c_289c41aabe55), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_SafeRemovalRequired ) , guid : :: windows :: core :: GUID::from_u128(0xafd97640_86a3_4210_b67c_289c41aabe55) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_SafeRemovalRequiredOverride: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xafd97640_86a3_4210_b67c_289c41aabe55), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_SafeRemovalRequiredOverride ) , guid : :: windows :: core :: GUID::from_u128(0xafd97640_86a3_4210_b67c_289c41aabe55) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_Security: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 25u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_Security ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_SecuritySDS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 26u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_SecuritySDS ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_Service: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_Service ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_SessionId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x83da6326_97a6_4088_9453_a1923f573b29), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_SessionId ) , guid : :: windows :: core :: GUID::from_u128(0x83da6326_97a6_4088_9453_a1923f573b29) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_ShowInUninstallUI: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x80d81ea6_7473_4b0c_8216_efc11a2c4c8b), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_ShowInUninstallUI ) , guid : :: windows :: core :: GUID::from_u128(0x80d81ea6_7473_4b0c_8216_efc11a2c4c8b) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_Siblings: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_Siblings ) , guid : :: windows :: core :: GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_SignalStrength: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x80d81ea6_7473_4b0c_8216_efc11a2c4c8b), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_SignalStrength ) , guid : :: windows :: core :: GUID::from_u128(0x80d81ea6_7473_4b0c_8216_efc11a2c4c8b) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_SoftRestartSupported: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 22u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_SoftRestartSupported ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_Stack: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_Stack ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_TransportRelations: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_TransportRelations ) , guid : :: windows :: core :: GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_UINumber: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 18u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_UINumber ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_UINumberDescFormat: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 31u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_UINumberDescFormat ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Device_UpperFilters: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 19u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Device_UpperFilters ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DrvPkg_BrandingIcon: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcf73bb51_3abf_44a2_85e0_9a3dc7a12132), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DrvPkg_BrandingIcon ) , guid : :: windows :: core :: GUID::from_u128(0xcf73bb51_3abf_44a2_85e0_9a3dc7a12132) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DrvPkg_DetailedDescription: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcf73bb51_3abf_44a2_85e0_9a3dc7a12132), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DrvPkg_DetailedDescription ) , guid : :: windows :: core :: GUID::from_u128(0xcf73bb51_3abf_44a2_85e0_9a3dc7a12132) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DrvPkg_DocumentationLink: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcf73bb51_3abf_44a2_85e0_9a3dc7a12132), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DrvPkg_DocumentationLink ) , guid : :: windows :: core :: GUID::from_u128(0xcf73bb51_3abf_44a2_85e0_9a3dc7a12132) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DrvPkg_Icon: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcf73bb51_3abf_44a2_85e0_9a3dc7a12132), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DrvPkg_Icon ) , guid : :: windows :: core :: GUID::from_u128(0xcf73bb51_3abf_44a2_85e0_9a3dc7a12132) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DrvPkg_Model: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcf73bb51_3abf_44a2_85e0_9a3dc7a12132), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DrvPkg_Model ) , guid : :: windows :: core :: GUID::from_u128(0xcf73bb51_3abf_44a2_85e0_9a3dc7a12132) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_DrvPkg_VendorWebSite: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcf73bb51_3abf_44a2_85e0_9a3dc7a12132), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_DrvPkg_VendorWebSite ) , guid : :: windows :: core :: GUID::from_u128(0xcf73bb51_3abf_44a2_85e0_9a3dc7a12132) , } }
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_NAME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_NAME ) , guid : :: windows :: core :: GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Devices_Properties', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/Devices/Pwm/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Pwm/mod.rs
@@ -1,5 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 pub const GUID_DEVINTERFACE_PWM_CONTROLLER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x60824b4c_eed1_4c9c_b49c_1b961461a819);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_PWM_CONTROLLER ) , guid : :: windows :: core :: GUID::from_u128(0x60824b4c_eed1_4c9c_b49c_1b961461a819) , } }
 #[doc = "*Required features: 'Win32_Devices_Pwm'*"]
 pub const IOCTL_PWM_CONTROLLER_GET_ACTUAL_PERIOD: u32 = 262148u32;
 #[doc = "*Required features: 'Win32_Devices_Pwm'*"]

--- a/crates/libs/windows/src/Windows/Win32/Devices/Sensors/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Sensors/mod.rs
@@ -229,38 +229,104 @@ pub unsafe fn EvaluateActivityThresholds(newsample: *const SENSOR_COLLECTION_LIS
 #[doc = "*Required features: 'Win32_Devices_Sensors'*"]
 pub const GNSS_CLEAR_ALL_ASSISTANCE_DATA: u32 = 1u32;
 pub const GUID_DEVINTERFACE_SENSOR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xba1bb692_9b7a_4833_9a1e_525ed134e7e2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_SENSOR ) , guid : :: windows :: core :: GUID::from_u128(0xba1bb692_9b7a_4833_9a1e_525ed134e7e2) , } }
 pub const GUID_SensorCategory_All: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc317c286_c468_4288_9975_d4c4587c442c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorCategory_All ) , guid : :: windows :: core :: GUID::from_u128(0xc317c286_c468_4288_9975_d4c4587c442c) , } }
 pub const GUID_SensorCategory_Biometric: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xca19690f_a2c7_477d_a99e_99ec6e2b5648);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorCategory_Biometric ) , guid : :: windows :: core :: GUID::from_u128(0xca19690f_a2c7_477d_a99e_99ec6e2b5648) , } }
 pub const GUID_SensorCategory_Electrical: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfb73fcd8_fc4a_483c_ac58_27b691c6beff);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorCategory_Electrical ) , guid : :: windows :: core :: GUID::from_u128(0xfb73fcd8_fc4a_483c_ac58_27b691c6beff) , } }
 pub const GUID_SensorCategory_Environmental: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x323439aa_7f66_492b_ba0c_73e9aa0a65d5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorCategory_Environmental ) , guid : :: windows :: core :: GUID::from_u128(0x323439aa_7f66_492b_ba0c_73e9aa0a65d5) , } }
 pub const GUID_SensorCategory_Light: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x17a665c0_9063_4216_b202_5c7a255e18ce);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorCategory_Light ) , guid : :: windows :: core :: GUID::from_u128(0x17a665c0_9063_4216_b202_5c7a255e18ce) , } }
 pub const GUID_SensorCategory_Location: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbfa794e4_f964_4fdb_90f6_51056bfe4b44);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorCategory_Location ) , guid : :: windows :: core :: GUID::from_u128(0xbfa794e4_f964_4fdb_90f6_51056bfe4b44) , } }
 pub const GUID_SensorCategory_Mechanical: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8d131d68_8ef7_4656_80b5_cccbd93791c5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorCategory_Mechanical ) , guid : :: windows :: core :: GUID::from_u128(0x8d131d68_8ef7_4656_80b5_cccbd93791c5) , } }
 pub const GUID_SensorCategory_Motion: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcd09daf1_3b2e_4c3d_b598_b5e5ff93fd46);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorCategory_Motion ) , guid : :: windows :: core :: GUID::from_u128(0xcd09daf1_3b2e_4c3d_b598_b5e5ff93fd46) , } }
 pub const GUID_SensorCategory_Orientation: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9e6c04b6_96fe_4954_b726_68682a473f69);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorCategory_Orientation ) , guid : :: windows :: core :: GUID::from_u128(0x9e6c04b6_96fe_4954_b726_68682a473f69) , } }
 pub const GUID_SensorCategory_Other: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2c90e7a9_f4c9_4fa2_af37_56d471fe5a3d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorCategory_Other ) , guid : :: windows :: core :: GUID::from_u128(0x2c90e7a9_f4c9_4fa2_af37_56d471fe5a3d) , } }
 pub const GUID_SensorCategory_PersonalActivity: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf1609081_1e12_412b_a14d_cbb0e95bd2e5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorCategory_PersonalActivity ) , guid : :: windows :: core :: GUID::from_u128(0xf1609081_1e12_412b_a14d_cbb0e95bd2e5) , } }
 pub const GUID_SensorCategory_Scanner: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb000e77e_f5b5_420f_815d_0270a726f270);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorCategory_Scanner ) , guid : :: windows :: core :: GUID::from_u128(0xb000e77e_f5b5_420f_815d_0270a726f270) , } }
 pub const GUID_SensorCategory_Unsupported: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2beae7fa_19b0_48c5_a1f6_b5480dc206b0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorCategory_Unsupported ) , guid : :: windows :: core :: GUID::from_u128(0x2beae7fa_19b0_48c5_a1f6_b5480dc206b0) , } }
 pub const GUID_SensorType_Accelerometer3D: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc2fb0f5f_e2d2_4c78_bcd0_352a9582819d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorType_Accelerometer3D ) , guid : :: windows :: core :: GUID::from_u128(0xc2fb0f5f_e2d2_4c78_bcd0_352a9582819d) , } }
 pub const GUID_SensorType_ActivityDetection: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9d9e0118_1807_4f2e_96e4_2ce57142e196);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorType_ActivityDetection ) , guid : :: windows :: core :: GUID::from_u128(0x9d9e0118_1807_4f2e_96e4_2ce57142e196) , } }
 pub const GUID_SensorType_AmbientLight: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x97f115c8_599a_4153_8894_d2d12899918a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorType_AmbientLight ) , guid : :: windows :: core :: GUID::from_u128(0x97f115c8_599a_4153_8894_d2d12899918a) , } }
 pub const GUID_SensorType_Barometer: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0e903829_ff8a_4a93_97df_3dcbde402288);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorType_Barometer ) , guid : :: windows :: core :: GUID::from_u128(0x0e903829_ff8a_4a93_97df_3dcbde402288) , } }
 pub const GUID_SensorType_Custom: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe83af229_8640_4d18_a213_e22675ebb2c3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorType_Custom ) , guid : :: windows :: core :: GUID::from_u128(0xe83af229_8640_4d18_a213_e22675ebb2c3) , } }
 pub const GUID_SensorType_FloorElevation: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xade4987f_7ac4_4dfa_9722_0a027181c747);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorType_FloorElevation ) , guid : :: windows :: core :: GUID::from_u128(0xade4987f_7ac4_4dfa_9722_0a027181c747) , } }
 pub const GUID_SensorType_GeomagneticOrientation: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe77195f8_2d1f_4823_971b_1c4467556c9d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorType_GeomagneticOrientation ) , guid : :: windows :: core :: GUID::from_u128(0xe77195f8_2d1f_4823_971b_1c4467556c9d) , } }
 pub const GUID_SensorType_GravityVector: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x03b52c73_bb76_463f_9524_38de76eb700b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorType_GravityVector ) , guid : :: windows :: core :: GUID::from_u128(0x03b52c73_bb76_463f_9524_38de76eb700b) , } }
 pub const GUID_SensorType_Gyrometer3D: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x09485f5a_759e_42c2_bd4b_a349b75c8643);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorType_Gyrometer3D ) , guid : :: windows :: core :: GUID::from_u128(0x09485f5a_759e_42c2_bd4b_a349b75c8643) , } }
 pub const GUID_SensorType_HingeAngle: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x82358065_f4c4_4da1_b272_13c23332a207);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorType_HingeAngle ) , guid : :: windows :: core :: GUID::from_u128(0x82358065_f4c4_4da1_b272_13c23332a207) , } }
 pub const GUID_SensorType_Humidity: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5c72bf67_bd7e_4257_990b_98a3ba3b400a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorType_Humidity ) , guid : :: windows :: core :: GUID::from_u128(0x5c72bf67_bd7e_4257_990b_98a3ba3b400a) , } }
 pub const GUID_SensorType_LinearAccelerometer: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x038b0283_97b4_41c8_bc24_5ff1aa48fec7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorType_LinearAccelerometer ) , guid : :: windows :: core :: GUID::from_u128(0x038b0283_97b4_41c8_bc24_5ff1aa48fec7) , } }
 pub const GUID_SensorType_Magnetometer3D: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x55e5effb_15c7_40df_8698_a84b7c863c53);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorType_Magnetometer3D ) , guid : :: windows :: core :: GUID::from_u128(0x55e5effb_15c7_40df_8698_a84b7c863c53) , } }
 pub const GUID_SensorType_Orientation: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcdb5d8f7_3cfd_41c8_8542_cce622cf5d6e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorType_Orientation ) , guid : :: windows :: core :: GUID::from_u128(0xcdb5d8f7_3cfd_41c8_8542_cce622cf5d6e) , } }
 pub const GUID_SensorType_Pedometer: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb19f89af_e3eb_444b_8dea_202575a71599);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorType_Pedometer ) , guid : :: windows :: core :: GUID::from_u128(0xb19f89af_e3eb_444b_8dea_202575a71599) , } }
 pub const GUID_SensorType_Proximity: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5220dae9_3179_4430_9f90_06266d2a34de);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorType_Proximity ) , guid : :: windows :: core :: GUID::from_u128(0x5220dae9_3179_4430_9f90_06266d2a34de) , } }
 pub const GUID_SensorType_RelativeOrientation: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x40993b51_4706_44dc_98d5_c920c037ffab);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorType_RelativeOrientation ) , guid : :: windows :: core :: GUID::from_u128(0x40993b51_4706_44dc_98d5_c920c037ffab) , } }
 pub const GUID_SensorType_SimpleDeviceOrientation: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x86a19291_0482_402c_bf4c_addac52b1c39);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorType_SimpleDeviceOrientation ) , guid : :: windows :: core :: GUID::from_u128(0x86a19291_0482_402c_bf4c_addac52b1c39) , } }
 pub const GUID_SensorType_Temperature: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x04fd0ec4_d5da_45fa_95a9_5db38ee19306);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SensorType_Temperature ) , guid : :: windows :: core :: GUID::from_u128(0x04fd0ec4_d5da_45fa_95a9_5db38ee19306) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
@@ -1455,17 +1521,41 @@ impl ::core::default::Default for QUATERNION {
     }
 }
 pub const SENSOR_CATEGORY_ALL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc317c286_c468_4288_9975_d4c4587c442c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_CATEGORY_ALL ) , guid : :: windows :: core :: GUID::from_u128(0xc317c286_c468_4288_9975_d4c4587c442c) , } }
 pub const SENSOR_CATEGORY_BIOMETRIC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xca19690f_a2c7_477d_a99e_99ec6e2b5648);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_CATEGORY_BIOMETRIC ) , guid : :: windows :: core :: GUID::from_u128(0xca19690f_a2c7_477d_a99e_99ec6e2b5648) , } }
 pub const SENSOR_CATEGORY_ELECTRICAL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfb73fcd8_fc4a_483c_ac58_27b691c6beff);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_CATEGORY_ELECTRICAL ) , guid : :: windows :: core :: GUID::from_u128(0xfb73fcd8_fc4a_483c_ac58_27b691c6beff) , } }
 pub const SENSOR_CATEGORY_ENVIRONMENTAL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x323439aa_7f66_492b_ba0c_73e9aa0a65d5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_CATEGORY_ENVIRONMENTAL ) , guid : :: windows :: core :: GUID::from_u128(0x323439aa_7f66_492b_ba0c_73e9aa0a65d5) , } }
 pub const SENSOR_CATEGORY_LIGHT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x17a665c0_9063_4216_b202_5c7a255e18ce);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_CATEGORY_LIGHT ) , guid : :: windows :: core :: GUID::from_u128(0x17a665c0_9063_4216_b202_5c7a255e18ce) , } }
 pub const SENSOR_CATEGORY_LOCATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbfa794e4_f964_4fdb_90f6_51056bfe4b44);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_CATEGORY_LOCATION ) , guid : :: windows :: core :: GUID::from_u128(0xbfa794e4_f964_4fdb_90f6_51056bfe4b44) , } }
 pub const SENSOR_CATEGORY_MECHANICAL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8d131d68_8ef7_4656_80b5_cccbd93791c5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_CATEGORY_MECHANICAL ) , guid : :: windows :: core :: GUID::from_u128(0x8d131d68_8ef7_4656_80b5_cccbd93791c5) , } }
 pub const SENSOR_CATEGORY_MOTION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcd09daf1_3b2e_4c3d_b598_b5e5ff93fd46);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_CATEGORY_MOTION ) , guid : :: windows :: core :: GUID::from_u128(0xcd09daf1_3b2e_4c3d_b598_b5e5ff93fd46) , } }
 pub const SENSOR_CATEGORY_ORIENTATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9e6c04b6_96fe_4954_b726_68682a473f69);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_CATEGORY_ORIENTATION ) , guid : :: windows :: core :: GUID::from_u128(0x9e6c04b6_96fe_4954_b726_68682a473f69) , } }
 pub const SENSOR_CATEGORY_OTHER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2c90e7a9_f4c9_4fa2_af37_56d471fe5a3d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_CATEGORY_OTHER ) , guid : :: windows :: core :: GUID::from_u128(0x2c90e7a9_f4c9_4fa2_af37_56d471fe5a3d) , } }
 pub const SENSOR_CATEGORY_SCANNER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb000e77e_f5b5_420f_815d_0270a726f270);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_CATEGORY_SCANNER ) , guid : :: windows :: core :: GUID::from_u128(0xb000e77e_f5b5_420f_815d_0270a726f270) , } }
 pub const SENSOR_CATEGORY_UNSUPPORTED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2beae7fa_19b0_48c5_a1f6_b5480dc206b0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_CATEGORY_UNSUPPORTED ) , guid : :: windows :: core :: GUID::from_u128(0x2beae7fa_19b0_48c5_a1f6_b5480dc206b0) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_Foundation', 'Win32_System_Com', 'Win32_System_Com_StructuredStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
@@ -1509,450 +1599,772 @@ pub const SensorConnectionType_External: SENSOR_CONNECTION_TYPES = 2i32;
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_ABSOLUTE_PRESSURE_PASCAL: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x38564a7c_f2f2_49bb_9b2b_ba60f66a58df), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_ABSOLUTE_PRESSURE_PASCAL ) , guid : :: windows :: core :: GUID::from_u128(0x38564a7c_f2f2_49bb_9b2b_ba60f66a58df) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_ACCELERATION_X_G: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x3f8a69a2_07c5_4e48_a965_cd797aab56d5), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_ACCELERATION_X_G ) , guid : :: windows :: core :: GUID::from_u128(0x3f8a69a2_07c5_4e48_a965_cd797aab56d5) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_ACCELERATION_Y_G: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x3f8a69a2_07c5_4e48_a965_cd797aab56d5), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_ACCELERATION_Y_G ) , guid : :: windows :: core :: GUID::from_u128(0x3f8a69a2_07c5_4e48_a965_cd797aab56d5) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_ACCELERATION_Z_G: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x3f8a69a2_07c5_4e48_a965_cd797aab56d5), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_ACCELERATION_Z_G ) , guid : :: windows :: core :: GUID::from_u128(0x3f8a69a2_07c5_4e48_a965_cd797aab56d5) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_ADDRESS1: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 23u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_ADDRESS1 ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_ADDRESS2: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 24u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_ADDRESS2 ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_ALTITUDE_ANTENNA_SEALEVEL_METERS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 36u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_ALTITUDE_ANTENNA_SEALEVEL_METERS ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_ALTITUDE_ELLIPSOID_ERROR_METERS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 29u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_ALTITUDE_ELLIPSOID_ERROR_METERS ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_ALTITUDE_ELLIPSOID_METERS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_ALTITUDE_ELLIPSOID_METERS ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_ALTITUDE_SEALEVEL_ERROR_METERS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 30u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_ALTITUDE_SEALEVEL_ERROR_METERS ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_ALTITUDE_SEALEVEL_METERS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_ALTITUDE_SEALEVEL_METERS ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_ANGULAR_ACCELERATION_X_DEGREES_PER_SECOND_SQUARED: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x3f8a69a2_07c5_4e48_a965_cd797aab56d5), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_ANGULAR_ACCELERATION_X_DEGREES_PER_SECOND_SQUARED ) , guid : :: windows :: core :: GUID::from_u128(0x3f8a69a2_07c5_4e48_a965_cd797aab56d5) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_ANGULAR_ACCELERATION_Y_DEGREES_PER_SECOND_SQUARED: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x3f8a69a2_07c5_4e48_a965_cd797aab56d5), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_ANGULAR_ACCELERATION_Y_DEGREES_PER_SECOND_SQUARED ) , guid : :: windows :: core :: GUID::from_u128(0x3f8a69a2_07c5_4e48_a965_cd797aab56d5) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_ANGULAR_ACCELERATION_Z_DEGREES_PER_SECOND_SQUARED: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x3f8a69a2_07c5_4e48_a965_cd797aab56d5), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_ANGULAR_ACCELERATION_Z_DEGREES_PER_SECOND_SQUARED ) , guid : :: windows :: core :: GUID::from_u128(0x3f8a69a2_07c5_4e48_a965_cd797aab56d5) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_ANGULAR_VELOCITY_X_DEGREES_PER_SECOND: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x3f8a69a2_07c5_4e48_a965_cd797aab56d5), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_ANGULAR_VELOCITY_X_DEGREES_PER_SECOND ) , guid : :: windows :: core :: GUID::from_u128(0x3f8a69a2_07c5_4e48_a965_cd797aab56d5) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_ANGULAR_VELOCITY_Y_DEGREES_PER_SECOND: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x3f8a69a2_07c5_4e48_a965_cd797aab56d5), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_ANGULAR_VELOCITY_Y_DEGREES_PER_SECOND ) , guid : :: windows :: core :: GUID::from_u128(0x3f8a69a2_07c5_4e48_a965_cd797aab56d5) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_ANGULAR_VELOCITY_Z_DEGREES_PER_SECOND: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x3f8a69a2_07c5_4e48_a965_cd797aab56d5), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_ANGULAR_VELOCITY_Z_DEGREES_PER_SECOND ) , guid : :: windows :: core :: GUID::from_u128(0x3f8a69a2_07c5_4e48_a965_cd797aab56d5) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_ATMOSPHERIC_PRESSURE_BAR: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8b0aa2f1_2d57_42ee_8cc0_4d27622b46c4), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_ATMOSPHERIC_PRESSURE_BAR ) , guid : :: windows :: core :: GUID::from_u128(0x8b0aa2f1_2d57_42ee_8cc0_4d27622b46c4) , } }
 pub const SENSOR_DATA_TYPE_BIOMETRIC_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2299288a_6d9e_4b0b_b7ec_3528f89e40af);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_BIOMETRIC_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x2299288a_6d9e_4b0b_b7ec_3528f89e40af) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_BOOLEAN_SWITCH_ARRAY_STATES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x38564a7c_f2f2_49bb_9b2b_ba60f66a58df), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_BOOLEAN_SWITCH_ARRAY_STATES ) , guid : :: windows :: core :: GUID::from_u128(0x38564a7c_f2f2_49bb_9b2b_ba60f66a58df) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_BOOLEAN_SWITCH_STATE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x38564a7c_f2f2_49bb_9b2b_ba60f66a58df), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_BOOLEAN_SWITCH_STATE ) , guid : :: windows :: core :: GUID::from_u128(0x38564a7c_f2f2_49bb_9b2b_ba60f66a58df) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CAPACITANCE_FARAD: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xbbb246d1_e242_4780_a2d3_cded84f35842), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CAPACITANCE_FARAD ) , guid : :: windows :: core :: GUID::from_u128(0xbbb246d1_e242_4780_a2d3_cded84f35842) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CITY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 25u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CITY ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 pub const SENSOR_DATA_TYPE_COMMON_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdb5e0cf2_cf1f_4c18_b46c_d86011d62150);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_COMMON_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xdb5e0cf2_cf1f_4c18_b46c_d86011d62150) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_COUNTRY_REGION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 28u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_COUNTRY_REGION ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CURRENT_AMPS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xbbb246d1_e242_4780_a2d3_cded84f35842), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CURRENT_AMPS ) , guid : :: windows :: core :: GUID::from_u128(0xbbb246d1_e242_4780_a2d3_cded84f35842) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_BOOLEAN_ARRAY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_BOOLEAN_ARRAY ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 pub const SENSOR_DATA_TYPE_CUSTOM_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_USAGE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_USAGE ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_VALUE1: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_VALUE1 ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_VALUE10: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 16u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_VALUE10 ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_VALUE11: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 17u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_VALUE11 ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_VALUE12: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 18u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_VALUE12 ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_VALUE13: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 19u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_VALUE13 ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_VALUE14: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 20u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_VALUE14 ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_VALUE15: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 21u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_VALUE15 ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_VALUE16: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 22u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_VALUE16 ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_VALUE17: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 23u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_VALUE17 ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_VALUE18: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 24u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_VALUE18 ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_VALUE19: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 25u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_VALUE19 ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_VALUE2: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_VALUE2 ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_VALUE20: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 26u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_VALUE20 ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_VALUE21: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 27u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_VALUE21 ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_VALUE22: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 28u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_VALUE22 ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_VALUE23: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 29u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_VALUE23 ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_VALUE24: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 30u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_VALUE24 ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_VALUE25: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 31u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_VALUE25 ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_VALUE26: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 32u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_VALUE26 ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_VALUE27: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 33u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_VALUE27 ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_VALUE28: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 34u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_VALUE28 ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_VALUE3: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_VALUE3 ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_VALUE4: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_VALUE4 ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_VALUE5: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_VALUE5 ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_VALUE6: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_VALUE6 ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_VALUE7: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_VALUE7 ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_VALUE8: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_VALUE8 ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_CUSTOM_VALUE9: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f), pid: 15u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_CUSTOM_VALUE9 ) , guid : :: windows :: core :: GUID::from_u128(0xb14c764f_07cf_41e8_9d82_ebe3d0776a6f) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_DGPS_DATA_AGE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 35u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_DGPS_DATA_AGE ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_DIFFERENTIAL_REFERENCE_STATION_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 37u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_DIFFERENTIAL_REFERENCE_STATION_ID ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_DISTANCE_X_METERS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_DISTANCE_X_METERS ) , guid : :: windows :: core :: GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_DISTANCE_Y_METERS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_DISTANCE_Y_METERS ) , guid : :: windows :: core :: GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_DISTANCE_Z_METERS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_DISTANCE_Z_METERS ) , guid : :: windows :: core :: GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_ELECTRICAL_FREQUENCY_HERTZ: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xbbb246d1_e242_4780_a2d3_cded84f35842), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_ELECTRICAL_FREQUENCY_HERTZ ) , guid : :: windows :: core :: GUID::from_u128(0xbbb246d1_e242_4780_a2d3_cded84f35842) , } }
 pub const SENSOR_DATA_TYPE_ELECTRICAL_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbbb246d1_e242_4780_a2d3_cded84f35842);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_ELECTRICAL_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xbbb246d1_e242_4780_a2d3_cded84f35842) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_ELECTRICAL_PERCENT_OF_RANGE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xbbb246d1_e242_4780_a2d3_cded84f35842), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_ELECTRICAL_PERCENT_OF_RANGE ) , guid : :: windows :: core :: GUID::from_u128(0xbbb246d1_e242_4780_a2d3_cded84f35842) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_ELECTRICAL_POWER_WATTS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xbbb246d1_e242_4780_a2d3_cded84f35842), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_ELECTRICAL_POWER_WATTS ) , guid : :: windows :: core :: GUID::from_u128(0xbbb246d1_e242_4780_a2d3_cded84f35842) , } }
 pub const SENSOR_DATA_TYPE_ENVIRONMENTAL_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8b0aa2f1_2d57_42ee_8cc0_4d27622b46c4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_ENVIRONMENTAL_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x8b0aa2f1_2d57_42ee_8cc0_4d27622b46c4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_ERROR_RADIUS_METERS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 22u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_ERROR_RADIUS_METERS ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_FIX_QUALITY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_FIX_QUALITY ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_FIX_TYPE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_FIX_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_FORCE_NEWTONS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x38564a7c_f2f2_49bb_9b2b_ba60f66a58df), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_FORCE_NEWTONS ) , guid : :: windows :: core :: GUID::from_u128(0x38564a7c_f2f2_49bb_9b2b_ba60f66a58df) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_GAUGE_PRESSURE_PASCAL: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x38564a7c_f2f2_49bb_9b2b_ba60f66a58df), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_GAUGE_PRESSURE_PASCAL ) , guid : :: windows :: core :: GUID::from_u128(0x38564a7c_f2f2_49bb_9b2b_ba60f66a58df) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_GEOIDAL_SEPARATION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 34u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_GEOIDAL_SEPARATION ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_GPS_OPERATION_MODE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 32u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_GPS_OPERATION_MODE ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_GPS_SELECTION_MODE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 31u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_GPS_SELECTION_MODE ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_GPS_STATUS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 33u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_GPS_STATUS ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 pub const SENSOR_DATA_TYPE_GUID_MECHANICAL_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x38564a7c_f2f2_49bb_9b2b_ba60f66a58df);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_GUID_MECHANICAL_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x38564a7c_f2f2_49bb_9b2b_ba60f66a58df) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_HORIZONAL_DILUTION_OF_PRECISION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_HORIZONAL_DILUTION_OF_PRECISION ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_HUMAN_PRESENCE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2299288a_6d9e_4b0b_b7ec_3528f89e40af), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_HUMAN_PRESENCE ) , guid : :: windows :: core :: GUID::from_u128(0x2299288a_6d9e_4b0b_b7ec_3528f89e40af) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_HUMAN_PROXIMITY_METERS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2299288a_6d9e_4b0b_b7ec_3528f89e40af), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_HUMAN_PROXIMITY_METERS ) , guid : :: windows :: core :: GUID::from_u128(0x2299288a_6d9e_4b0b_b7ec_3528f89e40af) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_INDUCTANCE_HENRY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xbbb246d1_e242_4780_a2d3_cded84f35842), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_INDUCTANCE_HENRY ) , guid : :: windows :: core :: GUID::from_u128(0xbbb246d1_e242_4780_a2d3_cded84f35842) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_LATITUDE_DEGREES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_LATITUDE_DEGREES ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_LIGHT_CHROMACITY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe4c77ce2_dcb7_46e9_8439_4fec548833a6), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_LIGHT_CHROMACITY ) , guid : :: windows :: core :: GUID::from_u128(0xe4c77ce2_dcb7_46e9_8439_4fec548833a6) , } }
 pub const SENSOR_DATA_TYPE_LIGHT_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe4c77ce2_dcb7_46e9_8439_4fec548833a6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_LIGHT_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xe4c77ce2_dcb7_46e9_8439_4fec548833a6) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_LIGHT_LEVEL_LUX: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe4c77ce2_dcb7_46e9_8439_4fec548833a6), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_LIGHT_LEVEL_LUX ) , guid : :: windows :: core :: GUID::from_u128(0xe4c77ce2_dcb7_46e9_8439_4fec548833a6) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_LIGHT_TEMPERATURE_KELVIN: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe4c77ce2_dcb7_46e9_8439_4fec548833a6), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_LIGHT_TEMPERATURE_KELVIN ) , guid : :: windows :: core :: GUID::from_u128(0xe4c77ce2_dcb7_46e9_8439_4fec548833a6) , } }
 pub const SENSOR_DATA_TYPE_LOCATION_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_LOCATION_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_LOCATION_SOURCE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 40u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_LOCATION_SOURCE ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_LONGITUDE_DEGREES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_LONGITUDE_DEGREES ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_MAGNETIC_FIELD_STRENGTH_X_MILLIGAUSS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd), pid: 19u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_MAGNETIC_FIELD_STRENGTH_X_MILLIGAUSS ) , guid : :: windows :: core :: GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_MAGNETIC_FIELD_STRENGTH_Y_MILLIGAUSS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd), pid: 20u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_MAGNETIC_FIELD_STRENGTH_Y_MILLIGAUSS ) , guid : :: windows :: core :: GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_MAGNETIC_FIELD_STRENGTH_Z_MILLIGAUSS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd), pid: 21u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_MAGNETIC_FIELD_STRENGTH_Z_MILLIGAUSS ) , guid : :: windows :: core :: GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_MAGNETIC_HEADING_COMPENSATED_MAGNETIC_NORTH_DEGREES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_MAGNETIC_HEADING_COMPENSATED_MAGNETIC_NORTH_DEGREES ) , guid : :: windows :: core :: GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_MAGNETIC_HEADING_COMPENSATED_TRUE_NORTH_DEGREES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_MAGNETIC_HEADING_COMPENSATED_TRUE_NORTH_DEGREES ) , guid : :: windows :: core :: GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_MAGNETIC_HEADING_DEGREES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_MAGNETIC_HEADING_DEGREES ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_MAGNETIC_HEADING_MAGNETIC_NORTH_DEGREES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_MAGNETIC_HEADING_MAGNETIC_NORTH_DEGREES ) , guid : :: windows :: core :: GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_MAGNETIC_HEADING_TRUE_NORTH_DEGREES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_MAGNETIC_HEADING_TRUE_NORTH_DEGREES ) , guid : :: windows :: core :: GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_MAGNETIC_HEADING_X_DEGREES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_MAGNETIC_HEADING_X_DEGREES ) , guid : :: windows :: core :: GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_MAGNETIC_HEADING_Y_DEGREES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_MAGNETIC_HEADING_Y_DEGREES ) , guid : :: windows :: core :: GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_MAGNETIC_HEADING_Z_DEGREES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_MAGNETIC_HEADING_Z_DEGREES ) , guid : :: windows :: core :: GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_MAGNETIC_VARIATION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_MAGNETIC_VARIATION ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_MAGNETOMETER_ACCURACY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd), pid: 22u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_MAGNETOMETER_ACCURACY ) , guid : :: windows :: core :: GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd) , } }
 pub const SENSOR_DATA_TYPE_MOTION_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3f8a69a2_07c5_4e48_a965_cd797aab56d5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_MOTION_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x3f8a69a2_07c5_4e48_a965_cd797aab56d5) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_MOTION_STATE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x3f8a69a2_07c5_4e48_a965_cd797aab56d5), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_MOTION_STATE ) , guid : :: windows :: core :: GUID::from_u128(0x3f8a69a2_07c5_4e48_a965_cd797aab56d5) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_MULTIVALUE_SWITCH_STATE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x38564a7c_f2f2_49bb_9b2b_ba60f66a58df), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_MULTIVALUE_SWITCH_STATE ) , guid : :: windows :: core :: GUID::from_u128(0x38564a7c_f2f2_49bb_9b2b_ba60f66a58df) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_NMEA_SENTENCE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 38u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_NMEA_SENTENCE ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 pub const SENSOR_DATA_TYPE_ORIENTATION_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_ORIENTATION_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_POSITION_DILUTION_OF_PRECISION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_POSITION_DILUTION_OF_PRECISION ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_POSTALCODE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 27u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_POSTALCODE ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_QUADRANT_ANGLE_DEGREES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd), pid: 15u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_QUADRANT_ANGLE_DEGREES ) , guid : :: windows :: core :: GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_QUATERNION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd), pid: 17u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_QUATERNION ) , guid : :: windows :: core :: GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_RELATIVE_HUMIDITY_PERCENT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8b0aa2f1_2d57_42ee_8cc0_4d27622b46c4), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_RELATIVE_HUMIDITY_PERCENT ) , guid : :: windows :: core :: GUID::from_u128(0x8b0aa2f1_2d57_42ee_8cc0_4d27622b46c4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_RESISTANCE_OHMS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xbbb246d1_e242_4780_a2d3_cded84f35842), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_RESISTANCE_OHMS ) , guid : :: windows :: core :: GUID::from_u128(0xbbb246d1_e242_4780_a2d3_cded84f35842) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_RFID_TAG_40_BIT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd7a59a3c_3421_44ab_8d3a_9de8ab6c4cae), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_RFID_TAG_40_BIT ) , guid : :: windows :: core :: GUID::from_u128(0xd7a59a3c_3421_44ab_8d3a_9de8ab6c4cae) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_ROTATION_MATRIX: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd), pid: 16u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_ROTATION_MATRIX ) , guid : :: windows :: core :: GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_SATELLITES_IN_VIEW: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 17u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_SATELLITES_IN_VIEW ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_SATELLITES_IN_VIEW_AZIMUTH: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 20u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_SATELLITES_IN_VIEW_AZIMUTH ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_SATELLITES_IN_VIEW_ELEVATION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 19u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_SATELLITES_IN_VIEW_ELEVATION ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_SATELLITES_IN_VIEW_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 39u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_SATELLITES_IN_VIEW_ID ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_SATELLITES_IN_VIEW_PRNS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 18u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_SATELLITES_IN_VIEW_PRNS ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_SATELLITES_IN_VIEW_STN_RATIO: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 21u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_SATELLITES_IN_VIEW_STN_RATIO ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_SATELLITES_USED_COUNT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 15u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_SATELLITES_USED_COUNT ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_SATELLITES_USED_PRNS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 16u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_SATELLITES_USED_PRNS ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_SATELLITES_USED_PRNS_AND_CONSTELLATIONS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 41u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_SATELLITES_USED_PRNS_AND_CONSTELLATIONS ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 pub const SENSOR_DATA_TYPE_SCANNER_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd7a59a3c_3421_44ab_8d3a_9de8ab6c4cae);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_SCANNER_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xd7a59a3c_3421_44ab_8d3a_9de8ab6c4cae) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_SIMPLE_DEVICE_ORIENTATION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd), pid: 18u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_SIMPLE_DEVICE_ORIENTATION ) , guid : :: windows :: core :: GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_SPEED_KNOTS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_SPEED_KNOTS ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_SPEED_METERS_PER_SECOND: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x3f8a69a2_07c5_4e48_a965_cd797aab56d5), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_SPEED_METERS_PER_SECOND ) , guid : :: windows :: core :: GUID::from_u128(0x3f8a69a2_07c5_4e48_a965_cd797aab56d5) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_STATE_PROVINCE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 26u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_STATE_PROVINCE ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_STRAIN: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x38564a7c_f2f2_49bb_9b2b_ba60f66a58df), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_STRAIN ) , guid : :: windows :: core :: GUID::from_u128(0x38564a7c_f2f2_49bb_9b2b_ba60f66a58df) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_TEMPERATURE_CELSIUS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8b0aa2f1_2d57_42ee_8cc0_4d27622b46c4), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_TEMPERATURE_CELSIUS ) , guid : :: windows :: core :: GUID::from_u128(0x8b0aa2f1_2d57_42ee_8cc0_4d27622b46c4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_TILT_X_DEGREES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_TILT_X_DEGREES ) , guid : :: windows :: core :: GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_TILT_Y_DEGREES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_TILT_Y_DEGREES ) , guid : :: windows :: core :: GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_TILT_Z_DEGREES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_TILT_Z_DEGREES ) , guid : :: windows :: core :: GUID::from_u128(0x1637d8a2_4248_4275_865d_558de84aedfd) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_TIMESTAMP: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xdb5e0cf2_cf1f_4c18_b46c_d86011d62150), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_TIMESTAMP ) , guid : :: windows :: core :: GUID::from_u128(0xdb5e0cf2_cf1f_4c18_b46c_d86011d62150) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_TOUCH_STATE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2299288a_6d9e_4b0b_b7ec_3528f89e40af), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_TOUCH_STATE ) , guid : :: windows :: core :: GUID::from_u128(0x2299288a_6d9e_4b0b_b7ec_3528f89e40af) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_TRUE_HEADING_DEGREES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_TRUE_HEADING_DEGREES ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_VERTICAL_DILUTION_OF_PRECISION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_VERTICAL_DILUTION_OF_PRECISION ) , guid : :: windows :: core :: GUID::from_u128(0x055c74d8_ca6f_47d6_95c6_1ed3637a0ff4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_VOLTAGE_VOLTS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xbbb246d1_e242_4780_a2d3_cded84f35842), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_VOLTAGE_VOLTS ) , guid : :: windows :: core :: GUID::from_u128(0xbbb246d1_e242_4780_a2d3_cded84f35842) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_WEIGHT_KILOGRAMS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x38564a7c_f2f2_49bb_9b2b_ba60f66a58df), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_WEIGHT_KILOGRAMS ) , guid : :: windows :: core :: GUID::from_u128(0x38564a7c_f2f2_49bb_9b2b_ba60f66a58df) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_WIND_DIRECTION_DEGREES_ANTICLOCKWISE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8b0aa2f1_2d57_42ee_8cc0_4d27622b46c4), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_WIND_DIRECTION_DEGREES_ANTICLOCKWISE ) , guid : :: windows :: core :: GUID::from_u128(0x8b0aa2f1_2d57_42ee_8cc0_4d27622b46c4) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_DATA_TYPE_WIND_SPEED_METERS_PER_SECOND: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8b0aa2f1_2d57_42ee_8cc0_4d27622b46c4), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_DATA_TYPE_WIND_SPEED_METERS_PER_SECOND ) , guid : :: windows :: core :: GUID::from_u128(0x8b0aa2f1_2d57_42ee_8cc0_4d27622b46c4) , } }
 pub const SENSOR_ERROR_PARAMETER_COMMON_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x77112bcd_fce1_4f43_b8b8_a88256adb4b3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_ERROR_PARAMETER_COMMON_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x77112bcd_fce1_4f43_b8b8_a88256adb4b3) , } }
 pub const SENSOR_EVENT_ACCELEROMETER_SHAKE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x825f5a94_0f48_4396_9ca0_6ecb5c99d915);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_EVENT_ACCELEROMETER_SHAKE ) , guid : :: windows :: core :: GUID::from_u128(0x825f5a94_0f48_4396_9ca0_6ecb5c99d915) , } }
 pub const SENSOR_EVENT_DATA_UPDATED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2ed0f2a4_0087_41d3_87db_6773370b3c88);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_EVENT_DATA_UPDATED ) , guid : :: windows :: core :: GUID::from_u128(0x2ed0f2a4_0087_41d3_87db_6773370b3c88) , } }
 pub const SENSOR_EVENT_PARAMETER_COMMON_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x64346e30_8728_4b34_bdf6_4f52442c5c28);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_EVENT_PARAMETER_COMMON_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x64346e30_8728_4b34_bdf6_4f52442c5c28) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_EVENT_PARAMETER_EVENT_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64346e30_8728_4b34_bdf6_4f52442c5c28), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_EVENT_PARAMETER_EVENT_ID ) , guid : :: windows :: core :: GUID::from_u128(0x64346e30_8728_4b34_bdf6_4f52442c5c28) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_EVENT_PARAMETER_STATE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64346e30_8728_4b34_bdf6_4f52442c5c28), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_EVENT_PARAMETER_STATE ) , guid : :: windows :: core :: GUID::from_u128(0x64346e30_8728_4b34_bdf6_4f52442c5c28) , } }
 pub const SENSOR_EVENT_PROPERTY_CHANGED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2358f099_84c9_4d3d_90df_c2421e2b2045);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_EVENT_PROPERTY_CHANGED ) , guid : :: windows :: core :: GUID::from_u128(0x2358f099_84c9_4d3d_90df_c2421e2b2045) , } }
 pub const SENSOR_EVENT_STATE_CHANGED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbfd96016_6bd7_4560_ad34_f2f6607e8f81);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_EVENT_STATE_CHANGED ) , guid : :: windows :: core :: GUID::from_u128(0xbfd96016_6bd7_4560_ad34_f2f6607e8f81) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_PROPERTY_ACCURACY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920), pid: 17u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_PROPERTY_ACCURACY ) , guid : :: windows :: core :: GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_PROPERTY_CHANGE_SENSITIVITY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_PROPERTY_CHANGE_SENSITIVITY ) , guid : :: windows :: core :: GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_PROPERTY_CLEAR_ASSISTANCE_DATA: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe1e962f4_6e65_45f7_9c36_d487b7b1bd34), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_PROPERTY_CLEAR_ASSISTANCE_DATA ) , guid : :: windows :: core :: GUID::from_u128(0xe1e962f4_6e65_45f7_9c36_d487b7b1bd34) , } }
 pub const SENSOR_PROPERTY_COMMON_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_PROPERTY_COMMON_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_PROPERTY_CONNECTION_TYPE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_PROPERTY_CONNECTION_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_PROPERTY_CURRENT_REPORT_INTERVAL: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_PROPERTY_CURRENT_REPORT_INTERVAL ) , guid : :: windows :: core :: GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_PROPERTY_DESCRIPTION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_PROPERTY_DESCRIPTION ) , guid : :: windows :: core :: GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_PROPERTY_DEVICE_PATH: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920), pid: 15u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_PROPERTY_DEVICE_PATH ) , guid : :: windows :: core :: GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_PROPERTY_FRIENDLY_NAME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_PROPERTY_FRIENDLY_NAME ) , guid : :: windows :: core :: GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_PROPERTY_HID_USAGE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920), pid: 22u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_PROPERTY_HID_USAGE ) , guid : :: windows :: core :: GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_PROPERTY_LIGHT_RESPONSE_CURVE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920), pid: 16u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_PROPERTY_LIGHT_RESPONSE_CURVE ) , guid : :: windows :: core :: GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
@@ -1998,46 +2410,76 @@ pub const SENSOR_PROPERTY_LIST_HEADER_SIZE: u32 = 8u32;
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_PROPERTY_LOCATION_DESIRED_ACCURACY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920), pid: 19u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_PROPERTY_LOCATION_DESIRED_ACCURACY ) , guid : :: windows :: core :: GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_PROPERTY_MANUFACTURER: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_PROPERTY_MANUFACTURER ) , guid : :: windows :: core :: GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_PROPERTY_MIN_REPORT_INTERVAL: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_PROPERTY_MIN_REPORT_INTERVAL ) , guid : :: windows :: core :: GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_PROPERTY_MODEL: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_PROPERTY_MODEL ) , guid : :: windows :: core :: GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_PROPERTY_PERSISTENT_UNIQUE_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_PROPERTY_PERSISTENT_UNIQUE_ID ) , guid : :: windows :: core :: GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_PROPERTY_RADIO_STATE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920), pid: 23u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_PROPERTY_RADIO_STATE ) , guid : :: windows :: core :: GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_PROPERTY_RADIO_STATE_PREVIOUS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920), pid: 24u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_PROPERTY_RADIO_STATE_PREVIOUS ) , guid : :: windows :: core :: GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_PROPERTY_RANGE_MAXIMUM: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920), pid: 21u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_PROPERTY_RANGE_MAXIMUM ) , guid : :: windows :: core :: GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_PROPERTY_RANGE_MINIMUM: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920), pid: 20u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_PROPERTY_RANGE_MINIMUM ) , guid : :: windows :: core :: GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_PROPERTY_RESOLUTION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920), pid: 18u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_PROPERTY_RESOLUTION ) , guid : :: windows :: core :: GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_PROPERTY_SERIAL_NUMBER: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_PROPERTY_SERIAL_NUMBER ) , guid : :: windows :: core :: GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_PROPERTY_STATE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_PROPERTY_STATE ) , guid : :: windows :: core :: GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920) , } }
 pub const SENSOR_PROPERTY_TEST_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe1e962f4_6e65_45f7_9c36_d487b7b1bd34);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_PROPERTY_TEST_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xe1e962f4_6e65_45f7_9c36_d487b7b1bd34) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_PROPERTY_TURN_ON_OFF_NMEA: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe1e962f4_6e65_45f7_9c36_d487b7b1bd34), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_PROPERTY_TURN_ON_OFF_NMEA ) , guid : :: windows :: core :: GUID::from_u128(0xe1e962f4_6e65_45f7_9c36_d487b7b1bd34) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SENSOR_PROPERTY_TYPE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_PROPERTY_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x7f8383ec_d3ec_495c_a8cf_b8bbe85c2920) , } }
 #[doc = "*Required features: 'Win32_Devices_Sensors'*"]
 pub type SENSOR_STATE = i32;
 #[doc = "*Required features: 'Win32_Devices_Sensors'*"]
@@ -2049,60 +2491,170 @@ pub const SensorState_Active: SENSOR_STATE = 2i32;
 #[doc = "*Required features: 'Win32_Devices_Sensors'*"]
 pub const SensorState_Error: SENSOR_STATE = 3i32;
 pub const SENSOR_TYPE_ACCELEROMETER_1D: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc04d2387_7340_4cc2_991e_3b18cb8ef2f4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_ACCELEROMETER_1D ) , guid : :: windows :: core :: GUID::from_u128(0xc04d2387_7340_4cc2_991e_3b18cb8ef2f4) , } }
 pub const SENSOR_TYPE_ACCELEROMETER_2D: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb2c517a8_f6b5_4ba6_a423_5df560b4cc07);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_ACCELEROMETER_2D ) , guid : :: windows :: core :: GUID::from_u128(0xb2c517a8_f6b5_4ba6_a423_5df560b4cc07) , } }
 pub const SENSOR_TYPE_ACCELEROMETER_3D: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc2fb0f5f_e2d2_4c78_bcd0_352a9582819d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_ACCELEROMETER_3D ) , guid : :: windows :: core :: GUID::from_u128(0xc2fb0f5f_e2d2_4c78_bcd0_352a9582819d) , } }
 pub const SENSOR_TYPE_AGGREGATED_DEVICE_ORIENTATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcdb5d8f7_3cfd_41c8_8542_cce622cf5d6e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_AGGREGATED_DEVICE_ORIENTATION ) , guid : :: windows :: core :: GUID::from_u128(0xcdb5d8f7_3cfd_41c8_8542_cce622cf5d6e) , } }
 pub const SENSOR_TYPE_AGGREGATED_QUADRANT_ORIENTATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9f81f1af_c4ab_4307_9904_c828bfb90829);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_AGGREGATED_QUADRANT_ORIENTATION ) , guid : :: windows :: core :: GUID::from_u128(0x9f81f1af_c4ab_4307_9904_c828bfb90829) , } }
 pub const SENSOR_TYPE_AGGREGATED_SIMPLE_DEVICE_ORIENTATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x86a19291_0482_402c_bf4c_addac52b1c39);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_AGGREGATED_SIMPLE_DEVICE_ORIENTATION ) , guid : :: windows :: core :: GUID::from_u128(0x86a19291_0482_402c_bf4c_addac52b1c39) , } }
 pub const SENSOR_TYPE_AMBIENT_LIGHT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x97f115c8_599a_4153_8894_d2d12899918a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_AMBIENT_LIGHT ) , guid : :: windows :: core :: GUID::from_u128(0x97f115c8_599a_4153_8894_d2d12899918a) , } }
 pub const SENSOR_TYPE_BARCODE_SCANNER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x990b3d8f_85bb_45ff_914d_998c04f372df);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_BARCODE_SCANNER ) , guid : :: windows :: core :: GUID::from_u128(0x990b3d8f_85bb_45ff_914d_998c04f372df) , } }
 pub const SENSOR_TYPE_BOOLEAN_SWITCH: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9c7e371f_1041_460b_8d5c_71e4752e350c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_BOOLEAN_SWITCH ) , guid : :: windows :: core :: GUID::from_u128(0x9c7e371f_1041_460b_8d5c_71e4752e350c) , } }
 pub const SENSOR_TYPE_BOOLEAN_SWITCH_ARRAY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x545c8ba5_b143_4545_868f_ca7fd986b4f6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_BOOLEAN_SWITCH_ARRAY ) , guid : :: windows :: core :: GUID::from_u128(0x545c8ba5_b143_4545_868f_ca7fd986b4f6) , } }
 pub const SENSOR_TYPE_CAPACITANCE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xca2ffb1c_2317_49c0_a0b4_b63ce63461a0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_CAPACITANCE ) , guid : :: windows :: core :: GUID::from_u128(0xca2ffb1c_2317_49c0_a0b4_b63ce63461a0) , } }
 pub const SENSOR_TYPE_COMPASS_1D: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa415f6c5_cb50_49d0_8e62_a8270bd7a26c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_COMPASS_1D ) , guid : :: windows :: core :: GUID::from_u128(0xa415f6c5_cb50_49d0_8e62_a8270bd7a26c) , } }
 pub const SENSOR_TYPE_COMPASS_2D: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x15655cc0_997a_4d30_84db_57caba3648bb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_COMPASS_2D ) , guid : :: windows :: core :: GUID::from_u128(0x15655cc0_997a_4d30_84db_57caba3648bb) , } }
 pub const SENSOR_TYPE_COMPASS_3D: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x76b5ce0d_17dd_414d_93a1_e127f40bdf6e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_COMPASS_3D ) , guid : :: windows :: core :: GUID::from_u128(0x76b5ce0d_17dd_414d_93a1_e127f40bdf6e) , } }
 pub const SENSOR_TYPE_CURRENT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5adc9fce_15a0_4bbe_a1ad_2d38a9ae831c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_CURRENT ) , guid : :: windows :: core :: GUID::from_u128(0x5adc9fce_15a0_4bbe_a1ad_2d38a9ae831c) , } }
 pub const SENSOR_TYPE_CUSTOM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe83af229_8640_4d18_a213_e22675ebb2c3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_CUSTOM ) , guid : :: windows :: core :: GUID::from_u128(0xe83af229_8640_4d18_a213_e22675ebb2c3) , } }
 pub const SENSOR_TYPE_DISTANCE_1D: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5f14ab2f_1407_4306_a93f_b1dbabe4f9c0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_DISTANCE_1D ) , guid : :: windows :: core :: GUID::from_u128(0x5f14ab2f_1407_4306_a93f_b1dbabe4f9c0) , } }
 pub const SENSOR_TYPE_DISTANCE_2D: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5cf9a46c_a9a2_4e55_b6a1_a04aafa95a92);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_DISTANCE_2D ) , guid : :: windows :: core :: GUID::from_u128(0x5cf9a46c_a9a2_4e55_b6a1_a04aafa95a92) , } }
 pub const SENSOR_TYPE_DISTANCE_3D: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa20cae31_0e25_4772_9fe5_96608a1354b2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_DISTANCE_3D ) , guid : :: windows :: core :: GUID::from_u128(0xa20cae31_0e25_4772_9fe5_96608a1354b2) , } }
 pub const SENSOR_TYPE_ELECTRICAL_POWER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x212f10f5_14ab_4376_9a43_a7794098c2fe);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_ELECTRICAL_POWER ) , guid : :: windows :: core :: GUID::from_u128(0x212f10f5_14ab_4376_9a43_a7794098c2fe) , } }
 pub const SENSOR_TYPE_ENVIRONMENTAL_ATMOSPHERIC_PRESSURE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0e903829_ff8a_4a93_97df_3dcbde402288);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_ENVIRONMENTAL_ATMOSPHERIC_PRESSURE ) , guid : :: windows :: core :: GUID::from_u128(0x0e903829_ff8a_4a93_97df_3dcbde402288) , } }
 pub const SENSOR_TYPE_ENVIRONMENTAL_HUMIDITY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5c72bf67_bd7e_4257_990b_98a3ba3b400a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_ENVIRONMENTAL_HUMIDITY ) , guid : :: windows :: core :: GUID::from_u128(0x5c72bf67_bd7e_4257_990b_98a3ba3b400a) , } }
 pub const SENSOR_TYPE_ENVIRONMENTAL_TEMPERATURE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x04fd0ec4_d5da_45fa_95a9_5db38ee19306);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_ENVIRONMENTAL_TEMPERATURE ) , guid : :: windows :: core :: GUID::from_u128(0x04fd0ec4_d5da_45fa_95a9_5db38ee19306) , } }
 pub const SENSOR_TYPE_ENVIRONMENTAL_WIND_DIRECTION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9ef57a35_9306_434d_af09_37fa5a9c00bd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_ENVIRONMENTAL_WIND_DIRECTION ) , guid : :: windows :: core :: GUID::from_u128(0x9ef57a35_9306_434d_af09_37fa5a9c00bd) , } }
 pub const SENSOR_TYPE_ENVIRONMENTAL_WIND_SPEED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdd50607b_a45f_42cd_8efd_ec61761c4226);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_ENVIRONMENTAL_WIND_SPEED ) , guid : :: windows :: core :: GUID::from_u128(0xdd50607b_a45f_42cd_8efd_ec61761c4226) , } }
 pub const SENSOR_TYPE_FORCE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc2ab2b02_1a1c_4778_a81b_954a1788cc75);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_FORCE ) , guid : :: windows :: core :: GUID::from_u128(0xc2ab2b02_1a1c_4778_a81b_954a1788cc75) , } }
 pub const SENSOR_TYPE_FREQUENCY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8cd2cbb6_73e6_4640_a709_72ae8fb60d7f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_FREQUENCY ) , guid : :: windows :: core :: GUID::from_u128(0x8cd2cbb6_73e6_4640_a709_72ae8fb60d7f) , } }
 pub const SENSOR_TYPE_GYROMETER_1D: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfa088734_f552_4584_8324_edfaf649652c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_GYROMETER_1D ) , guid : :: windows :: core :: GUID::from_u128(0xfa088734_f552_4584_8324_edfaf649652c) , } }
 pub const SENSOR_TYPE_GYROMETER_2D: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x31ef4f83_919b_48bf_8de0_5d7a9d240556);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_GYROMETER_2D ) , guid : :: windows :: core :: GUID::from_u128(0x31ef4f83_919b_48bf_8de0_5d7a9d240556) , } }
 pub const SENSOR_TYPE_GYROMETER_3D: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x09485f5a_759e_42c2_bd4b_a349b75c8643);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_GYROMETER_3D ) , guid : :: windows :: core :: GUID::from_u128(0x09485f5a_759e_42c2_bd4b_a349b75c8643) , } }
 pub const SENSOR_TYPE_HUMAN_PRESENCE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc138c12b_ad52_451c_9375_87f518ff10c6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_HUMAN_PRESENCE ) , guid : :: windows :: core :: GUID::from_u128(0xc138c12b_ad52_451c_9375_87f518ff10c6) , } }
 pub const SENSOR_TYPE_HUMAN_PROXIMITY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5220dae9_3179_4430_9f90_06266d2a34de);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_HUMAN_PROXIMITY ) , guid : :: windows :: core :: GUID::from_u128(0x5220dae9_3179_4430_9f90_06266d2a34de) , } }
 pub const SENSOR_TYPE_INCLINOMETER_1D: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb96f98c5_7a75_4ba7_94e9_ac868c966dd8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_INCLINOMETER_1D ) , guid : :: windows :: core :: GUID::from_u128(0xb96f98c5_7a75_4ba7_94e9_ac868c966dd8) , } }
 pub const SENSOR_TYPE_INCLINOMETER_2D: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xab140f6d_83eb_4264_b70b_b16a5b256a01);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_INCLINOMETER_2D ) , guid : :: windows :: core :: GUID::from_u128(0xab140f6d_83eb_4264_b70b_b16a5b256a01) , } }
 pub const SENSOR_TYPE_INCLINOMETER_3D: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb84919fb_ea85_4976_8444_6f6f5c6d31db);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_INCLINOMETER_3D ) , guid : :: windows :: core :: GUID::from_u128(0xb84919fb_ea85_4976_8444_6f6f5c6d31db) , } }
 pub const SENSOR_TYPE_INDUCTANCE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdc1d933f_c435_4c7d_a2fe_607192a524d3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_INDUCTANCE ) , guid : :: windows :: core :: GUID::from_u128(0xdc1d933f_c435_4c7d_a2fe_607192a524d3) , } }
 pub const SENSOR_TYPE_LOCATION_BROADCAST: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd26988cf_5162_4039_bb17_4c58b698e44a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_LOCATION_BROADCAST ) , guid : :: windows :: core :: GUID::from_u128(0xd26988cf_5162_4039_bb17_4c58b698e44a) , } }
 pub const SENSOR_TYPE_LOCATION_DEAD_RECKONING: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1a37d538_f28b_42da_9fce_a9d0a2a6d829);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_LOCATION_DEAD_RECKONING ) , guid : :: windows :: core :: GUID::from_u128(0x1a37d538_f28b_42da_9fce_a9d0a2a6d829) , } }
 pub const SENSOR_TYPE_LOCATION_GPS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xed4ca589_327a_4ff9_a560_91da4b48275e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_LOCATION_GPS ) , guid : :: windows :: core :: GUID::from_u128(0xed4ca589_327a_4ff9_a560_91da4b48275e) , } }
 pub const SENSOR_TYPE_LOCATION_LOOKUP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3b2eae4a_72ce_436d_96d2_3c5b8570e987);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_LOCATION_LOOKUP ) , guid : :: windows :: core :: GUID::from_u128(0x3b2eae4a_72ce_436d_96d2_3c5b8570e987) , } }
 pub const SENSOR_TYPE_LOCATION_OTHER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9b2d0566_0368_4f71_b88d_533f132031de);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_LOCATION_OTHER ) , guid : :: windows :: core :: GUID::from_u128(0x9b2d0566_0368_4f71_b88d_533f132031de) , } }
 pub const SENSOR_TYPE_LOCATION_STATIC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x095f8184_0fa9_4445_8e6e_b70f320b6b4c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_LOCATION_STATIC ) , guid : :: windows :: core :: GUID::from_u128(0x095f8184_0fa9_4445_8e6e_b70f320b6b4c) , } }
 pub const SENSOR_TYPE_LOCATION_TRIANGULATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x691c341a_5406_4fe1_942f_2246cbeb39e0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_LOCATION_TRIANGULATION ) , guid : :: windows :: core :: GUID::from_u128(0x691c341a_5406_4fe1_942f_2246cbeb39e0) , } }
 pub const SENSOR_TYPE_MOTION_DETECTOR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5c7c1a12_30a5_43b9_a4b2_cf09ec5b7be8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_MOTION_DETECTOR ) , guid : :: windows :: core :: GUID::from_u128(0x5c7c1a12_30a5_43b9_a4b2_cf09ec5b7be8) , } }
 pub const SENSOR_TYPE_MULTIVALUE_SWITCH: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb3ee4d76_37a4_4402_b25e_99c60a775fa1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_MULTIVALUE_SWITCH ) , guid : :: windows :: core :: GUID::from_u128(0xb3ee4d76_37a4_4402_b25e_99c60a775fa1) , } }
 pub const SENSOR_TYPE_POTENTIOMETER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2b3681a9_cadc_45aa_a6ff_54957c8bb440);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_POTENTIOMETER ) , guid : :: windows :: core :: GUID::from_u128(0x2b3681a9_cadc_45aa_a6ff_54957c8bb440) , } }
 pub const SENSOR_TYPE_PRESSURE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x26d31f34_6352_41cf_b793_ea0713d53d77);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_PRESSURE ) , guid : :: windows :: core :: GUID::from_u128(0x26d31f34_6352_41cf_b793_ea0713d53d77) , } }
 pub const SENSOR_TYPE_RESISTANCE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9993d2c8_c157_4a52_a7b5_195c76037231);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_RESISTANCE ) , guid : :: windows :: core :: GUID::from_u128(0x9993d2c8_c157_4a52_a7b5_195c76037231) , } }
 pub const SENSOR_TYPE_RFID_SCANNER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x44328ef5_02dd_4e8d_ad5d_9249832b2eca);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_RFID_SCANNER ) , guid : :: windows :: core :: GUID::from_u128(0x44328ef5_02dd_4e8d_ad5d_9249832b2eca) , } }
 pub const SENSOR_TYPE_SCALE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc06dd92c_7feb_438e_9bf6_82207fff5bb8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_SCALE ) , guid : :: windows :: core :: GUID::from_u128(0xc06dd92c_7feb_438e_9bf6_82207fff5bb8) , } }
 pub const SENSOR_TYPE_SPEEDOMETER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6bd73c1f_0bb4_4310_81b2_dfc18a52bf94);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_SPEEDOMETER ) , guid : :: windows :: core :: GUID::from_u128(0x6bd73c1f_0bb4_4310_81b2_dfc18a52bf94) , } }
 pub const SENSOR_TYPE_STRAIN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc6d1ec0e_6803_4361_ad3d_85bcc58c6d29);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_STRAIN ) , guid : :: windows :: core :: GUID::from_u128(0xc6d1ec0e_6803_4361_ad3d_85bcc58c6d29) , } }
 pub const SENSOR_TYPE_TOUCH: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x17db3018_06c4_4f7d_81af_9274b7599c27);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_TOUCH ) , guid : :: windows :: core :: GUID::from_u128(0x17db3018_06c4_4f7d_81af_9274b7599c27) , } }
 pub const SENSOR_TYPE_UNKNOWN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x10ba83e3_ef4f_41ed_9885_a87d6435a8e1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_UNKNOWN ) , guid : :: windows :: core :: GUID::from_u128(0x10ba83e3_ef4f_41ed_9885_a87d6435a8e1) , } }
 pub const SENSOR_TYPE_VOLTAGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc5484637_4fb7_4953_98b8_a56d8aa1fb1e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSOR_TYPE_VOLTAGE ) , guid : :: windows :: core :: GUID::from_u128(0xc5484637_4fb7_4953_98b8_a56d8aa1fb1e) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Devices_Sensors', 'Win32_Foundation', 'Win32_System_Com', 'Win32_System_Com_StructuredStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]

--- a/crates/libs/windows/src/Windows/Win32/Devices/Usb/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Usb/mod.rs
@@ -220,18 +220,44 @@ pub const FILE_DEVICE_USB_SCAN: u32 = 32768u32;
 #[doc = "*Required features: 'Win32_Devices_Usb'*"]
 pub const FullSpeed: u32 = 2u32;
 pub const GUID_DEVINTERFACE_USB_BILLBOARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5e9adaef_f879_473f_b807_4e5ea77d1b1c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_USB_BILLBOARD ) , guid : :: windows :: core :: GUID::from_u128(0x5e9adaef_f879_473f_b807_4e5ea77d1b1c) , } }
 pub const GUID_DEVINTERFACE_USB_DEVICE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa5dcbf10_6530_11d2_901f_00c04fb951ed);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_USB_DEVICE ) , guid : :: windows :: core :: GUID::from_u128(0xa5dcbf10_6530_11d2_901f_00c04fb951ed) , } }
 pub const GUID_DEVINTERFACE_USB_HOST_CONTROLLER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3abf6f2d_71c4_462a_8a92_1e6861e6af27);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_USB_HOST_CONTROLLER ) , guid : :: windows :: core :: GUID::from_u128(0x3abf6f2d_71c4_462a_8a92_1e6861e6af27) , } }
 pub const GUID_DEVINTERFACE_USB_HUB: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf18a0e88_c30c_11d0_8815_00a0c906bed8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_USB_HUB ) , guid : :: windows :: core :: GUID::from_u128(0xf18a0e88_c30c_11d0_8815_00a0c906bed8) , } }
 pub const GUID_USB_MSOS20_PLATFORM_CAPABILITY_ID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd8dd60df_4589_4cc7_9cd2_659d9e648a9f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_USB_MSOS20_PLATFORM_CAPABILITY_ID ) , guid : :: windows :: core :: GUID::from_u128(0xd8dd60df_4589_4cc7_9cd2_659d9e648a9f) , } }
 pub const GUID_USB_PERFORMANCE_TRACING: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd5de77a6_6ae9_425c_b1e2_f5615fd348a9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_USB_PERFORMANCE_TRACING ) , guid : :: windows :: core :: GUID::from_u128(0xd5de77a6_6ae9_425c_b1e2_f5615fd348a9) , } }
 pub const GUID_USB_TRANSFER_TRACING: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x681eb8aa_403d_452c_9f8a_f0616fac9540);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_USB_TRANSFER_TRACING ) , guid : :: windows :: core :: GUID::from_u128(0x681eb8aa_403d_452c_9f8a_f0616fac9540) , } }
 pub const GUID_USB_WMI_DEVICE_PERF_INFO: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x66c1aa3c_499f_49a0_a9a5_61e2359f6407);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_USB_WMI_DEVICE_PERF_INFO ) , guid : :: windows :: core :: GUID::from_u128(0x66c1aa3c_499f_49a0_a9a5_61e2359f6407) , } }
 pub const GUID_USB_WMI_NODE_INFO: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9c179357_dc7a_4f41_b66b_323b9ddcb5b1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_USB_WMI_NODE_INFO ) , guid : :: windows :: core :: GUID::from_u128(0x9c179357_dc7a_4f41_b66b_323b9ddcb5b1) , } }
 pub const GUID_USB_WMI_STD_DATA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4e623b20_cb14_11d1_b331_00a0c959bbd2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_USB_WMI_STD_DATA ) , guid : :: windows :: core :: GUID::from_u128(0x4e623b20_cb14_11d1_b331_00a0c959bbd2) , } }
 pub const GUID_USB_WMI_STD_NOTIFICATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4e623b20_cb14_11d1_b331_00a0c959bbd2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_USB_WMI_STD_NOTIFICATION ) , guid : :: windows :: core :: GUID::from_u128(0x4e623b20_cb14_11d1_b331_00a0c959bbd2) , } }
 pub const GUID_USB_WMI_SURPRISE_REMOVAL_NOTIFICATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9bbbf831_a2f2_43b4_96d1_86944b5914b3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_USB_WMI_SURPRISE_REMOVAL_NOTIFICATION ) , guid : :: windows :: core :: GUID::from_u128(0x9bbbf831_a2f2_43b4_96d1_86944b5914b3) , } }
 pub const GUID_USB_WMI_TRACING: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3a61881b_b4e6_4bf9_ae0f_3cd8f394e52f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_USB_WMI_TRACING ) , guid : :: windows :: core :: GUID::from_u128(0x3a61881b_b4e6_4bf9_ae0f_3cd8f394e52f) , } }
 #[doc = "*Required features: 'Win32_Devices_Usb'*"]
 pub const HCD_DIAGNOSTIC_MODE_OFF: u32 = 257u32;
 #[doc = "*Required features: 'Win32_Devices_Usb'*"]
@@ -5908,6 +5934,8 @@ pub const WMI_USB_PERFORMANCE_INFORMATION: u32 = 1u32;
 #[doc = "*Required features: 'Win32_Devices_Usb'*"]
 pub const WMI_USB_POWER_DEVICE_ENABLE: u32 = 2u32;
 pub const WinUSB_TestGuid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xda812bff_12c3_46a2_8e2b_dbd3b7834c43);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WinUSB_TestGuid ) , guid : :: windows :: core :: GUID::from_u128(0xda812bff_12c3_46a2_8e2b_dbd3b7834c43) , } }
 #[doc = "*Required features: 'Win32_Devices_Usb', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]

--- a/crates/libs/windows/src/Windows/Win32/Globalization/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Globalization/mod.rs
@@ -901,14 +901,32 @@ impl ::core::default::Default for DetectEncodingInfo {
     }
 }
 pub const ELS_GUID_LANGUAGE_DETECTION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcf7e00b1_909b_4d95_a8f4_611f7c377702);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ELS_GUID_LANGUAGE_DETECTION ) , guid : :: windows :: core :: GUID::from_u128(0xcf7e00b1_909b_4d95_a8f4_611f7c377702) , } }
 pub const ELS_GUID_SCRIPT_DETECTION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2d64b439_6caf_4f6b_b688_e5d0f4faa7d7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ELS_GUID_SCRIPT_DETECTION ) , guid : :: windows :: core :: GUID::from_u128(0x2d64b439_6caf_4f6b_b688_e5d0f4faa7d7) , } }
 pub const ELS_GUID_TRANSLITERATION_BENGALI_TO_LATIN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf4dfd825_91a4_489f_855e_9ad9bee55727);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ELS_GUID_TRANSLITERATION_BENGALI_TO_LATIN ) , guid : :: windows :: core :: GUID::from_u128(0xf4dfd825_91a4_489f_855e_9ad9bee55727) , } }
 pub const ELS_GUID_TRANSLITERATION_CYRILLIC_TO_LATIN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3dd12a98_5afd_4903_a13f_e17e6c0bfe01);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ELS_GUID_TRANSLITERATION_CYRILLIC_TO_LATIN ) , guid : :: windows :: core :: GUID::from_u128(0x3dd12a98_5afd_4903_a13f_e17e6c0bfe01) , } }
 pub const ELS_GUID_TRANSLITERATION_DEVANAGARI_TO_LATIN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc4a4dcfe_2661_4d02_9835_f48187109803);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ELS_GUID_TRANSLITERATION_DEVANAGARI_TO_LATIN ) , guid : :: windows :: core :: GUID::from_u128(0xc4a4dcfe_2661_4d02_9835_f48187109803) , } }
 pub const ELS_GUID_TRANSLITERATION_HANGUL_DECOMPOSITION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4ba2a721_e43d_41b7_b330_536ae1e48863);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ELS_GUID_TRANSLITERATION_HANGUL_DECOMPOSITION ) , guid : :: windows :: core :: GUID::from_u128(0x4ba2a721_e43d_41b7_b330_536ae1e48863) , } }
 pub const ELS_GUID_TRANSLITERATION_HANS_TO_HANT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3caccdc8_5590_42dc_9a7b_b5a6b5b3b63b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ELS_GUID_TRANSLITERATION_HANS_TO_HANT ) , guid : :: windows :: core :: GUID::from_u128(0x3caccdc8_5590_42dc_9a7b_b5a6b5b3b63b) , } }
 pub const ELS_GUID_TRANSLITERATION_HANT_TO_HANS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa3a8333b_f4fc_42f6_a0c4_0462fe7317cb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ELS_GUID_TRANSLITERATION_HANT_TO_HANS ) , guid : :: windows :: core :: GUID::from_u128(0xa3a8333b_f4fc_42f6_a0c4_0462fe7317cb) , } }
 pub const ELS_GUID_TRANSLITERATION_MALAYALAM_TO_LATIN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd8b983b1_f8bf_4a2b_bcd5_5b5ea20613e1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ELS_GUID_TRANSLITERATION_MALAYALAM_TO_LATIN ) , guid : :: windows :: core :: GUID::from_u128(0xd8b983b1_f8bf_4a2b_bcd5_5b5ea20613e1) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Globalization', 'Win32_Graphics_Gdi'*"]
 #[cfg(feature = "Win32_Graphics_Gdi")]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DXCore/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DXCore/mod.rs
@@ -1,7 +1,13 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 pub const DXCORE_ADAPTER_ATTRIBUTE_D3D11_GRAPHICS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8c47866b_7583_450d_f0f0_6bada895af4b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DXCORE_ADAPTER_ATTRIBUTE_D3D11_GRAPHICS ) , guid : :: windows :: core :: GUID::from_u128(0x8c47866b_7583_450d_f0f0_6bada895af4b) , } }
 pub const DXCORE_ADAPTER_ATTRIBUTE_D3D12_CORE_COMPUTE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x248e2800_a793_4724_abaa_23a6de1be090);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DXCORE_ADAPTER_ATTRIBUTE_D3D12_CORE_COMPUTE ) , guid : :: windows :: core :: GUID::from_u128(0x248e2800_a793_4724_abaa_23a6de1be090) , } }
 pub const DXCORE_ADAPTER_ATTRIBUTE_D3D12_GRAPHICS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0c9ece4d_2f6e_4f01_8c96_e89e331b47b1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DXCORE_ADAPTER_ATTRIBUTE_D3D12_GRAPHICS ) , guid : :: windows :: core :: GUID::from_u128(0x0c9ece4d_2f6e_4f01_8c96_e89e331b47b1) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Graphics_DXCore'*"]
 pub struct DXCoreAdapterMemoryBudget {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/mod.rs
@@ -2,70 +2,200 @@
 #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
 pub mod Common;
 pub const CLSID_D2D12DAffineTransform: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6aa97485_6354_4cfc_908c_e4a74f62c96c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D12DAffineTransform ) , guid : :: windows :: core :: GUID::from_u128(0x6aa97485_6354_4cfc_908c_e4a74f62c96c) , } }
 pub const CLSID_D2D13DPerspectiveTransform: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc2844d0b_3d86_46e7_85ba_526c9240f3fb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D13DPerspectiveTransform ) , guid : :: windows :: core :: GUID::from_u128(0xc2844d0b_3d86_46e7_85ba_526c9240f3fb) , } }
 pub const CLSID_D2D13DTransform: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe8467b04_ec61_4b8a_b5de_d4d73debea5a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D13DTransform ) , guid : :: windows :: core :: GUID::from_u128(0xe8467b04_ec61_4b8a_b5de_d4d73debea5a) , } }
 pub const CLSID_D2D1AlphaMask: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc80ecff0_3fd5_4f05_8328_c5d1724b4f0a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1AlphaMask ) , guid : :: windows :: core :: GUID::from_u128(0xc80ecff0_3fd5_4f05_8328_c5d1724b4f0a) , } }
 pub const CLSID_D2D1ArithmeticComposite: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfc151437_049a_4784_a24a_f1c4daf20987);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1ArithmeticComposite ) , guid : :: windows :: core :: GUID::from_u128(0xfc151437_049a_4784_a24a_f1c4daf20987) , } }
 pub const CLSID_D2D1Atlas: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x913e2be4_fdcf_4fe2_a5f0_2454f14ff408);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1Atlas ) , guid : :: windows :: core :: GUID::from_u128(0x913e2be4_fdcf_4fe2_a5f0_2454f14ff408) , } }
 pub const CLSID_D2D1BitmapSource: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5fb6c24d_c6dd_4231_9404_50f4d5c3252d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1BitmapSource ) , guid : :: windows :: core :: GUID::from_u128(0x5fb6c24d_c6dd_4231_9404_50f4d5c3252d) , } }
 pub const CLSID_D2D1Blend: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x81c5b77b_13f8_4cdd_ad20_c890547ac65d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1Blend ) , guid : :: windows :: core :: GUID::from_u128(0x81c5b77b_13f8_4cdd_ad20_c890547ac65d) , } }
 pub const CLSID_D2D1Border: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2a2d49c0_4acf_43c7_8c6a_7c4a27874d27);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1Border ) , guid : :: windows :: core :: GUID::from_u128(0x2a2d49c0_4acf_43c7_8c6a_7c4a27874d27) , } }
 pub const CLSID_D2D1Brightness: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8cea8d1e_77b0_4986_b3b9_2f0c0eae7887);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1Brightness ) , guid : :: windows :: core :: GUID::from_u128(0x8cea8d1e_77b0_4986_b3b9_2f0c0eae7887) , } }
 pub const CLSID_D2D1ChromaKey: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x74c01f5b_2a0d_408c_88e2_c7a3c7197742);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1ChromaKey ) , guid : :: windows :: core :: GUID::from_u128(0x74c01f5b_2a0d_408c_88e2_c7a3c7197742) , } }
 pub const CLSID_D2D1ColorManagement: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1a28524c_fdd6_4aa4_ae8f_837eb8267b37);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1ColorManagement ) , guid : :: windows :: core :: GUID::from_u128(0x1a28524c_fdd6_4aa4_ae8f_837eb8267b37) , } }
 pub const CLSID_D2D1ColorMatrix: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x921f03d6_641c_47df_852d_b4bb6153ae11);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1ColorMatrix ) , guid : :: windows :: core :: GUID::from_u128(0x921f03d6_641c_47df_852d_b4bb6153ae11) , } }
 pub const CLSID_D2D1Composite: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x48fc9f51_f6ac_48f1_8b58_3b28ac46f76d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1Composite ) , guid : :: windows :: core :: GUID::from_u128(0x48fc9f51_f6ac_48f1_8b58_3b28ac46f76d) , } }
 pub const CLSID_D2D1Contrast: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb648a78a_0ed5_4f80_a94a_8e825aca6b77);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1Contrast ) , guid : :: windows :: core :: GUID::from_u128(0xb648a78a_0ed5_4f80_a94a_8e825aca6b77) , } }
 pub const CLSID_D2D1ConvolveMatrix: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x407f8c08_5533_4331_a341_23cc3877843e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1ConvolveMatrix ) , guid : :: windows :: core :: GUID::from_u128(0x407f8c08_5533_4331_a341_23cc3877843e) , } }
 pub const CLSID_D2D1Crop: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe23f7110_0e9a_4324_af47_6a2c0c46f35b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1Crop ) , guid : :: windows :: core :: GUID::from_u128(0xe23f7110_0e9a_4324_af47_6a2c0c46f35b) , } }
 pub const CLSID_D2D1CrossFade: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x12f575e8_4db1_485f_9a84_03a07dd3829f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1CrossFade ) , guid : :: windows :: core :: GUID::from_u128(0x12f575e8_4db1_485f_9a84_03a07dd3829f) , } }
 pub const CLSID_D2D1DirectionalBlur: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x174319a6_58e9_49b2_bb63_caf2c811a3db);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1DirectionalBlur ) , guid : :: windows :: core :: GUID::from_u128(0x174319a6_58e9_49b2_bb63_caf2c811a3db) , } }
 pub const CLSID_D2D1DiscreteTransfer: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x90866fcd_488e_454b_af06_e5041b66c36c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1DiscreteTransfer ) , guid : :: windows :: core :: GUID::from_u128(0x90866fcd_488e_454b_af06_e5041b66c36c) , } }
 pub const CLSID_D2D1DisplacementMap: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xedc48364_0417_4111_9450_43845fa9f890);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1DisplacementMap ) , guid : :: windows :: core :: GUID::from_u128(0xedc48364_0417_4111_9450_43845fa9f890) , } }
 pub const CLSID_D2D1DistantDiffuse: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3e7efd62_a32d_46d4_a83c_5278889ac954);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1DistantDiffuse ) , guid : :: windows :: core :: GUID::from_u128(0x3e7efd62_a32d_46d4_a83c_5278889ac954) , } }
 pub const CLSID_D2D1DistantSpecular: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x428c1ee5_77b8_4450_8ab5_72219c21abda);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1DistantSpecular ) , guid : :: windows :: core :: GUID::from_u128(0x428c1ee5_77b8_4450_8ab5_72219c21abda) , } }
 pub const CLSID_D2D1DpiCompensation: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6c26c5c7_34e0_46fc_9cfd_e5823706e228);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1DpiCompensation ) , guid : :: windows :: core :: GUID::from_u128(0x6c26c5c7_34e0_46fc_9cfd_e5823706e228) , } }
 pub const CLSID_D2D1EdgeDetection: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xeff583ca_cb07_4aa9_ac5d_2cc44c76460f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1EdgeDetection ) , guid : :: windows :: core :: GUID::from_u128(0xeff583ca_cb07_4aa9_ac5d_2cc44c76460f) , } }
 pub const CLSID_D2D1Emboss: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb1c5eb2b_0348_43f0_8107_4957cacba2ae);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1Emboss ) , guid : :: windows :: core :: GUID::from_u128(0xb1c5eb2b_0348_43f0_8107_4957cacba2ae) , } }
 pub const CLSID_D2D1Exposure: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb56c8cfa_f634_41ee_bee0_ffa617106004);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1Exposure ) , guid : :: windows :: core :: GUID::from_u128(0xb56c8cfa_f634_41ee_bee0_ffa617106004) , } }
 pub const CLSID_D2D1Flood: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x61c23c20_ae69_4d8e_94cf_50078df638f2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1Flood ) , guid : :: windows :: core :: GUID::from_u128(0x61c23c20_ae69_4d8e_94cf_50078df638f2) , } }
 pub const CLSID_D2D1GammaTransfer: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x409444c4_c419_41a0_b0c1_8cd0c0a18e42);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1GammaTransfer ) , guid : :: windows :: core :: GUID::from_u128(0x409444c4_c419_41a0_b0c1_8cd0c0a18e42) , } }
 pub const CLSID_D2D1GaussianBlur: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1feb6d69_2fe6_4ac9_8c58_1d7f93e7a6a5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1GaussianBlur ) , guid : :: windows :: core :: GUID::from_u128(0x1feb6d69_2fe6_4ac9_8c58_1d7f93e7a6a5) , } }
 pub const CLSID_D2D1Grayscale: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x36dde0eb_3725_42e0_836d_52fb20aee644);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1Grayscale ) , guid : :: windows :: core :: GUID::from_u128(0x36dde0eb_3725_42e0_836d_52fb20aee644) , } }
 pub const CLSID_D2D1HdrToneMap: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7b0b748d_4610_4486_a90c_999d9a2e2b11);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1HdrToneMap ) , guid : :: windows :: core :: GUID::from_u128(0x7b0b748d_4610_4486_a90c_999d9a2e2b11) , } }
 pub const CLSID_D2D1HighlightsShadows: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcadc8384_323f_4c7e_a361_2e2b24df6ee4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1HighlightsShadows ) , guid : :: windows :: core :: GUID::from_u128(0xcadc8384_323f_4c7e_a361_2e2b24df6ee4) , } }
 pub const CLSID_D2D1Histogram: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x881db7d0_f7ee_4d4d_a6d2_4697acc66ee8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1Histogram ) , guid : :: windows :: core :: GUID::from_u128(0x881db7d0_f7ee_4d4d_a6d2_4697acc66ee8) , } }
 pub const CLSID_D2D1HueRotation: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0f4458ec_4b32_491b_9e85_bd73f44d3eb6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1HueRotation ) , guid : :: windows :: core :: GUID::from_u128(0x0f4458ec_4b32_491b_9e85_bd73f44d3eb6) , } }
 pub const CLSID_D2D1HueToRgb: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7b78a6bd_0141_4def_8a52_6356ee0cbdd5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1HueToRgb ) , guid : :: windows :: core :: GUID::from_u128(0x7b78a6bd_0141_4def_8a52_6356ee0cbdd5) , } }
 pub const CLSID_D2D1Invert: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe0c3784d_cb39_4e84_b6fd_6b72f0810263);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1Invert ) , guid : :: windows :: core :: GUID::from_u128(0xe0c3784d_cb39_4e84_b6fd_6b72f0810263) , } }
 pub const CLSID_D2D1LinearTransfer: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xad47c8fd_63ef_4acc_9b51_67979c036c06);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1LinearTransfer ) , guid : :: windows :: core :: GUID::from_u128(0xad47c8fd_63ef_4acc_9b51_67979c036c06) , } }
 pub const CLSID_D2D1LookupTable3D: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x349e0eda_0088_4a79_9ca3_c7e300202020);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1LookupTable3D ) , guid : :: windows :: core :: GUID::from_u128(0x349e0eda_0088_4a79_9ca3_c7e300202020) , } }
 pub const CLSID_D2D1LuminanceToAlpha: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x41251ab7_0beb_46f8_9da7_59e93fcce5de);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1LuminanceToAlpha ) , guid : :: windows :: core :: GUID::from_u128(0x41251ab7_0beb_46f8_9da7_59e93fcce5de) , } }
 pub const CLSID_D2D1Morphology: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xeae6c40d_626a_4c2d_bfcb_391001abe202);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1Morphology ) , guid : :: windows :: core :: GUID::from_u128(0xeae6c40d_626a_4c2d_bfcb_391001abe202) , } }
 pub const CLSID_D2D1Opacity: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x811d79a4_de28_4454_8094_c64685f8bd4c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1Opacity ) , guid : :: windows :: core :: GUID::from_u128(0x811d79a4_de28_4454_8094_c64685f8bd4c) , } }
 pub const CLSID_D2D1OpacityMetadata: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6c53006a_4450_4199_aa5b_ad1656fece5e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1OpacityMetadata ) , guid : :: windows :: core :: GUID::from_u128(0x6c53006a_4450_4199_aa5b_ad1656fece5e) , } }
 pub const CLSID_D2D1PointDiffuse: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb9e303c3_c08c_4f91_8b7b_38656bc48c20);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1PointDiffuse ) , guid : :: windows :: core :: GUID::from_u128(0xb9e303c3_c08c_4f91_8b7b_38656bc48c20) , } }
 pub const CLSID_D2D1PointSpecular: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x09c3ca26_3ae2_4f09_9ebc_ed3865d53f22);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1PointSpecular ) , guid : :: windows :: core :: GUID::from_u128(0x09c3ca26_3ae2_4f09_9ebc_ed3865d53f22) , } }
 pub const CLSID_D2D1Posterize: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2188945e_33a3_4366_b7bc_086bd02d0884);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1Posterize ) , guid : :: windows :: core :: GUID::from_u128(0x2188945e_33a3_4366_b7bc_086bd02d0884) , } }
 pub const CLSID_D2D1Premultiply: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x06eab419_deed_4018_80d2_3e1d471adeb2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1Premultiply ) , guid : :: windows :: core :: GUID::from_u128(0x06eab419_deed_4018_80d2_3e1d471adeb2) , } }
 pub const CLSID_D2D1RgbToHue: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x23f3e5ec_91e8_4d3d_ad0a_afadc1004aa1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1RgbToHue ) , guid : :: windows :: core :: GUID::from_u128(0x23f3e5ec_91e8_4d3d_ad0a_afadc1004aa1) , } }
 pub const CLSID_D2D1Saturation: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5cb2d9cf_327d_459f_a0ce_40c0b2086bf7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1Saturation ) , guid : :: windows :: core :: GUID::from_u128(0x5cb2d9cf_327d_459f_a0ce_40c0b2086bf7) , } }
 pub const CLSID_D2D1Scale: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9daf9369_3846_4d0e_a44e_0c607934a5d7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1Scale ) , guid : :: windows :: core :: GUID::from_u128(0x9daf9369_3846_4d0e_a44e_0c607934a5d7) , } }
 pub const CLSID_D2D1Sepia: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3a1af410_5f1d_4dbe_84df_915da79b7153);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1Sepia ) , guid : :: windows :: core :: GUID::from_u128(0x3a1af410_5f1d_4dbe_84df_915da79b7153) , } }
 pub const CLSID_D2D1Shadow: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc67ea361_1863_4e69_89db_695d3e9a5b6b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1Shadow ) , guid : :: windows :: core :: GUID::from_u128(0xc67ea361_1863_4e69_89db_695d3e9a5b6b) , } }
 pub const CLSID_D2D1Sharpen: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc9b887cb_c5ff_4dc5_9779_273dcf417c7d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1Sharpen ) , guid : :: windows :: core :: GUID::from_u128(0xc9b887cb_c5ff_4dc5_9779_273dcf417c7d) , } }
 pub const CLSID_D2D1SpotDiffuse: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x818a1105_7932_44f4_aa86_08ae7b2f2c93);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1SpotDiffuse ) , guid : :: windows :: core :: GUID::from_u128(0x818a1105_7932_44f4_aa86_08ae7b2f2c93) , } }
 pub const CLSID_D2D1SpotSpecular: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xedae421e_7654_4a37_9db8_71acc1beb3c1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1SpotSpecular ) , guid : :: windows :: core :: GUID::from_u128(0xedae421e_7654_4a37_9db8_71acc1beb3c1) , } }
 pub const CLSID_D2D1Straighten: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4da47b12_79a3_4fb0_8237_bbc3b2a4de08);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1Straighten ) , guid : :: windows :: core :: GUID::from_u128(0x4da47b12_79a3_4fb0_8237_bbc3b2a4de08) , } }
 pub const CLSID_D2D1TableTransfer: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5bf818c3_5e43_48cb_b631_868396d6a1d4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1TableTransfer ) , guid : :: windows :: core :: GUID::from_u128(0x5bf818c3_5e43_48cb_b631_868396d6a1d4) , } }
 pub const CLSID_D2D1TemperatureTint: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x89176087_8af9_4a08_aeb1_895f38db1766);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1TemperatureTint ) , guid : :: windows :: core :: GUID::from_u128(0x89176087_8af9_4a08_aeb1_895f38db1766) , } }
 pub const CLSID_D2D1Tile: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb0784138_3b76_4bc5_b13b_0fa2ad02659f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1Tile ) , guid : :: windows :: core :: GUID::from_u128(0xb0784138_3b76_4bc5_b13b_0fa2ad02659f) , } }
 pub const CLSID_D2D1Tint: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x36312b17_f7dd_4014_915d_ffca768cf211);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1Tint ) , guid : :: windows :: core :: GUID::from_u128(0x36312b17_f7dd_4014_915d_ffca768cf211) , } }
 pub const CLSID_D2D1Turbulence: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcf2bb6ae_889a_4ad7_ba29_a2fd732c9fc9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1Turbulence ) , guid : :: windows :: core :: GUID::from_u128(0xcf2bb6ae_889a_4ad7_ba29_a2fd732c9fc9) , } }
 pub const CLSID_D2D1UnPremultiply: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfb9ac489_ad8d_41ed_9999_bb6347d110f7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1UnPremultiply ) , guid : :: windows :: core :: GUID::from_u128(0xfb9ac489_ad8d_41ed_9999_bb6347d110f7) , } }
 pub const CLSID_D2D1Vignette: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc00c40be_5e67_4ca3_95b4_f4b02c115135);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1Vignette ) , guid : :: windows :: core :: GUID::from_u128(0xc00c40be_5e67_4ca3_95b4_f4b02c115135) , } }
 pub const CLSID_D2D1WhiteLevelAdjustment: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x44a1cadb_6cdd_4818_8ff4_26c1cfe95bdb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1WhiteLevelAdjustment ) , guid : :: windows :: core :: GUID::from_u128(0x44a1cadb_6cdd_4818_8ff4_26c1cfe95bdb) , } }
 pub const CLSID_D2D1YCbCr: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x99503cc1_66c7_45c9_a875_8ad8a7914401);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D2D1YCbCr ) , guid : :: windows :: core :: GUID::from_u128(0x99503cc1_66c7_45c9_a875_8ad8a7914401) , } }
 #[doc = "*Required features: 'Win32_Graphics_Direct2D', 'Foundation_Numerics'*"]
 #[cfg(feature = "Foundation_Numerics")]
 #[inline]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/Dxc/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/Dxc/mod.rs
@@ -1,15 +1,37 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 pub const CLSID_DxcAssembler: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd728db68_f903_4f80_94cd_dccf76ec7151);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DxcAssembler ) , guid : :: windows :: core :: GUID::from_u128(0xd728db68_f903_4f80_94cd_dccf76ec7151) , } }
 pub const CLSID_DxcCompiler: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x73e22d93_e6ce_47f3_b5bf_f0664f39c1b0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DxcCompiler ) , guid : :: windows :: core :: GUID::from_u128(0x73e22d93_e6ce_47f3_b5bf_f0664f39c1b0) , } }
 pub const CLSID_DxcCompilerArgs: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3e56ae82_224d_470f_a1a1_fe3016ee9f9d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DxcCompilerArgs ) , guid : :: windows :: core :: GUID::from_u128(0x3e56ae82_224d_470f_a1a1_fe3016ee9f9d) , } }
 pub const CLSID_DxcContainerBuilder: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x94134294_411f_4574_b4d0_8741e25240d2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DxcContainerBuilder ) , guid : :: windows :: core :: GUID::from_u128(0x94134294_411f_4574_b4d0_8741e25240d2) , } }
 pub const CLSID_DxcContainerReflection: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb9f54489_55b8_400c_ba3a_1675e4728b91);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DxcContainerReflection ) , guid : :: windows :: core :: GUID::from_u128(0xb9f54489_55b8_400c_ba3a_1675e4728b91) , } }
 pub const CLSID_DxcDiaDataSource: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcd1f6b73_2ab0_484d_8edc_ebe7a43ca09f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DxcDiaDataSource ) , guid : :: windows :: core :: GUID::from_u128(0xcd1f6b73_2ab0_484d_8edc_ebe7a43ca09f) , } }
 pub const CLSID_DxcLibrary: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6245d6af_66e0_48fd_80b4_4d271796748c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DxcLibrary ) , guid : :: windows :: core :: GUID::from_u128(0x6245d6af_66e0_48fd_80b4_4d271796748c) , } }
 pub const CLSID_DxcLinker: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xef6a8087_b0ea_4d56_9e45_d07e1a8b7806);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DxcLinker ) , guid : :: windows :: core :: GUID::from_u128(0xef6a8087_b0ea_4d56_9e45_d07e1a8b7806) , } }
 pub const CLSID_DxcOptimizer: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xae2cd79f_cc22_453f_9b6b_b124e7a5204c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DxcOptimizer ) , guid : :: windows :: core :: GUID::from_u128(0xae2cd79f_cc22_453f_9b6b_b124e7a5204c) , } }
 pub const CLSID_DxcPdbUtils: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x54621dfb_f2ce_457e_ae8c_ec355faeec7c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DxcPdbUtils ) , guid : :: windows :: core :: GUID::from_u128(0x54621dfb_f2ce_457e_ae8c_ec355faeec7c) , } }
 pub const CLSID_DxcValidator: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8ca3e215_f728_4cf3_8cdd_88af917587a1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DxcValidator ) , guid : :: windows :: core :: GUID::from_u128(0x8ca3e215_f728_4cf3_8cdd_88af917587a1) , } }
 #[doc = "*Required features: 'Win32_Graphics_Direct3D_Dxc'*"]
 pub type DXC_CP = u32;
 #[doc = "*Required features: 'Win32_Graphics_Direct3D_Dxc'*"]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D/mod.rs
@@ -1447,7 +1447,11 @@ pub const D3D11_TESSELLATOR_PARTITIONING_FRACTIONAL_ODD: D3D_TESSELLATOR_PARTITI
 #[doc = "*Required features: 'Win32_Graphics_Direct3D'*"]
 pub const D3D11_TESSELLATOR_PARTITIONING_FRACTIONAL_EVEN: D3D_TESSELLATOR_PARTITIONING = 4i32;
 pub const D3D_TEXTURE_LAYOUT_64KB_STANDARD_SWIZZLE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4c0f29e3_3f5f_4d35_84c9_bc0983b62c28);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D_TEXTURE_LAYOUT_64KB_STANDARD_SWIZZLE ) , guid : :: windows :: core :: GUID::from_u128(0x4c0f29e3_3f5f_4d35_84c9_bc0983b62c28) , } }
 pub const D3D_TEXTURE_LAYOUT_ROW_MAJOR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb5dc234f_72bb_4bec_9705_8cf258df6b6c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D_TEXTURE_LAYOUT_ROW_MAJOR ) , guid : :: windows :: core :: GUID::from_u128(0xb5dc234f_72bb_4bec_9705_8cf258df6b6c) , } }
 #[doc = "*Required features: 'Win32_Graphics_Direct3D'*"]
 #[repr(transparent)]
 pub struct ID3DBlob(::windows::core::IUnknown);
@@ -1607,6 +1611,14 @@ pub struct ID3DIncludeVtbl(#[cfg(feature = "Win32_Foundation")] pub unsafe exter
 #[doc = "*Required features: 'Win32_Graphics_Direct3D'*"]
 pub type PFN_DESTRUCTION_CALLBACK = ::core::option::Option<unsafe extern "system" fn(pdata: *mut ::core::ffi::c_void)>;
 pub const WKPDID_CommentStringW: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd0149dc0_90e8_4ec8_8144_e900ad266bb2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WKPDID_CommentStringW ) , guid : :: windows :: core :: GUID::from_u128(0xd0149dc0_90e8_4ec8_8144_e900ad266bb2) , } }
 pub const WKPDID_D3D12UniqueObjectId: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1b39de15_ec04_4bae_ba4d_8cef79fc04c1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WKPDID_D3D12UniqueObjectId ) , guid : :: windows :: core :: GUID::from_u128(0x1b39de15_ec04_4bae_ba4d_8cef79fc04c1) , } }
 pub const WKPDID_D3DDebugObjectName: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x429b8c22_9188_4b0c_8742_acb0bf85c200);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WKPDID_D3DDebugObjectName ) , guid : :: windows :: core :: GUID::from_u128(0x429b8c22_9188_4b0c_8742_acb0bf85c200) , } }
 pub const WKPDID_D3DDebugObjectNameW: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4cca5fd8_921f_42c8_8566_70caf2a9b741);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WKPDID_D3DDebugObjectNameW ) , guid : :: windows :: core :: GUID::from_u128(0x4cca5fd8_921f_42c8_8566_70caf2a9b741) , } }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D10/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D10/mod.rs
@@ -5939,7 +5939,11 @@ pub const D3D_SPEC_DATE_YEAR: u32 = 2006u32;
 #[doc = "*Required features: 'Win32_Graphics_Direct3D10'*"]
 pub const D3D_SPEC_VERSION: f64 = 1.050005f64;
 pub const DXGI_DEBUG_D3D10: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x243b4c52_3606_4d3a_99d7_a7e7b33ed706);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DXGI_DEBUG_D3D10 ) , guid : :: windows :: core :: GUID::from_u128(0x243b4c52_3606_4d3a_99d7_a7e7b33ed706) , } }
 pub const GUID_DeviceType: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd722fb4d_7a68_437a_b20c_5804ee2494a6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DeviceType ) , guid : :: windows :: core :: GUID::from_u128(0xd722fb4d_7a68_437a_b20c_5804ee2494a6) , } }
 #[doc = "*Required features: 'Win32_Graphics_Direct3D10'*"]
 #[repr(transparent)]
 pub struct ID3D10Asynchronous(::windows::core::IUnknown);

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11/mod.rs
@@ -138,6 +138,8 @@ impl ::core::default::Default for D3D11_AUTHENTICATED_CONFIGURE_ACCESSIBLE_ENCRY
     }
 }
 pub const D3D11_AUTHENTICATED_CONFIGURE_CRYPTO_SESSION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6346cc54_2cfc_4ad4_8224_d15837de7700);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_AUTHENTICATED_CONFIGURE_CRYPTO_SESSION ) , guid : :: windows :: core :: GUID::from_u128(0x6346cc54_2cfc_4ad4_8224_d15837de7700) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Graphics_Direct3D11', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -180,7 +182,11 @@ impl ::core::default::Default for D3D11_AUTHENTICATED_CONFIGURE_CRYPTO_SESSION_I
     }
 }
 pub const D3D11_AUTHENTICATED_CONFIGURE_ENCRYPTION_WHEN_ACCESSIBLE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x41fff286_6ae0_4d43_9d55_a46e9efd158a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_AUTHENTICATED_CONFIGURE_ENCRYPTION_WHEN_ACCESSIBLE ) , guid : :: windows :: core :: GUID::from_u128(0x41fff286_6ae0_4d43_9d55_a46e9efd158a) , } }
 pub const D3D11_AUTHENTICATED_CONFIGURE_INITIALIZE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x06114bdb_3523_470a_8dca_fbc2845154f0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_AUTHENTICATED_CONFIGURE_INITIALIZE ) , guid : :: windows :: core :: GUID::from_u128(0x06114bdb_3523_470a_8dca_fbc2845154f0) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Graphics_Direct3D11', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -305,6 +311,8 @@ impl ::core::default::Default for D3D11_AUTHENTICATED_CONFIGURE_OUTPUT {
     }
 }
 pub const D3D11_AUTHENTICATED_CONFIGURE_PROTECTION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x50455658_3f47_4362_bf99_bfdfcde9ed29);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_AUTHENTICATED_CONFIGURE_PROTECTION ) , guid : :: windows :: core :: GUID::from_u128(0x50455658_3f47_4362_bf99_bfdfcde9ed29) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Graphics_Direct3D11', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -339,6 +347,8 @@ impl ::core::default::Default for D3D11_AUTHENTICATED_CONFIGURE_PROTECTION_INPUT
     }
 }
 pub const D3D11_AUTHENTICATED_CONFIGURE_SHARED_RESOURCE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0772d047_1b40_48e8_9ca6_b5f510de9f01);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_AUTHENTICATED_CONFIGURE_SHARED_RESOURCE ) , guid : :: windows :: core :: GUID::from_u128(0x0772d047_1b40_48e8_9ca6_b5f510de9f01) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Graphics_Direct3D11', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -445,6 +455,8 @@ impl ::core::default::Default for D3D11_AUTHENTICATED_PROTECTION_FLAGS_0 {
     }
 }
 pub const D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_ATTRIBUTES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6214d9d2_432c_4abb_9fce_216eea269e3b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_ATTRIBUTES ) , guid : :: windows :: core :: GUID::from_u128(0x6214d9d2_432c_4abb_9fce_216eea269e3b) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Graphics_Direct3D11', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -605,6 +617,8 @@ impl ::core::default::Default for D3D11_AUTHENTICATED_QUERY_ACCESSIBILITY_OUTPUT
     }
 }
 pub const D3D11_AUTHENTICATED_QUERY_CHANNEL_TYPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbc1b18a5_b1fb_42ab_bd94_b5828b4bf7be);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_AUTHENTICATED_QUERY_CHANNEL_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0xbc1b18a5_b1fb_42ab_bd94_b5828b4bf7be) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Graphics_Direct3D11', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -645,6 +659,8 @@ impl ::core::default::Default for D3D11_AUTHENTICATED_QUERY_CHANNEL_TYPE_OUTPUT 
     }
 }
 pub const D3D11_AUTHENTICATED_QUERY_CRYPTO_SESSION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2634499e_d018_4d74_ac17_7f724059528d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_AUTHENTICATED_QUERY_CRYPTO_SESSION ) , guid : :: windows :: core :: GUID::from_u128(0x2634499e_d018_4d74_ac17_7f724059528d) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Graphics_Direct3D11', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -765,7 +781,11 @@ impl ::core::default::Default for D3D11_AUTHENTICATED_QUERY_CURRENT_ACCESSIBILIT
     }
 }
 pub const D3D11_AUTHENTICATED_QUERY_CURRENT_ENCRYPTION_WHEN_ACCESSIBLE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xec1791c7_dad3_4f15_9ec3_faa93d60d4f0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_AUTHENTICATED_QUERY_CURRENT_ENCRYPTION_WHEN_ACCESSIBLE ) , guid : :: windows :: core :: GUID::from_u128(0xec1791c7_dad3_4f15_9ec3_faa93d60d4f0) , } }
 pub const D3D11_AUTHENTICATED_QUERY_DEVICE_HANDLE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xec1c539d_8cff_4e2a_bcc4_f5692f99f480);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_AUTHENTICATED_QUERY_DEVICE_HANDLE ) , guid : :: windows :: core :: GUID::from_u128(0xec1c539d_8cff_4e2a_bcc4_f5692f99f480) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Graphics_Direct3D11', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -806,7 +826,11 @@ impl ::core::default::Default for D3D11_AUTHENTICATED_QUERY_DEVICE_HANDLE_OUTPUT
     }
 }
 pub const D3D11_AUTHENTICATED_QUERY_ENCRYPTION_WHEN_ACCESSIBLE_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf83a5958_e986_4bda_beb0_411f6a7a01b7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_AUTHENTICATED_QUERY_ENCRYPTION_WHEN_ACCESSIBLE_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xf83a5958_e986_4bda_beb0_411f6a7a01b7) , } }
 pub const D3D11_AUTHENTICATED_QUERY_ENCRYPTION_WHEN_ACCESSIBLE_GUID_COUNT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb30f7066_203c_4b07_93fc_ceaafd61241e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_AUTHENTICATED_QUERY_ENCRYPTION_WHEN_ACCESSIBLE_GUID_COUNT ) , guid : :: windows :: core :: GUID::from_u128(0xb30f7066_203c_4b07_93fc_ceaafd61241e) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Graphics_Direct3D11', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -890,7 +914,11 @@ impl ::core::default::Default for D3D11_AUTHENTICATED_QUERY_OUTPUT {
     }
 }
 pub const D3D11_AUTHENTICATED_QUERY_OUTPUT_ID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x839ddca3_9b4e_41e4_b053_892bd2a11ee7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_AUTHENTICATED_QUERY_OUTPUT_ID ) , guid : :: windows :: core :: GUID::from_u128(0x839ddca3_9b4e_41e4_b053_892bd2a11ee7) , } }
 pub const D3D11_AUTHENTICATED_QUERY_OUTPUT_ID_COUNT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2c042b5e_8c07_46d5_aabe_8f75cbad4c31);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_AUTHENTICATED_QUERY_OUTPUT_ID_COUNT ) , guid : :: windows :: core :: GUID::from_u128(0x2c042b5e_8c07_46d5_aabe_8f75cbad4c31) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Graphics_Direct3D11', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -1056,6 +1084,8 @@ impl ::core::default::Default for D3D11_AUTHENTICATED_QUERY_OUTPUT_ID_OUTPUT {
     }
 }
 pub const D3D11_AUTHENTICATED_QUERY_PROTECTION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa84eb584_c495_48aa_b94d_8bd2d6fbce05);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_AUTHENTICATED_QUERY_PROTECTION ) , guid : :: windows :: core :: GUID::from_u128(0xa84eb584_c495_48aa_b94d_8bd2d6fbce05) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Graphics_Direct3D11', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -1090,7 +1120,11 @@ impl ::core::default::Default for D3D11_AUTHENTICATED_QUERY_PROTECTION_OUTPUT {
     }
 }
 pub const D3D11_AUTHENTICATED_QUERY_RESTRICTED_SHARED_RESOURCE_PROCESS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x649bbadb_f0f4_4639_a15b_24393fc3abac);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_AUTHENTICATED_QUERY_RESTRICTED_SHARED_RESOURCE_PROCESS ) , guid : :: windows :: core :: GUID::from_u128(0x649bbadb_f0f4_4639_a15b_24393fc3abac) , } }
 pub const D3D11_AUTHENTICATED_QUERY_RESTRICTED_SHARED_RESOURCE_PROCESS_COUNT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0db207b3_9450_46a6_82de_1b96d44f9cf2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_AUTHENTICATED_QUERY_RESTRICTED_SHARED_RESOURCE_PROCESS_COUNT ) , guid : :: windows :: core :: GUID::from_u128(0x0db207b3_9450_46a6_82de_1b96d44f9cf2) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Graphics_Direct3D11', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -1211,6 +1245,8 @@ impl ::core::default::Default for D3D11_AUTHENTICATED_QUERY_RESTRICTED_SHARED_RE
     }
 }
 pub const D3D11_AUTHENTICATED_QUERY_UNRESTRICTED_PROTECTED_SHARED_RESOURCE_COUNT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x012f0bd6_e662_4474_befd_aa53e5143c6d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_AUTHENTICATED_QUERY_UNRESTRICTED_PROTECTED_SHARED_RESOURCE_COUNT ) , guid : :: windows :: core :: GUID::from_u128(0x012f0bd6_e662_4474_befd_aa53e5143c6d) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Graphics_Direct3D11', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -2103,6 +2139,8 @@ pub const D3D11_CRYPTO_SESSION_STATUS_KEY_LOST: D3D11_CRYPTO_SESSION_STATUS = 1i
 #[doc = "*Required features: 'Win32_Graphics_Direct3D11'*"]
 pub const D3D11_CRYPTO_SESSION_STATUS_KEY_AND_CONTENT_LOST: D3D11_CRYPTO_SESSION_STATUS = 2i32;
 pub const D3D11_CRYPTO_TYPE_AES128_CTR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9b6bd711_4f74_41c9_9e7b_0be2d7d93b4f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_CRYPTO_TYPE_AES128_CTR ) , guid : :: windows :: core :: GUID::from_u128(0x9b6bd711_4f74_41c9_9e7b_0be2d7d93b4f) , } }
 #[doc = "*Required features: 'Win32_Graphics_Direct3D11'*"]
 pub const D3D11_CS_4_X_BUCKET00_MAX_BYTES_TGSM_WRITABLE_PER_THREAD: u32 = 256u32;
 #[doc = "*Required features: 'Win32_Graphics_Direct3D11'*"]
@@ -2244,46 +2282,128 @@ pub const D3D11_DEBUG_FEATURE_NEVER_DISCARD_OFFERED_RESOURCE: u32 = 16u32;
 #[doc = "*Required features: 'Win32_Graphics_Direct3D11'*"]
 pub const D3D11_DEBUG_FEATURE_PRESENT_PER_RENDER_OP: u32 = 4u32;
 pub const D3D11_DECODER_BITSTREAM_ENCRYPTION_TYPE_CBCS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x422d9319_9d21_4bb7_9371_faf5a82c3e04);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_BITSTREAM_ENCRYPTION_TYPE_CBCS ) , guid : :: windows :: core :: GUID::from_u128(0x422d9319_9d21_4bb7_9371_faf5a82c3e04) , } }
 pub const D3D11_DECODER_BITSTREAM_ENCRYPTION_TYPE_CENC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb0405235_c13d_44f2_9ae5_dd48e08e5b67);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_BITSTREAM_ENCRYPTION_TYPE_CENC ) , guid : :: windows :: core :: GUID::from_u128(0xb0405235_c13d_44f2_9ae5_dd48e08e5b67) , } }
 pub const D3D11_DECODER_ENCRYPTION_HW_CENC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x89d6ac4f_09f2_4229_b2cd_37740a6dfd81);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_ENCRYPTION_HW_CENC ) , guid : :: windows :: core :: GUID::from_u128(0x89d6ac4f_09f2_4229_b2cd_37740a6dfd81) , } }
 pub const D3D11_DECODER_PROFILE_AV1_VLD_12BIT_PROFILE2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x17127009_a00f_4ce1_994e_bf4081f6f3f0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_AV1_VLD_12BIT_PROFILE2 ) , guid : :: windows :: core :: GUID::from_u128(0x17127009_a00f_4ce1_994e_bf4081f6f3f0) , } }
 pub const D3D11_DECODER_PROFILE_AV1_VLD_12BIT_PROFILE2_420: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2d80bed6_9cac_4835_9e91_327bbc4f9ee8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_AV1_VLD_12BIT_PROFILE2_420 ) , guid : :: windows :: core :: GUID::from_u128(0x2d80bed6_9cac_4835_9e91_327bbc4f9ee8) , } }
 pub const D3D11_DECODER_PROFILE_AV1_VLD_PROFILE0: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb8be4ccb_cf53_46ba_8d59_d6b8a6da5d2a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_AV1_VLD_PROFILE0 ) , guid : :: windows :: core :: GUID::from_u128(0xb8be4ccb_cf53_46ba_8d59_d6b8a6da5d2a) , } }
 pub const D3D11_DECODER_PROFILE_AV1_VLD_PROFILE1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6936ff0f_45b1_4163_9cc1_646ef6946108);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_AV1_VLD_PROFILE1 ) , guid : :: windows :: core :: GUID::from_u128(0x6936ff0f_45b1_4163_9cc1_646ef6946108) , } }
 pub const D3D11_DECODER_PROFILE_AV1_VLD_PROFILE2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0c5f2aa1_e541_4089_bb7b_98110a19d7c8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_AV1_VLD_PROFILE2 ) , guid : :: windows :: core :: GUID::from_u128(0x0c5f2aa1_e541_4089_bb7b_98110a19d7c8) , } }
 pub const D3D11_DECODER_PROFILE_H264_IDCT_FGT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1b81be67_a0c7_11d3_b984_00c04f2e73c5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_H264_IDCT_FGT ) , guid : :: windows :: core :: GUID::from_u128(0x1b81be67_a0c7_11d3_b984_00c04f2e73c5) , } }
 pub const D3D11_DECODER_PROFILE_H264_IDCT_NOFGT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1b81be66_a0c7_11d3_b984_00c04f2e73c5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_H264_IDCT_NOFGT ) , guid : :: windows :: core :: GUID::from_u128(0x1b81be66_a0c7_11d3_b984_00c04f2e73c5) , } }
 pub const D3D11_DECODER_PROFILE_H264_MOCOMP_FGT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1b81be65_a0c7_11d3_b984_00c04f2e73c5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_H264_MOCOMP_FGT ) , guid : :: windows :: core :: GUID::from_u128(0x1b81be65_a0c7_11d3_b984_00c04f2e73c5) , } }
 pub const D3D11_DECODER_PROFILE_H264_MOCOMP_NOFGT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1b81be64_a0c7_11d3_b984_00c04f2e73c5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_H264_MOCOMP_NOFGT ) , guid : :: windows :: core :: GUID::from_u128(0x1b81be64_a0c7_11d3_b984_00c04f2e73c5) , } }
 pub const D3D11_DECODER_PROFILE_H264_VLD_FGT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1b81be69_a0c7_11d3_b984_00c04f2e73c5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_H264_VLD_FGT ) , guid : :: windows :: core :: GUID::from_u128(0x1b81be69_a0c7_11d3_b984_00c04f2e73c5) , } }
 pub const D3D11_DECODER_PROFILE_H264_VLD_MULTIVIEW_NOFGT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x705b9d82_76cf_49d6_b7e6_ac8872db013c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_H264_VLD_MULTIVIEW_NOFGT ) , guid : :: windows :: core :: GUID::from_u128(0x705b9d82_76cf_49d6_b7e6_ac8872db013c) , } }
 pub const D3D11_DECODER_PROFILE_H264_VLD_NOFGT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1b81be68_a0c7_11d3_b984_00c04f2e73c5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_H264_VLD_NOFGT ) , guid : :: windows :: core :: GUID::from_u128(0x1b81be68_a0c7_11d3_b984_00c04f2e73c5) , } }
 pub const D3D11_DECODER_PROFILE_H264_VLD_STEREO_NOFGT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf9aaccbb_c2b6_4cfc_8779_5707b1760552);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_H264_VLD_STEREO_NOFGT ) , guid : :: windows :: core :: GUID::from_u128(0xf9aaccbb_c2b6_4cfc_8779_5707b1760552) , } }
 pub const D3D11_DECODER_PROFILE_H264_VLD_STEREO_PROGRESSIVE_NOFGT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd79be8da_0cf1_4c81_b82a_69a4e236f43d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_H264_VLD_STEREO_PROGRESSIVE_NOFGT ) , guid : :: windows :: core :: GUID::from_u128(0xd79be8da_0cf1_4c81_b82a_69a4e236f43d) , } }
 pub const D3D11_DECODER_PROFILE_H264_VLD_WITHFMOASO_NOFGT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd5f04ff9_3418_45d8_9561_32a76aae2ddd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_H264_VLD_WITHFMOASO_NOFGT ) , guid : :: windows :: core :: GUID::from_u128(0xd5f04ff9_3418_45d8_9561_32a76aae2ddd) , } }
 pub const D3D11_DECODER_PROFILE_HEVC_VLD_MAIN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5b11d51b_2f4c_4452_bcc3_09f2a1160cc0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_HEVC_VLD_MAIN ) , guid : :: windows :: core :: GUID::from_u128(0x5b11d51b_2f4c_4452_bcc3_09f2a1160cc0) , } }
 pub const D3D11_DECODER_PROFILE_HEVC_VLD_MAIN10: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x107af0e0_ef1a_4d19_aba8_67a163073d13);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_HEVC_VLD_MAIN10 ) , guid : :: windows :: core :: GUID::from_u128(0x107af0e0_ef1a_4d19_aba8_67a163073d13) , } }
 pub const D3D11_DECODER_PROFILE_MPEG1_VLD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6f3ec719_3735_42cc_8063_65cc3cb36616);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_MPEG1_VLD ) , guid : :: windows :: core :: GUID::from_u128(0x6f3ec719_3735_42cc_8063_65cc3cb36616) , } }
 pub const D3D11_DECODER_PROFILE_MPEG2_IDCT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbf22ad00_03ea_4690_8077_473346209b7e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_MPEG2_IDCT ) , guid : :: windows :: core :: GUID::from_u128(0xbf22ad00_03ea_4690_8077_473346209b7e) , } }
 pub const D3D11_DECODER_PROFILE_MPEG2_MOCOMP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe6a9f44b_61b0_4563_9ea4_63d2a3c6fe66);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_MPEG2_MOCOMP ) , guid : :: windows :: core :: GUID::from_u128(0xe6a9f44b_61b0_4563_9ea4_63d2a3c6fe66) , } }
 pub const D3D11_DECODER_PROFILE_MPEG2_VLD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xee27417f_5e28_4e65_beea_1d26b508adc9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_MPEG2_VLD ) , guid : :: windows :: core :: GUID::from_u128(0xee27417f_5e28_4e65_beea_1d26b508adc9) , } }
 pub const D3D11_DECODER_PROFILE_MPEG2and1_VLD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x86695f12_340e_4f04_9fd3_9253dd327460);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_MPEG2and1_VLD ) , guid : :: windows :: core :: GUID::from_u128(0x86695f12_340e_4f04_9fd3_9253dd327460) , } }
 pub const D3D11_DECODER_PROFILE_MPEG4PT2_VLD_ADVSIMPLE_GMC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xab998b5b_4258_44a9_9feb_94e597a6baae);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_MPEG4PT2_VLD_ADVSIMPLE_GMC ) , guid : :: windows :: core :: GUID::from_u128(0xab998b5b_4258_44a9_9feb_94e597a6baae) , } }
 pub const D3D11_DECODER_PROFILE_MPEG4PT2_VLD_ADVSIMPLE_NOGMC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xed418a9f_010d_4eda_9ae3_9a65358d8d2e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_MPEG4PT2_VLD_ADVSIMPLE_NOGMC ) , guid : :: windows :: core :: GUID::from_u128(0xed418a9f_010d_4eda_9ae3_9a65358d8d2e) , } }
 pub const D3D11_DECODER_PROFILE_MPEG4PT2_VLD_SIMPLE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xefd64d74_c9e8_41d7_a5e9_e9b0e39fa319);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_MPEG4PT2_VLD_SIMPLE ) , guid : :: windows :: core :: GUID::from_u128(0xefd64d74_c9e8_41d7_a5e9_e9b0e39fa319) , } }
 pub const D3D11_DECODER_PROFILE_VC1_D2010: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1b81bea4_a0c7_11d3_b984_00c04f2e73c5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_VC1_D2010 ) , guid : :: windows :: core :: GUID::from_u128(0x1b81bea4_a0c7_11d3_b984_00c04f2e73c5) , } }
 pub const D3D11_DECODER_PROFILE_VC1_IDCT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1b81bea2_a0c7_11d3_b984_00c04f2e73c5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_VC1_IDCT ) , guid : :: windows :: core :: GUID::from_u128(0x1b81bea2_a0c7_11d3_b984_00c04f2e73c5) , } }
 pub const D3D11_DECODER_PROFILE_VC1_MOCOMP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1b81bea1_a0c7_11d3_b984_00c04f2e73c5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_VC1_MOCOMP ) , guid : :: windows :: core :: GUID::from_u128(0x1b81bea1_a0c7_11d3_b984_00c04f2e73c5) , } }
 pub const D3D11_DECODER_PROFILE_VC1_POSTPROC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1b81bea0_a0c7_11d3_b984_00c04f2e73c5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_VC1_POSTPROC ) , guid : :: windows :: core :: GUID::from_u128(0x1b81bea0_a0c7_11d3_b984_00c04f2e73c5) , } }
 pub const D3D11_DECODER_PROFILE_VC1_VLD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1b81bea3_a0c7_11d3_b984_00c04f2e73c5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_VC1_VLD ) , guid : :: windows :: core :: GUID::from_u128(0x1b81bea3_a0c7_11d3_b984_00c04f2e73c5) , } }
 pub const D3D11_DECODER_PROFILE_VP8_VLD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x90b899ea_3a62_4705_88b3_8df04b2744e7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_VP8_VLD ) , guid : :: windows :: core :: GUID::from_u128(0x90b899ea_3a62_4705_88b3_8df04b2744e7) , } }
 pub const D3D11_DECODER_PROFILE_VP9_VLD_10BIT_PROFILE2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa4c749ef_6ecf_48aa_8448_50a7a1165ff7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_VP9_VLD_10BIT_PROFILE2 ) , guid : :: windows :: core :: GUID::from_u128(0xa4c749ef_6ecf_48aa_8448_50a7a1165ff7) , } }
 pub const D3D11_DECODER_PROFILE_VP9_VLD_PROFILE0: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x463707f8_a1d0_4585_876d_83aa6d60b89e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_VP9_VLD_PROFILE0 ) , guid : :: windows :: core :: GUID::from_u128(0x463707f8_a1d0_4585_876d_83aa6d60b89e) , } }
 pub const D3D11_DECODER_PROFILE_WMV8_MOCOMP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1b81be81_a0c7_11d3_b984_00c04f2e73c5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_WMV8_MOCOMP ) , guid : :: windows :: core :: GUID::from_u128(0x1b81be81_a0c7_11d3_b984_00c04f2e73c5) , } }
 pub const D3D11_DECODER_PROFILE_WMV8_POSTPROC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1b81be80_a0c7_11d3_b984_00c04f2e73c5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_WMV8_POSTPROC ) , guid : :: windows :: core :: GUID::from_u128(0x1b81be80_a0c7_11d3_b984_00c04f2e73c5) , } }
 pub const D3D11_DECODER_PROFILE_WMV9_IDCT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1b81be94_a0c7_11d3_b984_00c04f2e73c5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_WMV9_IDCT ) , guid : :: windows :: core :: GUID::from_u128(0x1b81be94_a0c7_11d3_b984_00c04f2e73c5) , } }
 pub const D3D11_DECODER_PROFILE_WMV9_MOCOMP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1b81be91_a0c7_11d3_b984_00c04f2e73c5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_WMV9_MOCOMP ) , guid : :: windows :: core :: GUID::from_u128(0x1b81be91_a0c7_11d3_b984_00c04f2e73c5) , } }
 pub const D3D11_DECODER_PROFILE_WMV9_POSTPROC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1b81be90_a0c7_11d3_b984_00c04f2e73c5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_DECODER_PROFILE_WMV9_POSTPROC ) , guid : :: windows :: core :: GUID::from_u128(0x1b81be90_a0c7_11d3_b984_00c04f2e73c5) , } }
 #[doc = "*Required features: 'Win32_Graphics_Direct3D11'*"]
 pub const D3D11_DEFAULT_BLEND_FACTOR_ALPHA: f32 = 1f32;
 #[doc = "*Required features: 'Win32_Graphics_Direct3D11'*"]
@@ -4269,6 +4389,8 @@ pub const D3D11_KEEP_RENDER_TARGETS_AND_DEPTH_STENCIL: u32 = 4294967295u32;
 #[doc = "*Required features: 'Win32_Graphics_Direct3D11'*"]
 pub const D3D11_KEEP_UNORDERED_ACCESS_VIEWS: u32 = 4294967295u32;
 pub const D3D11_KEY_EXCHANGE_HW_PROTECTION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb1170d8a_628d_4da3_ad3b_82ddb08b4970);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_KEY_EXCHANGE_HW_PROTECTION ) , guid : :: windows :: core :: GUID::from_u128(0xb1170d8a_628d_4da3_ad3b_82ddb08b4970) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Graphics_Direct3D11'*"]
 pub struct D3D11_KEY_EXCHANGE_HW_PROTECTION_DATA {
@@ -4370,6 +4492,8 @@ impl ::core::default::Default for D3D11_KEY_EXCHANGE_HW_PROTECTION_OUTPUT_DATA {
     }
 }
 pub const D3D11_KEY_EXCHANGE_RSAES_OAEP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc1949895_d72a_4a1d_8e5d_ed857d171520);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D11_KEY_EXCHANGE_RSAES_OAEP ) , guid : :: windows :: core :: GUID::from_u128(0xc1949895_d72a_4a1d_8e5d_ed857d171520) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Graphics_Direct3D11', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -12957,6 +13081,8 @@ pub const D3D_SHADER_REQUIRES_TILED_RESOURCES: u32 = 256u32;
 #[doc = "*Required features: 'Win32_Graphics_Direct3D11'*"]
 pub const D3D_SHADER_REQUIRES_UAVS_AT_EVERY_STAGE: u32 = 4u32;
 pub const DXGI_DEBUG_D3D11: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4b99317b_ac39_4aa6_bb0b_baa04784798f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DXGI_DEBUG_D3D11 ) , guid : :: windows :: core :: GUID::from_u128(0x4b99317b_ac39_4aa6_bb0b_baa04784798f) , } }
 #[doc = "*Required features: 'Win32_Graphics_Direct3D11'*"]
 #[repr(transparent)]
 pub struct ID3D11Asynchronous(::windows::core::IUnknown);

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/mod.rs
@@ -1,8 +1,16 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 pub const CLSID_D3D12Debug: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf2352aeb_dd84_49fe_b97b_a9dcfdcc1b4f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D3D12Debug ) , guid : :: windows :: core :: GUID::from_u128(0xf2352aeb_dd84_49fe_b97b_a9dcfdcc1b4f) , } }
 pub const CLSID_D3D12DeviceRemovedExtendedData: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4a75bbc4_9ff4_4ad8_9f18_abae84dc5ff2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D3D12DeviceRemovedExtendedData ) , guid : :: windows :: core :: GUID::from_u128(0x4a75bbc4_9ff4_4ad8_9f18_abae84dc5ff2) , } }
 pub const CLSID_D3D12SDKConfiguration: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7cda6aca_a03e_49c8_9458_0334d20e07ce);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D3D12SDKConfiguration ) , guid : :: windows :: core :: GUID::from_u128(0x7cda6aca_a03e_49c8_9458_0334d20e07ce) , } }
 pub const CLSID_D3D12Tools: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe38216b1_3c8c_4833_aa09_0a06b65d96c8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_D3D12Tools ) , guid : :: windows :: core :: GUID::from_u128(0xe38216b1_3c8c_4833_aa09_0a06b65d96c8) , } }
 #[doc = "*Required features: 'Win32_Graphics_Direct3D12', 'Win32_Graphics_Direct3D'*"]
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 #[inline]
@@ -61,6 +69,8 @@ pub unsafe fn D3D12EnableExperimentalFeatures(numfeatures: u32, piids: *const ::
     unimplemented!("Unsupported target OS");
 }
 pub const D3D12ExperimentalShaderModels: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x76f5573e_f13a_40f5_b297_81ce9e18933f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D12ExperimentalShaderModels ) , guid : :: windows :: core :: GUID::from_u128(0x76f5573e_f13a_40f5_b297_81ce9e18933f) , } }
 #[doc = "*Required features: 'Win32_Graphics_Direct3D12'*"]
 #[inline]
 pub unsafe fn D3D12GetDebugInterface<T: ::windows::core::Interface>(result__: *mut ::core::option::Option<T>) -> ::windows::core::Result<()> {
@@ -93,6 +103,8 @@ pub unsafe fn D3D12GetInterface<T: ::windows::core::Interface>(rclsid: *const ::
 #[cfg(feature = "Win32_Foundation")]
 pub type D3D12MessageFunc = ::core::option::Option<unsafe extern "system" fn(category: D3D12_MESSAGE_CATEGORY, severity: D3D12_MESSAGE_SEVERITY, id: D3D12_MESSAGE_ID, pdescription: super::super::Foundation::PSTR, pcontext: *mut ::core::ffi::c_void)>;
 pub const D3D12MetaCommand: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc734c97e_8077_48c8_9fdc_d9d1dd31dd77);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D12MetaCommand ) , guid : :: windows :: core :: GUID::from_u128(0xc734c97e_8077_48c8_9fdc_d9d1dd31dd77) , } }
 #[doc = "*Required features: 'Win32_Graphics_Direct3D12', 'Win32_Graphics_Direct3D'*"]
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 #[inline]
@@ -124,6 +136,8 @@ pub unsafe fn D3D12SerializeVersionedRootSignature(prootsignature: *const D3D12_
     unimplemented!("Unsupported target OS");
 }
 pub const D3D12TiledResourceTier4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc9c4725f_a81a_4f56_8c5b_c51039d694fb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D12TiledResourceTier4 ) , guid : :: windows :: core :: GUID::from_u128(0xc9c4725f_a81a_4f56_8c5b_c51039d694fb) , } }
 #[doc = "*Required features: 'Win32_Graphics_Direct3D12'*"]
 pub const D3D12_16BIT_INDEX_STRIP_CUT_VALUE: u32 = 65535u32;
 #[doc = "*Required features: 'Win32_Graphics_Direct3D12'*"]
@@ -8160,6 +8174,8 @@ pub const D3D12_PROGRAMMABLE_SAMPLE_POSITIONS_TIER_1: D3D12_PROGRAMMABLE_SAMPLE_
 #[doc = "*Required features: 'Win32_Graphics_Direct3D12'*"]
 pub const D3D12_PROGRAMMABLE_SAMPLE_POSITIONS_TIER_2: D3D12_PROGRAMMABLE_SAMPLE_POSITIONS_TIER = 2i32;
 pub const D3D12_PROTECTED_RESOURCES_SESSION_HARDWARE_PROTECTED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x62b0084e_c70e_4daa_a109_30ff8d5a0482);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3D12_PROTECTED_RESOURCES_SESSION_HARDWARE_PROTECTED ) , guid : :: windows :: core :: GUID::from_u128(0x62b0084e_c70e_4daa_a109_30ff8d5a0482) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Graphics_Direct3D12'*"]
 pub struct D3D12_PROTECTED_RESOURCE_SESSION_DESC {
@@ -13795,6 +13811,8 @@ pub const D3D_SHADER_REQUIRES_WAVE_MMA: u32 = 134217728u32;
 #[doc = "*Required features: 'Win32_Graphics_Direct3D12'*"]
 pub const D3D_SHADER_REQUIRES_WAVE_OPS: u32 = 16384u32;
 pub const DXGI_DEBUG_D3D12: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcf59a98c_a950_4326_91ef_9bbaa17bfd95);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DXGI_DEBUG_D3D12 ) , guid : :: windows :: core :: GUID::from_u128(0xcf59a98c_a950_4326_91ef_9bbaa17bfd95) , } }
 #[doc = "*Required features: 'Win32_Graphics_Direct3D12'*"]
 #[repr(transparent)]
 pub struct ID3D12CommandAllocator(::windows::core::IUnknown);
@@ -29941,3 +29959,5 @@ pub type PFN_D3D12_SERIALIZE_ROOT_SIGNATURE = ::core::option::Option<unsafe exte
 #[cfg(feature = "Win32_Graphics_Direct3D")]
 pub type PFN_D3D12_SERIALIZE_VERSIONED_ROOT_SIGNATURE = ::core::option::Option<unsafe extern "system" fn(prootsignature: *const D3D12_VERSIONED_ROOT_SIGNATURE_DESC, ppblob: *mut ::core::option::Option<super::Direct3D::ID3DBlob>, pperrorblob: *mut ::core::option::Option<super::Direct3D::ID3DBlob>) -> ::windows::core::HRESULT>;
 pub const WKPDID_D3DAutoDebugObjectNameW: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd4902e36_757a_4942_9594_b6769afa43cd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WKPDID_D3DAutoDebugObjectNameW ) , guid : :: windows :: core :: GUID::from_u128(0xd4902e36_757a_4942_9594_b6769afa43cd) , } }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D9/mod.rs
@@ -1407,23 +1407,59 @@ impl ::core::default::Default for D3DAUTHENTICATEDCHANNEL_QUERY_OUTPUT {
     }
 }
 pub const D3DAUTHENTICATEDCONFIGURE_CRYPTOSESSION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6346cc54_2cfc_4ad4_8224_d15837de7700);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3DAUTHENTICATEDCONFIGURE_CRYPTOSESSION ) , guid : :: windows :: core :: GUID::from_u128(0x6346cc54_2cfc_4ad4_8224_d15837de7700) , } }
 pub const D3DAUTHENTICATEDCONFIGURE_ENCRYPTIONWHENACCESSIBLE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x41fff286_6ae0_4d43_9d55_a46e9efd158a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3DAUTHENTICATEDCONFIGURE_ENCRYPTIONWHENACCESSIBLE ) , guid : :: windows :: core :: GUID::from_u128(0x41fff286_6ae0_4d43_9d55_a46e9efd158a) , } }
 pub const D3DAUTHENTICATEDCONFIGURE_INITIALIZE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x06114bdb_3523_470a_8dca_fbc2845154f0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3DAUTHENTICATEDCONFIGURE_INITIALIZE ) , guid : :: windows :: core :: GUID::from_u128(0x06114bdb_3523_470a_8dca_fbc2845154f0) , } }
 pub const D3DAUTHENTICATEDCONFIGURE_PROTECTION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x50455658_3f47_4362_bf99_bfdfcde9ed29);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3DAUTHENTICATEDCONFIGURE_PROTECTION ) , guid : :: windows :: core :: GUID::from_u128(0x50455658_3f47_4362_bf99_bfdfcde9ed29) , } }
 pub const D3DAUTHENTICATEDCONFIGURE_SHAREDRESOURCE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0772d047_1b40_48e8_9ca6_b5f510de9f01);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3DAUTHENTICATEDCONFIGURE_SHAREDRESOURCE ) , guid : :: windows :: core :: GUID::from_u128(0x0772d047_1b40_48e8_9ca6_b5f510de9f01) , } }
 pub const D3DAUTHENTICATEDQUERY_ACCESSIBILITYATTRIBUTES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6214d9d2_432c_4abb_9fce_216eea269e3b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3DAUTHENTICATEDQUERY_ACCESSIBILITYATTRIBUTES ) , guid : :: windows :: core :: GUID::from_u128(0x6214d9d2_432c_4abb_9fce_216eea269e3b) , } }
 pub const D3DAUTHENTICATEDQUERY_CHANNELTYPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbc1b18a5_b1fb_42ab_bd94_b5828b4bf7be);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3DAUTHENTICATEDQUERY_CHANNELTYPE ) , guid : :: windows :: core :: GUID::from_u128(0xbc1b18a5_b1fb_42ab_bd94_b5828b4bf7be) , } }
 pub const D3DAUTHENTICATEDQUERY_CRYPTOSESSION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2634499e_d018_4d74_ac17_7f724059528d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3DAUTHENTICATEDQUERY_CRYPTOSESSION ) , guid : :: windows :: core :: GUID::from_u128(0x2634499e_d018_4d74_ac17_7f724059528d) , } }
 pub const D3DAUTHENTICATEDQUERY_CURRENTENCRYPTIONWHENACCESSIBLE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xec1791c7_dad3_4f15_9ec3_faa93d60d4f0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3DAUTHENTICATEDQUERY_CURRENTENCRYPTIONWHENACCESSIBLE ) , guid : :: windows :: core :: GUID::from_u128(0xec1791c7_dad3_4f15_9ec3_faa93d60d4f0) , } }
 pub const D3DAUTHENTICATEDQUERY_DEVICEHANDLE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xec1c539d_8cff_4e2a_bcc4_f5692f99f480);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3DAUTHENTICATEDQUERY_DEVICEHANDLE ) , guid : :: windows :: core :: GUID::from_u128(0xec1c539d_8cff_4e2a_bcc4_f5692f99f480) , } }
 pub const D3DAUTHENTICATEDQUERY_ENCRYPTIONWHENACCESSIBLEGUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf83a5958_e986_4bda_beb0_411f6a7a01b7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3DAUTHENTICATEDQUERY_ENCRYPTIONWHENACCESSIBLEGUID ) , guid : :: windows :: core :: GUID::from_u128(0xf83a5958_e986_4bda_beb0_411f6a7a01b7) , } }
 pub const D3DAUTHENTICATEDQUERY_ENCRYPTIONWHENACCESSIBLEGUIDCOUNT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb30f7066_203c_4b07_93fc_ceaafd61241e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3DAUTHENTICATEDQUERY_ENCRYPTIONWHENACCESSIBLEGUIDCOUNT ) , guid : :: windows :: core :: GUID::from_u128(0xb30f7066_203c_4b07_93fc_ceaafd61241e) , } }
 pub const D3DAUTHENTICATEDQUERY_OUTPUTID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x839ddca3_9b4e_41e4_b053_892bd2a11ee7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3DAUTHENTICATEDQUERY_OUTPUTID ) , guid : :: windows :: core :: GUID::from_u128(0x839ddca3_9b4e_41e4_b053_892bd2a11ee7) , } }
 pub const D3DAUTHENTICATEDQUERY_OUTPUTIDCOUNT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2c042b5e_8c07_46d5_aabe_8f75cbad4c31);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3DAUTHENTICATEDQUERY_OUTPUTIDCOUNT ) , guid : :: windows :: core :: GUID::from_u128(0x2c042b5e_8c07_46d5_aabe_8f75cbad4c31) , } }
 pub const D3DAUTHENTICATEDQUERY_PROTECTION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa84eb584_c495_48aa_b94d_8bd2d6fbce05);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3DAUTHENTICATEDQUERY_PROTECTION ) , guid : :: windows :: core :: GUID::from_u128(0xa84eb584_c495_48aa_b94d_8bd2d6fbce05) , } }
 pub const D3DAUTHENTICATEDQUERY_RESTRICTEDSHAREDRESOURCEPROCESS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x649bbadb_f0f4_4639_a15b_24393fc3abac);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3DAUTHENTICATEDQUERY_RESTRICTEDSHAREDRESOURCEPROCESS ) , guid : :: windows :: core :: GUID::from_u128(0x649bbadb_f0f4_4639_a15b_24393fc3abac) , } }
 pub const D3DAUTHENTICATEDQUERY_RESTRICTEDSHAREDRESOURCEPROCESSCOUNT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0db207b3_9450_46a6_82de_1b96d44f9cf2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3DAUTHENTICATEDQUERY_RESTRICTEDSHAREDRESOURCEPROCESSCOUNT ) , guid : :: windows :: core :: GUID::from_u128(0x0db207b3_9450_46a6_82de_1b96d44f9cf2) , } }
 pub const D3DAUTHENTICATEDQUERY_UNRESTRICTEDPROTECTEDSHAREDRESOURCECOUNT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x012f0bd6_e662_4474_befd_aa53e5143c6d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3DAUTHENTICATEDQUERY_UNRESTRICTEDPROTECTEDSHAREDRESOURCECOUNT ) , guid : :: windows :: core :: GUID::from_u128(0x012f0bd6_e662_4474_befd_aa53e5143c6d) , } }
 #[doc = "*Required features: 'Win32_Graphics_Direct3D9'*"]
 pub type D3DBACKBUFFER_TYPE = u32;
 #[doc = "*Required features: 'Win32_Graphics_Direct3D9'*"]
@@ -1972,7 +2008,11 @@ pub const D3DCREATE_SCREENSAVER: i32 = 268435456i32;
 #[doc = "*Required features: 'Win32_Graphics_Direct3D9'*"]
 pub const D3DCREATE_SOFTWARE_VERTEXPROCESSING: i32 = 32i32;
 pub const D3DCRYPTOTYPE_AES128_CTR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9b6bd711_4f74_41c9_9e7b_0be2d7d93b4f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3DCRYPTOTYPE_AES128_CTR ) , guid : :: windows :: core :: GUID::from_u128(0x9b6bd711_4f74_41c9_9e7b_0be2d7d93b4f) , } }
 pub const D3DCRYPTOTYPE_PROPRIETARY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xab4e9afd_1d1c_46e6_a72f_0869917b0de8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3DCRYPTOTYPE_PROPRIETARY ) , guid : :: windows :: core :: GUID::from_u128(0xab4e9afd_1d1c_46e6_a72f_0869917b0de8) , } }
 #[doc = "*Required features: 'Win32_Graphics_Direct3D9'*"]
 pub const D3DCS_BACK: i32 = 32i32;
 #[doc = "*Required features: 'Win32_Graphics_Direct3D9'*"]
@@ -2892,7 +2932,11 @@ pub const D3DISSUE_BEGIN: u32 = 2u32;
 #[doc = "*Required features: 'Win32_Graphics_Direct3D9'*"]
 pub const D3DISSUE_END: u32 = 1u32;
 pub const D3DKEYEXCHANGE_DXVA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x43d3775c_38e5_4924_8d86_d3fccf153e9b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3DKEYEXCHANGE_DXVA ) , guid : :: windows :: core :: GUID::from_u128(0x43d3775c_38e5_4924_8d86_d3fccf153e9b) , } }
 pub const D3DKEYEXCHANGE_RSAES_OAEP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc1949895_d72a_4a1d_8e5d_ed857d171520);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( D3DKEYEXCHANGE_RSAES_OAEP ) , guid : :: windows :: core :: GUID::from_u128(0xc1949895_d72a_4a1d_8e5d_ed857d171520) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Graphics_Direct3D9', 'Win32_Graphics_Direct3D'*"]
 #[cfg(feature = "Win32_Graphics_Direct3D")]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectDraw/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectDraw/mod.rs
@@ -92,8 +92,14 @@ impl ::core::default::Default for ATTACHLIST {
 #[doc = "*Required features: 'Win32_Graphics_DirectDraw'*"]
 pub const CCHDEVICENAME: u32 = 32u32;
 pub const CLSID_DirectDraw: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd7b70ee0_4340_11cf_b063_0020afc2cd35);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DirectDraw ) , guid : :: windows :: core :: GUID::from_u128(0xd7b70ee0_4340_11cf_b063_0020afc2cd35) , } }
 pub const CLSID_DirectDraw7: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3c305196_50db_11d3_9cfe_00c04fd930c5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DirectDraw7 ) , guid : :: windows :: core :: GUID::from_u128(0x3c305196_50db_11d3_9cfe_00c04fd930c5) , } }
 pub const CLSID_DirectDrawClipper: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x593817a0_7db3_11cf_a2de_00aa00b93356);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DirectDrawClipper ) , guid : :: windows :: core :: GUID::from_u128(0x593817a0_7db3_11cf_a2de_00aa00b93356) , } }
 #[doc = "*Required features: 'Win32_Graphics_DirectDraw'*"]
 pub const D3DFMT_INTERNAL_D15S1: u32 = 73u32;
 #[doc = "*Required features: 'Win32_Graphics_DirectDraw'*"]
@@ -9955,12 +9961,26 @@ pub const DDVPTARGET_VBI: i32 = 2i32;
 #[doc = "*Required features: 'Win32_Graphics_DirectDraw'*"]
 pub const DDVPTARGET_VIDEO: i32 = 1i32;
 pub const DDVPTYPE_BROOKTREE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1352a560_da61_11cf_9b06_00a0c903a3b8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DDVPTYPE_BROOKTREE ) , guid : :: windows :: core :: GUID::from_u128(0x1352a560_da61_11cf_9b06_00a0c903a3b8) , } }
 pub const DDVPTYPE_CCIR656: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfca326a0_da60_11cf_9b06_00a0c903a3b8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DDVPTYPE_CCIR656 ) , guid : :: windows :: core :: GUID::from_u128(0xfca326a0_da60_11cf_9b06_00a0c903a3b8) , } }
 pub const DDVPTYPE_E_HREFH_VREFH: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x54f39980_da60_11cf_9b06_00a0c903a3b8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DDVPTYPE_E_HREFH_VREFH ) , guid : :: windows :: core :: GUID::from_u128(0x54f39980_da60_11cf_9b06_00a0c903a3b8) , } }
 pub const DDVPTYPE_E_HREFH_VREFL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x92783220_da60_11cf_9b06_00a0c903a3b8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DDVPTYPE_E_HREFH_VREFL ) , guid : :: windows :: core :: GUID::from_u128(0x92783220_da60_11cf_9b06_00a0c903a3b8) , } }
 pub const DDVPTYPE_E_HREFL_VREFH: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa07a02e0_da60_11cf_9b06_00a0c903a3b8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DDVPTYPE_E_HREFL_VREFH ) , guid : :: windows :: core :: GUID::from_u128(0xa07a02e0_da60_11cf_9b06_00a0c903a3b8) , } }
 pub const DDVPTYPE_E_HREFL_VREFL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe09c77e0_da60_11cf_9b06_00a0c903a3b8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DDVPTYPE_E_HREFL_VREFL ) , guid : :: windows :: core :: GUID::from_u128(0xe09c77e0_da60_11cf_9b06_00a0c903a3b8) , } }
 pub const DDVPTYPE_PHILIPS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x332cf160_da61_11cf_9b06_00a0c903a3b8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DDVPTYPE_PHILIPS ) , guid : :: windows :: core :: GUID::from_u128(0x332cf160_da61_11cf_9b06_00a0c903a3b8) , } }
 #[doc = "*Required features: 'Win32_Graphics_DirectDraw'*"]
 pub const DDVPWAIT_BEGIN: i32 = 1i32;
 #[doc = "*Required features: 'Win32_Graphics_DirectDraw'*"]
@@ -14123,34 +14143,92 @@ pub unsafe fn DirectDrawEnumerateW(lpcallback: LPDDENUMCALLBACKW, lpcontext: *mu
     unimplemented!("Unsupported target OS");
 }
 pub const GUID_ColorControlCallbacks: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xefd60cc2_49e7_11d0_889d_00aa00bbb76a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ColorControlCallbacks ) , guid : :: windows :: core :: GUID::from_u128(0xefd60cc2_49e7_11d0_889d_00aa00bbb76a) , } }
 pub const GUID_D3DCallbacks: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7bf06990_8794_11d0_9139_080036d2ef02);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_D3DCallbacks ) , guid : :: windows :: core :: GUID::from_u128(0x7bf06990_8794_11d0_9139_080036d2ef02) , } }
 pub const GUID_D3DCallbacks2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0ba584e1_70b6_11d0_889d_00aa00bbb76a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_D3DCallbacks2 ) , guid : :: windows :: core :: GUID::from_u128(0x0ba584e1_70b6_11d0_889d_00aa00bbb76a) , } }
 pub const GUID_D3DCallbacks3: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xddf41230_ec0a_11d0_a9b6_00aa00c0993e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_D3DCallbacks3 ) , guid : :: windows :: core :: GUID::from_u128(0xddf41230_ec0a_11d0_a9b6_00aa00c0993e) , } }
 pub const GUID_D3DCaps: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7bf06991_8794_11d0_9139_080036d2ef02);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_D3DCaps ) , guid : :: windows :: core :: GUID::from_u128(0x7bf06991_8794_11d0_9139_080036d2ef02) , } }
 pub const GUID_D3DExtendedCaps: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7de41f80_9d93_11d0_89ab_00a0c9054129);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_D3DExtendedCaps ) , guid : :: windows :: core :: GUID::from_u128(0x7de41f80_9d93_11d0_89ab_00a0c9054129) , } }
 pub const GUID_D3DParseUnknownCommandCallback: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2e04ffa0_98e4_11d1_8ce1_00a0c90629a8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_D3DParseUnknownCommandCallback ) , guid : :: windows :: core :: GUID::from_u128(0x2e04ffa0_98e4_11d1_8ce1_00a0c90629a8) , } }
 pub const GUID_DDMoreCaps: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x880baf30_b030_11d0_8ea7_00609797ea5b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DDMoreCaps ) , guid : :: windows :: core :: GUID::from_u128(0x880baf30_b030_11d0_8ea7_00609797ea5b) , } }
 pub const GUID_DDMoreSurfaceCaps: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3b8a0466_f269_11d1_880b_00c04fd930c5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DDMoreSurfaceCaps ) , guid : :: windows :: core :: GUID::from_u128(0x3b8a0466_f269_11d1_880b_00c04fd930c5) , } }
 pub const GUID_DDStereoMode: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf828169c_a8e8_11d2_a1f2_00a0c983eaf6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DDStereoMode ) , guid : :: windows :: core :: GUID::from_u128(0xf828169c_a8e8_11d2_a1f2_00a0c983eaf6) , } }
 pub const GUID_DxApi: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8a79bef0_b915_11d0_9144_080036d2ef02);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DxApi ) , guid : :: windows :: core :: GUID::from_u128(0x8a79bef0_b915_11d0_9144_080036d2ef02) , } }
 pub const GUID_GetHeapAlignment: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x42e02f16_7b41_11d2_8bff_00a0c983eaf6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_GetHeapAlignment ) , guid : :: windows :: core :: GUID::from_u128(0x42e02f16_7b41_11d2_8bff_00a0c983eaf6) , } }
 pub const GUID_KernelCallbacks: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x80863800_6b06_11d0_9b06_00a0c903a3b8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_KernelCallbacks ) , guid : :: windows :: core :: GUID::from_u128(0x80863800_6b06_11d0_9b06_00a0c903a3b8) , } }
 pub const GUID_KernelCaps: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xffaa7540_7aa8_11d0_9b06_00a0c903a3b8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_KernelCaps ) , guid : :: windows :: core :: GUID::from_u128(0xffaa7540_7aa8_11d0_9b06_00a0c903a3b8) , } }
 pub const GUID_Miscellaneous2Callbacks: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x406b2f00_3e5a_11d1_b640_00aa00a1f96a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_Miscellaneous2Callbacks ) , guid : :: windows :: core :: GUID::from_u128(0x406b2f00_3e5a_11d1_b640_00aa00a1f96a) , } }
 pub const GUID_MiscellaneousCallbacks: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xefd60cc0_49e7_11d0_889d_00aa00bbb76a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MiscellaneousCallbacks ) , guid : :: windows :: core :: GUID::from_u128(0xefd60cc0_49e7_11d0_889d_00aa00bbb76a) , } }
 pub const GUID_MotionCompCallbacks: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb1122b40_5da5_11d1_8fcf_00c04fc29b4e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MotionCompCallbacks ) , guid : :: windows :: core :: GUID::from_u128(0xb1122b40_5da5_11d1_8fcf_00c04fc29b4e) , } }
 pub const GUID_NTCallbacks: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fe9ecde_df89_11d1_9db0_0060082771ba);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NTCallbacks ) , guid : :: windows :: core :: GUID::from_u128(0x6fe9ecde_df89_11d1_9db0_0060082771ba) , } }
 pub const GUID_NTPrivateDriverCaps: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfad16a23_7b66_11d2_83d7_00c04f7ce58c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NTPrivateDriverCaps ) , guid : :: windows :: core :: GUID::from_u128(0xfad16a23_7b66_11d2_83d7_00c04f7ce58c) , } }
 pub const GUID_NonLocalVidMemCaps: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x86c4fa80_8d84_11d0_94e8_00c04fc34137);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NonLocalVidMemCaps ) , guid : :: windows :: core :: GUID::from_u128(0x86c4fa80_8d84_11d0_94e8_00c04fc34137) , } }
 pub const GUID_OptSurfaceKmodeInfo: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe05c8472_51d4_11d1_8cce_00a0c90629a8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_OptSurfaceKmodeInfo ) , guid : :: windows :: core :: GUID::from_u128(0xe05c8472_51d4_11d1_8cce_00a0c90629a8) , } }
 pub const GUID_OptSurfaceUmodeInfo: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9d792804_5fa8_11d1_8cd0_00a0c90629a8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_OptSurfaceUmodeInfo ) , guid : :: windows :: core :: GUID::from_u128(0x9d792804_5fa8_11d1_8cd0_00a0c90629a8) , } }
 pub const GUID_UpdateNonLocalHeap: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x42e02f17_7b41_11d2_8bff_00a0c983eaf6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_UpdateNonLocalHeap ) , guid : :: windows :: core :: GUID::from_u128(0x42e02f17_7b41_11d2_8bff_00a0c983eaf6) , } }
 pub const GUID_UserModeDriverInfo: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf0b0e8e2_5f97_11d1_8cd0_00a0c90629a8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_UserModeDriverInfo ) , guid : :: windows :: core :: GUID::from_u128(0xf0b0e8e2_5f97_11d1_8cd0_00a0c90629a8) , } }
 pub const GUID_UserModeDriverPassword: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x97f861b6_60a1_11d1_8cd0_00a0c90629a8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_UserModeDriverPassword ) , guid : :: windows :: core :: GUID::from_u128(0x97f861b6_60a1_11d1_8cd0_00a0c90629a8) , } }
 pub const GUID_VPE2Callbacks: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x52882147_2d47_469a_a0d1_03455890f6c8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_VPE2Callbacks ) , guid : :: windows :: core :: GUID::from_u128(0x52882147_2d47_469a_a0d1_03455890f6c8) , } }
 pub const GUID_VideoPortCallbacks: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xefd60cc1_49e7_11d0_889d_00aa00bbb76a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_VideoPortCallbacks ) , guid : :: windows :: core :: GUID::from_u128(0xefd60cc1_49e7_11d0_889d_00aa00bbb76a) , } }
 pub const GUID_VideoPortCaps: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xefd60cc3_49e7_11d0_889d_00aa00bbb76a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_VideoPortCaps ) , guid : :: windows :: core :: GUID::from_u128(0xefd60cc3_49e7_11d0_889d_00aa00bbb76a) , } }
 pub const GUID_ZPixelFormats: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x93869880_36cf_11d1_9b1b_00aa00bbb8ae);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ZPixelFormats ) , guid : :: windows :: core :: GUID::from_u128(0x93869880_36cf_11d1_9b1b_00aa00bbb8ae) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Graphics_DirectDraw'*"]
 pub struct HEAPALIAS {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectManipulation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectManipulation/mod.rs
@@ -1,10 +1,22 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 pub const CLSID_AutoScrollBehavior: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x26126a51_3c70_4c9a_aec2_948849eeb093);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_AutoScrollBehavior ) , guid : :: windows :: core :: GUID::from_u128(0x26126a51_3c70_4c9a_aec2_948849eeb093) , } }
 pub const CLSID_DeferContactService: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd7b67cf4_84bb_434e_86ae_6592bbc9abd9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DeferContactService ) , guid : :: windows :: core :: GUID::from_u128(0xd7b67cf4_84bb_434e_86ae_6592bbc9abd9) , } }
 pub const CLSID_DragDropConfigurationBehavior: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x09b01b3e_ba6c_454d_82e8_95e352329f23);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DragDropConfigurationBehavior ) , guid : :: windows :: core :: GUID::from_u128(0x09b01b3e_ba6c_454d_82e8_95e352329f23) , } }
 pub const CLSID_HorizontalIndicatorContent: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe7d18cf5_3ec7_44d5_a76b_3770f3cf903d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_HorizontalIndicatorContent ) , guid : :: windows :: core :: GUID::from_u128(0xe7d18cf5_3ec7_44d5_a76b_3770f3cf903d) , } }
 pub const CLSID_VerticalIndicatorContent: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa10b5f17_afe0_4aa2_91e9_3e7001d2e6b4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_VerticalIndicatorContent ) , guid : :: windows :: core :: GUID::from_u128(0xa10b5f17_afe0_4aa2_91e9_3e7001d2e6b4) , } }
 pub const CLSID_VirtualViewportContent: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3206a19a_86f0_4cb4_a7f3_16e3b7e2d852);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_VirtualViewportContent ) , guid : :: windows :: core :: GUID::from_u128(0x3206a19a_86f0_4cb4_a7f3_16e3b7e2d852) , } }
 pub const DCompManipulationCompositor: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x79dea627_a08a_43ac_8ef5_6900b9299126);
 #[doc = "*Required features: 'Win32_Graphics_DirectManipulation'*"]
 pub type DIRECTMANIPULATION_AUTOSCROLL_CONFIGURATION = i32;

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/mod.rs
@@ -333,11 +333,19 @@ pub const DXGI_COMPUTE_PREEMPTION_INSTRUCTION_BOUNDARY: DXGI_COMPUTE_PREEMPTION_
 #[doc = "*Required features: 'Win32_Graphics_Dxgi'*"]
 pub const DXGI_CREATE_FACTORY_DEBUG: u32 = 1u32;
 pub const DXGI_DEBUG_ALL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe48ae283_da80_490b_87e6_43e9a9cfda08);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DXGI_DEBUG_ALL ) , guid : :: windows :: core :: GUID::from_u128(0xe48ae283_da80_490b_87e6_43e9a9cfda08) , } }
 pub const DXGI_DEBUG_APP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x06cd6e01_4219_4ebd_8709_27ed23360c62);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DXGI_DEBUG_APP ) , guid : :: windows :: core :: GUID::from_u128(0x06cd6e01_4219_4ebd_8709_27ed23360c62) , } }
 #[doc = "*Required features: 'Win32_Graphics_Dxgi'*"]
 pub const DXGI_DEBUG_BINARY_VERSION: u32 = 1u32;
 pub const DXGI_DEBUG_DX: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x35cdd7fc_13b2_421d_a5d7_7e4451287d64);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DXGI_DEBUG_DX ) , guid : :: windows :: core :: GUID::from_u128(0x35cdd7fc_13b2_421d_a5d7_7e4451287d64) , } }
 pub const DXGI_DEBUG_DXGI: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x25cddaa4_b1c6_47e1_ac3e_98875b5a2e2a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DXGI_DEBUG_DXGI ) , guid : :: windows :: core :: GUID::from_u128(0x25cddaa4_b1c6_47e1_ac3e_98875b5a2e2a) , } }
 #[doc = "*Required features: 'Win32_Graphics_Dxgi'*"]
 pub type DXGI_DEBUG_RLO_FLAGS = u32;
 #[doc = "*Required features: 'Win32_Graphics_Dxgi'*"]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/mod.rs
@@ -2,272 +2,802 @@
 #[cfg(feature = "Win32_Graphics_Imaging_D2D")]
 pub mod D2D;
 pub const CATID_WICBitmapDecoders: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7ed96837_96f0_4812_b211_f13c24117ed3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_WICBitmapDecoders ) , guid : :: windows :: core :: GUID::from_u128(0x7ed96837_96f0_4812_b211_f13c24117ed3) , } }
 pub const CATID_WICBitmapEncoders: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xac757296_3522_4e11_9862_c17be5a1767e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_WICBitmapEncoders ) , guid : :: windows :: core :: GUID::from_u128(0xac757296_3522_4e11_9862_c17be5a1767e) , } }
 pub const CATID_WICFormatConverters: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7835eae8_bf14_49d1_93ce_533a407b2248);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_WICFormatConverters ) , guid : :: windows :: core :: GUID::from_u128(0x7835eae8_bf14_49d1_93ce_533a407b2248) , } }
 pub const CATID_WICMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x05af94d8_7174_4cd2_be4a_4124b80ee4b8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_WICMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0x05af94d8_7174_4cd2_be4a_4124b80ee4b8) , } }
 pub const CATID_WICMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xabe3b9a4_257d_4b97_bd1a_294af496222e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_WICMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0xabe3b9a4_257d_4b97_bd1a_294af496222e) , } }
 pub const CATID_WICPixelFormats: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2b46e70f_cda7_473e_89f6_dc9630a2390b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_WICPixelFormats ) , guid : :: windows :: core :: GUID::from_u128(0x2b46e70f_cda7_473e_89f6_dc9630a2390b) , } }
 pub const CLSID_WIC8BIMIPTCDigestMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x02805f1e_d5aa_415b_82c5_61c033a988a6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WIC8BIMIPTCDigestMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0x02805f1e_d5aa_415b_82c5_61c033a988a6) , } }
 pub const CLSID_WIC8BIMIPTCDigestMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2db5e62b_0d67_495f_8f9d_c2f0188647ac);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WIC8BIMIPTCDigestMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0x2db5e62b_0d67_495f_8f9d_c2f0188647ac) , } }
 pub const CLSID_WIC8BIMIPTCMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0010668c_0801_4da6_a4a4_826522b6d28f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WIC8BIMIPTCMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0x0010668c_0801_4da6_a4a4_826522b6d28f) , } }
 pub const CLSID_WIC8BIMIPTCMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x00108226_ee41_44a2_9e9c_4be4d5b1d2cd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WIC8BIMIPTCMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0x00108226_ee41_44a2_9e9c_4be4d5b1d2cd) , } }
 pub const CLSID_WIC8BIMResolutionInfoMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5805137a_e348_4f7c_b3cc_6db9965a0599);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WIC8BIMResolutionInfoMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0x5805137a_e348_4f7c_b3cc_6db9965a0599) , } }
 pub const CLSID_WIC8BIMResolutionInfoMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4ff2fe0e_e74a_4b71_98c4_ab7dc16707ba);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WIC8BIMResolutionInfoMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0x4ff2fe0e_e74a_4b71_98c4_ab7dc16707ba) , } }
 pub const CLSID_WICAPEMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1767b93a_b021_44ea_920f_863c11f4f768);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICAPEMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0x1767b93a_b021_44ea_920f_863c11f4f768) , } }
 pub const CLSID_WICAPEMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbd6edfca_2890_482f_b233_8d7339a1cf8d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICAPEMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0xbd6edfca_2890_482f_b233_8d7339a1cf8d) , } }
 pub const CLSID_WICAdngDecoder: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x981d9411_909e_42a7_8f5d_a747ff052edb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICAdngDecoder ) , guid : :: windows :: core :: GUID::from_u128(0x981d9411_909e_42a7_8f5d_a747ff052edb) , } }
 pub const CLSID_WICApp0MetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x43324b33_a78f_480f_9111_9638aaccc832);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICApp0MetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0x43324b33_a78f_480f_9111_9638aaccc832) , } }
 pub const CLSID_WICApp0MetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf3c633a2_46c8_498e_8fbb_cc6f721bbcde);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICApp0MetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0xf3c633a2_46c8_498e_8fbb_cc6f721bbcde) , } }
 pub const CLSID_WICApp13MetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaa7e3c50_864c_4604_bc04_8b0b76e637f6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICApp13MetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0xaa7e3c50_864c_4604_bc04_8b0b76e637f6) , } }
 pub const CLSID_WICApp13MetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7b19a919_a9d6_49e5_bd45_02c34e4e4cd5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICApp13MetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0x7b19a919_a9d6_49e5_bd45_02c34e4e4cd5) , } }
 pub const CLSID_WICApp1MetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdde33513_774e_4bcd_ae79_02f4adfe62fc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICApp1MetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0xdde33513_774e_4bcd_ae79_02f4adfe62fc) , } }
 pub const CLSID_WICApp1MetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xee366069_1832_420f_b381_0479ad066f19);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICApp1MetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0xee366069_1832_420f_b381_0479ad066f19) , } }
 pub const CLSID_WICBmpDecoder: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6b462062_7cbf_400d_9fdb_813dd10f2778);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICBmpDecoder ) , guid : :: windows :: core :: GUID::from_u128(0x6b462062_7cbf_400d_9fdb_813dd10f2778) , } }
 pub const CLSID_WICBmpEncoder: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x69be8bb4_d66d_47c8_865a_ed1589433782);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICBmpEncoder ) , guid : :: windows :: core :: GUID::from_u128(0x69be8bb4_d66d_47c8_865a_ed1589433782) , } }
 pub const CLSID_WICDdsDecoder: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9053699f_a341_429d_9e90_ee437cf80c73);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICDdsDecoder ) , guid : :: windows :: core :: GUID::from_u128(0x9053699f_a341_429d_9e90_ee437cf80c73) , } }
 pub const CLSID_WICDdsEncoder: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa61dde94_66ce_4ac1_881b_71680588895e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICDdsEncoder ) , guid : :: windows :: core :: GUID::from_u128(0xa61dde94_66ce_4ac1_881b_71680588895e) , } }
 pub const CLSID_WICDdsMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x276c88ca_7533_4a86_b676_66b36080d484);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICDdsMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0x276c88ca_7533_4a86_b676_66b36080d484) , } }
 pub const CLSID_WICDdsMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfd688bbd_31ed_4db7_a723_934927d38367);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICDdsMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0xfd688bbd_31ed_4db7_a723_934927d38367) , } }
 pub const CLSID_WICDefaultFormatConverter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1a3f11dc_b514_4b17_8c5f_2154513852f1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICDefaultFormatConverter ) , guid : :: windows :: core :: GUID::from_u128(0x1a3f11dc_b514_4b17_8c5f_2154513852f1) , } }
 pub const CLSID_WICExifMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd9403860_297f_4a49_bf9b_77898150a442);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICExifMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0xd9403860_297f_4a49_bf9b_77898150a442) , } }
 pub const CLSID_WICExifMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc9a14cda_c339_460b_9078_d4debcfabe91);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICExifMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0xc9a14cda_c339_460b_9078_d4debcfabe91) , } }
 pub const CLSID_WICFormatConverterHighColor: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xac75d454_9f37_48f8_b972_4e19bc856011);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICFormatConverterHighColor ) , guid : :: windows :: core :: GUID::from_u128(0xac75d454_9f37_48f8_b972_4e19bc856011) , } }
 pub const CLSID_WICFormatConverterNChannel: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc17cabb2_d4a3_47d7_a557_339b2efbd4f1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICFormatConverterNChannel ) , guid : :: windows :: core :: GUID::from_u128(0xc17cabb2_d4a3_47d7_a557_339b2efbd4f1) , } }
 pub const CLSID_WICFormatConverterWMPhoto: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9cb5172b_d600_46ba_ab77_77bb7e3a00d9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICFormatConverterWMPhoto ) , guid : :: windows :: core :: GUID::from_u128(0x9cb5172b_d600_46ba_ab77_77bb7e3a00d9) , } }
 pub const CLSID_WICGCEMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb92e345d_f52d_41f3_b562_081bc772e3b9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICGCEMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0xb92e345d_f52d_41f3_b562_081bc772e3b9) , } }
 pub const CLSID_WICGCEMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaf95dc76_16b2_47f4_b3ea_3c31796693e7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICGCEMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0xaf95dc76_16b2_47f4_b3ea_3c31796693e7) , } }
 pub const CLSID_WICGifCommentMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x32557d3b_69dc_4f95_836e_f5972b2f6159);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICGifCommentMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0x32557d3b_69dc_4f95_836e_f5972b2f6159) , } }
 pub const CLSID_WICGifCommentMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa02797fc_c4ae_418c_af95_e637c7ead2a1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICGifCommentMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0xa02797fc_c4ae_418c_af95_e637c7ead2a1) , } }
 pub const CLSID_WICGifDecoder: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x381dda3c_9ce9_4834_a23e_1f98f8fc52be);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICGifDecoder ) , guid : :: windows :: core :: GUID::from_u128(0x381dda3c_9ce9_4834_a23e_1f98f8fc52be) , } }
 pub const CLSID_WICGifEncoder: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x114f5598_0b22_40a0_86a1_c83ea495adbd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICGifEncoder ) , guid : :: windows :: core :: GUID::from_u128(0x114f5598_0b22_40a0_86a1_c83ea495adbd) , } }
 pub const CLSID_WICGpsMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3697790b_223b_484e_9925_c4869218f17a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICGpsMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0x3697790b_223b_484e_9925_c4869218f17a) , } }
 pub const CLSID_WICGpsMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcb8c13e4_62b5_4c96_a48b_6ba6ace39c76);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICGpsMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0xcb8c13e4_62b5_4c96_a48b_6ba6ace39c76) , } }
 pub const CLSID_WICHeifDecoder: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe9a4a80a_44fe_4de4_8971_7150b10a5199);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICHeifDecoder ) , guid : :: windows :: core :: GUID::from_u128(0xe9a4a80a_44fe_4de4_8971_7150b10a5199) , } }
 pub const CLSID_WICHeifEncoder: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0dbecec1_9eb3_4860_9c6f_ddbe86634575);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICHeifEncoder ) , guid : :: windows :: core :: GUID::from_u128(0x0dbecec1_9eb3_4860_9c6f_ddbe86634575) , } }
 pub const CLSID_WICHeifHDRMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2438de3d_94d9_4be8_84a8_4de95a575e75);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICHeifHDRMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0x2438de3d_94d9_4be8_84a8_4de95a575e75) , } }
 pub const CLSID_WICHeifMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xacddfc3f_85ec_41bc_bdef_1bc262e4db05);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICHeifMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0xacddfc3f_85ec_41bc_bdef_1bc262e4db05) , } }
 pub const CLSID_WICHeifMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3ae45e79_40bc_4401_ace5_dd3cb16e6afe);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICHeifMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0x3ae45e79_40bc_4401_ace5_dd3cb16e6afe) , } }
 pub const CLSID_WICIMDMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7447a267_0015_42c8_a8f1_fb3b94c68361);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICIMDMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0x7447a267_0015_42c8_a8f1_fb3b94c68361) , } }
 pub const CLSID_WICIMDMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8c89071f_452e_4e95_9682_9d1024627172);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICIMDMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0x8c89071f_452e_4e95_9682_9d1024627172) , } }
 pub const CLSID_WICIPTCMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x03012959_f4f6_44d7_9d09_daa087a9db57);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICIPTCMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0x03012959_f4f6_44d7_9d09_daa087a9db57) , } }
 pub const CLSID_WICIPTCMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1249b20c_5dd0_44fe_b0b3_8f92c8e6d080);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICIPTCMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0x1249b20c_5dd0_44fe_b0b3_8f92c8e6d080) , } }
 pub const CLSID_WICIRBMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd4dcd3d7_b4c2_47d9_a6bf_b89ba396a4a3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICIRBMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0xd4dcd3d7_b4c2_47d9_a6bf_b89ba396a4a3) , } }
 pub const CLSID_WICIRBMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5c5c1935_0235_4434_80bc_251bc1ec39c6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICIRBMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0x5c5c1935_0235_4434_80bc_251bc1ec39c6) , } }
 pub const CLSID_WICIcoDecoder: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc61bfcdf_2e0f_4aad_a8d7_e06bafebcdfe);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICIcoDecoder ) , guid : :: windows :: core :: GUID::from_u128(0xc61bfcdf_2e0f_4aad_a8d7_e06bafebcdfe) , } }
 pub const CLSID_WICIfdMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8f914656_9d0a_4eb2_9019_0bf96d8a9ee6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICIfdMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0x8f914656_9d0a_4eb2_9019_0bf96d8a9ee6) , } }
 pub const CLSID_WICIfdMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb1ebfc28_c9bd_47a2_8d33_b948769777a7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICIfdMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0xb1ebfc28_c9bd_47a2_8d33_b948769777a7) , } }
 pub const CLSID_WICImagingCategories: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfae3d380_fea4_4623_8c75_c6b61110b681);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICImagingCategories ) , guid : :: windows :: core :: GUID::from_u128(0xfae3d380_fea4_4623_8c75_c6b61110b681) , } }
 pub const CLSID_WICImagingFactory: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcacaf262_9370_4615_a13b_9f5539da4c0a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICImagingFactory ) , guid : :: windows :: core :: GUID::from_u128(0xcacaf262_9370_4615_a13b_9f5539da4c0a) , } }
 pub const CLSID_WICImagingFactory1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcacaf262_9370_4615_a13b_9f5539da4c0a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICImagingFactory1 ) , guid : :: windows :: core :: GUID::from_u128(0xcacaf262_9370_4615_a13b_9f5539da4c0a) , } }
 pub const CLSID_WICImagingFactory2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x317d06e8_5f24_433d_bdf7_79ce68d8abc2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICImagingFactory2 ) , guid : :: windows :: core :: GUID::from_u128(0x317d06e8_5f24_433d_bdf7_79ce68d8abc2) , } }
 pub const CLSID_WICInteropMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb5c8b898_0074_459f_b700_860d4651ea14);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICInteropMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0xb5c8b898_0074_459f_b700_860d4651ea14) , } }
 pub const CLSID_WICInteropMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x122ec645_cd7e_44d8_b186_2c8c20c3b50f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICInteropMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0x122ec645_cd7e_44d8_b186_2c8c20c3b50f) , } }
 pub const CLSID_WICJpegChrominanceMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x50b1904b_f28f_4574_93f4_0bade82c69e9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICJpegChrominanceMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0x50b1904b_f28f_4574_93f4_0bade82c69e9) , } }
 pub const CLSID_WICJpegChrominanceMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3ff566f0_6e6b_49d4_96e6_b78886692c62);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICJpegChrominanceMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0x3ff566f0_6e6b_49d4_96e6_b78886692c62) , } }
 pub const CLSID_WICJpegCommentMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9f66347c_60c4_4c4d_ab58_d2358685f607);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICJpegCommentMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0x9f66347c_60c4_4c4d_ab58_d2358685f607) , } }
 pub const CLSID_WICJpegCommentMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe573236f_55b1_4eda_81ea_9f65db0290d3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICJpegCommentMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0xe573236f_55b1_4eda_81ea_9f65db0290d3) , } }
 pub const CLSID_WICJpegDecoder: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9456a480_e88b_43ea_9e73_0b2d9b71b1ca);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICJpegDecoder ) , guid : :: windows :: core :: GUID::from_u128(0x9456a480_e88b_43ea_9e73_0b2d9b71b1ca) , } }
 pub const CLSID_WICJpegEncoder: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1a34f5c1_4a5a_46dc_b644_1f4567e7a676);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICJpegEncoder ) , guid : :: windows :: core :: GUID::from_u128(0x1a34f5c1_4a5a_46dc_b644_1f4567e7a676) , } }
 pub const CLSID_WICJpegLuminanceMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x356f2f88_05a6_4728_b9a4_1bfbce04d838);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICJpegLuminanceMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0x356f2f88_05a6_4728_b9a4_1bfbce04d838) , } }
 pub const CLSID_WICJpegLuminanceMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1d583abc_8a0e_4657_9982_a380ca58fb4b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICJpegLuminanceMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0x1d583abc_8a0e_4657_9982_a380ca58fb4b) , } }
 pub const CLSID_WICJpegQualcommPhoneEncoder: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x68ed5c62_f534_4979_b2b3_686a12b2b34c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICJpegQualcommPhoneEncoder ) , guid : :: windows :: core :: GUID::from_u128(0x68ed5c62_f534_4979_b2b3_686a12b2b34c) , } }
 pub const CLSID_WICLSDMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x41070793_59e4_479a_a1f7_954adc2ef5fc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICLSDMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0x41070793_59e4_479a_a1f7_954adc2ef5fc) , } }
 pub const CLSID_WICLSDMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x73c037e7_e5d9_4954_876a_6da81d6e5768);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICLSDMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0x73c037e7_e5d9_4954_876a_6da81d6e5768) , } }
 pub const CLSID_WICPlanarFormatConverter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x184132b8_32f8_4784_9131_dd7224b23438);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICPlanarFormatConverter ) , guid : :: windows :: core :: GUID::from_u128(0x184132b8_32f8_4784_9131_dd7224b23438) , } }
 pub const CLSID_WICPngBkgdMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0ce7a4a6_03e8_4a60_9d15_282ef32ee7da);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICPngBkgdMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0x0ce7a4a6_03e8_4a60_9d15_282ef32ee7da) , } }
 pub const CLSID_WICPngBkgdMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x68e3f2fd_31ae_4441_bb6a_fd7047525f90);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICPngBkgdMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0x68e3f2fd_31ae_4441_bb6a_fd7047525f90) , } }
 pub const CLSID_WICPngChrmMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf90b5f36_367b_402a_9dd1_bc0fd59d8f62);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICPngChrmMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0xf90b5f36_367b_402a_9dd1_bc0fd59d8f62) , } }
 pub const CLSID_WICPngChrmMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe23ce3eb_5608_4e83_bcef_27b1987e51d7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICPngChrmMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0xe23ce3eb_5608_4e83_bcef_27b1987e51d7) , } }
 pub const CLSID_WICPngDecoder: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x389ea17b_5078_4cde_b6ef_25c15175c751);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICPngDecoder ) , guid : :: windows :: core :: GUID::from_u128(0x389ea17b_5078_4cde_b6ef_25c15175c751) , } }
 pub const CLSID_WICPngDecoder1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x389ea17b_5078_4cde_b6ef_25c15175c751);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICPngDecoder1 ) , guid : :: windows :: core :: GUID::from_u128(0x389ea17b_5078_4cde_b6ef_25c15175c751) , } }
 pub const CLSID_WICPngDecoder2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe018945b_aa86_4008_9bd4_6777a1e40c11);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICPngDecoder2 ) , guid : :: windows :: core :: GUID::from_u128(0xe018945b_aa86_4008_9bd4_6777a1e40c11) , } }
 pub const CLSID_WICPngEncoder: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x27949969_876a_41d7_9447_568f6a35a4dc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICPngEncoder ) , guid : :: windows :: core :: GUID::from_u128(0x27949969_876a_41d7_9447_568f6a35a4dc) , } }
 pub const CLSID_WICPngGamaMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3692ca39_e082_4350_9e1f_3704cb083cd5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICPngGamaMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0x3692ca39_e082_4350_9e1f_3704cb083cd5) , } }
 pub const CLSID_WICPngGamaMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xff036d13_5d4b_46dd_b10f_106693d9fe4f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICPngGamaMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0xff036d13_5d4b_46dd_b10f_106693d9fe4f) , } }
 pub const CLSID_WICPngHistMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x877a0bb7_a313_4491_87b5_2e6d0594f520);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICPngHistMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0x877a0bb7_a313_4491_87b5_2e6d0594f520) , } }
 pub const CLSID_WICPngHistMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8a03e749_672e_446e_bf1f_2c11d233b6ff);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICPngHistMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0x8a03e749_672e_446e_bf1f_2c11d233b6ff) , } }
 pub const CLSID_WICPngIccpMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf5d3e63b_cb0f_4628_a478_6d8244be36b1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICPngIccpMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0xf5d3e63b_cb0f_4628_a478_6d8244be36b1) , } }
 pub const CLSID_WICPngIccpMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x16671e5f_0ce6_4cc4_9768_e89fe5018ade);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICPngIccpMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0x16671e5f_0ce6_4cc4_9768_e89fe5018ade) , } }
 pub const CLSID_WICPngItxtMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaabfb2fa_3e1e_4a8f_8977_5556fb94ea23);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICPngItxtMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0xaabfb2fa_3e1e_4a8f_8977_5556fb94ea23) , } }
 pub const CLSID_WICPngItxtMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x31879719_e751_4df8_981d_68dff67704ed);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICPngItxtMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0x31879719_e751_4df8_981d_68dff67704ed) , } }
 pub const CLSID_WICPngSrgbMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfb40360c_547e_4956_a3b9_d4418859ba66);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICPngSrgbMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0xfb40360c_547e_4956_a3b9_d4418859ba66) , } }
 pub const CLSID_WICPngSrgbMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa6ee35c6_87ec_47df_9f22_1d5aad840c82);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICPngSrgbMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0xa6ee35c6_87ec_47df_9f22_1d5aad840c82) , } }
 pub const CLSID_WICPngTextMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4b59afcc_b8c3_408a_b670_89e5fab6fda7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICPngTextMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0x4b59afcc_b8c3_408a_b670_89e5fab6fda7) , } }
 pub const CLSID_WICPngTextMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb5ebafb9_253e_4a72_a744_0762d2685683);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICPngTextMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0xb5ebafb9_253e_4a72_a744_0762d2685683) , } }
 pub const CLSID_WICPngTimeMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd94edf02_efe5_4f0d_85c8_f5a68b3000b1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICPngTimeMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0xd94edf02_efe5_4f0d_85c8_f5a68b3000b1) , } }
 pub const CLSID_WICPngTimeMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1ab78400_b5a3_4d91_8ace_33fcd1499be6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICPngTimeMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0x1ab78400_b5a3_4d91_8ace_33fcd1499be6) , } }
 pub const CLSID_WICRAWDecoder: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x41945702_8302_44a6_9445_ac98e8afa086);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICRAWDecoder ) , guid : :: windows :: core :: GUID::from_u128(0x41945702_8302_44a6_9445_ac98e8afa086) , } }
 pub const CLSID_WICSubIfdMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x50d42f09_ecd1_4b41_b65d_da1fdaa75663);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICSubIfdMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0x50d42f09_ecd1_4b41_b65d_da1fdaa75663) , } }
 pub const CLSID_WICSubIfdMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8ade5386_8e9b_4f4c_acf2_f0008706b238);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICSubIfdMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0x8ade5386_8e9b_4f4c_acf2_f0008706b238) , } }
 pub const CLSID_WICThumbnailMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfb012959_f4f6_44d7_9d09_daa087a9db57);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICThumbnailMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0xfb012959_f4f6_44d7_9d09_daa087a9db57) , } }
 pub const CLSID_WICThumbnailMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd049b20c_5dd0_44fe_b0b3_8f92c8e6d080);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICThumbnailMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0xd049b20c_5dd0_44fe_b0b3_8f92c8e6d080) , } }
 pub const CLSID_WICTiffDecoder: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb54e85d9_fe23_499f_8b88_6acea713752b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICTiffDecoder ) , guid : :: windows :: core :: GUID::from_u128(0xb54e85d9_fe23_499f_8b88_6acea713752b) , } }
 pub const CLSID_WICTiffEncoder: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0131be10_2001_4c5f_a9b0_cc88fab64ce8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICTiffEncoder ) , guid : :: windows :: core :: GUID::from_u128(0x0131be10_2001_4c5f_a9b0_cc88fab64ce8) , } }
 pub const CLSID_WICUnknownMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x699745c2_5066_4b82_a8e3_d40478dbec8c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICUnknownMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0x699745c2_5066_4b82_a8e3_d40478dbec8c) , } }
 pub const CLSID_WICUnknownMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa09cca86_27ba_4f39_9053_121fa4dc08fc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICUnknownMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0xa09cca86_27ba_4f39_9053_121fa4dc08fc) , } }
 pub const CLSID_WICWebpAnimMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x076f9911_a348_465c_a807_a252f3f2d3de);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICWebpAnimMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0x076f9911_a348_465c_a807_a252f3f2d3de) , } }
 pub const CLSID_WICWebpAnmfMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x85a10b03_c9f6_439f_be5e_c0fbef67807c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICWebpAnmfMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0x85a10b03_c9f6_439f_be5e_c0fbef67807c) , } }
 pub const CLSID_WICWebpDecoder: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7693e886_51c9_4070_8419_9f70738ec8fa);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICWebpDecoder ) , guid : :: windows :: core :: GUID::from_u128(0x7693e886_51c9_4070_8419_9f70738ec8fa) , } }
 pub const CLSID_WICWmpDecoder: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa26cec36_234c_4950_ae16_e34aace71d0d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICWmpDecoder ) , guid : :: windows :: core :: GUID::from_u128(0xa26cec36_234c_4950_ae16_e34aace71d0d) , } }
 pub const CLSID_WICWmpEncoder: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xac4ce3cb_e1c1_44cd_8215_5a1665509ec2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICWmpEncoder ) , guid : :: windows :: core :: GUID::from_u128(0xac4ce3cb_e1c1_44cd_8215_5a1665509ec2) , } }
 pub const CLSID_WICXMPAltMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaa94dcc2_b8b0_4898_b835_000aabd74393);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICXMPAltMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0xaa94dcc2_b8b0_4898_b835_000aabd74393) , } }
 pub const CLSID_WICXMPAltMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x076c2a6c_f78f_4c46_a723_3583e70876ea);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICXMPAltMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0x076c2a6c_f78f_4c46_a723_3583e70876ea) , } }
 pub const CLSID_WICXMPBagMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe7e79a30_4f2c_4fab_8d00_394f2d6bbebe);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICXMPBagMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0xe7e79a30_4f2c_4fab_8d00_394f2d6bbebe) , } }
 pub const CLSID_WICXMPBagMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xed822c8c_d6be_4301_a631_0e1416bad28f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICXMPBagMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0xed822c8c_d6be_4301_a631_0e1416bad28f) , } }
 pub const CLSID_WICXMPMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x72b624df_ae11_4948_a65c_351eb0829419);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICXMPMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0x72b624df_ae11_4948_a65c_351eb0829419) , } }
 pub const CLSID_WICXMPMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1765e14e_1bd4_462e_b6b1_590bf1262ac6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICXMPMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0x1765e14e_1bd4_462e_b6b1_590bf1262ac6) , } }
 pub const CLSID_WICXMPSeqMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7f12e753_fc71_43d7_a51d_92f35977abb5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICXMPSeqMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0x7f12e753_fc71_43d7_a51d_92f35977abb5) , } }
 pub const CLSID_WICXMPSeqMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6d68d1de_d432_4b0f_923a_091183a9bda7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICXMPSeqMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0x6d68d1de_d432_4b0f_923a_091183a9bda7) , } }
 pub const CLSID_WICXMPStructMetadataReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x01b90d9a_8209_47f7_9c52_e1244bf50ced);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICXMPStructMetadataReader ) , guid : :: windows :: core :: GUID::from_u128(0x01b90d9a_8209_47f7_9c52_e1244bf50ced) , } }
 pub const CLSID_WICXMPStructMetadataWriter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x22c21f93_7ddb_411c_9b17_c5b7bd064abc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WICXMPStructMetadataWriter ) , guid : :: windows :: core :: GUID::from_u128(0x22c21f93_7ddb_411c_9b17_c5b7bd064abc) , } }
 #[doc = "*Required features: 'Win32_Graphics_Imaging'*"]
 pub const FACILITY_WINCODEC_ERR: u32 = 2200u32;
 pub const GUID_ContainerFormatAdng: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf3ff6d0d_38c0_41c4_b1fe_1f3824f17b84);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ContainerFormatAdng ) , guid : :: windows :: core :: GUID::from_u128(0xf3ff6d0d_38c0_41c4_b1fe_1f3824f17b84) , } }
 pub const GUID_ContainerFormatBmp: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0af1d87e_fcfe_4188_bdeb_a7906471cbe3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ContainerFormatBmp ) , guid : :: windows :: core :: GUID::from_u128(0x0af1d87e_fcfe_4188_bdeb_a7906471cbe3) , } }
 pub const GUID_ContainerFormatDds: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9967cb95_2e85_4ac8_8ca2_83d7ccd425c9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ContainerFormatDds ) , guid : :: windows :: core :: GUID::from_u128(0x9967cb95_2e85_4ac8_8ca2_83d7ccd425c9) , } }
 pub const GUID_ContainerFormatGif: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1f8a5601_7d4d_4cbd_9c82_1bc8d4eeb9a5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ContainerFormatGif ) , guid : :: windows :: core :: GUID::from_u128(0x1f8a5601_7d4d_4cbd_9c82_1bc8d4eeb9a5) , } }
 pub const GUID_ContainerFormatHeif: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe1e62521_6787_405b_a339_500715b5763f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ContainerFormatHeif ) , guid : :: windows :: core :: GUID::from_u128(0xe1e62521_6787_405b_a339_500715b5763f) , } }
 pub const GUID_ContainerFormatIco: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa3a860c4_338f_4c17_919a_fba4b5628f21);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ContainerFormatIco ) , guid : :: windows :: core :: GUID::from_u128(0xa3a860c4_338f_4c17_919a_fba4b5628f21) , } }
 pub const GUID_ContainerFormatJpeg: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x19e4a5aa_5662_4fc5_a0c0_1758028e1057);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ContainerFormatJpeg ) , guid : :: windows :: core :: GUID::from_u128(0x19e4a5aa_5662_4fc5_a0c0_1758028e1057) , } }
 pub const GUID_ContainerFormatPng: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1b7cfaf4_713f_473c_bbcd_6137425faeaf);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ContainerFormatPng ) , guid : :: windows :: core :: GUID::from_u128(0x1b7cfaf4_713f_473c_bbcd_6137425faeaf) , } }
 pub const GUID_ContainerFormatRaw: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfe99ce60_f19c_433c_a3ae_00acefa9ca21);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ContainerFormatRaw ) , guid : :: windows :: core :: GUID::from_u128(0xfe99ce60_f19c_433c_a3ae_00acefa9ca21) , } }
 pub const GUID_ContainerFormatTiff: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x163bcc30_e2e9_4f0b_961d_a3e9fdb788a3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ContainerFormatTiff ) , guid : :: windows :: core :: GUID::from_u128(0x163bcc30_e2e9_4f0b_961d_a3e9fdb788a3) , } }
 pub const GUID_ContainerFormatWebp: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe094b0e2_67f2_45b3_b0ea_115337ca7cf3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ContainerFormatWebp ) , guid : :: windows :: core :: GUID::from_u128(0xe094b0e2_67f2_45b3_b0ea_115337ca7cf3) , } }
 pub const GUID_ContainerFormatWmp: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x57a37caa_367a_4540_916b_f183c5093a4b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ContainerFormatWmp ) , guid : :: windows :: core :: GUID::from_u128(0x57a37caa_367a_4540_916b_f183c5093a4b) , } }
 pub const GUID_MetadataFormat8BIMIPTC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0010568c_0852_4e6a_b191_5c33ac5b0430);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormat8BIMIPTC ) , guid : :: windows :: core :: GUID::from_u128(0x0010568c_0852_4e6a_b191_5c33ac5b0430) , } }
 pub const GUID_MetadataFormat8BIMIPTCDigest: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1ca32285_9ccd_4786_8bd8_79539db6a006);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormat8BIMIPTCDigest ) , guid : :: windows :: core :: GUID::from_u128(0x1ca32285_9ccd_4786_8bd8_79539db6a006) , } }
 pub const GUID_MetadataFormat8BIMResolutionInfo: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x739f305d_81db_43cb_ac5e_55013ef9f003);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormat8BIMResolutionInfo ) , guid : :: windows :: core :: GUID::from_u128(0x739f305d_81db_43cb_ac5e_55013ef9f003) , } }
 pub const GUID_MetadataFormatAPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2e043dc2_c967_4e05_875e_618bf67e85c3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatAPE ) , guid : :: windows :: core :: GUID::from_u128(0x2e043dc2_c967_4e05_875e_618bf67e85c3) , } }
 pub const GUID_MetadataFormatApp0: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x79007028_268d_45d6_a3c2_354e6a504bc9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatApp0 ) , guid : :: windows :: core :: GUID::from_u128(0x79007028_268d_45d6_a3c2_354e6a504bc9) , } }
 pub const GUID_MetadataFormatApp1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8fd3dfc3_f951_492b_817f_69c2e6d9a5b0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatApp1 ) , guid : :: windows :: core :: GUID::from_u128(0x8fd3dfc3_f951_492b_817f_69c2e6d9a5b0) , } }
 pub const GUID_MetadataFormatApp13: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x326556a2_f502_4354_9cc0_8e3f48eaf6b5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatApp13 ) , guid : :: windows :: core :: GUID::from_u128(0x326556a2_f502_4354_9cc0_8e3f48eaf6b5) , } }
 pub const GUID_MetadataFormatChunkbKGD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe14d3571_6b47_4dea_b60a_87ce0a78dfb7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatChunkbKGD ) , guid : :: windows :: core :: GUID::from_u128(0xe14d3571_6b47_4dea_b60a_87ce0a78dfb7) , } }
 pub const GUID_MetadataFormatChunkcHRM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9db3655b_2842_44b3_8067_12e9b375556a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatChunkcHRM ) , guid : :: windows :: core :: GUID::from_u128(0x9db3655b_2842_44b3_8067_12e9b375556a) , } }
 pub const GUID_MetadataFormatChunkgAMA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf00935a5_1d5d_4cd1_81b2_9324d7eca781);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatChunkgAMA ) , guid : :: windows :: core :: GUID::from_u128(0xf00935a5_1d5d_4cd1_81b2_9324d7eca781) , } }
 pub const GUID_MetadataFormatChunkhIST: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc59a82da_db74_48a4_bd6a_b69c4931ef95);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatChunkhIST ) , guid : :: windows :: core :: GUID::from_u128(0xc59a82da_db74_48a4_bd6a_b69c4931ef95) , } }
 pub const GUID_MetadataFormatChunkiCCP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xeb4349ab_b685_450f_91b5_e802e892536c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatChunkiCCP ) , guid : :: windows :: core :: GUID::from_u128(0xeb4349ab_b685_450f_91b5_e802e892536c) , } }
 pub const GUID_MetadataFormatChunkiTXt: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc2bec729_0b68_4b77_aa0e_6295a6ac1814);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatChunkiTXt ) , guid : :: windows :: core :: GUID::from_u128(0xc2bec729_0b68_4b77_aa0e_6295a6ac1814) , } }
 pub const GUID_MetadataFormatChunksRGB: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc115fd36_cc6f_4e3f_8363_524b87c6b0d9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatChunksRGB ) , guid : :: windows :: core :: GUID::from_u128(0xc115fd36_cc6f_4e3f_8363_524b87c6b0d9) , } }
 pub const GUID_MetadataFormatChunktEXt: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x568d8936_c0a9_4923_905d_df2b38238fbc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatChunktEXt ) , guid : :: windows :: core :: GUID::from_u128(0x568d8936_c0a9_4923_905d_df2b38238fbc) , } }
 pub const GUID_MetadataFormatChunktIME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6b00ae2d_e24b_460a_98b6_878bd03072fd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatChunktIME ) , guid : :: windows :: core :: GUID::from_u128(0x6b00ae2d_e24b_460a_98b6_878bd03072fd) , } }
 pub const GUID_MetadataFormatDds: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4a064603_8c33_4e60_9c29_136231702d08);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatDds ) , guid : :: windows :: core :: GUID::from_u128(0x4a064603_8c33_4e60_9c29_136231702d08) , } }
 pub const GUID_MetadataFormatExif: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1c3c4f9d_b84a_467d_9493_36cfbd59ea57);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatExif ) , guid : :: windows :: core :: GUID::from_u128(0x1c3c4f9d_b84a_467d_9493_36cfbd59ea57) , } }
 pub const GUID_MetadataFormatGCE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2a25cad8_deeb_4c69_a788_0ec2266dcafd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatGCE ) , guid : :: windows :: core :: GUID::from_u128(0x2a25cad8_deeb_4c69_a788_0ec2266dcafd) , } }
 pub const GUID_MetadataFormatGifComment: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc4b6e0e0_cfb4_4ad3_ab33_9aad2355a34a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatGifComment ) , guid : :: windows :: core :: GUID::from_u128(0xc4b6e0e0_cfb4_4ad3_ab33_9aad2355a34a) , } }
 pub const GUID_MetadataFormatGps: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7134ab8a_9351_44ad_af62_448db6b502ec);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatGps ) , guid : :: windows :: core :: GUID::from_u128(0x7134ab8a_9351_44ad_af62_448db6b502ec) , } }
 pub const GUID_MetadataFormatHeif: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x817ef3e1_1288_45f4_a852_260d9e7cce83);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatHeif ) , guid : :: windows :: core :: GUID::from_u128(0x817ef3e1_1288_45f4_a852_260d9e7cce83) , } }
 pub const GUID_MetadataFormatHeifHDR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x568b8d8a_1e65_438c_8968_d60e1012beb9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatHeifHDR ) , guid : :: windows :: core :: GUID::from_u128(0x568b8d8a_1e65_438c_8968_d60e1012beb9) , } }
 pub const GUID_MetadataFormatIMD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbd2bb086_4d52_48dd_9677_db483e85ae8f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatIMD ) , guid : :: windows :: core :: GUID::from_u128(0xbd2bb086_4d52_48dd_9677_db483e85ae8f) , } }
 pub const GUID_MetadataFormatIPTC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4fab0914_e129_4087_a1d1_bc812d45a7b5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatIPTC ) , guid : :: windows :: core :: GUID::from_u128(0x4fab0914_e129_4087_a1d1_bc812d45a7b5) , } }
 pub const GUID_MetadataFormatIRB: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x16100d66_8570_4bb9_b92d_fda4b23ece67);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatIRB ) , guid : :: windows :: core :: GUID::from_u128(0x16100d66_8570_4bb9_b92d_fda4b23ece67) , } }
 pub const GUID_MetadataFormatIfd: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x537396c6_2d8a_4bb6_9bf8_2f0a8e2a3adf);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatIfd ) , guid : :: windows :: core :: GUID::from_u128(0x537396c6_2d8a_4bb6_9bf8_2f0a8e2a3adf) , } }
 pub const GUID_MetadataFormatInterop: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xed686f8e_681f_4c8b_bd41_a8addbf6b3fc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatInterop ) , guid : :: windows :: core :: GUID::from_u128(0xed686f8e_681f_4c8b_bd41_a8addbf6b3fc) , } }
 pub const GUID_MetadataFormatJpegChrominance: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf73d0dcf_cec6_4f85_9b0e_1c3956b1bef7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatJpegChrominance ) , guid : :: windows :: core :: GUID::from_u128(0xf73d0dcf_cec6_4f85_9b0e_1c3956b1bef7) , } }
 pub const GUID_MetadataFormatJpegComment: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x220e5f33_afd3_474e_9d31_7d4fe730f557);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatJpegComment ) , guid : :: windows :: core :: GUID::from_u128(0x220e5f33_afd3_474e_9d31_7d4fe730f557) , } }
 pub const GUID_MetadataFormatJpegLuminance: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x86908007_edfc_4860_8d4b_4ee6e83e6058);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatJpegLuminance ) , guid : :: windows :: core :: GUID::from_u128(0x86908007_edfc_4860_8d4b_4ee6e83e6058) , } }
 pub const GUID_MetadataFormatLSD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe256031e_6299_4929_b98d_5ac884afba92);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatLSD ) , guid : :: windows :: core :: GUID::from_u128(0xe256031e_6299_4929_b98d_5ac884afba92) , } }
 pub const GUID_MetadataFormatSubIfd: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x58a2e128_2db9_4e57_bb14_5177891ed331);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatSubIfd ) , guid : :: windows :: core :: GUID::from_u128(0x58a2e128_2db9_4e57_bb14_5177891ed331) , } }
 pub const GUID_MetadataFormatThumbnail: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x243dcee9_8703_40ee_8ef0_22a600b8058c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatThumbnail ) , guid : :: windows :: core :: GUID::from_u128(0x243dcee9_8703_40ee_8ef0_22a600b8058c) , } }
 pub const GUID_MetadataFormatUnknown: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa45e592f_9078_4a7c_adb5_4edc4fd61b1f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatUnknown ) , guid : :: windows :: core :: GUID::from_u128(0xa45e592f_9078_4a7c_adb5_4edc4fd61b1f) , } }
 pub const GUID_MetadataFormatWebpANIM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6dc4fda6_78e6_4102_ae35_bcfa1edcc78b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatWebpANIM ) , guid : :: windows :: core :: GUID::from_u128(0x6dc4fda6_78e6_4102_ae35_bcfa1edcc78b) , } }
 pub const GUID_MetadataFormatWebpANMF: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x43c105ee_b93b_4abb_b003_a08c0d870471);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatWebpANMF ) , guid : :: windows :: core :: GUID::from_u128(0x43c105ee_b93b_4abb_b003_a08c0d870471) , } }
 pub const GUID_MetadataFormatXMP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbb5acc38_f216_4cec_a6c5_5f6e739763a9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatXMP ) , guid : :: windows :: core :: GUID::from_u128(0xbb5acc38_f216_4cec_a6c5_5f6e739763a9) , } }
 pub const GUID_MetadataFormatXMPAlt: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7b08a675_91aa_481b_a798_4da94908613b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatXMPAlt ) , guid : :: windows :: core :: GUID::from_u128(0x7b08a675_91aa_481b_a798_4da94908613b) , } }
 pub const GUID_MetadataFormatXMPBag: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x833cca5f_dcb7_4516_806f_6596ab26dce4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatXMPBag ) , guid : :: windows :: core :: GUID::from_u128(0x833cca5f_dcb7_4516_806f_6596ab26dce4) , } }
 pub const GUID_MetadataFormatXMPSeq: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x63e8df02_eb6c_456c_a224_b25e794fd648);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatXMPSeq ) , guid : :: windows :: core :: GUID::from_u128(0x63e8df02_eb6c_456c_a224_b25e794fd648) , } }
 pub const GUID_MetadataFormatXMPStruct: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x22383cf1_ed17_4e2e_af17_d85b8f6b30d0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MetadataFormatXMPStruct ) , guid : :: windows :: core :: GUID::from_u128(0x22383cf1_ed17_4e2e_af17_d85b8f6b30d0) , } }
 pub const GUID_VendorMicrosoft: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf0e749ca_edef_4589_a73a_ee0e626a2a2b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_VendorMicrosoft ) , guid : :: windows :: core :: GUID::from_u128(0xf0e749ca_edef_4589_a73a_ee0e626a2a2b) , } }
 pub const GUID_VendorMicrosoftBuiltIn: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x257a30fd_06b6_462b_aea4_63f70b86e533);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_VendorMicrosoftBuiltIn ) , guid : :: windows :: core :: GUID::from_u128(0x257a30fd_06b6_462b_aea4_63f70b86e533) , } }
 pub const GUID_WICPixelFormat112bpp6ChannelsAlpha: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc937);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat112bpp6ChannelsAlpha ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc937) , } }
 pub const GUID_WICPixelFormat112bpp7Channels: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc92a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat112bpp7Channels ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc92a) , } }
 pub const GUID_WICPixelFormat128bpp7ChannelsAlpha: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc938);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat128bpp7ChannelsAlpha ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc938) , } }
 pub const GUID_WICPixelFormat128bpp8Channels: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc92b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat128bpp8Channels ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc92b) , } }
 pub const GUID_WICPixelFormat128bppPRGBAFloat: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc91a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat128bppPRGBAFloat ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc91a) , } }
 pub const GUID_WICPixelFormat128bppRGBAFixedPoint: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc91e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat128bppRGBAFixedPoint ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc91e) , } }
 pub const GUID_WICPixelFormat128bppRGBAFloat: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc919);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat128bppRGBAFloat ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc919) , } }
 pub const GUID_WICPixelFormat128bppRGBFixedPoint: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc941);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat128bppRGBFixedPoint ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc941) , } }
 pub const GUID_WICPixelFormat128bppRGBFloat: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc91b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat128bppRGBFloat ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc91b) , } }
 pub const GUID_WICPixelFormat144bpp8ChannelsAlpha: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc939);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat144bpp8ChannelsAlpha ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc939) , } }
 pub const GUID_WICPixelFormat16bppBGR555: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc909);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat16bppBGR555 ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc909) , } }
 pub const GUID_WICPixelFormat16bppBGR565: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc90a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat16bppBGR565 ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc90a) , } }
 pub const GUID_WICPixelFormat16bppBGRA5551: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x05ec7c2b_f1e6_4961_ad46_e1cc810a87d2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat16bppBGRA5551 ) , guid : :: windows :: core :: GUID::from_u128(0x05ec7c2b_f1e6_4961_ad46_e1cc810a87d2) , } }
 pub const GUID_WICPixelFormat16bppCbCr: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xff95ba6e_11e0_4263_bb45_01721f3460a4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat16bppCbCr ) , guid : :: windows :: core :: GUID::from_u128(0xff95ba6e_11e0_4263_bb45_01721f3460a4) , } }
 pub const GUID_WICPixelFormat16bppCbQuantizedDctCoefficients: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd2c4ff61_56a5_49c2_8b5c_4c1925964837);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat16bppCbQuantizedDctCoefficients ) , guid : :: windows :: core :: GUID::from_u128(0xd2c4ff61_56a5_49c2_8b5c_4c1925964837) , } }
 pub const GUID_WICPixelFormat16bppCrQuantizedDctCoefficients: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2fe354f0_1680_42d8_9231_e73c0565bfc1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat16bppCrQuantizedDctCoefficients ) , guid : :: windows :: core :: GUID::from_u128(0x2fe354f0_1680_42d8_9231_e73c0565bfc1) , } }
 pub const GUID_WICPixelFormat16bppGray: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc90b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat16bppGray ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc90b) , } }
 pub const GUID_WICPixelFormat16bppGrayFixedPoint: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc913);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat16bppGrayFixedPoint ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc913) , } }
 pub const GUID_WICPixelFormat16bppGrayHalf: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc93e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat16bppGrayHalf ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc93e) , } }
 pub const GUID_WICPixelFormat16bppYQuantizedDctCoefficients: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa355f433_48e8_4a42_84d8_e2aa26ca80a4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat16bppYQuantizedDctCoefficients ) , guid : :: windows :: core :: GUID::from_u128(0xa355f433_48e8_4a42_84d8_e2aa26ca80a4) , } }
 pub const GUID_WICPixelFormat1bppIndexed: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc901);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat1bppIndexed ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc901) , } }
 pub const GUID_WICPixelFormat24bpp3Channels: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc920);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat24bpp3Channels ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc920) , } }
 pub const GUID_WICPixelFormat24bppBGR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc90c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat24bppBGR ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc90c) , } }
 pub const GUID_WICPixelFormat24bppRGB: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc90d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat24bppRGB ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc90d) , } }
 pub const GUID_WICPixelFormat2bppGray: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc906);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat2bppGray ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc906) , } }
 pub const GUID_WICPixelFormat2bppIndexed: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc902);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat2bppIndexed ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc902) , } }
 pub const GUID_WICPixelFormat32bpp3ChannelsAlpha: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc92e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat32bpp3ChannelsAlpha ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc92e) , } }
 pub const GUID_WICPixelFormat32bpp4Channels: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc921);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat32bpp4Channels ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc921) , } }
 pub const GUID_WICPixelFormat32bppBGR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc90e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat32bppBGR ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc90e) , } }
 pub const GUID_WICPixelFormat32bppBGR101010: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc914);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat32bppBGR101010 ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc914) , } }
 pub const GUID_WICPixelFormat32bppBGRA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc90f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat32bppBGRA ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc90f) , } }
 pub const GUID_WICPixelFormat32bppCMYK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc91c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat32bppCMYK ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc91c) , } }
 pub const GUID_WICPixelFormat32bppGrayFixedPoint: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc93f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat32bppGrayFixedPoint ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc93f) , } }
 pub const GUID_WICPixelFormat32bppGrayFloat: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc911);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat32bppGrayFloat ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc911) , } }
 pub const GUID_WICPixelFormat32bppPBGRA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc910);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat32bppPBGRA ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc910) , } }
 pub const GUID_WICPixelFormat32bppPRGBA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3cc4a650_a527_4d37_a916_3142c7ebedba);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat32bppPRGBA ) , guid : :: windows :: core :: GUID::from_u128(0x3cc4a650_a527_4d37_a916_3142c7ebedba) , } }
 pub const GUID_WICPixelFormat32bppR10G10B10A2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x604e1bb5_8a3c_4b65_b11c_bc0b8dd75b7f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat32bppR10G10B10A2 ) , guid : :: windows :: core :: GUID::from_u128(0x604e1bb5_8a3c_4b65_b11c_bc0b8dd75b7f) , } }
 pub const GUID_WICPixelFormat32bppR10G10B10A2HDR10: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9c215c5d_1acc_4f0e_a4bc_70fb3ae8fd28);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat32bppR10G10B10A2HDR10 ) , guid : :: windows :: core :: GUID::from_u128(0x9c215c5d_1acc_4f0e_a4bc_70fb3ae8fd28) , } }
 pub const GUID_WICPixelFormat32bppRGB: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd98c6b95_3efe_47d6_bb25_eb1748ab0cf1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat32bppRGB ) , guid : :: windows :: core :: GUID::from_u128(0xd98c6b95_3efe_47d6_bb25_eb1748ab0cf1) , } }
 pub const GUID_WICPixelFormat32bppRGBA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf5c7ad2d_6a8d_43dd_a7a8_a29935261ae9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat32bppRGBA ) , guid : :: windows :: core :: GUID::from_u128(0xf5c7ad2d_6a8d_43dd_a7a8_a29935261ae9) , } }
 pub const GUID_WICPixelFormat32bppRGBA1010102: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x25238d72_fcf9_4522_b514_5578e5ad55e0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat32bppRGBA1010102 ) , guid : :: windows :: core :: GUID::from_u128(0x25238d72_fcf9_4522_b514_5578e5ad55e0) , } }
 pub const GUID_WICPixelFormat32bppRGBA1010102XR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x00de6b9a_c101_434b_b502_d0165ee1122c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat32bppRGBA1010102XR ) , guid : :: windows :: core :: GUID::from_u128(0x00de6b9a_c101_434b_b502_d0165ee1122c) , } }
 pub const GUID_WICPixelFormat32bppRGBE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc93d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat32bppRGBE ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc93d) , } }
 pub const GUID_WICPixelFormat40bpp4ChannelsAlpha: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc92f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat40bpp4ChannelsAlpha ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc92f) , } }
 pub const GUID_WICPixelFormat40bpp5Channels: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc922);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat40bpp5Channels ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc922) , } }
 pub const GUID_WICPixelFormat40bppCMYKAlpha: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc92c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat40bppCMYKAlpha ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc92c) , } }
 pub const GUID_WICPixelFormat48bpp3Channels: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc926);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat48bpp3Channels ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc926) , } }
 pub const GUID_WICPixelFormat48bpp5ChannelsAlpha: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc930);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat48bpp5ChannelsAlpha ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc930) , } }
 pub const GUID_WICPixelFormat48bpp6Channels: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc923);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat48bpp6Channels ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc923) , } }
 pub const GUID_WICPixelFormat48bppBGR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe605a384_b468_46ce_bb2e_36f180e64313);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat48bppBGR ) , guid : :: windows :: core :: GUID::from_u128(0xe605a384_b468_46ce_bb2e_36f180e64313) , } }
 pub const GUID_WICPixelFormat48bppBGRFixedPoint: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x49ca140e_cab6_493b_9ddf_60187c37532a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat48bppBGRFixedPoint ) , guid : :: windows :: core :: GUID::from_u128(0x49ca140e_cab6_493b_9ddf_60187c37532a) , } }
 pub const GUID_WICPixelFormat48bppRGB: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc915);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat48bppRGB ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc915) , } }
 pub const GUID_WICPixelFormat48bppRGBFixedPoint: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc912);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat48bppRGBFixedPoint ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc912) , } }
 pub const GUID_WICPixelFormat48bppRGBHalf: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc93b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat48bppRGBHalf ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc93b) , } }
 pub const GUID_WICPixelFormat4bppGray: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc907);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat4bppGray ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc907) , } }
 pub const GUID_WICPixelFormat4bppIndexed: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc903);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat4bppIndexed ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc903) , } }
 pub const GUID_WICPixelFormat56bpp6ChannelsAlpha: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc931);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat56bpp6ChannelsAlpha ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc931) , } }
 pub const GUID_WICPixelFormat56bpp7Channels: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc924);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat56bpp7Channels ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc924) , } }
 pub const GUID_WICPixelFormat64bpp3ChannelsAlpha: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc934);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat64bpp3ChannelsAlpha ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc934) , } }
 pub const GUID_WICPixelFormat64bpp4Channels: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc927);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat64bpp4Channels ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc927) , } }
 pub const GUID_WICPixelFormat64bpp7ChannelsAlpha: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc932);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat64bpp7ChannelsAlpha ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc932) , } }
 pub const GUID_WICPixelFormat64bpp8Channels: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc925);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat64bpp8Channels ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc925) , } }
 pub const GUID_WICPixelFormat64bppBGRA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1562ff7c_d352_46f9_979e_42976b792246);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat64bppBGRA ) , guid : :: windows :: core :: GUID::from_u128(0x1562ff7c_d352_46f9_979e_42976b792246) , } }
 pub const GUID_WICPixelFormat64bppBGRAFixedPoint: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x356de33c_54d2_4a23_bb04_9b7bf9b1d42d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat64bppBGRAFixedPoint ) , guid : :: windows :: core :: GUID::from_u128(0x356de33c_54d2_4a23_bb04_9b7bf9b1d42d) , } }
 pub const GUID_WICPixelFormat64bppCMYK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc91f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat64bppCMYK ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc91f) , } }
 pub const GUID_WICPixelFormat64bppPBGRA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8c518e8e_a4ec_468b_ae70_c9a35a9c5530);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat64bppPBGRA ) , guid : :: windows :: core :: GUID::from_u128(0x8c518e8e_a4ec_468b_ae70_c9a35a9c5530) , } }
 pub const GUID_WICPixelFormat64bppPRGBA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc917);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat64bppPRGBA ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc917) , } }
 pub const GUID_WICPixelFormat64bppPRGBAHalf: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x58ad26c2_c623_4d9d_b320_387e49f8c442);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat64bppPRGBAHalf ) , guid : :: windows :: core :: GUID::from_u128(0x58ad26c2_c623_4d9d_b320_387e49f8c442) , } }
 pub const GUID_WICPixelFormat64bppRGB: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa1182111_186d_4d42_bc6a_9c8303a8dff9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat64bppRGB ) , guid : :: windows :: core :: GUID::from_u128(0xa1182111_186d_4d42_bc6a_9c8303a8dff9) , } }
 pub const GUID_WICPixelFormat64bppRGBA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc916);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat64bppRGBA ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc916) , } }
 pub const GUID_WICPixelFormat64bppRGBAFixedPoint: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc91d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat64bppRGBAFixedPoint ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc91d) , } }
 pub const GUID_WICPixelFormat64bppRGBAHalf: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc93a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat64bppRGBAHalf ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc93a) , } }
 pub const GUID_WICPixelFormat64bppRGBFixedPoint: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc940);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat64bppRGBFixedPoint ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc940) , } }
 pub const GUID_WICPixelFormat64bppRGBHalf: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc942);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat64bppRGBHalf ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc942) , } }
 pub const GUID_WICPixelFormat72bpp8ChannelsAlpha: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc933);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat72bpp8ChannelsAlpha ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc933) , } }
 pub const GUID_WICPixelFormat80bpp4ChannelsAlpha: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc935);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat80bpp4ChannelsAlpha ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc935) , } }
 pub const GUID_WICPixelFormat80bpp5Channels: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc928);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat80bpp5Channels ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc928) , } }
 pub const GUID_WICPixelFormat80bppCMYKAlpha: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc92d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat80bppCMYKAlpha ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc92d) , } }
 pub const GUID_WICPixelFormat8bppAlpha: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe6cd0116_eeba_4161_aa85_27dd9fb3a895);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat8bppAlpha ) , guid : :: windows :: core :: GUID::from_u128(0xe6cd0116_eeba_4161_aa85_27dd9fb3a895) , } }
 pub const GUID_WICPixelFormat8bppCb: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1339f224_6bfe_4c3e_9302_e4f3a6d0ca2a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat8bppCb ) , guid : :: windows :: core :: GUID::from_u128(0x1339f224_6bfe_4c3e_9302_e4f3a6d0ca2a) , } }
 pub const GUID_WICPixelFormat8bppCr: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb8145053_2116_49f0_8835_ed844b205c51);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat8bppCr ) , guid : :: windows :: core :: GUID::from_u128(0xb8145053_2116_49f0_8835_ed844b205c51) , } }
 pub const GUID_WICPixelFormat8bppGray: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc908);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat8bppGray ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc908) , } }
 pub const GUID_WICPixelFormat8bppIndexed: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc904);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat8bppIndexed ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc904) , } }
 pub const GUID_WICPixelFormat8bppY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x91b4db54_2df9_42f0_b449_2909bb3df88e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat8bppY ) , guid : :: windows :: core :: GUID::from_u128(0x91b4db54_2df9_42f0_b449_2909bb3df88e) , } }
 pub const GUID_WICPixelFormat96bpp5ChannelsAlpha: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc936);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat96bpp5ChannelsAlpha ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc936) , } }
 pub const GUID_WICPixelFormat96bpp6Channels: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc929);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat96bpp6Channels ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc929) , } }
 pub const GUID_WICPixelFormat96bppRGBFixedPoint: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc918);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat96bppRGBFixedPoint ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc918) , } }
 pub const GUID_WICPixelFormat96bppRGBFloat: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe3fed78f_e8db_4acf_84c1_e97f6136b327);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormat96bppRGBFloat ) , guid : :: windows :: core :: GUID::from_u128(0xe3fed78f_e8db_4acf_84c1_e97f6136b327) , } }
 pub const GUID_WICPixelFormatBlackWhite: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc905);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormatBlackWhite ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc905) , } }
 pub const GUID_WICPixelFormatDontCare: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc900);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_WICPixelFormatDontCare ) , guid : :: windows :: core :: GUID::from_u128(0x6fddc324_4e03_4bfe_b185_3d77768dc900) , } }
 #[doc = "*Required features: 'Win32_Graphics_Imaging'*"]
 #[repr(transparent)]
 pub struct IWICBitmap(::windows::core::IUnknown);

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Printing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Printing/mod.rs
@@ -1336,11 +1336,23 @@ pub const CHKBOXS_OFF_ON: u32 = 2u32;
 #[doc = "*Required features: 'Win32_Graphics_Printing'*"]
 pub const CHKBOXS_OFF_PDATA: u32 = 5u32;
 pub const CLSID_OEMPTPROVIDER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x91723892_45d2_48e2_9ec9_562379daf992);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_OEMPTPROVIDER ) , guid : :: windows :: core :: GUID::from_u128(0x91723892_45d2_48e2_9ec9_562379daf992) , } }
 pub const CLSID_OEMRENDER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6d6abf26_9f38_11d1_882a_00c04fb961ec);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_OEMRENDER ) , guid : :: windows :: core :: GUID::from_u128(0x6d6abf26_9f38_11d1_882a_00c04fb961ec) , } }
 pub const CLSID_OEMUI: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xabce80d7_9f46_11d1_882a_00c04fb961ec);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_OEMUI ) , guid : :: windows :: core :: GUID::from_u128(0xabce80d7_9f46_11d1_882a_00c04fb961ec) , } }
 pub const CLSID_OEMUIMXDC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4e144300_5b43_4288_932a_5e4dd6d82bed);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_OEMUIMXDC ) , guid : :: windows :: core :: GUID::from_u128(0x4e144300_5b43_4288_932a_5e4dd6d82bed) , } }
 pub const CLSID_PTPROVIDER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x46ac151b_8490_4531_96cc_55bf2bf19e11);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_PTPROVIDER ) , guid : :: windows :: core :: GUID::from_u128(0x46ac151b_8490_4531_96cc_55bf2bf19e11) , } }
 pub const CLSID_XPSRASTERIZER_FACTORY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x503e79bf_1d09_4764_9d72_1eb0c65967c6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_XPSRASTERIZER_FACTORY ) , guid : :: windows :: core :: GUID::from_u128(0x503e79bf_1d09_4764_9d72_1eb0c65967c6) , } }
 #[doc = "*Required features: 'Win32_Graphics_Printing'*"]
 pub const COLOR_OPTIMIZATION: u32 = 1u32;
 #[repr(C)]
@@ -5426,6 +5438,8 @@ pub const FG_CANCHANGE: u32 = 128u32;
 #[doc = "*Required features: 'Win32_Graphics_Printing'*"]
 pub const FILL_WITH_DEFAULTS: u32 = 1u32;
 pub const FMTID_PrinterPropertyBag: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x75f9adca_097d_45c3_a6e4_bab29e276f3e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FMTID_PrinterPropertyBag ) , guid : :: windows :: core :: GUID::from_u128(0x75f9adca_097d_45c3_a6e4_bab29e276f3e) , } }
 #[doc = "*Required features: 'Win32_Graphics_Printing'*"]
 pub const FNT_INFO_CURRENTFONTID: u32 = 10u32;
 #[doc = "*Required features: 'Win32_Graphics_Printing'*"]
@@ -5795,7 +5809,11 @@ impl ::core::default::Default for GLYPHRUN {
 #[doc = "*Required features: 'Win32_Graphics_Printing'*"]
 pub const GPD_OEMCUSTOMDATA: u32 = 1u32;
 pub const GUID_DEVINTERFACE_IPPUSB_PRINT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf2f40381_f46d_4e51_bce7_62de6cf2d098);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_IPPUSB_PRINT ) , guid : :: windows :: core :: GUID::from_u128(0xf2f40381_f46d_4e51_bce7_62de6cf2d098) , } }
 pub const GUID_DEVINTERFACE_USBPRINT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x28d78fad_5a12_11d1_ae5b_0000f803a8c2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_USBPRINT ) , guid : :: windows :: core :: GUID::from_u128(0x28d78fad_5a12_11d1_ae5b_0000f803a8c2) , } }
 #[doc = "*Required features: 'Win32_Graphics_Printing', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
@@ -19471,6 +19489,8 @@ pub const NOTIFICATION_CONFIG_EVENT_TRIGGER: NOTIFICATION_CONFIG_FLAGS = 4i32;
 #[doc = "*Required features: 'Win32_Graphics_Printing'*"]
 pub const NOTIFICATION_CONFIG_ASYNC_CHANNEL: NOTIFICATION_CONFIG_FLAGS = 8i32;
 pub const NOTIFICATION_RELEASE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xba9a5027_a70e_4ae7_9b7d_eb3e06ad4157);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( NOTIFICATION_RELEASE ) , guid : :: windows :: core :: GUID::from_u128(0xba9a5027_a70e_4ae7_9b7d_eb3e06ad4157) , } }
 #[doc = "*Required features: 'Win32_Graphics_Printing'*"]
 pub const NO_BORDER_PRINT: u32 = 1u32;
 #[doc = "*Required features: 'Win32_Graphics_Printing'*"]
@@ -21296,8 +21316,14 @@ pub const PRINTER_EVENT_FLAG_NO_UI: u32 = 1u32;
 #[doc = "*Required features: 'Win32_Graphics_Printing'*"]
 pub const PRINTER_EVENT_INITIALIZE: u32 = 3u32;
 pub const PRINTER_EXTENSION_DETAILEDREASON_PRINTER_STATUS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5d5a1704_dfd1_4181_8eee_815c86edad31);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PRINTER_EXTENSION_DETAILEDREASON_PRINTER_STATUS ) , guid : :: windows :: core :: GUID::from_u128(0x5d5a1704_dfd1_4181_8eee_815c86edad31) , } }
 pub const PRINTER_EXTENSION_REASON_DRIVER_EVENT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x23bb1328_63de_4293_915b_a6a23d929acb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PRINTER_EXTENSION_REASON_DRIVER_EVENT ) , guid : :: windows :: core :: GUID::from_u128(0x23bb1328_63de_4293_915b_a6a23d929acb) , } }
 pub const PRINTER_EXTENSION_REASON_PRINT_PREFERENCES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xec8f261f_267c_469f_b5d6_3933023c29cc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PRINTER_EXTENSION_REASON_PRINT_PREFERENCES ) , guid : :: windows :: core :: GUID::from_u128(0xec8f261f_267c_469f_b5d6_3933023c29cc) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Graphics_Printing', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -23020,6 +23046,8 @@ impl ::core::default::Default for PRINTPROVIDOR {
     }
 }
 pub const PRINT_APP_BIDI_NOTIFY_CHANNEL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2abad223_b994_4aca_82fc_4571b1b585ac);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PRINT_APP_BIDI_NOTIFY_CHANNEL ) , guid : :: windows :: core :: GUID::from_u128(0x2abad223_b994_4aca_82fc_4571b1b585ac) , } }
 #[doc = "*Required features: 'Win32_Graphics_Printing'*"]
 pub type PRINT_EXECUTION_CONTEXT = i32;
 #[doc = "*Required features: 'Win32_Graphics_Printing'*"]
@@ -23103,6 +23131,8 @@ impl ::core::default::Default for PRINT_FEATURE_OPTION {
     }
 }
 pub const PRINT_PORT_MONITOR_NOTIFY_CHANNEL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x25df3b0e_74a9_47f5_80ce_79b4b1eb5c58);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PRINT_PORT_MONITOR_NOTIFY_CHANNEL ) , guid : :: windows :: core :: GUID::from_u128(0x25df3b0e_74a9_47f5_80ce_79b4b1eb5c58) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Graphics_Printing', 'Win32_UI_WindowsAndMessaging'*"]
 #[cfg(feature = "Win32_UI_WindowsAndMessaging")]

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/Apo/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/Apo/mod.rs
@@ -1948,95 +1948,159 @@ pub struct IAudioSystemEffectsCustomFormatsVtbl(
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_APO_SWFallback_ProcessingModes: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd3993a3f_99c2_4402_b5ec_a92a0367664b), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_APO_SWFallback_ProcessingModes ) , guid : :: windows :: core :: GUID::from_u128(0xd3993a3f_99c2_4402_b5ec_a92a0367664b) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_CompositeFX_EndpointEffectClsid: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d), pid: 15u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_CompositeFX_EndpointEffectClsid ) , guid : :: windows :: core :: GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_CompositeFX_KeywordDetector_EndpointEffectClsid: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d), pid: 18u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_CompositeFX_KeywordDetector_EndpointEffectClsid ) , guid : :: windows :: core :: GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_CompositeFX_KeywordDetector_ModeEffectClsid: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d), pid: 17u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_CompositeFX_KeywordDetector_ModeEffectClsid ) , guid : :: windows :: core :: GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_CompositeFX_KeywordDetector_StreamEffectClsid: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d), pid: 16u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_CompositeFX_KeywordDetector_StreamEffectClsid ) , guid : :: windows :: core :: GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_CompositeFX_ModeEffectClsid: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_CompositeFX_ModeEffectClsid ) , guid : :: windows :: core :: GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_CompositeFX_Offload_ModeEffectClsid: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d), pid: 20u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_CompositeFX_Offload_ModeEffectClsid ) , guid : :: windows :: core :: GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_CompositeFX_Offload_StreamEffectClsid: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d), pid: 19u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_CompositeFX_Offload_StreamEffectClsid ) , guid : :: windows :: core :: GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_CompositeFX_StreamEffectClsid: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_CompositeFX_StreamEffectClsid ) , guid : :: windows :: core :: GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_EFX_KeywordDetector_ProcessingModes_Supported_For_Streaming: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd3993a3f_99c2_4402_b5ec_a92a0367664b), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_EFX_KeywordDetector_ProcessingModes_Supported_For_Streaming ) , guid : :: windows :: core :: GUID::from_u128(0xd3993a3f_99c2_4402_b5ec_a92a0367664b) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_EFX_ProcessingModes_Supported_For_Streaming: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd3993a3f_99c2_4402_b5ec_a92a0367664b), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_EFX_ProcessingModes_Supported_For_Streaming ) , guid : :: windows :: core :: GUID::from_u128(0xd3993a3f_99c2_4402_b5ec_a92a0367664b) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FX_Association: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d), pid: 0u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FX_Association ) , guid : :: windows :: core :: GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FX_EndpointEffectClsid: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FX_EndpointEffectClsid ) , guid : :: windows :: core :: GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FX_FriendlyName: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FX_FriendlyName ) , guid : :: windows :: core :: GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FX_KeywordDetector_EndpointEffectClsid: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FX_KeywordDetector_EndpointEffectClsid ) , guid : :: windows :: core :: GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FX_KeywordDetector_ModeEffectClsid: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FX_KeywordDetector_ModeEffectClsid ) , guid : :: windows :: core :: GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FX_KeywordDetector_StreamEffectClsid: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FX_KeywordDetector_StreamEffectClsid ) , guid : :: windows :: core :: GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FX_ModeEffectClsid: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FX_ModeEffectClsid ) , guid : :: windows :: core :: GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FX_Offload_ModeEffectClsid: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FX_Offload_ModeEffectClsid ) , guid : :: windows :: core :: GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FX_Offload_StreamEffectClsid: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FX_Offload_StreamEffectClsid ) , guid : :: windows :: core :: GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FX_PostMixEffectClsid: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FX_PostMixEffectClsid ) , guid : :: windows :: core :: GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FX_PreMixEffectClsid: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d), pid: 1u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FX_PreMixEffectClsid ) , guid : :: windows :: core :: GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FX_StreamEffectClsid: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FX_StreamEffectClsid ) , guid : :: windows :: core :: GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FX_UserInterfaceClsid: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FX_UserInterfaceClsid ) , guid : :: windows :: core :: GUID::from_u128(0xd04e05a6_594b_4fb6_a80d_01af5eed7d1d) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_MFX_KeywordDetector_ProcessingModes_Supported_For_Streaming: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd3993a3f_99c2_4402_b5ec_a92a0367664b), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_MFX_KeywordDetector_ProcessingModes_Supported_For_Streaming ) , guid : :: windows :: core :: GUID::from_u128(0xd3993a3f_99c2_4402_b5ec_a92a0367664b) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_MFX_Offload_ProcessingModes_Supported_For_Streaming: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd3993a3f_99c2_4402_b5ec_a92a0367664b), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_MFX_Offload_ProcessingModes_Supported_For_Streaming ) , guid : :: windows :: core :: GUID::from_u128(0xd3993a3f_99c2_4402_b5ec_a92a0367664b) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_MFX_ProcessingModes_Supported_For_Streaming: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd3993a3f_99c2_4402_b5ec_a92a0367664b), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_MFX_ProcessingModes_Supported_For_Streaming ) , guid : :: windows :: core :: GUID::from_u128(0xd3993a3f_99c2_4402_b5ec_a92a0367664b) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_SFX_KeywordDetector_ProcessingModes_Supported_For_Streaming: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd3993a3f_99c2_4402_b5ec_a92a0367664b), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_SFX_KeywordDetector_ProcessingModes_Supported_For_Streaming ) , guid : :: windows :: core :: GUID::from_u128(0xd3993a3f_99c2_4402_b5ec_a92a0367664b) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_SFX_Offload_ProcessingModes_Supported_For_Streaming: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd3993a3f_99c2_4402_b5ec_a92a0367664b), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_SFX_Offload_ProcessingModes_Supported_For_Streaming ) , guid : :: windows :: core :: GUID::from_u128(0xd3993a3f_99c2_4402_b5ec_a92a0367664b) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Apo', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_SFX_ProcessingModes_Supported_For_Streaming: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd3993a3f_99c2_4402_b5ec_a92a0367664b), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_SFX_ProcessingModes_Supported_For_Streaming ) , guid : :: windows :: core :: GUID::from_u128(0xd3993a3f_99c2_4402_b5ec_a92a0367664b) , } }
 pub const SID_AudioProcessingObjectLoggingService: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8b8008af_09f9_456e_a173_bdb58499bce7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SID_AudioProcessingObjectLoggingService ) , guid : :: windows :: core :: GUID::from_u128(0x8b8008af_09f9_456e_a173_bdb58499bce7) , } }
 pub const SID_AudioProcessingObjectRTQueue: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x458c1a1f_6899_4c12_99ac_e2e6ac253104);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SID_AudioProcessingObjectRTQueue ) , guid : :: windows :: core :: GUID::from_u128(0x458c1a1f_6899_4c12_99ac_e2e6ac253104) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Media_Audio_Apo'*"]
 pub struct UNCOMPRESSEDAUDIOFORMAT {

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectMusic/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectMusic/mod.rs
@@ -1,9 +1,19 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 pub const CLSID_DirectMusic: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x636b9f10_0c7d_11d1_95b2_0020afdc7421);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DirectMusic ) , guid : :: windows :: core :: GUID::from_u128(0x636b9f10_0c7d_11d1_95b2_0020afdc7421) , } }
 pub const CLSID_DirectMusicCollection: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x480ff4b0_28b2_11d1_bef7_00c04fbf8fef);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DirectMusicCollection ) , guid : :: windows :: core :: GUID::from_u128(0x480ff4b0_28b2_11d1_bef7_00c04fbf8fef) , } }
 pub const CLSID_DirectMusicSynth: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x58c2b4d0_46e7_11d1_89ac_00a0c9054129);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DirectMusicSynth ) , guid : :: windows :: core :: GUID::from_u128(0x58c2b4d0_46e7_11d1_89ac_00a0c9054129) , } }
 pub const CLSID_DirectMusicSynthSink: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaec17ce3_a514_11d1_afa6_00aa0024d8b6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DirectMusicSynthSink ) , guid : :: windows :: core :: GUID::from_u128(0xaec17ce3_a514_11d1_afa6_00aa0024d8b6) , } }
 pub const CLSID_DirectSoundPrivate: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x11ab3ec0_25ec_11d1_a4d8_00c04fc28aca);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DirectSoundPrivate ) , guid : :: windows :: core :: GUID::from_u128(0x11ab3ec0_25ec_11d1_a4d8_00c04fc28aca) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Media_Audio_DirectMusic'*"]
 pub struct CONNECTION {
@@ -297,14 +307,32 @@ impl ::core::default::Default for DLSID {
     }
 }
 pub const DLSID_GMInHardware: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x178f2f24_c364_11d1_a760_0000f875ac12);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DLSID_GMInHardware ) , guid : :: windows :: core :: GUID::from_u128(0x178f2f24_c364_11d1_a760_0000f875ac12) , } }
 pub const DLSID_GSInHardware: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x178f2f25_c364_11d1_a760_0000f875ac12);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DLSID_GSInHardware ) , guid : :: windows :: core :: GUID::from_u128(0x178f2f25_c364_11d1_a760_0000f875ac12) , } }
 pub const DLSID_ManufacturersID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb03e1181_8095_11d2_a1ef_00600833dbd8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DLSID_ManufacturersID ) , guid : :: windows :: core :: GUID::from_u128(0xb03e1181_8095_11d2_a1ef_00600833dbd8) , } }
 pub const DLSID_ProductID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb03e1182_8095_11d2_a1ef_00600833dbd8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DLSID_ProductID ) , guid : :: windows :: core :: GUID::from_u128(0xb03e1182_8095_11d2_a1ef_00600833dbd8) , } }
 pub const DLSID_SampleMemorySize: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x178f2f28_c364_11d1_a760_0000f875ac12);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DLSID_SampleMemorySize ) , guid : :: windows :: core :: GUID::from_u128(0x178f2f28_c364_11d1_a760_0000f875ac12) , } }
 pub const DLSID_SamplePlaybackRate: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2a91f713_a4bf_11d2_bbdf_00600833dbd8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DLSID_SamplePlaybackRate ) , guid : :: windows :: core :: GUID::from_u128(0x2a91f713_a4bf_11d2_bbdf_00600833dbd8) , } }
 pub const DLSID_SupportsDLS1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x178f2f27_c364_11d1_a760_0000f875ac12);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DLSID_SupportsDLS1 ) , guid : :: windows :: core :: GUID::from_u128(0x178f2f27_c364_11d1_a760_0000f875ac12) , } }
 pub const DLSID_SupportsDLS2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf14599e5_4689_11d2_afa6_00aa0024d8b6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DLSID_SupportsDLS2 ) , guid : :: windows :: core :: GUID::from_u128(0xf14599e5_4689_11d2_afa6_00aa0024d8b6) , } }
 pub const DLSID_XGInHardware: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x178f2f26_c364_11d1_a760_0000f875ac12);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DLSID_XGInHardware ) , guid : :: windows :: core :: GUID::from_u128(0x178f2f26_c364_11d1_a760_0000f875ac12) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Media_Audio_DirectMusic'*"]
 pub struct DLSVERSION {
@@ -1834,6 +1862,8 @@ impl ::core::default::Default for DSPROPERTY_DIRECTSOUNDDEVICE_WAVEDEVICEMAPPING
     }
 }
 pub const DSPROPSETID_DirectSoundDevice: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x84624f82_25ec_11d1_a4d8_00c04fc28aca);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DSPROPSETID_DirectSoundDevice ) , guid : :: windows :: core :: GUID::from_u128(0x84624f82_25ec_11d1_a4d8_00c04fc28aca) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_DirectMusic'*"]
 pub const DV_AUDIOMODE: u32 = 3840u32;
 #[doc = "*Required features: 'Win32_Media_Audio_DirectMusic'*"]
@@ -1877,26 +1907,68 @@ pub const F_WSMP_NO_COMPRESSION: i32 = 2i32;
 #[doc = "*Required features: 'Win32_Media_Audio_DirectMusic'*"]
 pub const F_WSMP_NO_TRUNCATION: i32 = 1i32;
 pub const GUID_DMUS_PROP_DLS1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x178f2f27_c364_11d1_a760_0000f875ac12);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DMUS_PROP_DLS1 ) , guid : :: windows :: core :: GUID::from_u128(0x178f2f27_c364_11d1_a760_0000f875ac12) , } }
 pub const GUID_DMUS_PROP_DLS2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf14599e5_4689_11d2_afa6_00aa0024d8b6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DMUS_PROP_DLS2 ) , guid : :: windows :: core :: GUID::from_u128(0xf14599e5_4689_11d2_afa6_00aa0024d8b6) , } }
 pub const GUID_DMUS_PROP_Effects: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcda8d611_684a_11d2_871e_00600893b1bd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DMUS_PROP_Effects ) , guid : :: windows :: core :: GUID::from_u128(0xcda8d611_684a_11d2_871e_00600893b1bd) , } }
 pub const GUID_DMUS_PROP_GM_Hardware: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x178f2f24_c364_11d1_a760_0000f875ac12);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DMUS_PROP_GM_Hardware ) , guid : :: windows :: core :: GUID::from_u128(0x178f2f24_c364_11d1_a760_0000f875ac12) , } }
 pub const GUID_DMUS_PROP_GS_Capable: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6496aba2_61b0_11d2_afa6_00aa0024d8b6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DMUS_PROP_GS_Capable ) , guid : :: windows :: core :: GUID::from_u128(0x6496aba2_61b0_11d2_afa6_00aa0024d8b6) , } }
 pub const GUID_DMUS_PROP_GS_Hardware: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x178f2f25_c364_11d1_a760_0000f875ac12);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DMUS_PROP_GS_Hardware ) , guid : :: windows :: core :: GUID::from_u128(0x178f2f25_c364_11d1_a760_0000f875ac12) , } }
 pub const GUID_DMUS_PROP_INSTRUMENT2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x865fd372_9f67_11d2_872a_00600893b1bd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DMUS_PROP_INSTRUMENT2 ) , guid : :: windows :: core :: GUID::from_u128(0x865fd372_9f67_11d2_872a_00600893b1bd) , } }
 pub const GUID_DMUS_PROP_LegacyCaps: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcfa7cdc2_00a1_11d2_aad5_0000f875ac12);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DMUS_PROP_LegacyCaps ) , guid : :: windows :: core :: GUID::from_u128(0xcfa7cdc2_00a1_11d2_aad5_0000f875ac12) , } }
 pub const GUID_DMUS_PROP_MemorySize: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x178f2f28_c364_11d1_a760_0000f875ac12);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DMUS_PROP_MemorySize ) , guid : :: windows :: core :: GUID::from_u128(0x178f2f28_c364_11d1_a760_0000f875ac12) , } }
 pub const GUID_DMUS_PROP_SampleMemorySize: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x178f2f28_c364_11d1_a760_0000f875ac12);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DMUS_PROP_SampleMemorySize ) , guid : :: windows :: core :: GUID::from_u128(0x178f2f28_c364_11d1_a760_0000f875ac12) , } }
 pub const GUID_DMUS_PROP_SamplePlaybackRate: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2a91f713_a4bf_11d2_bbdf_00600833dbd8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DMUS_PROP_SamplePlaybackRate ) , guid : :: windows :: core :: GUID::from_u128(0x2a91f713_a4bf_11d2_bbdf_00600833dbd8) , } }
 pub const GUID_DMUS_PROP_SetSynthSink: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0a3a5ba5_37b6_11d2_b9f9_0000f875ac12);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DMUS_PROP_SetSynthSink ) , guid : :: windows :: core :: GUID::from_u128(0x0a3a5ba5_37b6_11d2_b9f9_0000f875ac12) , } }
 pub const GUID_DMUS_PROP_SinkUsesDSound: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbe208857_8952_11d2_ba1c_0000f875ac12);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DMUS_PROP_SinkUsesDSound ) , guid : :: windows :: core :: GUID::from_u128(0xbe208857_8952_11d2_ba1c_0000f875ac12) , } }
 pub const GUID_DMUS_PROP_SynthSink_DSOUND: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0aa97844_c877_11d1_870c_00600893b1bd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DMUS_PROP_SynthSink_DSOUND ) , guid : :: windows :: core :: GUID::from_u128(0x0aa97844_c877_11d1_870c_00600893b1bd) , } }
 pub const GUID_DMUS_PROP_SynthSink_WAVE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0aa97845_c877_11d1_870c_00600893b1bd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DMUS_PROP_SynthSink_WAVE ) , guid : :: windows :: core :: GUID::from_u128(0x0aa97845_c877_11d1_870c_00600893b1bd) , } }
 pub const GUID_DMUS_PROP_Volume: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfedfae25_e46e_11d1_aace_0000f875ac12);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DMUS_PROP_Volume ) , guid : :: windows :: core :: GUID::from_u128(0xfedfae25_e46e_11d1_aace_0000f875ac12) , } }
 pub const GUID_DMUS_PROP_WavesReverb: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x04cb5622_32e5_11d2_afa6_00aa0024d8b6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DMUS_PROP_WavesReverb ) , guid : :: windows :: core :: GUID::from_u128(0x04cb5622_32e5_11d2_afa6_00aa0024d8b6) , } }
 pub const GUID_DMUS_PROP_WriteLatency: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x268a0fa0_60f2_11d2_afa6_00aa0024d8b6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DMUS_PROP_WriteLatency ) , guid : :: windows :: core :: GUID::from_u128(0x268a0fa0_60f2_11d2_afa6_00aa0024d8b6) , } }
 pub const GUID_DMUS_PROP_WritePeriod: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x268a0fa1_60f2_11d2_afa6_00aa0024d8b6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DMUS_PROP_WritePeriod ) , guid : :: windows :: core :: GUID::from_u128(0x268a0fa1_60f2_11d2_afa6_00aa0024d8b6) , } }
 pub const GUID_DMUS_PROP_XG_Capable: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6496aba1_61b0_11d2_afa6_00aa0024d8b6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DMUS_PROP_XG_Capable ) , guid : :: windows :: core :: GUID::from_u128(0x6496aba1_61b0_11d2_afa6_00aa0024d8b6) , } }
 pub const GUID_DMUS_PROP_XG_Hardware: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x178f2f26_c364_11d1_a760_0000f875ac12);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DMUS_PROP_XG_Hardware ) , guid : :: windows :: core :: GUID::from_u128(0x178f2f26_c364_11d1_a760_0000f875ac12) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_DirectMusic'*"]
 #[repr(transparent)]
 pub struct IDirectMusic(::windows::core::IUnknown);

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectSound/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/DirectSound/mod.rs
@@ -1,14 +1,30 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 pub const CLSID_DirectSound: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x47d4d946_62e8_11cf_93bc_444553540000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DirectSound ) , guid : :: windows :: core :: GUID::from_u128(0x47d4d946_62e8_11cf_93bc_444553540000) , } }
 pub const CLSID_DirectSound8: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3901cc3f_84b5_4fa4_ba35_aa8172b8a09b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DirectSound8 ) , guid : :: windows :: core :: GUID::from_u128(0x3901cc3f_84b5_4fa4_ba35_aa8172b8a09b) , } }
 pub const CLSID_DirectSoundCapture: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb0210780_89cd_11d0_af08_00a0c925cd16);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DirectSoundCapture ) , guid : :: windows :: core :: GUID::from_u128(0xb0210780_89cd_11d0_af08_00a0c925cd16) , } }
 pub const CLSID_DirectSoundCapture8: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe4bcac13_7f99_4908_9a8e_74e3bf24b6e1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DirectSoundCapture8 ) , guid : :: windows :: core :: GUID::from_u128(0xe4bcac13_7f99_4908_9a8e_74e3bf24b6e1) , } }
 pub const CLSID_DirectSoundFullDuplex: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfea4300c_7959_4147_b26a_2377b9e7a91d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DirectSoundFullDuplex ) , guid : :: windows :: core :: GUID::from_u128(0xfea4300c_7959_4147_b26a_2377b9e7a91d) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_DirectSound'*"]
 pub const DIRECTSOUND_VERSION: u32 = 1792u32;
 pub const DS3DALG_HRTF_FULL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc2413340_1c1b_11d2_94f5_00c04fc28aca);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DS3DALG_HRTF_FULL ) , guid : :: windows :: core :: GUID::from_u128(0xc2413340_1c1b_11d2_94f5_00c04fc28aca) , } }
 pub const DS3DALG_HRTF_LIGHT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc2413342_1c1b_11d2_94f5_00c04fc28aca);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DS3DALG_HRTF_LIGHT ) , guid : :: windows :: core :: GUID::from_u128(0xc2413342_1c1b_11d2_94f5_00c04fc28aca) , } }
 pub const DS3DALG_NO_VIRTUALIZATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc241333f_1c1b_11d2_94f5_00c04fc28aca);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DS3DALG_NO_VIRTUALIZATION ) , guid : :: windows :: core :: GUID::from_u128(0xc241333f_1c1b_11d2_94f5_00c04fc28aca) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Media_Audio_DirectSound', 'Win32_Graphics_Direct3D'*"]
 #[cfg(feature = "Win32_Graphics_Direct3D")]
@@ -755,9 +771,17 @@ pub const DSCFX_LOCHARDWARE: u32 = 1u32;
 #[doc = "*Required features: 'Win32_Media_Audio_DirectSound'*"]
 pub const DSCFX_LOCSOFTWARE: u32 = 2u32;
 pub const DSDEVID_DefaultCapture: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdef00001_9c6d_47ed_aaf1_4dda8f2b5c03);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DSDEVID_DefaultCapture ) , guid : :: windows :: core :: GUID::from_u128(0xdef00001_9c6d_47ed_aaf1_4dda8f2b5c03) , } }
 pub const DSDEVID_DefaultPlayback: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdef00000_9c6d_47ed_aaf1_4dda8f2b5c03);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DSDEVID_DefaultPlayback ) , guid : :: windows :: core :: GUID::from_u128(0xdef00000_9c6d_47ed_aaf1_4dda8f2b5c03) , } }
 pub const DSDEVID_DefaultVoiceCapture: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdef00003_9c6d_47ed_aaf1_4dda8f2b5c03);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DSDEVID_DefaultVoiceCapture ) , guid : :: windows :: core :: GUID::from_u128(0xdef00003_9c6d_47ed_aaf1_4dda8f2b5c03) , } }
 pub const DSDEVID_DefaultVoicePlayback: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdef00002_9c6d_47ed_aaf1_4dda8f2b5c03);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DSDEVID_DefaultVoicePlayback ) , guid : :: windows :: core :: GUID::from_u128(0xdef00002_9c6d_47ed_aaf1_4dda8f2b5c03) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Media_Audio_DirectSound'*"]
 pub struct DSEFFECTDESC {
@@ -1651,21 +1675,53 @@ pub unsafe fn DirectSoundFullDuplexCreate<'a, Param4: ::windows::core::IntoParam
     unimplemented!("Unsupported target OS");
 }
 pub const GUID_All_Objects: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaa114de5_c262_4169_a1c8_23d698cc73b5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_All_Objects ) , guid : :: windows :: core :: GUID::from_u128(0xaa114de5_c262_4169_a1c8_23d698cc73b5) , } }
 pub const GUID_DSCFX_CLASS_AEC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbf963d80_c559_11d0_8a2b_00a0c9255ac1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DSCFX_CLASS_AEC ) , guid : :: windows :: core :: GUID::from_u128(0xbf963d80_c559_11d0_8a2b_00a0c9255ac1) , } }
 pub const GUID_DSCFX_CLASS_NS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe07f903f_62fd_4e60_8cdd_dea7236665b5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DSCFX_CLASS_NS ) , guid : :: windows :: core :: GUID::from_u128(0xe07f903f_62fd_4e60_8cdd_dea7236665b5) , } }
 pub const GUID_DSCFX_MS_AEC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcdebb919_379a_488a_8765_f53cfd36de40);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DSCFX_MS_AEC ) , guid : :: windows :: core :: GUID::from_u128(0xcdebb919_379a_488a_8765_f53cfd36de40) , } }
 pub const GUID_DSCFX_MS_NS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x11c5c73b_66e9_4ba1_a0ba_e814c6eed92d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DSCFX_MS_NS ) , guid : :: windows :: core :: GUID::from_u128(0x11c5c73b_66e9_4ba1_a0ba_e814c6eed92d) , } }
 pub const GUID_DSCFX_SYSTEM_AEC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1c22c56d_9879_4f5b_a389_27996ddc2810);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DSCFX_SYSTEM_AEC ) , guid : :: windows :: core :: GUID::from_u128(0x1c22c56d_9879_4f5b_a389_27996ddc2810) , } }
 pub const GUID_DSCFX_SYSTEM_NS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5ab0882e_7274_4516_877d_4eee99ba4fd0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DSCFX_SYSTEM_NS ) , guid : :: windows :: core :: GUID::from_u128(0x5ab0882e_7274_4516_877d_4eee99ba4fd0) , } }
 pub const GUID_DSFX_STANDARD_CHORUS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xefe6629c_81f7_4281_bd91_c9d604a95af6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DSFX_STANDARD_CHORUS ) , guid : :: windows :: core :: GUID::from_u128(0xefe6629c_81f7_4281_bd91_c9d604a95af6) , } }
 pub const GUID_DSFX_STANDARD_COMPRESSOR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xef011f79_4000_406d_87af_bffb3fc39d57);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DSFX_STANDARD_COMPRESSOR ) , guid : :: windows :: core :: GUID::from_u128(0xef011f79_4000_406d_87af_bffb3fc39d57) , } }
 pub const GUID_DSFX_STANDARD_DISTORTION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xef114c90_cd1d_484e_96e5_09cfaf912a21);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DSFX_STANDARD_DISTORTION ) , guid : :: windows :: core :: GUID::from_u128(0xef114c90_cd1d_484e_96e5_09cfaf912a21) , } }
 pub const GUID_DSFX_STANDARD_ECHO: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xef3e932c_d40b_4f51_8ccf_3f98f1b29d5d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DSFX_STANDARD_ECHO ) , guid : :: windows :: core :: GUID::from_u128(0xef3e932c_d40b_4f51_8ccf_3f98f1b29d5d) , } }
 pub const GUID_DSFX_STANDARD_FLANGER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xefca3d92_dfd8_4672_a603_7420894bad98);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DSFX_STANDARD_FLANGER ) , guid : :: windows :: core :: GUID::from_u128(0xefca3d92_dfd8_4672_a603_7420894bad98) , } }
 pub const GUID_DSFX_STANDARD_GARGLE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdafd8210_5711_4b91_9fe3_f75b7ae279bf);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DSFX_STANDARD_GARGLE ) , guid : :: windows :: core :: GUID::from_u128(0xdafd8210_5711_4b91_9fe3_f75b7ae279bf) , } }
 pub const GUID_DSFX_STANDARD_I3DL2REVERB: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xef985e71_d5c7_42d4_ba4d_2d073e2e96f4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DSFX_STANDARD_I3DL2REVERB ) , guid : :: windows :: core :: GUID::from_u128(0xef985e71_d5c7_42d4_ba4d_2d073e2e96f4) , } }
 pub const GUID_DSFX_STANDARD_PARAMEQ: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x120ced89_3bf4_4173_a132_3cb406cf3231);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DSFX_STANDARD_PARAMEQ ) , guid : :: windows :: core :: GUID::from_u128(0x120ced89_3bf4_4173_a132_3cb406cf3231) , } }
 pub const GUID_DSFX_WAVES_REVERB: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x87fc0268_9a55_4360_95aa_004a1d9de26c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DSFX_WAVES_REVERB ) , guid : :: windows :: core :: GUID::from_u128(0x87fc0268_9a55_4360_95aa_004a1d9de26c) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_DirectSound'*"]
 #[inline]
 pub unsafe fn GetDeviceID(pguidsrc: *const ::windows::core::GUID) -> ::windows::core::Result<::windows::core::GUID> {

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/Endpoints/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/Endpoints/mod.rs
@@ -31,15 +31,23 @@ pub const DEVINTERFACE_AUDIOENDPOINTPLUGIN: ::windows::core::GUID = ::windows::c
 #[doc = "*Required features: 'Win32_Media_Audio_Endpoints', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_AudioEndpointPlugin2_FactoryCLSID: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x12d83bd7_cf12_46be_8540_812710d3021c), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_AudioEndpointPlugin2_FactoryCLSID ) , guid : :: windows :: core :: GUID::from_u128(0x12d83bd7_cf12_46be_8540_812710d3021c) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Endpoints', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_AudioEndpointPlugin_DataFlow: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x12d83bd7_cf12_46be_8540_812710d3021c), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_AudioEndpointPlugin_DataFlow ) , guid : :: windows :: core :: GUID::from_u128(0x12d83bd7_cf12_46be_8540_812710d3021c) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Endpoints', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_AudioEndpointPlugin_FactoryCLSID: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x12d83bd7_cf12_46be_8540_812710d3021c), pid: 1u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_AudioEndpointPlugin_FactoryCLSID ) , guid : :: windows :: core :: GUID::from_u128(0x12d83bd7_cf12_46be_8540_812710d3021c) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Endpoints', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_AudioEndpointPlugin_PnPInterface: super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x12d83bd7_cf12_46be_8540_812710d3021c), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_AudioEndpointPlugin_PnPInterface ) , guid : :: windows :: core :: GUID::from_u128(0x12d83bd7_cf12_46be_8540_812710d3021c) , } }
 #[doc = "*Required features: 'Win32_Media_Audio_Endpoints'*"]
 pub type EndpointConnectorType = i32;
 #[doc = "*Required features: 'Win32_Media_Audio_Endpoints'*"]

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/mod.rs
@@ -1967,9 +1967,17 @@ pub const DEVICE_STATE_NOTPRESENT: u32 = 4u32;
 #[doc = "*Required features: 'Win32_Media_Audio'*"]
 pub const DEVICE_STATE_UNPLUGGED: u32 = 8u32;
 pub const DEVINTERFACE_AUDIO_CAPTURE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2eef81be_33fa_4800_9670_1cd474972c3f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVINTERFACE_AUDIO_CAPTURE ) , guid : :: windows :: core :: GUID::from_u128(0x2eef81be_33fa_4800_9670_1cd474972c3f) , } }
 pub const DEVINTERFACE_AUDIO_RENDER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe6327cad_dcec_4949_ae8a_991e976a79d2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVINTERFACE_AUDIO_RENDER ) , guid : :: windows :: core :: GUID::from_u128(0xe6327cad_dcec_4949_ae8a_991e976a79d2) , } }
 pub const DEVINTERFACE_MIDI_INPUT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x504be32c_ccf6_4d2c_b73f_6f8b3747e22b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVINTERFACE_MIDI_INPUT ) , guid : :: windows :: core :: GUID::from_u128(0x504be32c_ccf6_4d2c_b73f_6f8b3747e22b) , } }
 pub const DEVINTERFACE_MIDI_OUTPUT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6dc23320_ab33_4ce4_80d4_bbb3ebbf2814);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVINTERFACE_MIDI_OUTPUT ) , guid : :: windows :: core :: GUID::from_u128(0x6dc23320_ab33_4ce4_80d4_bbb3ebbf2814) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Media_Audio'*"]
 pub struct DIRECTX_AUDIO_ACTIVATION_PARAMS {
@@ -2077,6 +2085,8 @@ pub const eCommunications: ERole = 2i32;
 #[doc = "*Required features: 'Win32_Media_Audio'*"]
 pub const ERole_enum_count: ERole = 3i32;
 pub const EVENTCONTEXT_VOLUMESLIDER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe2c2e9de_09b1_4b04_84e5_07931225ee04);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( EVENTCONTEXT_VOLUMESLIDER ) , guid : :: windows :: core :: GUID::from_u128(0xe2c2e9de_09b1_4b04_84e5_07931225ee04) , } }
 #[doc = "*Required features: 'Win32_Media_Audio'*"]
 pub type EndpointFormFactor = i32;
 #[doc = "*Required features: 'Win32_Media_Audio'*"]
@@ -10053,51 +10063,83 @@ impl ::core::default::Default for PCMWAVEFORMAT {
 #[doc = "*Required features: 'Win32_Media_Audio', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AudioEndpointLogo_IconEffects: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf1ab780d_2010_4ed3_a3a6_8b87f0f0c476), pid: 0u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AudioEndpointLogo_IconEffects ) , guid : :: windows :: core :: GUID::from_u128(0xf1ab780d_2010_4ed3_a3a6_8b87f0f0c476) , } }
 #[doc = "*Required features: 'Win32_Media_Audio', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AudioEndpointLogo_IconPath: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf1ab780d_2010_4ed3_a3a6_8b87f0f0c476), pid: 1u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AudioEndpointLogo_IconPath ) , guid : :: windows :: core :: GUID::from_u128(0xf1ab780d_2010_4ed3_a3a6_8b87f0f0c476) , } }
 #[doc = "*Required features: 'Win32_Media_Audio', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AudioEndpointSettings_LaunchContract: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x14242002_0320_4de4_9555_a7d82b73c286), pid: 1u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AudioEndpointSettings_LaunchContract ) , guid : :: windows :: core :: GUID::from_u128(0x14242002_0320_4de4_9555_a7d82b73c286) , } }
 #[doc = "*Required features: 'Win32_Media_Audio', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AudioEndpointSettings_MenuText: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x14242002_0320_4de4_9555_a7d82b73c286), pid: 0u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AudioEndpointSettings_MenuText ) , guid : :: windows :: core :: GUID::from_u128(0x14242002_0320_4de4_9555_a7d82b73c286) , } }
 #[doc = "*Required features: 'Win32_Media_Audio', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AudioEndpoint_Association: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1da5d803_d492_4edd_8c23_e0c0ffee7f0e), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AudioEndpoint_Association ) , guid : :: windows :: core :: GUID::from_u128(0x1da5d803_d492_4edd_8c23_e0c0ffee7f0e) , } }
 #[doc = "*Required features: 'Win32_Media_Audio', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AudioEndpoint_ControlPanelPageProvider: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1da5d803_d492_4edd_8c23_e0c0ffee7f0e), pid: 1u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AudioEndpoint_ControlPanelPageProvider ) , guid : :: windows :: core :: GUID::from_u128(0x1da5d803_d492_4edd_8c23_e0c0ffee7f0e) , } }
 #[doc = "*Required features: 'Win32_Media_Audio', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AudioEndpoint_Default_VolumeInDb: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1da5d803_d492_4edd_8c23_e0c0ffee7f0e), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AudioEndpoint_Default_VolumeInDb ) , guid : :: windows :: core :: GUID::from_u128(0x1da5d803_d492_4edd_8c23_e0c0ffee7f0e) , } }
 #[doc = "*Required features: 'Win32_Media_Audio', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AudioEndpoint_Disable_SysFx: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1da5d803_d492_4edd_8c23_e0c0ffee7f0e), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AudioEndpoint_Disable_SysFx ) , guid : :: windows :: core :: GUID::from_u128(0x1da5d803_d492_4edd_8c23_e0c0ffee7f0e) , } }
 #[doc = "*Required features: 'Win32_Media_Audio', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AudioEndpoint_FormFactor: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1da5d803_d492_4edd_8c23_e0c0ffee7f0e), pid: 0u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AudioEndpoint_FormFactor ) , guid : :: windows :: core :: GUID::from_u128(0x1da5d803_d492_4edd_8c23_e0c0ffee7f0e) , } }
 #[doc = "*Required features: 'Win32_Media_Audio', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AudioEndpoint_FullRangeSpeakers: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1da5d803_d492_4edd_8c23_e0c0ffee7f0e), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AudioEndpoint_FullRangeSpeakers ) , guid : :: windows :: core :: GUID::from_u128(0x1da5d803_d492_4edd_8c23_e0c0ffee7f0e) , } }
 #[doc = "*Required features: 'Win32_Media_Audio', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AudioEndpoint_GUID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1da5d803_d492_4edd_8c23_e0c0ffee7f0e), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AudioEndpoint_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x1da5d803_d492_4edd_8c23_e0c0ffee7f0e) , } }
 #[doc = "*Required features: 'Win32_Media_Audio', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AudioEndpoint_JackSubType: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1da5d803_d492_4edd_8c23_e0c0ffee7f0e), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AudioEndpoint_JackSubType ) , guid : :: windows :: core :: GUID::from_u128(0x1da5d803_d492_4edd_8c23_e0c0ffee7f0e) , } }
 #[doc = "*Required features: 'Win32_Media_Audio', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AudioEndpoint_PhysicalSpeakers: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1da5d803_d492_4edd_8c23_e0c0ffee7f0e), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AudioEndpoint_PhysicalSpeakers ) , guid : :: windows :: core :: GUID::from_u128(0x1da5d803_d492_4edd_8c23_e0c0ffee7f0e) , } }
 #[doc = "*Required features: 'Win32_Media_Audio', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AudioEndpoint_Supports_EventDriven_Mode: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1da5d803_d492_4edd_8c23_e0c0ffee7f0e), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AudioEndpoint_Supports_EventDriven_Mode ) , guid : :: windows :: core :: GUID::from_u128(0x1da5d803_d492_4edd_8c23_e0c0ffee7f0e) , } }
 #[doc = "*Required features: 'Win32_Media_Audio', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AudioEngine_DeviceFormat: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf19f064d_082c_4e27_bc73_6882a1bb8e4c), pid: 0u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AudioEngine_DeviceFormat ) , guid : :: windows :: core :: GUID::from_u128(0xf19f064d_082c_4e27_bc73_6882a1bb8e4c) , } }
 #[doc = "*Required features: 'Win32_Media_Audio', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AudioEngine_OEMFormat: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe4870e26_3cc5_4cd2_ba46_ca0a9a70ed04), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AudioEngine_OEMFormat ) , guid : :: windows :: core :: GUID::from_u128(0xe4870e26_3cc5_4cd2_ba46_ca0a9a70ed04) , } }
 #[doc = "*Required features: 'Win32_Media_Audio'*"]
 pub type PROCESS_LOOPBACK_MODE = i32;
 #[doc = "*Required features: 'Win32_Media_Audio'*"]

--- a/crates/libs/windows/src/Windows/Win32/Media/DeviceManager/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DeviceManager/mod.rs
@@ -4,6 +4,8 @@ pub const ALLOW_OUTOFBAND_NOTIFICATION: u32 = 2u32;
 #[doc = "*Required features: 'Win32_Media_DeviceManager'*"]
 pub const DO_NOT_VIRTUALIZE_STORAGES_AS_DEVICES: u32 = 1u32;
 pub const EVENT_WMDM_CONTENT_TRANSFER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x339c9bf4_bcfe_4ed8_94df_eaf8c26ab61b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( EVENT_WMDM_CONTENT_TRANSFER ) , guid : :: windows :: core :: GUID::from_u128(0x339c9bf4_bcfe_4ed8_94df_eaf8c26ab61b) , } }
 #[doc = "*Required features: 'Win32_Media_DeviceManager'*"]
 #[repr(transparent)]
 pub struct IComponentAuthenticate(::windows::core::IUnknown);
@@ -6608,9 +6610,17 @@ pub const SAC_PROTOCOL_WMDM: u32 = 1u32;
 #[doc = "*Required features: 'Win32_Media_DeviceManager'*"]
 pub const SAC_SESSION_KEYLEN: u32 = 8u32;
 pub const SCP_EVENTID_ACQSECURECLOCK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x86248cc9_4a59_43e2_9146_48a7f3f4140c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SCP_EVENTID_ACQSECURECLOCK ) , guid : :: windows :: core :: GUID::from_u128(0x86248cc9_4a59_43e2_9146_48a7f3f4140c) , } }
 pub const SCP_EVENTID_DRMINFO: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x213dd287_41d2_432b_9e3f_3b4f7b3581dd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SCP_EVENTID_DRMINFO ) , guid : :: windows :: core :: GUID::from_u128(0x213dd287_41d2_432b_9e3f_3b4f7b3581dd) , } }
 pub const SCP_EVENTID_NEEDTOINDIV: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x87a507c7_b469_4386_b976_d5d1ce538a6f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SCP_EVENTID_NEEDTOINDIV ) , guid : :: windows :: core :: GUID::from_u128(0x87a507c7_b469_4386_b976_d5d1ce538a6f) , } }
 pub const SCP_PARAMID_DRMVERSION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x41d0155d_7cc7_4217_ada9_005074624da4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SCP_PARAMID_DRMVERSION ) , guid : :: windows :: core :: GUID::from_u128(0x41d0155d_7cc7_4217_ada9_005074624da4) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Media_DeviceManager'*"]
 pub struct WMDMDATETIME {
@@ -6906,8 +6916,14 @@ pub const WMDM_DEVICECAP_CANSTREAMRECORD: u32 = 8u32;
 #[doc = "*Required features: 'Win32_Media_DeviceManager'*"]
 pub const WMDM_DEVICECAP_HASSECURECLOCK: u32 = 256u32;
 pub const WMDM_DEVICE_PROTOCOL_MSC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa4d2c26c_a881_44bb_bd5d_1f703c71f7a9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMDM_DEVICE_PROTOCOL_MSC ) , guid : :: windows :: core :: GUID::from_u128(0xa4d2c26c_a881_44bb_bd5d_1f703c71f7a9) , } }
 pub const WMDM_DEVICE_PROTOCOL_MTP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x979e54e5_0afc_4604_8d93_dc798a4bcf45);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMDM_DEVICE_PROTOCOL_MTP ) , guid : :: windows :: core :: GUID::from_u128(0x979e54e5_0afc_4604_8d93_dc798a4bcf45) , } }
 pub const WMDM_DEVICE_PROTOCOL_RAPI: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2a11ed91_8c8f_41e4_82d1_8386e003561c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMDM_DEVICE_PROTOCOL_RAPI ) , guid : :: windows :: core :: GUID::from_u128(0x2a11ed91_8c8f_41e4_82d1_8386e003561c) , } }
 #[doc = "*Required features: 'Win32_Media_DeviceManager'*"]
 pub const WMDM_DEVICE_TYPE_DECODE: u32 = 4u32;
 #[doc = "*Required features: 'Win32_Media_DeviceManager'*"]
@@ -7518,6 +7534,8 @@ pub const WMDM_SEEK_REMOTECONTROL: u32 = 1u32;
 #[doc = "*Required features: 'Win32_Media_DeviceManager'*"]
 pub const WMDM_SEEK_STREAMINGAUDIO: u32 = 2u32;
 pub const WMDM_SERVICE_PROVIDER_VENDOR_MICROSOFT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7de8686d_78ee_43ea_a496_c625ac91cc5d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMDM_SERVICE_PROVIDER_VENDOR_MICROSOFT ) , guid : :: windows :: core :: GUID::from_u128(0x7de8686d_78ee_43ea_a496_c625ac91cc5d) , } }
 #[doc = "*Required features: 'Win32_Media_DeviceManager'*"]
 pub type WMDM_SESSION_TYPE = i32;
 #[doc = "*Required features: 'Win32_Media_DeviceManager'*"]

--- a/crates/libs/windows/src/Windows/Win32/Media/DirectShow/Xml/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DirectShow/Xml/mod.rs
@@ -1,5 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 pub const CLSID_XMLGraphBuilder: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1bb05961_5fbf_11d2_a521_44df07c10000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_XMLGraphBuilder ) , guid : :: windows :: core :: GUID::from_u128(0x1bb05961_5fbf_11d2_a521_44df07c10000) , } }
 #[doc = "*Required features: 'Win32_Media_DirectShow_Xml'*"]
 #[repr(transparent)]
 pub struct IXMLGraphBuilder(::windows::core::IUnknown);

--- a/crates/libs/windows/src/Windows/Win32/Media/DxMediaObjects/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DxMediaObjects/mod.rs
@@ -1,14 +1,34 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 pub const DMOCATEGORY_ACOUSTIC_ECHO_CANCEL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbf963d80_c559_11d0_8a2b_00a0c9255ac1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DMOCATEGORY_ACOUSTIC_ECHO_CANCEL ) , guid : :: windows :: core :: GUID::from_u128(0xbf963d80_c559_11d0_8a2b_00a0c9255ac1) , } }
 pub const DMOCATEGORY_AGC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe88c9ba0_c557_11d0_8a2b_00a0c9255ac1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DMOCATEGORY_AGC ) , guid : :: windows :: core :: GUID::from_u128(0xe88c9ba0_c557_11d0_8a2b_00a0c9255ac1) , } }
 pub const DMOCATEGORY_AUDIO_CAPTURE_EFFECT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf665aaba_3e09_4920_aa5f_219811148f09);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DMOCATEGORY_AUDIO_CAPTURE_EFFECT ) , guid : :: windows :: core :: GUID::from_u128(0xf665aaba_3e09_4920_aa5f_219811148f09) , } }
 pub const DMOCATEGORY_AUDIO_DECODER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x57f2db8b_e6bb_4513_9d43_dcd2a6593125);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DMOCATEGORY_AUDIO_DECODER ) , guid : :: windows :: core :: GUID::from_u128(0x57f2db8b_e6bb_4513_9d43_dcd2a6593125) , } }
 pub const DMOCATEGORY_AUDIO_EFFECT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf3602b3f_0592_48df_a4cd_674721e7ebeb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DMOCATEGORY_AUDIO_EFFECT ) , guid : :: windows :: core :: GUID::from_u128(0xf3602b3f_0592_48df_a4cd_674721e7ebeb) , } }
 pub const DMOCATEGORY_AUDIO_ENCODER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x33d9a761_90c8_11d0_bd43_00a0c911ce86);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DMOCATEGORY_AUDIO_ENCODER ) , guid : :: windows :: core :: GUID::from_u128(0x33d9a761_90c8_11d0_bd43_00a0c911ce86) , } }
 pub const DMOCATEGORY_AUDIO_NOISE_SUPPRESS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe07f903f_62fd_4e60_8cdd_dea7236665b5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DMOCATEGORY_AUDIO_NOISE_SUPPRESS ) , guid : :: windows :: core :: GUID::from_u128(0xe07f903f_62fd_4e60_8cdd_dea7236665b5) , } }
 pub const DMOCATEGORY_VIDEO_DECODER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4a69b442_28be_4991_969c_b500adf5d8a8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DMOCATEGORY_VIDEO_DECODER ) , guid : :: windows :: core :: GUID::from_u128(0x4a69b442_28be_4991_969c_b500adf5d8a8) , } }
 pub const DMOCATEGORY_VIDEO_EFFECT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd990ee14_776c_4723_be46_3da2f56f10b9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DMOCATEGORY_VIDEO_EFFECT ) , guid : :: windows :: core :: GUID::from_u128(0xd990ee14_776c_4723_be46_3da2f56f10b9) , } }
 pub const DMOCATEGORY_VIDEO_ENCODER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x33d9a760_90c8_11d0_bd43_00a0c911ce86);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DMOCATEGORY_VIDEO_ENCODER ) , guid : :: windows :: core :: GUID::from_u128(0x33d9a760_90c8_11d0_bd43_00a0c911ce86) , } }
 #[doc = "*Required features: 'Win32_Media_DxMediaObjects'*"]
 #[inline]
 pub unsafe fn DMOEnum(guidcategory: *const ::windows::core::GUID, dwflags: u32, cintypes: u32, pintypes: *const DMO_PARTIAL_MEDIATYPE, couttypes: u32, pouttypes: *const DMO_PARTIAL_MEDIATYPE) -> ::windows::core::Result<IEnumDMO> {

--- a/crates/libs/windows/src/Windows/Win32/Media/KernelStreaming/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/KernelStreaming/mod.rs
@@ -361,12 +361,18 @@ impl ::core::default::Default for DEVCAPS {
 #[doc = "*Required features: 'Win32_Media_KernelStreaming', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_KsAudio_Controller_DeviceInterface_Path: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x13e004d6_b066_43bd_913b_a415cd13da87), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_KsAudio_Controller_DeviceInterface_Path ) , guid : :: windows :: core :: GUID::from_u128(0x13e004d6_b066_43bd_913b_a415cd13da87) , } }
 #[doc = "*Required features: 'Win32_Media_KernelStreaming', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_KsAudio_PacketSize_Constraints: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x13e004d6_b066_43bd_913b_a415cd13da87), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_KsAudio_PacketSize_Constraints ) , guid : :: windows :: core :: GUID::from_u128(0x13e004d6_b066_43bd_913b_a415cd13da87) , } }
 #[doc = "*Required features: 'Win32_Media_KernelStreaming', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_KsAudio_PacketSize_Constraints2: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9404f781_7191_409b_8b0b_80bf6ec229ae), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_KsAudio_PacketSize_Constraints2 ) , guid : :: windows :: core :: GUID::from_u128(0x9404f781_7191_409b_8b0b_80bf6ec229ae) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Media_KernelStreaming'*"]
 pub struct DS3DVECTOR {

--- a/crates/libs/windows/src/Windows/Win32/Media/MediaPlayer/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/MediaPlayer/mod.rs
@@ -1,7 +1,13 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 pub const CLSID_WMPMediaPluginRegistrar: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5569e7f5_424b_4b93_89ca_79d17924689a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WMPMediaPluginRegistrar ) , guid : :: windows :: core :: GUID::from_u128(0x5569e7f5_424b_4b93_89ca_79d17924689a) , } }
 pub const CLSID_WMPSkinManager: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb2a7fd52_301f_4348_b93a_638c6de49229);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WMPSkinManager ) , guid : :: windows :: core :: GUID::from_u128(0xb2a7fd52_301f_4348_b93a_638c6de49229) , } }
 pub const CLSID_XFeedsManager: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfe6b11c3_c72e_4061_86c6_9d163121f229);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_XFeedsManager ) , guid : :: windows :: core :: GUID::from_u128(0xfe6b11c3_c72e_4061_86c6_9d163121f229) , } }
 #[doc = "*Required features: 'Win32_Media_MediaPlayer'*"]
 pub const DISPID_DELTA: u32 = 50u32;
 #[doc = "*Required features: 'Win32_Media_MediaPlayer'*"]
@@ -19226,8 +19232,14 @@ pub const WMP_MDRT_FLAGS_UNREPORTED_ADDED_ITEMS: u32 = 2u32;
 #[doc = "*Required features: 'Win32_Media_MediaPlayer'*"]
 pub const WMP_MDRT_FLAGS_UNREPORTED_DELETED_ITEMS: u32 = 1u32;
 pub const WMP_PLUGINTYPE_DSP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6434baea_4954_498d_abd5_2b07123e1f04);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMP_PLUGINTYPE_DSP ) , guid : :: windows :: core :: GUID::from_u128(0x6434baea_4954_498d_abd5_2b07123e1f04) , } }
 pub const WMP_PLUGINTYPE_DSP_OUTOFPROC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xef29b174_c347_44cc_9a4f_2399118ff38c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMP_PLUGINTYPE_DSP_OUTOFPROC ) , guid : :: windows :: core :: GUID::from_u128(0xef29b174_c347_44cc_9a4f_2399118ff38c) , } }
 pub const WMP_PLUGINTYPE_RENDERING: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa8554541_115d_406a_a4c7_51111c330183);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMP_PLUGINTYPE_RENDERING ) , guid : :: windows :: core :: GUID::from_u128(0xa8554541_115d_406a_a4c7_51111c330183) , } }
 #[repr(C, packed(1))]
 #[doc = "*Required features: 'Win32_Media_MediaPlayer'*"]
 pub struct WMP_WMDM_METADATA_ROUND_TRIP_DEVICE2PC {
@@ -19285,79 +19297,227 @@ impl ::core::default::Default for WMP_WMDM_METADATA_ROUND_TRIP_PC2DEVICE {
     }
 }
 pub const WMProfile_V40_100Video: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8f99ddd8_6684_456b_a0a3_33e1316895f0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V40_100Video ) , guid : :: windows :: core :: GUID::from_u128(0x8f99ddd8_6684_456b_a0a3_33e1316895f0) , } }
 pub const WMProfile_V40_128Audio: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x93ddbe12_13dc_4e32_a35e_40378e34279a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V40_128Audio ) , guid : :: windows :: core :: GUID::from_u128(0x93ddbe12_13dc_4e32_a35e_40378e34279a) , } }
 pub const WMProfile_V40_16AMRadio: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0f4be81f_d57d_41e1_b2e3_2fad986bfec2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V40_16AMRadio ) , guid : :: windows :: core :: GUID::from_u128(0x0f4be81f_d57d_41e1_b2e3_2fad986bfec2) , } }
 pub const WMProfile_V40_1MBVideo: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb4482a4c_cc17_4b07_a94e_9818d5e0f13f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V40_1MBVideo ) , guid : :: windows :: core :: GUID::from_u128(0xb4482a4c_cc17_4b07_a94e_9818d5e0f13f) , } }
 pub const WMProfile_V40_250Video: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x541841c3_9339_4f7b_9a22_b11540894e42);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V40_250Video ) , guid : :: windows :: core :: GUID::from_u128(0x541841c3_9339_4f7b_9a22_b11540894e42) , } }
 pub const WMProfile_V40_2856100MBR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5a1c2206_dc5e_4186_beb2_4c5a994b132e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V40_2856100MBR ) , guid : :: windows :: core :: GUID::from_u128(0x5a1c2206_dc5e_4186_beb2_4c5a994b132e) , } }
 pub const WMProfile_V40_288FMRadioMono: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7fa57fc8_6ea4_4645_8abf_b6e5a8f814a1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V40_288FMRadioMono ) , guid : :: windows :: core :: GUID::from_u128(0x7fa57fc8_6ea4_4645_8abf_b6e5a8f814a1) , } }
 pub const WMProfile_V40_288FMRadioStereo: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x22fcf466_aa40_431f_a289_06d0ea1a1e40);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V40_288FMRadioStereo ) , guid : :: windows :: core :: GUID::from_u128(0x22fcf466_aa40_431f_a289_06d0ea1a1e40) , } }
 pub const WMProfile_V40_288VideoAudio: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xac617f2d_6cbe_4e84_8e9a_ce151a12a354);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V40_288VideoAudio ) , guid : :: windows :: core :: GUID::from_u128(0xac617f2d_6cbe_4e84_8e9a_ce151a12a354) , } }
 pub const WMProfile_V40_288VideoVoice: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbb2bc274_0eb6_4da9_b550_ecf7f2b9948f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V40_288VideoVoice ) , guid : :: windows :: core :: GUID::from_u128(0xbb2bc274_0eb6_4da9_b550_ecf7f2b9948f) , } }
 pub const WMProfile_V40_288VideoWebServer: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xabf2f00d_d555_4815_94ce_8275f3a70bfe);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V40_288VideoWebServer ) , guid : :: windows :: core :: GUID::from_u128(0xabf2f00d_d555_4815_94ce_8275f3a70bfe) , } }
 pub const WMProfile_V40_3MBVideo: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x55374ac0_309b_4396_b88f_e6e292113f28);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V40_3MBVideo ) , guid : :: windows :: core :: GUID::from_u128(0x55374ac0_309b_4396_b88f_e6e292113f28) , } }
 pub const WMProfile_V40_512Video: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x70440e6d_c4ef_4f84_8cd0_d5c28686e784);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V40_512Video ) , guid : :: windows :: core :: GUID::from_u128(0x70440e6d_c4ef_4f84_8cd0_d5c28686e784) , } }
 pub const WMProfile_V40_56DialUpStereo: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe8026f87_e905_4594_a3c7_00d00041d1d9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V40_56DialUpStereo ) , guid : :: windows :: core :: GUID::from_u128(0xe8026f87_e905_4594_a3c7_00d00041d1d9) , } }
 pub const WMProfile_V40_56DialUpVideo: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe21713bb_652f_4dab_99de_71e04400270f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V40_56DialUpVideo ) , guid : :: windows :: core :: GUID::from_u128(0xe21713bb_652f_4dab_99de_71e04400270f) , } }
 pub const WMProfile_V40_56DialUpVideoWebServer: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb756ff10_520f_4749_a399_b780e2fc9250);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V40_56DialUpVideoWebServer ) , guid : :: windows :: core :: GUID::from_u128(0xb756ff10_520f_4749_a399_b780e2fc9250) , } }
 pub const WMProfile_V40_64Audio: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4820b3f7_cbec_41dc_9391_78598714c8e5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V40_64Audio ) , guid : :: windows :: core :: GUID::from_u128(0x4820b3f7_cbec_41dc_9391_78598714c8e5) , } }
 pub const WMProfile_V40_6VoiceAudio: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd508978a_11a0_4d15_b0da_acdc99d4f890);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V40_6VoiceAudio ) , guid : :: windows :: core :: GUID::from_u128(0xd508978a_11a0_4d15_b0da_acdc99d4f890) , } }
 pub const WMProfile_V40_96Audio: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0efa0ee3_9e64_41e2_837f_3c0038f327ba);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V40_96Audio ) , guid : :: windows :: core :: GUID::from_u128(0x0efa0ee3_9e64_41e2_837f_3c0038f327ba) , } }
 pub const WMProfile_V40_DialUpMBR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfd7f47f1_72a6_45a4_80f0_3aecefc32c07);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V40_DialUpMBR ) , guid : :: windows :: core :: GUID::from_u128(0xfd7f47f1_72a6_45a4_80f0_3aecefc32c07) , } }
 pub const WMProfile_V40_IntranetMBR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x82cd3321_a94a_4ffc_9c2b_092c10ca16e7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V40_IntranetMBR ) , guid : :: windows :: core :: GUID::from_u128(0x82cd3321_a94a_4ffc_9c2b_092c10ca16e7) , } }
 pub const WMProfile_V70_100Video: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd9f3c932_5ea9_4c6d_89b4_2686e515426e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V70_100Video ) , guid : :: windows :: core :: GUID::from_u128(0xd9f3c932_5ea9_4c6d_89b4_2686e515426e) , } }
 pub const WMProfile_V70_128Audio: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc64cf5da_df45_40d3_8027_de698d68dc66);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V70_128Audio ) , guid : :: windows :: core :: GUID::from_u128(0xc64cf5da_df45_40d3_8027_de698d68dc66) , } }
 pub const WMProfile_V70_1500FilmContentVideo: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf6a5f6df_ee3f_434c_a433_523ce55f516b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V70_1500FilmContentVideo ) , guid : :: windows :: core :: GUID::from_u128(0xf6a5f6df_ee3f_434c_a433_523ce55f516b) , } }
 pub const WMProfile_V70_1500Video: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0b89164a_5490_4686_9e37_5a80884e5146);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V70_1500Video ) , guid : :: windows :: core :: GUID::from_u128(0x0b89164a_5490_4686_9e37_5a80884e5146) , } }
 pub const WMProfile_V70_150VideoPDA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0f472967_e3c6_4797_9694_f0304c5e2f17);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V70_150VideoPDA ) , guid : :: windows :: core :: GUID::from_u128(0x0f472967_e3c6_4797_9694_f0304c5e2f17) , } }
 pub const WMProfile_V70_2000Video: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaa980124_bf10_4e4f_9afd_4329a7395cff);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V70_2000Video ) , guid : :: windows :: core :: GUID::from_u128(0xaa980124_bf10_4e4f_9afd_4329a7395cff) , } }
 pub const WMProfile_V70_225VideoPDA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf55ea573_4c02_42b5_9026_a8260c438a9f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V70_225VideoPDA ) , guid : :: windows :: core :: GUID::from_u128(0xf55ea573_4c02_42b5_9026_a8260c438a9f) , } }
 pub const WMProfile_V70_256Video: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xafe69b3a_403f_4a1b_8007_0e21cfb3df84);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V70_256Video ) , guid : :: windows :: core :: GUID::from_u128(0xafe69b3a_403f_4a1b_8007_0e21cfb3df84) , } }
 pub const WMProfile_V70_2856100MBR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x07df7a25_3fe2_4a5b_8b1e_348b0721ca70);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V70_2856100MBR ) , guid : :: windows :: core :: GUID::from_u128(0x07df7a25_3fe2_4a5b_8b1e_348b0721ca70) , } }
 pub const WMProfile_V70_288FMRadioMono: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc012a833_a03b_44a5_96dc_ed95cc65582d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V70_288FMRadioMono ) , guid : :: windows :: core :: GUID::from_u128(0xc012a833_a03b_44a5_96dc_ed95cc65582d) , } }
 pub const WMProfile_V70_288FMRadioStereo: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe96d67c9_1a39_4dc4_b900_b1184dc83620);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V70_288FMRadioStereo ) , guid : :: windows :: core :: GUID::from_u128(0xe96d67c9_1a39_4dc4_b900_b1184dc83620) , } }
 pub const WMProfile_V70_288VideoAudio: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x58bba0ee_896a_4948_9953_85b736f83947);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V70_288VideoAudio ) , guid : :: windows :: core :: GUID::from_u128(0x58bba0ee_896a_4948_9953_85b736f83947) , } }
 pub const WMProfile_V70_288VideoVoice: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb952f38e_7dbc_4533_a9ca_b00b1c6e9800);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V70_288VideoVoice ) , guid : :: windows :: core :: GUID::from_u128(0xb952f38e_7dbc_4533_a9ca_b00b1c6e9800) , } }
 pub const WMProfile_V70_288VideoWebServer: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x70a32e2b_e2df_4ebd_9105_d9ca194a2d50);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V70_288VideoWebServer ) , guid : :: windows :: core :: GUID::from_u128(0x70a32e2b_e2df_4ebd_9105_d9ca194a2d50) , } }
 pub const WMProfile_V70_384Video: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf3d45fbb_8782_44df_97c6_8678e2f9b13d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V70_384Video ) , guid : :: windows :: core :: GUID::from_u128(0xf3d45fbb_8782_44df_97c6_8678e2f9b13d) , } }
 pub const WMProfile_V70_56DialUpStereo: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x674ee767_0949_4fac_875e_f4c9c292013b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V70_56DialUpStereo ) , guid : :: windows :: core :: GUID::from_u128(0x674ee767_0949_4fac_875e_f4c9c292013b) , } }
 pub const WMProfile_V70_56VideoWebServer: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdef99e40_57bc_4ab3_b2d1_b6e3caf64257);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V70_56VideoWebServer ) , guid : :: windows :: core :: GUID::from_u128(0xdef99e40_57bc_4ab3_b2d1_b6e3caf64257) , } }
 pub const WMProfile_V70_64Audio: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb29cffc6_f131_41db_b5e8_99d8b0b945f4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V70_64Audio ) , guid : :: windows :: core :: GUID::from_u128(0xb29cffc6_f131_41db_b5e8_99d8b0b945f4) , } }
 pub const WMProfile_V70_64AudioISDN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x91dea458_9d60_4212_9c59_d40919c939e4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V70_64AudioISDN ) , guid : :: windows :: core :: GUID::from_u128(0x91dea458_9d60_4212_9c59_d40919c939e4) , } }
 pub const WMProfile_V70_64VideoISDN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc2b7a7e9_7b8e_4992_a1a1_068217a3b311);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V70_64VideoISDN ) , guid : :: windows :: core :: GUID::from_u128(0xc2b7a7e9_7b8e_4992_a1a1_068217a3b311) , } }
 pub const WMProfile_V70_6VoiceAudio: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xeaba9fbf_b64f_49b3_aa0c_73fbdd150ad0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V70_6VoiceAudio ) , guid : :: windows :: core :: GUID::from_u128(0xeaba9fbf_b64f_49b3_aa0c_73fbdd150ad0) , } }
 pub const WMProfile_V70_700FilmContentVideo: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7a747920_2449_4d76_99cb_fdb0c90484d4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V70_700FilmContentVideo ) , guid : :: windows :: core :: GUID::from_u128(0x7a747920_2449_4d76_99cb_fdb0c90484d4) , } }
 pub const WMProfile_V70_768Video: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0326ebb6_f76e_4964_b0db_e729978d35ee);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V70_768Video ) , guid : :: windows :: core :: GUID::from_u128(0x0326ebb6_f76e_4964_b0db_e729978d35ee) , } }
 pub const WMProfile_V70_96Audio: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa9d4b819_16cc_4a59_9f37_693dbb0302d6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V70_96Audio ) , guid : :: windows :: core :: GUID::from_u128(0xa9d4b819_16cc_4a59_9f37_693dbb0302d6) , } }
 pub const WMProfile_V70_DialUpMBR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5b16e74b_4068_45b5_b80e_7bf8c80d2c2f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V70_DialUpMBR ) , guid : :: windows :: core :: GUID::from_u128(0x5b16e74b_4068_45b5_b80e_7bf8c80d2c2f) , } }
 pub const WMProfile_V70_IntranetMBR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x045880dc_34b6_4ca9_a326_73557ed143f3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V70_IntranetMBR ) , guid : :: windows :: core :: GUID::from_u128(0x045880dc_34b6_4ca9_a326_73557ed143f3) , } }
 pub const WMProfile_V80_100768VideoMBR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5bdb5a0e_979e_47d3_9596_73b386392a55);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V80_100768VideoMBR ) , guid : :: windows :: core :: GUID::from_u128(0x5bdb5a0e_979e_47d3_9596_73b386392a55) , } }
 pub const WMProfile_V80_100Video: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa2e300b4_c2d4_4fc0_b5dd_ecbd948dc0df);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V80_100Video ) , guid : :: windows :: core :: GUID::from_u128(0xa2e300b4_c2d4_4fc0_b5dd_ecbd948dc0df) , } }
 pub const WMProfile_V80_128StereoAudio: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x407b9450_8bdc_4ee5_88b8_6f527bd941f2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V80_128StereoAudio ) , guid : :: windows :: core :: GUID::from_u128(0x407b9450_8bdc_4ee5_88b8_6f527bd941f2) , } }
 pub const WMProfile_V80_1400NTSCVideo: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x931d1bee_617a_4bcd_9905_ccd0786683ee);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V80_1400NTSCVideo ) , guid : :: windows :: core :: GUID::from_u128(0x931d1bee_617a_4bcd_9905_ccd0786683ee) , } }
 pub const WMProfile_V80_150VideoPDA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaee16dfa_2c14_4a2f_ad3f_a3034031784f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V80_150VideoPDA ) , guid : :: windows :: core :: GUID::from_u128(0xaee16dfa_2c14_4a2f_ad3f_a3034031784f) , } }
 pub const WMProfile_V80_255VideoPDA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfeedbcdf_3fac_4c93_ac0d_47941ec72c0b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V80_255VideoPDA ) , guid : :: windows :: core :: GUID::from_u128(0xfeedbcdf_3fac_4c93_ac0d_47941ec72c0b) , } }
 pub const WMProfile_V80_256Video: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbbc75500_33d2_4466_b86b_122b201cc9ae);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V80_256Video ) , guid : :: windows :: core :: GUID::from_u128(0xbbc75500_33d2_4466_b86b_122b201cc9ae) , } }
 pub const WMProfile_V80_288100VideoMBR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd8722c69_2419_4b36_b4e0_6e17b60564e5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V80_288100VideoMBR ) , guid : :: windows :: core :: GUID::from_u128(0xd8722c69_2419_4b36_b4e0_6e17b60564e5) , } }
 pub const WMProfile_V80_28856VideoMBR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd66920c4_c21f_4ec8_a0b4_95cf2bd57fc4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V80_28856VideoMBR ) , guid : :: windows :: core :: GUID::from_u128(0xd66920c4_c21f_4ec8_a0b4_95cf2bd57fc4) , } }
 pub const WMProfile_V80_288MonoAudio: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7ea3126d_e1ba_4716_89af_f65cee0c0c67);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V80_288MonoAudio ) , guid : :: windows :: core :: GUID::from_u128(0x7ea3126d_e1ba_4716_89af_f65cee0c0c67) , } }
 pub const WMProfile_V80_288StereoAudio: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7e4cab5c_35dc_45bb_a7c0_19b28070d0cc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V80_288StereoAudio ) , guid : :: windows :: core :: GUID::from_u128(0x7e4cab5c_35dc_45bb_a7c0_19b28070d0cc) , } }
 pub const WMProfile_V80_288Video: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3df678d9_1352_4186_bbf8_74f0c19b6ae2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V80_288Video ) , guid : :: windows :: core :: GUID::from_u128(0x3df678d9_1352_4186_bbf8_74f0c19b6ae2) , } }
 pub const WMProfile_V80_288VideoOnly: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8c45b4c7_4aeb_4f78_a5ec_88420b9dadef);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V80_288VideoOnly ) , guid : :: windows :: core :: GUID::from_u128(0x8c45b4c7_4aeb_4f78_a5ec_88420b9dadef) , } }
 pub const WMProfile_V80_32StereoAudio: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x60907f9f_b352_47e5_b210_0ef1f47e9f9d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V80_32StereoAudio ) , guid : :: windows :: core :: GUID::from_u128(0x60907f9f_b352_47e5_b210_0ef1f47e9f9d) , } }
 pub const WMProfile_V80_384PALVideo: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9227c692_ae62_4f72_a7ea_736062d0e21e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V80_384PALVideo ) , guid : :: windows :: core :: GUID::from_u128(0x9227c692_ae62_4f72_a7ea_736062d0e21e) , } }
 pub const WMProfile_V80_384Video: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x29b00c2b_09a9_48bd_ad09_cdae117d1da7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V80_384Video ) , guid : :: windows :: core :: GUID::from_u128(0x29b00c2b_09a9_48bd_ad09_cdae117d1da7) , } }
 pub const WMProfile_V80_48StereoAudio: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5ee06be5_492b_480a_8a8f_12f373ecf9d4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V80_48StereoAudio ) , guid : :: windows :: core :: GUID::from_u128(0x5ee06be5_492b_480a_8a8f_12f373ecf9d4) , } }
 pub const WMProfile_V80_56Video: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x254e8a96_2612_405c_8039_f0bf725ced7d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V80_56Video ) , guid : :: windows :: core :: GUID::from_u128(0x254e8a96_2612_405c_8039_f0bf725ced7d) , } }
 pub const WMProfile_V80_56VideoOnly: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6e2a6955_81df_4943_ba50_68a986a708f6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V80_56VideoOnly ) , guid : :: windows :: core :: GUID::from_u128(0x6e2a6955_81df_4943_ba50_68a986a708f6) , } }
 pub const WMProfile_V80_64StereoAudio: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x09bb5bc4_3176_457f_8dd6_3cd919123e2d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V80_64StereoAudio ) , guid : :: windows :: core :: GUID::from_u128(0x09bb5bc4_3176_457f_8dd6_3cd919123e2d) , } }
 pub const WMProfile_V80_700NTSCVideo: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc8c2985f_e5d9_4538_9e23_9b21bf78f745);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V80_700NTSCVideo ) , guid : :: windows :: core :: GUID::from_u128(0xc8c2985f_e5d9_4538_9e23_9b21bf78f745) , } }
 pub const WMProfile_V80_700PALVideo: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xec298949_639b_45e2_96fd_4ab32d5919c2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V80_700PALVideo ) , guid : :: windows :: core :: GUID::from_u128(0xec298949_639b_45e2_96fd_4ab32d5919c2) , } }
 pub const WMProfile_V80_768Video: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x74d01102_e71a_4820_8f0d_13d2ec1e4872);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V80_768Video ) , guid : :: windows :: core :: GUID::from_u128(0x74d01102_e71a_4820_8f0d_13d2ec1e4872) , } }
 pub const WMProfile_V80_96StereoAudio: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1fc81930_61f2_436f_9d33_349f2a1c0f10);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V80_96StereoAudio ) , guid : :: windows :: core :: GUID::from_u128(0x1fc81930_61f2_436f_9d33_349f2a1c0f10) , } }
 pub const WMProfile_V80_BESTVBRVideo: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x048439ba_309c_440e_9cb4_3dcca3756423);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V80_BESTVBRVideo ) , guid : :: windows :: core :: GUID::from_u128(0x048439ba_309c_440e_9cb4_3dcca3756423) , } }
 pub const WMProfile_V80_FAIRVBRVideo: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3510a862_5850_4886_835f_d78ec6a64042);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V80_FAIRVBRVideo ) , guid : :: windows :: core :: GUID::from_u128(0x3510a862_5850_4886_835f_d78ec6a64042) , } }
 pub const WMProfile_V80_HIGHVBRVideo: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0f10d9d3_3b04_4fb0_a3d3_88d4ac854acc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMProfile_V80_HIGHVBRVideo ) , guid : :: windows :: core :: GUID::from_u128(0x0f10d9d3_3b04_4fb0_a3d3_88d4ac854acc) , } }
 pub const WindowsMediaPlayer: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6bf52a52_394a_11d3_b153_00c04f79faa6);
 #[doc = "*Required features: 'Win32_Media_MediaPlayer'*"]
 #[repr(transparent)]

--- a/crates/libs/windows/src/Windows/Win32/Media/Multimedia/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Multimedia/mod.rs
@@ -1635,7 +1635,11 @@ impl ::core::default::Default for CHANNEL_CAPS {
     }
 }
 pub const CLSID_AVIFile: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x00020000_0000_0000_c000_000000000046);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_AVIFile ) , guid : :: windows :: core :: GUID::from_u128(0x00020000_0000_0000_c000_000000000046) , } }
 pub const CLSID_AVISimpleUnMarshal: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x00020009_0000_0000_c000_000000000046);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_AVISimpleUnMarshal ) , guid : :: windows :: core :: GUID::from_u128(0x00020009_0000_0000_c000_000000000046) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Media_Multimedia', 'Win32_Graphics_Gdi'*"]
 #[cfg(feature = "Win32_Graphics_Gdi")]

--- a/crates/libs/windows/src/Windows/Win32/Media/PictureAcquisition/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/PictureAcquisition/mod.rs
@@ -1291,30 +1291,48 @@ pub const PHOTOACQ_RUN_DEFAULT: u32 = 0u32;
 #[doc = "*Required features: 'Win32_Media_PictureAcquisition', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PhotoAcquire_CameraSequenceNumber: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f23377_7ac6_4b7a_8443_345e731fa57a), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PhotoAcquire_CameraSequenceNumber ) , guid : :: windows :: core :: GUID::from_u128(0x00f23377_7ac6_4b7a_8443_345e731fa57a) , } }
 #[doc = "*Required features: 'Win32_Media_PictureAcquisition', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PhotoAcquire_DuplicateDetectionID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f23377_7ac6_4b7a_8443_345e731fa57a), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PhotoAcquire_DuplicateDetectionID ) , guid : :: windows :: core :: GUID::from_u128(0x00f23377_7ac6_4b7a_8443_345e731fa57a) , } }
 #[doc = "*Required features: 'Win32_Media_PictureAcquisition', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PhotoAcquire_FinalFilename: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f23377_7ac6_4b7a_8443_345e731fa57a), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PhotoAcquire_FinalFilename ) , guid : :: windows :: core :: GUID::from_u128(0x00f23377_7ac6_4b7a_8443_345e731fa57a) , } }
 #[doc = "*Required features: 'Win32_Media_PictureAcquisition', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PhotoAcquire_GroupTag: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f23377_7ac6_4b7a_8443_345e731fa57a), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PhotoAcquire_GroupTag ) , guid : :: windows :: core :: GUID::from_u128(0x00f23377_7ac6_4b7a_8443_345e731fa57a) , } }
 #[doc = "*Required features: 'Win32_Media_PictureAcquisition', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PhotoAcquire_IntermediateFile: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f23377_7ac6_4b7a_8443_345e731fa57a), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PhotoAcquire_IntermediateFile ) , guid : :: windows :: core :: GUID::from_u128(0x00f23377_7ac6_4b7a_8443_345e731fa57a) , } }
 #[doc = "*Required features: 'Win32_Media_PictureAcquisition', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PhotoAcquire_OriginalFilename: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f23377_7ac6_4b7a_8443_345e731fa57a), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PhotoAcquire_OriginalFilename ) , guid : :: windows :: core :: GUID::from_u128(0x00f23377_7ac6_4b7a_8443_345e731fa57a) , } }
 #[doc = "*Required features: 'Win32_Media_PictureAcquisition', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PhotoAcquire_RelativePathname: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f23377_7ac6_4b7a_8443_345e731fa57a), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PhotoAcquire_RelativePathname ) , guid : :: windows :: core :: GUID::from_u128(0x00f23377_7ac6_4b7a_8443_345e731fa57a) , } }
 #[doc = "*Required features: 'Win32_Media_PictureAcquisition', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PhotoAcquire_SkipImport: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f23377_7ac6_4b7a_8443_345e731fa57a), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PhotoAcquire_SkipImport ) , guid : :: windows :: core :: GUID::from_u128(0x00f23377_7ac6_4b7a_8443_345e731fa57a) , } }
 #[doc = "*Required features: 'Win32_Media_PictureAcquisition', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PhotoAcquire_TransferResult: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f23377_7ac6_4b7a_8443_345e731fa57a), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PhotoAcquire_TransferResult ) , guid : :: windows :: core :: GUID::from_u128(0x00f23377_7ac6_4b7a_8443_345e731fa57a) , } }
 #[doc = "*Required features: 'Win32_Media_PictureAcquisition'*"]
 pub type PROGRESS_DIALOG_CHECKBOX_ID = i32;
 #[doc = "*Required features: 'Win32_Media_PictureAcquisition'*"]

--- a/crates/libs/windows/src/Windows/Win32/Media/WindowsMediaFormat/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/WindowsMediaFormat/mod.rs
@@ -31,12 +31,26 @@ impl ::core::default::Default for AM_WMT_EVENT_DATA {
     }
 }
 pub const CLSID_ClientNetManager: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcd12a3ce_9c42_11d2_beed_0060082f2054);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_ClientNetManager ) , guid : :: windows :: core :: GUID::from_u128(0xcd12a3ce_9c42_11d2_beed_0060082f2054) , } }
 pub const CLSID_WMBandwidthSharing_Exclusive: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaf6060aa_5197_11d2_b6af_00c04fd908e9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WMBandwidthSharing_Exclusive ) , guid : :: windows :: core :: GUID::from_u128(0xaf6060aa_5197_11d2_b6af_00c04fd908e9) , } }
 pub const CLSID_WMBandwidthSharing_Partial: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaf6060ab_5197_11d2_b6af_00c04fd908e9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WMBandwidthSharing_Partial ) , guid : :: windows :: core :: GUID::from_u128(0xaf6060ab_5197_11d2_b6af_00c04fd908e9) , } }
 pub const CLSID_WMMUTEX_Bitrate: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd6e22a01_35da_11d1_9034_00a0c90349be);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WMMUTEX_Bitrate ) , guid : :: windows :: core :: GUID::from_u128(0xd6e22a01_35da_11d1_9034_00a0c90349be) , } }
 pub const CLSID_WMMUTEX_Language: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd6e22a00_35da_11d1_9034_00a0c90349be);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WMMUTEX_Language ) , guid : :: windows :: core :: GUID::from_u128(0xd6e22a00_35da_11d1_9034_00a0c90349be) , } }
 pub const CLSID_WMMUTEX_Presentation: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd6e22a02_35da_11d1_9034_00a0c90349be);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WMMUTEX_Presentation ) , guid : :: windows :: core :: GUID::from_u128(0xd6e22a02_35da_11d1_9034_00a0c90349be) , } }
 pub const CLSID_WMMUTEX_Unknown: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd6e22a03_35da_11d1_9034_00a0c90349be);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WMMUTEX_Unknown ) , guid : :: windows :: core :: GUID::from_u128(0xd6e22a03_35da_11d1_9034_00a0c90349be) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Media_WindowsMediaFormat'*"]
 pub struct DRM_COPY_OPL {
@@ -13808,10 +13822,20 @@ impl ::core::default::Default for WMDRM_IMPORT_INIT_STRUCT {
 #[doc = "*Required features: 'Win32_Media_WindowsMediaFormat'*"]
 pub const WMDRM_IMPORT_INIT_STRUCT_DEFINED: u32 = 1u32;
 pub const WMFORMAT_MPEG2Video: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe06d80e3_db46_11cf_b4d1_00805f6cbbea);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMFORMAT_MPEG2Video ) , guid : :: windows :: core :: GUID::from_u128(0xe06d80e3_db46_11cf_b4d1_00805f6cbbea) , } }
 pub const WMFORMAT_Script: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5c8510f2_debe_4ca7_bba5_f07a104f8dff);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMFORMAT_Script ) , guid : :: windows :: core :: GUID::from_u128(0x5c8510f2_debe_4ca7_bba5_f07a104f8dff) , } }
 pub const WMFORMAT_VideoInfo: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x05589f80_c356_11ce_bf01_00aa0055595a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMFORMAT_VideoInfo ) , guid : :: windows :: core :: GUID::from_u128(0x05589f80_c356_11ce_bf01_00aa0055595a) , } }
 pub const WMFORMAT_WaveFormatEx: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x05589f81_c356_11ce_bf01_00aa0055595a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMFORMAT_WaveFormatEx ) , guid : :: windows :: core :: GUID::from_u128(0x05589f81_c356_11ce_bf01_00aa0055595a) , } }
 pub const WMFORMAT_WebStream: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xda1e6b13_8359_4050_b398_388e965bf00c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMFORMAT_WebStream ) , guid : :: windows :: core :: GUID::from_u128(0xda1e6b13_8359_4050_b398_388e965bf00c) , } }
 #[doc = "*Required features: 'Win32_Media_WindowsMediaFormat', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
@@ -13828,53 +13852,149 @@ pub unsafe fn WMIsContentProtected<'a, Param0: ::windows::core::IntoParam<'a, su
     unimplemented!("Unsupported target OS");
 }
 pub const WMMEDIASUBTYPE_ACELPnet: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x00000130_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_ACELPnet ) , guid : :: windows :: core :: GUID::from_u128(0x00000130_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_Base: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x00000000_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_Base ) , guid : :: windows :: core :: GUID::from_u128(0x00000000_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_DRM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x00000009_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_DRM ) , guid : :: windows :: core :: GUID::from_u128(0x00000009_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_I420: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x30323449_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_I420 ) , guid : :: windows :: core :: GUID::from_u128(0x30323449_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_IYUV: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x56555949_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_IYUV ) , guid : :: windows :: core :: GUID::from_u128(0x56555949_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_M4S2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3253344d_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_M4S2 ) , guid : :: windows :: core :: GUID::from_u128(0x3253344d_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_MP3: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x00000055_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_MP3 ) , guid : :: windows :: core :: GUID::from_u128(0x00000055_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_MP43: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3334504d_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_MP43 ) , guid : :: windows :: core :: GUID::from_u128(0x3334504d_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_MP4S: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5334504d_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_MP4S ) , guid : :: windows :: core :: GUID::from_u128(0x5334504d_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_MPEG2_VIDEO: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe06d8026_db46_11cf_b4d1_00805f6cbbea);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_MPEG2_VIDEO ) , guid : :: windows :: core :: GUID::from_u128(0xe06d8026_db46_11cf_b4d1_00805f6cbbea) , } }
 pub const WMMEDIASUBTYPE_MSS1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3153534d_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_MSS1 ) , guid : :: windows :: core :: GUID::from_u128(0x3153534d_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_MSS2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3253534d_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_MSS2 ) , guid : :: windows :: core :: GUID::from_u128(0x3253534d_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_P422: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x32323450_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_P422 ) , guid : :: windows :: core :: GUID::from_u128(0x32323450_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_PCM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x00000001_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_PCM ) , guid : :: windows :: core :: GUID::from_u128(0x00000001_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_RGB1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe436eb78_524f_11ce_9f53_0020af0ba770);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_RGB1 ) , guid : :: windows :: core :: GUID::from_u128(0xe436eb78_524f_11ce_9f53_0020af0ba770) , } }
 pub const WMMEDIASUBTYPE_RGB24: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe436eb7d_524f_11ce_9f53_0020af0ba770);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_RGB24 ) , guid : :: windows :: core :: GUID::from_u128(0xe436eb7d_524f_11ce_9f53_0020af0ba770) , } }
 pub const WMMEDIASUBTYPE_RGB32: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe436eb7e_524f_11ce_9f53_0020af0ba770);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_RGB32 ) , guid : :: windows :: core :: GUID::from_u128(0xe436eb7e_524f_11ce_9f53_0020af0ba770) , } }
 pub const WMMEDIASUBTYPE_RGB4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe436eb79_524f_11ce_9f53_0020af0ba770);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_RGB4 ) , guid : :: windows :: core :: GUID::from_u128(0xe436eb79_524f_11ce_9f53_0020af0ba770) , } }
 pub const WMMEDIASUBTYPE_RGB555: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe436eb7c_524f_11ce_9f53_0020af0ba770);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_RGB555 ) , guid : :: windows :: core :: GUID::from_u128(0xe436eb7c_524f_11ce_9f53_0020af0ba770) , } }
 pub const WMMEDIASUBTYPE_RGB565: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe436eb7b_524f_11ce_9f53_0020af0ba770);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_RGB565 ) , guid : :: windows :: core :: GUID::from_u128(0xe436eb7b_524f_11ce_9f53_0020af0ba770) , } }
 pub const WMMEDIASUBTYPE_RGB8: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe436eb7a_524f_11ce_9f53_0020af0ba770);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_RGB8 ) , guid : :: windows :: core :: GUID::from_u128(0xe436eb7a_524f_11ce_9f53_0020af0ba770) , } }
 pub const WMMEDIASUBTYPE_UYVY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x59565955_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_UYVY ) , guid : :: windows :: core :: GUID::from_u128(0x59565955_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_VIDEOIMAGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1d4a45f2_e5f6_4b44_8388_f0ae5c0e0c37);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_VIDEOIMAGE ) , guid : :: windows :: core :: GUID::from_u128(0x1d4a45f2_e5f6_4b44_8388_f0ae5c0e0c37) , } }
 pub const WMMEDIASUBTYPE_WMAudioV2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x00000161_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_WMAudioV2 ) , guid : :: windows :: core :: GUID::from_u128(0x00000161_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_WMAudioV7: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x00000161_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_WMAudioV7 ) , guid : :: windows :: core :: GUID::from_u128(0x00000161_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_WMAudioV8: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x00000161_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_WMAudioV8 ) , guid : :: windows :: core :: GUID::from_u128(0x00000161_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_WMAudioV9: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x00000162_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_WMAudioV9 ) , guid : :: windows :: core :: GUID::from_u128(0x00000162_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_WMAudio_Lossless: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x00000163_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_WMAudio_Lossless ) , guid : :: windows :: core :: GUID::from_u128(0x00000163_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_WMSP1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0000000a_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_WMSP1 ) , guid : :: windows :: core :: GUID::from_u128(0x0000000a_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_WMSP2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0000000b_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_WMSP2 ) , guid : :: windows :: core :: GUID::from_u128(0x0000000b_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_WMV1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x31564d57_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_WMV1 ) , guid : :: windows :: core :: GUID::from_u128(0x31564d57_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_WMV2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x32564d57_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_WMV2 ) , guid : :: windows :: core :: GUID::from_u128(0x32564d57_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_WMV3: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x33564d57_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_WMV3 ) , guid : :: windows :: core :: GUID::from_u128(0x33564d57_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_WMVA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x41564d57_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_WMVA ) , guid : :: windows :: core :: GUID::from_u128(0x41564d57_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_WMVP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x50564d57_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_WMVP ) , guid : :: windows :: core :: GUID::from_u128(0x50564d57_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_WVC1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x31435657_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_WVC1 ) , guid : :: windows :: core :: GUID::from_u128(0x31435657_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_WVP2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x32505657_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_WVP2 ) , guid : :: windows :: core :: GUID::from_u128(0x32505657_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_WebStream: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x776257d4_c627_41cb_8f81_7ac7ff1c40cc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_WebStream ) , guid : :: windows :: core :: GUID::from_u128(0x776257d4_c627_41cb_8f81_7ac7ff1c40cc) , } }
 pub const WMMEDIASUBTYPE_YUY2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x32595559_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_YUY2 ) , guid : :: windows :: core :: GUID::from_u128(0x32595559_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_YV12: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x32315659_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_YV12 ) , guid : :: windows :: core :: GUID::from_u128(0x32315659_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_YVU9: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x39555659_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_YVU9 ) , guid : :: windows :: core :: GUID::from_u128(0x39555659_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIASUBTYPE_YVYU: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x55595659_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIASUBTYPE_YVYU ) , guid : :: windows :: core :: GUID::from_u128(0x55595659_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIATYPE_Audio: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x73647561_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIATYPE_Audio ) , guid : :: windows :: core :: GUID::from_u128(0x73647561_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIATYPE_FileTransfer: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd9e47579_930e_4427_adfc_ad80f290e470);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIATYPE_FileTransfer ) , guid : :: windows :: core :: GUID::from_u128(0xd9e47579_930e_4427_adfc_ad80f290e470) , } }
 pub const WMMEDIATYPE_Image: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x34a50fd8_8aa5_4386_81fe_a0efe0488e31);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIATYPE_Image ) , guid : :: windows :: core :: GUID::from_u128(0x34a50fd8_8aa5_4386_81fe_a0efe0488e31) , } }
 pub const WMMEDIATYPE_Script: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x73636d64_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIATYPE_Script ) , guid : :: windows :: core :: GUID::from_u128(0x73636d64_0000_0010_8000_00aa00389b71) , } }
 pub const WMMEDIATYPE_Text: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9bba1ea7_5ab2_4829_ba57_0940209bcf3e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIATYPE_Text ) , guid : :: windows :: core :: GUID::from_u128(0x9bba1ea7_5ab2_4829_ba57_0940209bcf3e) , } }
 pub const WMMEDIATYPE_Video: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x73646976_0000_0010_8000_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMMEDIATYPE_Video ) , guid : :: windows :: core :: GUID::from_u128(0x73646976_0000_0010_8000_00aa00389b71) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Media_WindowsMediaFormat', 'Win32_Foundation', 'Win32_Graphics_Gdi'*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Graphics_Gdi"))]
@@ -13950,6 +14070,8 @@ impl ::core::default::Default for WMSCRIPTFORMAT {
     }
 }
 pub const WMSCRIPTTYPE_TwoStrings: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x82f38a70_c29f_11d1_97ad_00a0c95ea850);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMSCRIPTTYPE_TwoStrings ) , guid : :: windows :: core :: GUID::from_u128(0x82f38a70_c29f_11d1_97ad_00a0c95ea850) , } }
 #[doc = "*Required features: 'Win32_Media_WindowsMediaFormat'*"]
 pub type WMT_ATTR_DATATYPE = i32;
 #[doc = "*Required features: 'Win32_Media_WindowsMediaFormat'*"]
@@ -14058,7 +14180,11 @@ pub const WMT_CREDENTIAL_PROXY: WMT_CREDENTIAL_FLAGS = 8i32;
 #[doc = "*Required features: 'Win32_Media_WindowsMediaFormat'*"]
 pub const WMT_CREDENTIAL_ENCRYPT: WMT_CREDENTIAL_FLAGS = 16i32;
 pub const WMT_DMOCATEGORY_AUDIO_WATERMARK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x65221c5a_fa75_4b39_b50c_06c336b6a3ef);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMT_DMOCATEGORY_AUDIO_WATERMARK ) , guid : :: windows :: core :: GUID::from_u128(0x65221c5a_fa75_4b39_b50c_06c336b6a3ef) , } }
 pub const WMT_DMOCATEGORY_VIDEO_WATERMARK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x187cc922_8efc_4404_9daf_63f4830df1bc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WMT_DMOCATEGORY_VIDEO_WATERMARK ) , guid : :: windows :: core :: GUID::from_u128(0x187cc922_8efc_4404_9daf_63f4830df1bc) , } }
 #[doc = "*Required features: 'Win32_Media_WindowsMediaFormat'*"]
 pub type WMT_DRMLA_TRUST = i32;
 #[doc = "*Required features: 'Win32_Media_WindowsMediaFormat'*"]
@@ -15362,15 +15488,35 @@ impl ::core::default::Default for WM_SYNCHRONISED_LYRICS {
     }
 }
 pub const WM_SampleExtensionGUID_ChromaLocation: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4c5acca0_9276_4b2c_9e4c_a0edefdd217e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WM_SampleExtensionGUID_ChromaLocation ) , guid : :: windows :: core :: GUID::from_u128(0x4c5acca0_9276_4b2c_9e4c_a0edefdd217e) , } }
 pub const WM_SampleExtensionGUID_ColorSpaceInfo: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf79ada56_30eb_4f2b_9f7a_f24b139a1157);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WM_SampleExtensionGUID_ColorSpaceInfo ) , guid : :: windows :: core :: GUID::from_u128(0xf79ada56_30eb_4f2b_9f7a_f24b139a1157) , } }
 pub const WM_SampleExtensionGUID_ContentType: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd590dc20_07bc_436c_9cf7_f3bbfbf1a4dc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WM_SampleExtensionGUID_ContentType ) , guid : :: windows :: core :: GUID::from_u128(0xd590dc20_07bc_436c_9cf7_f3bbfbf1a4dc) , } }
 pub const WM_SampleExtensionGUID_FileName: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe165ec0e_19ed_45d7_b4a7_25cbd1e28e9b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WM_SampleExtensionGUID_FileName ) , guid : :: windows :: core :: GUID::from_u128(0xe165ec0e_19ed_45d7_b4a7_25cbd1e28e9b) , } }
 pub const WM_SampleExtensionGUID_OutputCleanPoint: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf72a3c6f_6eb4_4ebc_b192_09ad9759e828);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WM_SampleExtensionGUID_OutputCleanPoint ) , guid : :: windows :: core :: GUID::from_u128(0xf72a3c6f_6eb4_4ebc_b192_09ad9759e828) , } }
 pub const WM_SampleExtensionGUID_PixelAspectRatio: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1b1ee554_f9ea_4bc8_821a_376b74e4c4b8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WM_SampleExtensionGUID_PixelAspectRatio ) , guid : :: windows :: core :: GUID::from_u128(0x1b1ee554_f9ea_4bc8_821a_376b74e4c4b8) , } }
 pub const WM_SampleExtensionGUID_SampleDuration: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc6bd9450_867f_4907_83a3_c77921b733ad);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WM_SampleExtensionGUID_SampleDuration ) , guid : :: windows :: core :: GUID::from_u128(0xc6bd9450_867f_4907_83a3_c77921b733ad) , } }
 pub const WM_SampleExtensionGUID_SampleProtectionSalt: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5403deee_b9ee_438f_aa83_3804997e569d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WM_SampleExtensionGUID_SampleProtectionSalt ) , guid : :: windows :: core :: GUID::from_u128(0x5403deee_b9ee_438f_aa83_3804997e569d) , } }
 pub const WM_SampleExtensionGUID_Timecode: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x399595ec_8667_4e2d_8fdb_98814ce76c1e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WM_SampleExtensionGUID_Timecode ) , guid : :: windows :: core :: GUID::from_u128(0x399595ec_8667_4e2d_8fdb_98814ce76c1e) , } }
 pub const WM_SampleExtensionGUID_UserDataInfo: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x732bb4fa_78be_4549_99bd_02db1a55b7a8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WM_SampleExtensionGUID_UserDataInfo ) , guid : :: windows :: core :: GUID::from_u128(0x732bb4fa_78be_4549_99bd_02db1a55b7a8) , } }
 #[doc = "*Required features: 'Win32_Media_WindowsMediaFormat'*"]
 pub const WM_SampleExtension_ChromaLocation_Size: u32 = 1u32;
 #[doc = "*Required features: 'Win32_Media_WindowsMediaFormat'*"]

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/Ndis/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/Ndis/mod.rs
@@ -1122,195 +1122,575 @@ impl ::core::default::Default for GEN_GET_TIME_CAPS {
     }
 }
 pub const GUID_DEVINTERFACE_NET: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcac88484_7515_4c03_82e6_71a87abac361);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_NET ) , guid : :: windows :: core :: GUID::from_u128(0xcac88484_7515_4c03_82e6_71a87abac361) , } }
 pub const GUID_DEVINTERFACE_NETUIO: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x08336f60_0679_4c6c_85d2_ae7ced65fff7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_NETUIO ) , guid : :: windows :: core :: GUID::from_u128(0x08336f60_0679_4c6c_85d2_ae7ced65fff7) , } }
 pub const GUID_NDIS_802_11_ADD_KEY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xab8b5a62_1d51_49d8_ba5c_fa980be03a1d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_ADD_KEY ) , guid : :: windows :: core :: GUID::from_u128(0xab8b5a62_1d51_49d8_ba5c_fa980be03a1d) , } }
 pub const GUID_NDIS_802_11_ADD_WEP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4307bff0_2129_11d4_97eb_00c04f79c403);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_ADD_WEP ) , guid : :: windows :: core :: GUID::from_u128(0x4307bff0_2129_11d4_97eb_00c04f79c403) , } }
 pub const GUID_NDIS_802_11_ASSOCIATION_INFORMATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa08d4dd0_960e_40bd_8cf6_c538af98f2e3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_ASSOCIATION_INFORMATION ) , guid : :: windows :: core :: GUID::from_u128(0xa08d4dd0_960e_40bd_8cf6_c538af98f2e3) , } }
 pub const GUID_NDIS_802_11_AUTHENTICATION_MODE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x43920a24_2129_11d4_97eb_00c04f79c403);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_AUTHENTICATION_MODE ) , guid : :: windows :: core :: GUID::from_u128(0x43920a24_2129_11d4_97eb_00c04f79c403) , } }
 pub const GUID_NDIS_802_11_BSSID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2504b6c2_1fa5_11d4_97eb_00c04f79c403);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_BSSID ) , guid : :: windows :: core :: GUID::from_u128(0x2504b6c2_1fa5_11d4_97eb_00c04f79c403) , } }
 pub const GUID_NDIS_802_11_BSSID_LIST: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x69526f9a_2062_11d4_97eb_00c04f79c403);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_BSSID_LIST ) , guid : :: windows :: core :: GUID::from_u128(0x69526f9a_2062_11d4_97eb_00c04f79c403) , } }
 pub const GUID_NDIS_802_11_BSSID_LIST_SCAN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0d9e01e1_ba70_11d4_b675_002048570337);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_BSSID_LIST_SCAN ) , guid : :: windows :: core :: GUID::from_u128(0x0d9e01e1_ba70_11d4_b675_002048570337) , } }
 pub const GUID_NDIS_802_11_CONFIGURATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4a4df982_2068_11d4_97eb_00c04f79c403);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_CONFIGURATION ) , guid : :: windows :: core :: GUID::from_u128(0x4a4df982_2068_11d4_97eb_00c04f79c403) , } }
 pub const GUID_NDIS_802_11_DESIRED_RATES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x452ee08e_2536_11d4_97eb_00c04f79c403);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_DESIRED_RATES ) , guid : :: windows :: core :: GUID::from_u128(0x452ee08e_2536_11d4_97eb_00c04f79c403) , } }
 pub const GUID_NDIS_802_11_DISASSOCIATE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x43671f40_2129_11d4_97eb_00c04f79c403);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_DISASSOCIATE ) , guid : :: windows :: core :: GUID::from_u128(0x43671f40_2129_11d4_97eb_00c04f79c403) , } }
 pub const GUID_NDIS_802_11_FRAGMENTATION_THRESHOLD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x69aaa7c4_2062_11d4_97eb_00c04f79c403);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_FRAGMENTATION_THRESHOLD ) , guid : :: windows :: core :: GUID::from_u128(0x69aaa7c4_2062_11d4_97eb_00c04f79c403) , } }
 pub const GUID_NDIS_802_11_INFRASTRUCTURE_MODE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x697d5a7e_2062_11d4_97eb_00c04f79c403);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_INFRASTRUCTURE_MODE ) , guid : :: windows :: core :: GUID::from_u128(0x697d5a7e_2062_11d4_97eb_00c04f79c403) , } }
 pub const GUID_NDIS_802_11_MEDIA_STREAM_MODE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0a56af66_d84b_49eb_a28d_5282cbb6d0cd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_MEDIA_STREAM_MODE ) , guid : :: windows :: core :: GUID::from_u128(0x0a56af66_d84b_49eb_a28d_5282cbb6d0cd) , } }
 pub const GUID_NDIS_802_11_NETWORK_TYPES_SUPPORTED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8531d6e6_2041_11d4_97eb_00c04f79c403);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_NETWORK_TYPES_SUPPORTED ) , guid : :: windows :: core :: GUID::from_u128(0x8531d6e6_2041_11d4_97eb_00c04f79c403) , } }
 pub const GUID_NDIS_802_11_NETWORK_TYPE_IN_USE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x857e2326_2041_11d4_97eb_00c04f79c403);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_NETWORK_TYPE_IN_USE ) , guid : :: windows :: core :: GUID::from_u128(0x857e2326_2041_11d4_97eb_00c04f79c403) , } }
 pub const GUID_NDIS_802_11_NUMBER_OF_ANTENNAS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x01779336_2064_11d4_97eb_00c04f79c403);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_NUMBER_OF_ANTENNAS ) , guid : :: windows :: core :: GUID::from_u128(0x01779336_2064_11d4_97eb_00c04f79c403) , } }
 pub const GUID_NDIS_802_11_POWER_MODE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x85be837c_2041_11d4_97eb_00c04f79c403);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_POWER_MODE ) , guid : :: windows :: core :: GUID::from_u128(0x85be837c_2041_11d4_97eb_00c04f79c403) , } }
 pub const GUID_NDIS_802_11_PRIVACY_FILTER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6733c4e9_4792_11d4_97f1_00c04f79c403);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_PRIVACY_FILTER ) , guid : :: windows :: core :: GUID::from_u128(0x6733c4e9_4792_11d4_97f1_00c04f79c403) , } }
 pub const GUID_NDIS_802_11_RELOAD_DEFAULTS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x748b14e8_32ee_4425_b91b_c9848c58b55a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_RELOAD_DEFAULTS ) , guid : :: windows :: core :: GUID::from_u128(0x748b14e8_32ee_4425_b91b_c9848c58b55a) , } }
 pub const GUID_NDIS_802_11_REMOVE_KEY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x73cb28e9_3188_42d5_b553_b21237e6088c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_REMOVE_KEY ) , guid : :: windows :: core :: GUID::from_u128(0x73cb28e9_3188_42d5_b553_b21237e6088c) , } }
 pub const GUID_NDIS_802_11_REMOVE_WEP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x433c345c_2129_11d4_97eb_00c04f79c403);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_REMOVE_WEP ) , guid : :: windows :: core :: GUID::from_u128(0x433c345c_2129_11d4_97eb_00c04f79c403) , } }
 pub const GUID_NDIS_802_11_RSSI: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1507db16_2053_11d4_97eb_00c04f79c403);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_RSSI ) , guid : :: windows :: core :: GUID::from_u128(0x1507db16_2053_11d4_97eb_00c04f79c403) , } }
 pub const GUID_NDIS_802_11_RSSI_TRIGGER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x155689b8_2053_11d4_97eb_00c04f79c403);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_RSSI_TRIGGER ) , guid : :: windows :: core :: GUID::from_u128(0x155689b8_2053_11d4_97eb_00c04f79c403) , } }
 pub const GUID_NDIS_802_11_RTS_THRESHOLD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0134d07e_2064_11d4_97eb_00c04f79c403);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_RTS_THRESHOLD ) , guid : :: windows :: core :: GUID::from_u128(0x0134d07e_2064_11d4_97eb_00c04f79c403) , } }
 pub const GUID_NDIS_802_11_RX_ANTENNA_SELECTED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x01ac07a2_2064_11d4_97eb_00c04f79c403);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_RX_ANTENNA_SELECTED ) , guid : :: windows :: core :: GUID::from_u128(0x01ac07a2_2064_11d4_97eb_00c04f79c403) , } }
 pub const GUID_NDIS_802_11_SSID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7d2a90ea_2041_11d4_97eb_00c04f79c403);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_SSID ) , guid : :: windows :: core :: GUID::from_u128(0x7d2a90ea_2041_11d4_97eb_00c04f79c403) , } }
 pub const GUID_NDIS_802_11_STATISTICS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x42bb73b0_2129_11d4_97eb_00c04f79c403);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_STATISTICS ) , guid : :: windows :: core :: GUID::from_u128(0x42bb73b0_2129_11d4_97eb_00c04f79c403) , } }
 pub const GUID_NDIS_802_11_SUPPORTED_RATES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x49db8722_2068_11d4_97eb_00c04f79c403);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_SUPPORTED_RATES ) , guid : :: windows :: core :: GUID::from_u128(0x49db8722_2068_11d4_97eb_00c04f79c403) , } }
 pub const GUID_NDIS_802_11_TEST: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4b9ca16a_6a60_4e9d_920c_6335953fa0b5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_TEST ) , guid : :: windows :: core :: GUID::from_u128(0x4b9ca16a_6a60_4e9d_920c_6335953fa0b5) , } }
 pub const GUID_NDIS_802_11_TX_ANTENNA_SELECTED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x01dbb74a_2064_11d4_97eb_00c04f79c403);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_TX_ANTENNA_SELECTED ) , guid : :: windows :: core :: GUID::from_u128(0x01dbb74a_2064_11d4_97eb_00c04f79c403) , } }
 pub const GUID_NDIS_802_11_TX_POWER_LEVEL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x11e6ba76_2053_11d4_97eb_00c04f79c403);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_TX_POWER_LEVEL ) , guid : :: windows :: core :: GUID::from_u128(0x11e6ba76_2053_11d4_97eb_00c04f79c403) , } }
 pub const GUID_NDIS_802_11_WEP_STATUS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb027a21f_3cfa_4125_800b_3f7a18fddcdc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_11_WEP_STATUS ) , guid : :: windows :: core :: GUID::from_u128(0xb027a21f_3cfa_4125_800b_3f7a18fddcdc) , } }
 pub const GUID_NDIS_802_3_CURRENT_ADDRESS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x44795700_a61b_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_3_CURRENT_ADDRESS ) , guid : :: windows :: core :: GUID::from_u128(0x44795700_a61b_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_802_3_MAC_OPTIONS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x44795703_a61b_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_3_MAC_OPTIONS ) , guid : :: windows :: core :: GUID::from_u128(0x44795703_a61b_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_802_3_MAXIMUM_LIST_SIZE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x44795702_a61b_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_3_MAXIMUM_LIST_SIZE ) , guid : :: windows :: core :: GUID::from_u128(0x44795702_a61b_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_802_3_MULTICAST_LIST: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x44795701_a61b_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_3_MULTICAST_LIST ) , guid : :: windows :: core :: GUID::from_u128(0x44795701_a61b_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_802_3_PERMANENT_ADDRESS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x447956ff_a61b_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_3_PERMANENT_ADDRESS ) , guid : :: windows :: core :: GUID::from_u128(0x447956ff_a61b_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_802_3_RCV_ERROR_ALIGNMENT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x44795704_a61b_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_3_RCV_ERROR_ALIGNMENT ) , guid : :: windows :: core :: GUID::from_u128(0x44795704_a61b_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_802_3_XMIT_MORE_COLLISIONS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x44795706_a61b_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_3_XMIT_MORE_COLLISIONS ) , guid : :: windows :: core :: GUID::from_u128(0x44795706_a61b_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_802_3_XMIT_ONE_COLLISION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x44795705_a61b_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_3_XMIT_ONE_COLLISION ) , guid : :: windows :: core :: GUID::from_u128(0x44795705_a61b_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_802_5_CURRENT_ADDRESS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x44795708_a61b_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_5_CURRENT_ADDRESS ) , guid : :: windows :: core :: GUID::from_u128(0x44795708_a61b_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_802_5_CURRENT_FUNCTIONAL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x44795709_a61b_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_5_CURRENT_FUNCTIONAL ) , guid : :: windows :: core :: GUID::from_u128(0x44795709_a61b_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_802_5_CURRENT_GROUP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4479570a_a61b_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_5_CURRENT_GROUP ) , guid : :: windows :: core :: GUID::from_u128(0x4479570a_a61b_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_802_5_CURRENT_RING_STATE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xacf14032_a61c_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_5_CURRENT_RING_STATE ) , guid : :: windows :: core :: GUID::from_u128(0xacf14032_a61c_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_802_5_CURRENT_RING_STATUS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x890a36ec_a61c_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_5_CURRENT_RING_STATUS ) , guid : :: windows :: core :: GUID::from_u128(0x890a36ec_a61c_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_802_5_LAST_OPEN_STATUS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4479570b_a61b_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_5_LAST_OPEN_STATUS ) , guid : :: windows :: core :: GUID::from_u128(0x4479570b_a61b_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_802_5_LINE_ERRORS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xacf14033_a61c_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_5_LINE_ERRORS ) , guid : :: windows :: core :: GUID::from_u128(0xacf14033_a61c_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_802_5_LOST_FRAMES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xacf14034_a61c_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_5_LOST_FRAMES ) , guid : :: windows :: core :: GUID::from_u128(0xacf14034_a61c_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_802_5_PERMANENT_ADDRESS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x44795707_a61b_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_802_5_PERMANENT_ADDRESS ) , guid : :: windows :: core :: GUID::from_u128(0x44795707_a61b_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_ENUMERATE_ADAPTER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x981f2d7f_b1f3_11d0_8dd7_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_ENUMERATE_ADAPTER ) , guid : :: windows :: core :: GUID::from_u128(0x981f2d7f_b1f3_11d0_8dd7_00c04fc3358c) , } }
 pub const GUID_NDIS_ENUMERATE_ADAPTERS_EX: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x16716917_4306_4be4_9b5a_3809ae44b125);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_ENUMERATE_ADAPTERS_EX ) , guid : :: windows :: core :: GUID::from_u128(0x16716917_4306_4be4_9b5a_3809ae44b125) , } }
 pub const GUID_NDIS_ENUMERATE_VC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x981f2d82_b1f3_11d0_8dd7_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_ENUMERATE_VC ) , guid : :: windows :: core :: GUID::from_u128(0x981f2d82_b1f3_11d0_8dd7_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_CO_DRIVER_VERSION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x791ad198_e35c_11d0_9692_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_CO_DRIVER_VERSION ) , guid : :: windows :: core :: GUID::from_u128(0x791ad198_e35c_11d0_9692_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_CO_HARDWARE_STATUS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x791ad192_e35c_11d0_9692_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_CO_HARDWARE_STATUS ) , guid : :: windows :: core :: GUID::from_u128(0x791ad192_e35c_11d0_9692_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_CO_LINK_SPEED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x791ad195_e35c_11d0_9692_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_CO_LINK_SPEED ) , guid : :: windows :: core :: GUID::from_u128(0x791ad195_e35c_11d0_9692_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_CO_MAC_OPTIONS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x791ad19a_e35c_11d0_9692_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_CO_MAC_OPTIONS ) , guid : :: windows :: core :: GUID::from_u128(0x791ad19a_e35c_11d0_9692_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_CO_MEDIA_CONNECT_STATUS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x791ad19b_e35c_11d0_9692_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_CO_MEDIA_CONNECT_STATUS ) , guid : :: windows :: core :: GUID::from_u128(0x791ad19b_e35c_11d0_9692_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_CO_MEDIA_IN_USE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x791ad194_e35c_11d0_9692_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_CO_MEDIA_IN_USE ) , guid : :: windows :: core :: GUID::from_u128(0x791ad194_e35c_11d0_9692_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_CO_MEDIA_SUPPORTED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x791ad193_e35c_11d0_9692_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_CO_MEDIA_SUPPORTED ) , guid : :: windows :: core :: GUID::from_u128(0x791ad193_e35c_11d0_9692_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_CO_MINIMUM_LINK_SPEED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x791ad19d_e35c_11d0_9692_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_CO_MINIMUM_LINK_SPEED ) , guid : :: windows :: core :: GUID::from_u128(0x791ad19d_e35c_11d0_9692_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_CO_RCV_PDUS_ERROR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0a214808_e35f_11d0_9692_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_CO_RCV_PDUS_ERROR ) , guid : :: windows :: core :: GUID::from_u128(0x0a214808_e35f_11d0_9692_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_CO_RCV_PDUS_NO_BUFFER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0a214809_e35f_11d0_9692_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_CO_RCV_PDUS_NO_BUFFER ) , guid : :: windows :: core :: GUID::from_u128(0x0a214809_e35f_11d0_9692_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_CO_RCV_PDUS_OK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0a214806_e35f_11d0_9692_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_CO_RCV_PDUS_OK ) , guid : :: windows :: core :: GUID::from_u128(0x0a214806_e35f_11d0_9692_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_CO_VENDOR_DESCRIPTION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x791ad197_e35c_11d0_9692_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_CO_VENDOR_DESCRIPTION ) , guid : :: windows :: core :: GUID::from_u128(0x791ad197_e35c_11d0_9692_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_CO_VENDOR_DRIVER_VERSION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x791ad19c_e35c_11d0_9692_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_CO_VENDOR_DRIVER_VERSION ) , guid : :: windows :: core :: GUID::from_u128(0x791ad19c_e35c_11d0_9692_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_CO_VENDOR_ID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x791ad196_e35c_11d0_9692_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_CO_VENDOR_ID ) , guid : :: windows :: core :: GUID::from_u128(0x791ad196_e35c_11d0_9692_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_CO_XMIT_PDUS_ERROR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0a214807_e35f_11d0_9692_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_CO_XMIT_PDUS_ERROR ) , guid : :: windows :: core :: GUID::from_u128(0x0a214807_e35f_11d0_9692_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_CO_XMIT_PDUS_OK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0a214805_e35f_11d0_9692_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_CO_XMIT_PDUS_OK ) , guid : :: windows :: core :: GUID::from_u128(0x0a214805_e35f_11d0_9692_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_CURRENT_LOOKAHEAD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5ec10361_a61a_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_CURRENT_LOOKAHEAD ) , guid : :: windows :: core :: GUID::from_u128(0x5ec10361_a61a_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_CURRENT_PACKET_FILTER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5ec10360_a61a_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_CURRENT_PACKET_FILTER ) , guid : :: windows :: core :: GUID::from_u128(0x5ec10360_a61a_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_DRIVER_VERSION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5ec10362_a61a_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_DRIVER_VERSION ) , guid : :: windows :: core :: GUID::from_u128(0x5ec10362_a61a_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_ENUMERATE_PORTS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf1d6abe8_15e4_4407_81b7_6b830c777cd9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_ENUMERATE_PORTS ) , guid : :: windows :: core :: GUID::from_u128(0xf1d6abe8_15e4_4407_81b7_6b830c777cd9) , } }
 pub const GUID_NDIS_GEN_HARDWARE_STATUS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5ec10354_a61a_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_HARDWARE_STATUS ) , guid : :: windows :: core :: GUID::from_u128(0x5ec10354_a61a_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_INTERRUPT_MODERATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd9c8eea5_f16e_467c_84d5_6345a22ce213);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_INTERRUPT_MODERATION ) , guid : :: windows :: core :: GUID::from_u128(0xd9c8eea5_f16e_467c_84d5_6345a22ce213) , } }
 pub const GUID_NDIS_GEN_INTERRUPT_MODERATION_PARAMETERS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd789adfa_9c56_433b_ad01_7574f3cedbe9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_INTERRUPT_MODERATION_PARAMETERS ) , guid : :: windows :: core :: GUID::from_u128(0xd789adfa_9c56_433b_ad01_7574f3cedbe9) , } }
 pub const GUID_NDIS_GEN_LINK_PARAMETERS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8c7d3579_252b_4614_82c5_a650daa15049);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_LINK_PARAMETERS ) , guid : :: windows :: core :: GUID::from_u128(0x8c7d3579_252b_4614_82c5_a650daa15049) , } }
 pub const GUID_NDIS_GEN_LINK_SPEED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5ec10359_a61a_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_LINK_SPEED ) , guid : :: windows :: core :: GUID::from_u128(0x5ec10359_a61a_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_LINK_STATE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xba1f4c14_a945_4762_b916_0b5515b6f43a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_LINK_STATE ) , guid : :: windows :: core :: GUID::from_u128(0xba1f4c14_a945_4762_b916_0b5515b6f43a) , } }
 pub const GUID_NDIS_GEN_MAC_OPTIONS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5ec10365_a61a_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_MAC_OPTIONS ) , guid : :: windows :: core :: GUID::from_u128(0x5ec10365_a61a_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_MAXIMUM_FRAME_SIZE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5ec10358_a61a_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_MAXIMUM_FRAME_SIZE ) , guid : :: windows :: core :: GUID::from_u128(0x5ec10358_a61a_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_MAXIMUM_LOOKAHEAD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5ec10357_a61a_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_MAXIMUM_LOOKAHEAD ) , guid : :: windows :: core :: GUID::from_u128(0x5ec10357_a61a_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_MAXIMUM_SEND_PACKETS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5ec10367_a61a_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_MAXIMUM_SEND_PACKETS ) , guid : :: windows :: core :: GUID::from_u128(0x5ec10367_a61a_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_MAXIMUM_TOTAL_SIZE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5ec10363_a61a_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_MAXIMUM_TOTAL_SIZE ) , guid : :: windows :: core :: GUID::from_u128(0x5ec10363_a61a_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_MEDIA_CONNECT_STATUS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5ec10366_a61a_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_MEDIA_CONNECT_STATUS ) , guid : :: windows :: core :: GUID::from_u128(0x5ec10366_a61a_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_MEDIA_IN_USE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5ec10356_a61a_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_MEDIA_IN_USE ) , guid : :: windows :: core :: GUID::from_u128(0x5ec10356_a61a_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_MEDIA_SUPPORTED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5ec10355_a61a_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_MEDIA_SUPPORTED ) , guid : :: windows :: core :: GUID::from_u128(0x5ec10355_a61a_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_PCI_DEVICE_CUSTOM_PROPERTIES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaa39f5ab_e260_4d01_82b0_b737c880ea05);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_PCI_DEVICE_CUSTOM_PROPERTIES ) , guid : :: windows :: core :: GUID::from_u128(0xaa39f5ab_e260_4d01_82b0_b737c880ea05) , } }
 pub const GUID_NDIS_GEN_PHYSICAL_MEDIUM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x418ca16d_3937_4208_940a_ec6196278085);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_PHYSICAL_MEDIUM ) , guid : :: windows :: core :: GUID::from_u128(0x418ca16d_3937_4208_940a_ec6196278085) , } }
 pub const GUID_NDIS_GEN_PHYSICAL_MEDIUM_EX: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x899e7782_035b_43f9_8bb6_2b58971612e5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_PHYSICAL_MEDIUM_EX ) , guid : :: windows :: core :: GUID::from_u128(0x899e7782_035b_43f9_8bb6_2b58971612e5) , } }
 pub const GUID_NDIS_GEN_PORT_AUTHENTICATION_PARAMETERS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaab6ac31_86fb_48fb_8b48_63db235ace16);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_PORT_AUTHENTICATION_PARAMETERS ) , guid : :: windows :: core :: GUID::from_u128(0xaab6ac31_86fb_48fb_8b48_63db235ace16) , } }
 pub const GUID_NDIS_GEN_PORT_STATE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fbf2a5f_8b8f_4920_8143_e6c460f52524);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_PORT_STATE ) , guid : :: windows :: core :: GUID::from_u128(0x6fbf2a5f_8b8f_4920_8143_e6c460f52524) , } }
 pub const GUID_NDIS_GEN_RCV_ERROR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x447956fd_a61b_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_RCV_ERROR ) , guid : :: windows :: core :: GUID::from_u128(0x447956fd_a61b_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_RCV_NO_BUFFER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x447956fe_a61b_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_RCV_NO_BUFFER ) , guid : :: windows :: core :: GUID::from_u128(0x447956fe_a61b_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_RCV_OK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x447956fb_a61b_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_RCV_OK ) , guid : :: windows :: core :: GUID::from_u128(0x447956fb_a61b_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_RECEIVE_BLOCK_SIZE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5ec1035d_a61a_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_RECEIVE_BLOCK_SIZE ) , guid : :: windows :: core :: GUID::from_u128(0x5ec1035d_a61a_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_RECEIVE_BUFFER_SPACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5ec1035b_a61a_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_RECEIVE_BUFFER_SPACE ) , guid : :: windows :: core :: GUID::from_u128(0x5ec1035b_a61a_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_STATISTICS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x368c45b5_c129_43c1_939e_7edc2d7fe621);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_STATISTICS ) , guid : :: windows :: core :: GUID::from_u128(0x368c45b5_c129_43c1_939e_7edc2d7fe621) , } }
 pub const GUID_NDIS_GEN_TRANSMIT_BLOCK_SIZE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5ec1035c_a61a_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_TRANSMIT_BLOCK_SIZE ) , guid : :: windows :: core :: GUID::from_u128(0x5ec1035c_a61a_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_TRANSMIT_BUFFER_SPACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5ec1035a_a61a_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_TRANSMIT_BUFFER_SPACE ) , guid : :: windows :: core :: GUID::from_u128(0x5ec1035a_a61a_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_VENDOR_DESCRIPTION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5ec1035f_a61a_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_VENDOR_DESCRIPTION ) , guid : :: windows :: core :: GUID::from_u128(0x5ec1035f_a61a_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_VENDOR_DRIVER_VERSION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x447956f9_a61b_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_VENDOR_DRIVER_VERSION ) , guid : :: windows :: core :: GUID::from_u128(0x447956f9_a61b_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_VENDOR_ID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5ec1035e_a61a_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_VENDOR_ID ) , guid : :: windows :: core :: GUID::from_u128(0x5ec1035e_a61a_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_VLAN_ID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x765dc702_c5e8_4b67_843b_3f5a4ff2648b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_VLAN_ID ) , guid : :: windows :: core :: GUID::from_u128(0x765dc702_c5e8_4b67_843b_3f5a4ff2648b) , } }
 pub const GUID_NDIS_GEN_XMIT_ERROR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x447956fc_a61b_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_XMIT_ERROR ) , guid : :: windows :: core :: GUID::from_u128(0x447956fc_a61b_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_GEN_XMIT_OK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x447956fa_a61b_11d0_8dd4_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_GEN_XMIT_OK ) , guid : :: windows :: core :: GUID::from_u128(0x447956fa_a61b_11d0_8dd4_00c04fc3358c) , } }
 pub const GUID_NDIS_HD_SPLIT_CURRENT_CONFIG: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x81d1303c_ab00_4e49_80b1_5e6e0bf9be53);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_HD_SPLIT_CURRENT_CONFIG ) , guid : :: windows :: core :: GUID::from_u128(0x81d1303c_ab00_4e49_80b1_5e6e0bf9be53) , } }
 pub const GUID_NDIS_HD_SPLIT_PARAMETERS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8c048bea_2913_4458_b68e_17f6c1e5c60e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_HD_SPLIT_PARAMETERS ) , guid : :: windows :: core :: GUID::from_u128(0x8c048bea_2913_4458_b68e_17f6c1e5c60e) , } }
 pub const GUID_NDIS_LAN_CLASS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xad498944_762f_11d0_8dcb_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_LAN_CLASS ) , guid : :: windows :: core :: GUID::from_u128(0xad498944_762f_11d0_8dcb_00c04fc3358c) , } }
 pub const GUID_NDIS_NDK_CAPABILITIES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7969ba4d_dd80_4bc7_b3e6_68043997e519);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_NDK_CAPABILITIES ) , guid : :: windows :: core :: GUID::from_u128(0x7969ba4d_dd80_4bc7_b3e6_68043997e519) , } }
 pub const GUID_NDIS_NDK_STATE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x530c69c9_2f51_49de_a1af_088d54ffa474);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_NDK_STATE ) , guid : :: windows :: core :: GUID::from_u128(0x530c69c9_2f51_49de_a1af_088d54ffa474) , } }
 pub const GUID_NDIS_NOTIFY_ADAPTER_ARRIVAL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x981f2d81_b1f3_11d0_8dd7_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_NOTIFY_ADAPTER_ARRIVAL ) , guid : :: windows :: core :: GUID::from_u128(0x981f2d81_b1f3_11d0_8dd7_00c04fc3358c) , } }
 pub const GUID_NDIS_NOTIFY_ADAPTER_REMOVAL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x981f2d80_b1f3_11d0_8dd7_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_NOTIFY_ADAPTER_REMOVAL ) , guid : :: windows :: core :: GUID::from_u128(0x981f2d80_b1f3_11d0_8dd7_00c04fc3358c) , } }
 pub const GUID_NDIS_NOTIFY_BIND: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5413531c_b1f3_11d0_8dd7_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_NOTIFY_BIND ) , guid : :: windows :: core :: GUID::from_u128(0x5413531c_b1f3_11d0_8dd7_00c04fc3358c) , } }
 pub const GUID_NDIS_NOTIFY_DEVICE_POWER_OFF: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x81bc8189_b026_46ab_b964_f182e342934e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_NOTIFY_DEVICE_POWER_OFF ) , guid : :: windows :: core :: GUID::from_u128(0x81bc8189_b026_46ab_b964_f182e342934e) , } }
 pub const GUID_NDIS_NOTIFY_DEVICE_POWER_OFF_EX: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4159353c_5cd7_42ce_8fe4_a45a2380cc4f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_NOTIFY_DEVICE_POWER_OFF_EX ) , guid : :: windows :: core :: GUID::from_u128(0x4159353c_5cd7_42ce_8fe4_a45a2380cc4f) , } }
 pub const GUID_NDIS_NOTIFY_DEVICE_POWER_ON: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5f81cfd0_f046_4342_af61_895acedaefd9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_NOTIFY_DEVICE_POWER_ON ) , guid : :: windows :: core :: GUID::from_u128(0x5f81cfd0_f046_4342_af61_895acedaefd9) , } }
 pub const GUID_NDIS_NOTIFY_DEVICE_POWER_ON_EX: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2b440188_92ac_4f60_9b2d_20a30cbb6bbe);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_NOTIFY_DEVICE_POWER_ON_EX ) , guid : :: windows :: core :: GUID::from_u128(0x2b440188_92ac_4f60_9b2d_20a30cbb6bbe) , } }
 pub const GUID_NDIS_NOTIFY_FILTER_ARRIVAL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0b6d3c89_5917_43ca_b578_d01a7967c41c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_NOTIFY_FILTER_ARRIVAL ) , guid : :: windows :: core :: GUID::from_u128(0x0b6d3c89_5917_43ca_b578_d01a7967c41c) , } }
 pub const GUID_NDIS_NOTIFY_FILTER_REMOVAL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1f177cd9_5955_4721_9f6a_78ebdfaef889);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_NOTIFY_FILTER_REMOVAL ) , guid : :: windows :: core :: GUID::from_u128(0x1f177cd9_5955_4721_9f6a_78ebdfaef889) , } }
 pub const GUID_NDIS_NOTIFY_UNBIND: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6e3ce1ec_b1f3_11d0_8dd7_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_NOTIFY_UNBIND ) , guid : :: windows :: core :: GUID::from_u128(0x6e3ce1ec_b1f3_11d0_8dd7_00c04fc3358c) , } }
 pub const GUID_NDIS_NOTIFY_VC_ARRIVAL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x182f9e0c_b1f3_11d0_8dd7_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_NOTIFY_VC_ARRIVAL ) , guid : :: windows :: core :: GUID::from_u128(0x182f9e0c_b1f3_11d0_8dd7_00c04fc3358c) , } }
 pub const GUID_NDIS_NOTIFY_VC_REMOVAL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x981f2d79_b1f3_11d0_8dd7_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_NOTIFY_VC_REMOVAL ) , guid : :: windows :: core :: GUID::from_u128(0x981f2d79_b1f3_11d0_8dd7_00c04fc3358c) , } }
 pub const GUID_NDIS_PM_ACTIVE_CAPABILITIES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb2cf76e3_b3ae_4394_a01f_338c9870e939);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_PM_ACTIVE_CAPABILITIES ) , guid : :: windows :: core :: GUID::from_u128(0xb2cf76e3_b3ae_4394_a01f_338c9870e939) , } }
 pub const GUID_NDIS_PM_ADMIN_CONFIG: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1528d111_708a_4ca4_9215_c05771161cda);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_PM_ADMIN_CONFIG ) , guid : :: windows :: core :: GUID::from_u128(0x1528d111_708a_4ca4_9215_c05771161cda) , } }
 pub const GUID_NDIS_RECEIVE_FILTER_ENUM_FILTERS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3f2c141d_83bc_11dd_94b8_001d09162bc3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_RECEIVE_FILTER_ENUM_FILTERS ) , guid : :: windows :: core :: GUID::from_u128(0x3f2c141d_83bc_11dd_94b8_001d09162bc3) , } }
 pub const GUID_NDIS_RECEIVE_FILTER_ENUM_QUEUES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3f2c141b_83bc_11dd_94b8_001d09162bc3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_RECEIVE_FILTER_ENUM_QUEUES ) , guid : :: windows :: core :: GUID::from_u128(0x3f2c141b_83bc_11dd_94b8_001d09162bc3) , } }
 pub const GUID_NDIS_RECEIVE_FILTER_GLOBAL_PARAMETERS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3f2c141a_83bc_11dd_94b8_001d09162bc3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_RECEIVE_FILTER_GLOBAL_PARAMETERS ) , guid : :: windows :: core :: GUID::from_u128(0x3f2c141a_83bc_11dd_94b8_001d09162bc3) , } }
 pub const GUID_NDIS_RECEIVE_FILTER_HARDWARE_CAPABILITIES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3f2c1419_83bc_11dd_94b8_001d09162bc3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_RECEIVE_FILTER_HARDWARE_CAPABILITIES ) , guid : :: windows :: core :: GUID::from_u128(0x3f2c1419_83bc_11dd_94b8_001d09162bc3) , } }
 pub const GUID_NDIS_RECEIVE_FILTER_PARAMETERS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3f2c141e_83bc_11dd_94b8_001d09162bc3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_RECEIVE_FILTER_PARAMETERS ) , guid : :: windows :: core :: GUID::from_u128(0x3f2c141e_83bc_11dd_94b8_001d09162bc3) , } }
 pub const GUID_NDIS_RECEIVE_FILTER_QUEUE_PARAMETERS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3f2c141c_83bc_11dd_94b8_001d09162bc3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_RECEIVE_FILTER_QUEUE_PARAMETERS ) , guid : :: windows :: core :: GUID::from_u128(0x3f2c141c_83bc_11dd_94b8_001d09162bc3) , } }
 pub const GUID_NDIS_RECEIVE_SCALE_CAPABILITIES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x26c28774_4252_48fe_a610_a58a398c0eb1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_RECEIVE_SCALE_CAPABILITIES ) , guid : :: windows :: core :: GUID::from_u128(0x26c28774_4252_48fe_a610_a58a398c0eb1) , } }
 pub const GUID_NDIS_RSS_ENABLED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9565cd55_3402_4e32_a5b6_2f143f2f2c30);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_RSS_ENABLED ) , guid : :: windows :: core :: GUID::from_u128(0x9565cd55_3402_4e32_a5b6_2f143f2f2c30) , } }
 pub const GUID_NDIS_STATUS_DOT11_ASSOCIATION_COMPLETION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x458bbea7_45a4_4ae2_b176_e51f96fc0568);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_DOT11_ASSOCIATION_COMPLETION ) , guid : :: windows :: core :: GUID::from_u128(0x458bbea7_45a4_4ae2_b176_e51f96fc0568) , } }
 pub const GUID_NDIS_STATUS_DOT11_ASSOCIATION_START: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3927843b_6980_4b48_b15b_4de50977ac40);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_DOT11_ASSOCIATION_START ) , guid : :: windows :: core :: GUID::from_u128(0x3927843b_6980_4b48_b15b_4de50977ac40) , } }
 pub const GUID_NDIS_STATUS_DOT11_CONNECTION_COMPLETION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x96efd9c9_7f1b_4a89_bc04_3e9e271765f1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_DOT11_CONNECTION_COMPLETION ) , guid : :: windows :: core :: GUID::from_u128(0x96efd9c9_7f1b_4a89_bc04_3e9e271765f1) , } }
 pub const GUID_NDIS_STATUS_DOT11_CONNECTION_START: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7b74299d_998f_4454_ad08_c5af28576d1b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_DOT11_CONNECTION_START ) , guid : :: windows :: core :: GUID::from_u128(0x7b74299d_998f_4454_ad08_c5af28576d1b) , } }
 pub const GUID_NDIS_STATUS_DOT11_DISASSOCIATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3fbeb6fc_0fe2_43fd_b2ad_bd99b5f93e13);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_DOT11_DISASSOCIATION ) , guid : :: windows :: core :: GUID::from_u128(0x3fbeb6fc_0fe2_43fd_b2ad_bd99b5f93e13) , } }
 pub const GUID_NDIS_STATUS_DOT11_LINK_QUALITY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa3285184_ea99_48ed_825e_a426b11c2754);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_DOT11_LINK_QUALITY ) , guid : :: windows :: core :: GUID::from_u128(0xa3285184_ea99_48ed_825e_a426b11c2754) , } }
 pub const GUID_NDIS_STATUS_DOT11_MPDU_MAX_LENGTH_CHANGED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1d6560ec_8e48_4a3e_9fd5_a01b698db6c5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_DOT11_MPDU_MAX_LENGTH_CHANGED ) , guid : :: windows :: core :: GUID::from_u128(0x1d6560ec_8e48_4a3e_9fd5_a01b698db6c5) , } }
 pub const GUID_NDIS_STATUS_DOT11_PHY_STATE_CHANGED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdeb45316_71b5_4736_bdef_0a9e9f4e62dc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_DOT11_PHY_STATE_CHANGED ) , guid : :: windows :: core :: GUID::from_u128(0xdeb45316_71b5_4736_bdef_0a9e9f4e62dc) , } }
 pub const GUID_NDIS_STATUS_DOT11_PMKID_CANDIDATE_LIST: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x26d8b8f6_db82_49eb_8bf3_4c130ef06950);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_DOT11_PMKID_CANDIDATE_LIST ) , guid : :: windows :: core :: GUID::from_u128(0x26d8b8f6_db82_49eb_8bf3_4c130ef06950) , } }
 pub const GUID_NDIS_STATUS_DOT11_ROAMING_COMPLETION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdd9d47d1_282b_41e4_b924_66368817fcd3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_DOT11_ROAMING_COMPLETION ) , guid : :: windows :: core :: GUID::from_u128(0xdd9d47d1_282b_41e4_b924_66368817fcd3) , } }
 pub const GUID_NDIS_STATUS_DOT11_ROAMING_START: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb2412d0d_26c8_4f4e_93df_f7b705a0b433);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_DOT11_ROAMING_START ) , guid : :: windows :: core :: GUID::from_u128(0xb2412d0d_26c8_4f4e_93df_f7b705a0b433) , } }
 pub const GUID_NDIS_STATUS_DOT11_SCAN_CONFIRM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8500591e_a0c7_4efb_9342_b674b002cbe6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_DOT11_SCAN_CONFIRM ) , guid : :: windows :: core :: GUID::from_u128(0x8500591e_a0c7_4efb_9342_b674b002cbe6) , } }
 pub const GUID_NDIS_STATUS_DOT11_TKIPMIC_FAILURE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x442c2ae4_9bc5_4b90_a889_455ef220f4ee);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_DOT11_TKIPMIC_FAILURE ) , guid : :: windows :: core :: GUID::from_u128(0x442c2ae4_9bc5_4b90_a889_455ef220f4ee) , } }
 pub const GUID_NDIS_STATUS_EXTERNAL_CONNECTIVITY_CHANGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfd306974_c420_4433_b0fe_4cf6a613f59f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_EXTERNAL_CONNECTIVITY_CHANGE ) , guid : :: windows :: core :: GUID::from_u128(0xfd306974_c420_4433_b0fe_4cf6a613f59f) , } }
 pub const GUID_NDIS_STATUS_HD_SPLIT_CURRENT_CONFIG: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6c744b0e_ee9c_4205_90a2_015f6d65f403);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_HD_SPLIT_CURRENT_CONFIG ) , guid : :: windows :: core :: GUID::from_u128(0x6c744b0e_ee9c_4205_90a2_015f6d65f403) , } }
 pub const GUID_NDIS_STATUS_LINK_SPEED_CHANGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x981f2d85_b1f3_11d0_8dd7_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_LINK_SPEED_CHANGE ) , guid : :: windows :: core :: GUID::from_u128(0x981f2d85_b1f3_11d0_8dd7_00c04fc3358c) , } }
 pub const GUID_NDIS_STATUS_LINK_STATE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x64c6f797_878c_4311_9246_65dba89c3a61);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_LINK_STATE ) , guid : :: windows :: core :: GUID::from_u128(0x64c6f797_878c_4311_9246_65dba89c3a61) , } }
 pub const GUID_NDIS_STATUS_MEDIA_CONNECT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x981f2d7d_b1f3_11d0_8dd7_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_MEDIA_CONNECT ) , guid : :: windows :: core :: GUID::from_u128(0x981f2d7d_b1f3_11d0_8dd7_00c04fc3358c) , } }
 pub const GUID_NDIS_STATUS_MEDIA_DISCONNECT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x981f2d7e_b1f3_11d0_8dd7_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_MEDIA_DISCONNECT ) , guid : :: windows :: core :: GUID::from_u128(0x981f2d7e_b1f3_11d0_8dd7_00c04fc3358c) , } }
 pub const GUID_NDIS_STATUS_MEDIA_SPECIFIC_INDICATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x981f2d84_b1f3_11d0_8dd7_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_MEDIA_SPECIFIC_INDICATION ) , guid : :: windows :: core :: GUID::from_u128(0x981f2d84_b1f3_11d0_8dd7_00c04fc3358c) , } }
 pub const GUID_NDIS_STATUS_NETWORK_CHANGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xca8a56f9_ce81_40e6_a70f_a067a476e9e9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_NETWORK_CHANGE ) , guid : :: windows :: core :: GUID::from_u128(0xca8a56f9_ce81_40e6_a70f_a067a476e9e9) , } }
 pub const GUID_NDIS_STATUS_OPER_STATUS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf917b663_845e_4d3d_b6d4_15eb27af81c5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_OPER_STATUS ) , guid : :: windows :: core :: GUID::from_u128(0xf917b663_845e_4d3d_b6d4_15eb27af81c5) , } }
 pub const GUID_NDIS_STATUS_PACKET_FILTER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd47c5407_2e75_46dd_8146_1d7ed2d6ab1d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_PACKET_FILTER ) , guid : :: windows :: core :: GUID::from_u128(0xd47c5407_2e75_46dd_8146_1d7ed2d6ab1d) , } }
 pub const GUID_NDIS_STATUS_PM_OFFLOAD_REJECTED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xadd1d481_711e_4d1a_92ca_a62db9329712);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_PM_OFFLOAD_REJECTED ) , guid : :: windows :: core :: GUID::from_u128(0xadd1d481_711e_4d1a_92ca_a62db9329712) , } }
 pub const GUID_NDIS_STATUS_PM_WAKE_REASON: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0933fd58_ca62_438f_83da_dfc1cccb8145);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_PM_WAKE_REASON ) , guid : :: windows :: core :: GUID::from_u128(0x0933fd58_ca62_438f_83da_dfc1cccb8145) , } }
 pub const GUID_NDIS_STATUS_PM_WOL_PATTERN_REJECTED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf72cf68e_18d4_4d63_9a19_e69b13916b1a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_PM_WOL_PATTERN_REJECTED ) , guid : :: windows :: core :: GUID::from_u128(0xf72cf68e_18d4_4d63_9a19_e69b13916b1a) , } }
 pub const GUID_NDIS_STATUS_PORT_STATE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1dac0dfe_43e5_44b7_b759_7bf46de32e81);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_PORT_STATE ) , guid : :: windows :: core :: GUID::from_u128(0x1dac0dfe_43e5_44b7_b759_7bf46de32e81) , } }
 pub const GUID_NDIS_STATUS_RESET_END: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x981f2d77_b1f3_11d0_8dd7_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_RESET_END ) , guid : :: windows :: core :: GUID::from_u128(0x981f2d77_b1f3_11d0_8dd7_00c04fc3358c) , } }
 pub const GUID_NDIS_STATUS_RESET_START: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x981f2d76_b1f3_11d0_8dd7_00c04fc3358c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_RESET_START ) , guid : :: windows :: core :: GUID::from_u128(0x981f2d76_b1f3_11d0_8dd7_00c04fc3358c) , } }
 pub const GUID_NDIS_STATUS_TASK_OFFLOAD_CURRENT_CONFIG: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x45049fc6_54d8_40c8_9c3d_b011c4e715bc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_TASK_OFFLOAD_CURRENT_CONFIG ) , guid : :: windows :: core :: GUID::from_u128(0x45049fc6_54d8_40c8_9c3d_b011c4e715bc) , } }
 pub const GUID_NDIS_STATUS_TASK_OFFLOAD_HARDWARE_CAPABILITIES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb6b8158b_217c_4b2a_be86_6a04beea65b8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_TASK_OFFLOAD_HARDWARE_CAPABILITIES ) , guid : :: windows :: core :: GUID::from_u128(0xb6b8158b_217c_4b2a_be86_6a04beea65b8) , } }
 pub const GUID_NDIS_STATUS_TCP_CONNECTION_OFFLOAD_CURRENT_CONFIG: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf8edaeff_24e4_4ae6_a413_0b27f76b243d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_TCP_CONNECTION_OFFLOAD_CURRENT_CONFIG ) , guid : :: windows :: core :: GUID::from_u128(0xf8edaeff_24e4_4ae6_a413_0b27f76b243d) , } }
 pub const GUID_NDIS_STATUS_TCP_CONNECTION_OFFLOAD_HARDWARE_CAPABILITIES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x391969b6_402c_43bf_8922_39eae0da1bb5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_STATUS_TCP_CONNECTION_OFFLOAD_HARDWARE_CAPABILITIES ) , guid : :: windows :: core :: GUID::from_u128(0x391969b6_402c_43bf_8922_39eae0da1bb5) , } }
 pub const GUID_NDIS_SWITCH_MICROSOFT_VENDOR_ID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x202547fe_1c9c_40b9_bba1_08ada1f98b3c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_SWITCH_MICROSOFT_VENDOR_ID ) , guid : :: windows :: core :: GUID::from_u128(0x202547fe_1c9c_40b9_bba1_08ada1f98b3c) , } }
 pub const GUID_NDIS_SWITCH_PORT_PROPERTY_PROFILE_ID_DEFAULT_EXTERNAL_NIC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0b347846_0a0c_470a_9b7a_0d965850698f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_SWITCH_PORT_PROPERTY_PROFILE_ID_DEFAULT_EXTERNAL_NIC ) , guid : :: windows :: core :: GUID::from_u128(0x0b347846_0a0c_470a_9b7a_0d965850698f) , } }
 pub const GUID_NDIS_TCP_CONNECTION_OFFLOAD_CURRENT_CONFIG: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2ee6aef1_0851_458b_bf0d_792343d1cde1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_TCP_CONNECTION_OFFLOAD_CURRENT_CONFIG ) , guid : :: windows :: core :: GUID::from_u128(0x2ee6aef1_0851_458b_bf0d_792343d1cde1) , } }
 pub const GUID_NDIS_TCP_CONNECTION_OFFLOAD_HARDWARE_CAPABILITIES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8ce71f2c_d63a_4390_a487_18fa47262ceb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_TCP_CONNECTION_OFFLOAD_HARDWARE_CAPABILITIES ) , guid : :: windows :: core :: GUID::from_u128(0x8ce71f2c_d63a_4390_a487_18fa47262ceb) , } }
 pub const GUID_NDIS_TCP_OFFLOAD_CURRENT_CONFIG: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x68542fed_5c74_461e_8934_91c6f9c60960);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_TCP_OFFLOAD_CURRENT_CONFIG ) , guid : :: windows :: core :: GUID::from_u128(0x68542fed_5c74_461e_8934_91c6f9c60960) , } }
 pub const GUID_NDIS_TCP_OFFLOAD_HARDWARE_CAPABILITIES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcd5f1102_590f_4ada_ab65_5b31b1dc0172);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_TCP_OFFLOAD_HARDWARE_CAPABILITIES ) , guid : :: windows :: core :: GUID::from_u128(0xcd5f1102_590f_4ada_ab65_5b31b1dc0172) , } }
 pub const GUID_NDIS_TCP_OFFLOAD_PARAMETERS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8ead9a22_7f69_4bc6_949a_c8187b074e61);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_TCP_OFFLOAD_PARAMETERS ) , guid : :: windows :: core :: GUID::from_u128(0x8ead9a22_7f69_4bc6_949a_c8187b074e61) , } }
 pub const GUID_NDIS_TCP_RSC_STATISTICS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x83104445_9b5d_4ee6_a2a5_2bd3fb3c36af);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_TCP_RSC_STATISTICS ) , guid : :: windows :: core :: GUID::from_u128(0x83104445_9b5d_4ee6_a2a5_2bd3fb3c36af) , } }
 pub const GUID_NDIS_WAKE_ON_MAGIC_PACKET_ONLY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa14f1c97_8839_4f8a_9996_a28996ebbf1d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NDIS_WAKE_ON_MAGIC_PACKET_ONLY ) , guid : :: windows :: core :: GUID::from_u128(0xa14f1c97_8839_4f8a_9996_a28996ebbf1d) , } }
 pub const GUID_NIC_SWITCH_CURRENT_CAPABILITIES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe76fdaf3_0be7_4d95_87e9_5aead4b590e9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NIC_SWITCH_CURRENT_CAPABILITIES ) , guid : :: windows :: core :: GUID::from_u128(0xe76fdaf3_0be7_4d95_87e9_5aead4b590e9) , } }
 pub const GUID_NIC_SWITCH_HARDWARE_CAPABILITIES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x37cab40c_d1e8_4301_8c1d_58465e0c4c0f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NIC_SWITCH_HARDWARE_CAPABILITIES ) , guid : :: windows :: core :: GUID::from_u128(0x37cab40c_d1e8_4301_8c1d_58465e0c4c0f) , } }
 pub const GUID_PM_ADD_PROTOCOL_OFFLOAD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0c06c112_0d93_439b_9e6d_26be130c9784);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PM_ADD_PROTOCOL_OFFLOAD ) , guid : :: windows :: core :: GUID::from_u128(0x0c06c112_0d93_439b_9e6d_26be130c9784) , } }
 pub const GUID_PM_ADD_WOL_PATTERN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fc83ba7_52bc_4faa_ac51_7d2ffe63ba90);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PM_ADD_WOL_PATTERN ) , guid : :: windows :: core :: GUID::from_u128(0x6fc83ba7_52bc_4faa_ac51_7d2ffe63ba90) , } }
 pub const GUID_PM_CURRENT_CAPABILITIES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3abdbd14_d44a_4a3f_9a63_a0a42a51b131);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PM_CURRENT_CAPABILITIES ) , guid : :: windows :: core :: GUID::from_u128(0x3abdbd14_d44a_4a3f_9a63_a0a42a51b131) , } }
 pub const GUID_PM_GET_PROTOCOL_OFFLOAD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa6435cd9_149f_498e_951b_2d94bea3e3a3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PM_GET_PROTOCOL_OFFLOAD ) , guid : :: windows :: core :: GUID::from_u128(0xa6435cd9_149f_498e_951b_2d94bea3e3a3) , } }
 pub const GUID_PM_HARDWARE_CAPABILITIES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xece5360d_3291_4a6e_8044_00511fed27ee);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PM_HARDWARE_CAPABILITIES ) , guid : :: windows :: core :: GUID::from_u128(0xece5360d_3291_4a6e_8044_00511fed27ee) , } }
 pub const GUID_PM_PARAMETERS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x560245d2_e251_409c_a280_311935be3b28);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PM_PARAMETERS ) , guid : :: windows :: core :: GUID::from_u128(0x560245d2_e251_409c_a280_311935be3b28) , } }
 pub const GUID_PM_PROTOCOL_OFFLOAD_LIST: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x736ec5ab_ca8f_4043_bb58_da402a48d9cc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PM_PROTOCOL_OFFLOAD_LIST ) , guid : :: windows :: core :: GUID::from_u128(0x736ec5ab_ca8f_4043_bb58_da402a48d9cc) , } }
 pub const GUID_PM_REMOVE_PROTOCOL_OFFLOAD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdecd7be2_a6b0_43ca_ae45_d000d20e5265);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PM_REMOVE_PROTOCOL_OFFLOAD ) , guid : :: windows :: core :: GUID::from_u128(0xdecd7be2_a6b0_43ca_ae45_d000d20e5265) , } }
 pub const GUID_PM_REMOVE_WOL_PATTERN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa037a915_c6ca_4322_b3e3_ef754ec498dc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PM_REMOVE_WOL_PATTERN ) , guid : :: windows :: core :: GUID::from_u128(0xa037a915_c6ca_4322_b3e3_ef754ec498dc) , } }
 pub const GUID_PM_WOL_PATTERN_LIST: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4022be37_7ee2_47be_a5a5_050fc79afc75);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PM_WOL_PATTERN_LIST ) , guid : :: windows :: core :: GUID::from_u128(0x4022be37_7ee2_47be_a5a5_050fc79afc75) , } }
 pub const GUID_RECEIVE_FILTER_CURRENT_CAPABILITIES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4054e80f_2bc1_4ccc_b033_4abc0c4a1e8c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_RECEIVE_FILTER_CURRENT_CAPABILITIES ) , guid : :: windows :: core :: GUID::from_u128(0x4054e80f_2bc1_4ccc_b033_4abc0c4a1e8c) , } }
 pub const GUID_STATUS_MEDIA_SPECIFIC_INDICATION_EX: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaaacfca7_954a_4632_a16e_a8a63793a9e5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_STATUS_MEDIA_SPECIFIC_INDICATION_EX ) , guid : :: windows :: core :: GUID::from_u128(0xaaacfca7_954a_4632_a16e_a8a63793a9e5) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_Ndis'*"]
 pub const IOCTL_NDIS_RESERVED5: u32 = 1507380u32;
 #[doc = "*Required features: 'Win32_NetworkManagement_Ndis'*"]
@@ -9392,6 +9772,8 @@ pub const OFFLOAD_IPSEC_UDPESP_ENCAPTYPE_IKE: UDP_ENCAP_TYPE = 0i32;
 #[doc = "*Required features: 'Win32_NetworkManagement_Ndis'*"]
 pub const OFFLOAD_IPSEC_UDPESP_ENCAPTYPE_OTHER: UDP_ENCAP_TYPE = 1i32;
 pub const UNSPECIFIED_NETWORK_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x12ba5bde_143e_4c0d_b66d_2379bb141913);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( UNSPECIFIED_NETWORK_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x12ba5bde_143e_4c0d_b66d_2379bb141913) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_Ndis'*"]
 pub const WAN_PROTOCOL_KEEPS_STATS: u32 = 1u32;
 #[repr(C)]

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/NetManagement/mod.rs
@@ -15737,6 +15737,8 @@ pub const SW_AUTOPROF_LOAD_MASK: u32 = 1u32;
 #[doc = "*Required features: 'Win32_NetworkManagement_NetManagement'*"]
 pub const SW_AUTOPROF_SAVE_MASK: u32 = 2u32;
 pub const ServiceAccountPasswordGUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x262e99c9_6160_4871_acec_4e61736b6f21);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ServiceAccountPasswordGUID ) , guid : :: windows :: core :: GUID::from_u128(0x262e99c9_6160_4871_acec_4e61736b6f21) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_NetManagement', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/P2P/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/P2P/mod.rs
@@ -1170,7 +1170,11 @@ pub const NS_PNRPCLOUD: u32 = 39u32;
 #[doc = "*Required features: 'Win32_NetworkManagement_P2P'*"]
 pub const NS_PNRPNAME: u32 = 38u32;
 pub const NS_PROVIDER_PNRPCLOUD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x03fe89ce_766d_4976_b9c1_bb9bc42c7b4d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( NS_PROVIDER_PNRPCLOUD ) , guid : :: windows :: core :: GUID::from_u128(0x03fe89ce_766d_4976_b9c1_bb9bc42c7b4d) , } }
 pub const NS_PROVIDER_PNRPNAME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x03fe89cd_766d_4976_b9c1_bb9bc42c7b4d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( NS_PROVIDER_PNRPNAME ) , guid : :: windows :: core :: GUID::from_u128(0x03fe89cd_766d_4976_b9c1_bb9bc42c7b4d) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_NetworkManagement_P2P', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -1663,6 +1667,8 @@ pub const PEER_EVENT_PEOPLE_NEAR_ME_CHANGED: PEER_COLLAB_EVENT_TYPE = 10i32;
 #[doc = "*Required features: 'Win32_NetworkManagement_P2P'*"]
 pub const PEER_EVENT_REQUEST_STATUS_CHANGED: PEER_COLLAB_EVENT_TYPE = 11i32;
 pub const PEER_COLLAB_OBJECTID_USER_PICTURE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdd15f41f_fc4e_4922_b035_4c06a754d01d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PEER_COLLAB_OBJECTID_USER_PICTURE ) , guid : :: windows :: core :: GUID::from_u128(0xdd15f41f_fc4e_4922_b035_4c06a754d01d) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_P2P'*"]
 pub type PEER_CONNECTION_FLAGS = i32;
 #[doc = "*Required features: 'Win32_NetworkManagement_P2P'*"]
@@ -2781,8 +2787,14 @@ pub const PEER_DISABLE_PRESENCE: PEER_GROUP_PROPERTY_FLAGS = 2i32;
 #[doc = "*Required features: 'Win32_NetworkManagement_P2P'*"]
 pub const PEER_DEFER_EXPIRATION: PEER_GROUP_PROPERTY_FLAGS = 4i32;
 pub const PEER_GROUP_ROLE_ADMIN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x04387127_aa56_450a_8ce5_4f565c6790f4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PEER_GROUP_ROLE_ADMIN ) , guid : :: windows :: core :: GUID::from_u128(0x04387127_aa56_450a_8ce5_4f565c6790f4) , } }
 pub const PEER_GROUP_ROLE_INVITING_MEMBER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4370fd89_dc18_4cfb_8dbf_9853a8a9f905);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PEER_GROUP_ROLE_INVITING_MEMBER ) , guid : :: windows :: core :: GUID::from_u128(0x4370fd89_dc18_4cfb_8dbf_9853a8a9f905) , } }
 pub const PEER_GROUP_ROLE_MEMBER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf12dc4c7_0857_4ca0_93fc_b1bb19a3d8c2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PEER_GROUP_ROLE_MEMBER ) , guid : :: windows :: core :: GUID::from_u128(0xf12dc4c7_0857_4ca0_93fc_b1bb19a3d8c2) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_P2P'*"]
 pub type PEER_GROUP_STATUS = i32;
 #[doc = "*Required features: 'Win32_NetworkManagement_P2P'*"]
@@ -6413,8 +6425,14 @@ pub unsafe fn PeerPnrpUpdateRegistration(hregistration: *const ::core::ffi::c_vo
     unimplemented!("Unsupported target OS");
 }
 pub const SVCID_PNRPCLOUD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc2239ce6_00c0_4fbf_bad6_18139385a49a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SVCID_PNRPCLOUD ) , guid : :: windows :: core :: GUID::from_u128(0xc2239ce6_00c0_4fbf_bad6_18139385a49a) , } }
 pub const SVCID_PNRPNAME_V1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc2239ce5_00c0_4fbf_bad6_18139385a49a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SVCID_PNRPNAME_V1 ) , guid : :: windows :: core :: GUID::from_u128(0xc2239ce5_00c0_4fbf_bad6_18139385a49a) , } }
 pub const SVCID_PNRPNAME_V2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc2239ce7_00c0_4fbf_bad6_18139385a49a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SVCID_PNRPNAME_V2 ) , guid : :: windows :: core :: GUID::from_u128(0xc2239ce7_00c0_4fbf_bad6_18139385a49a) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_P2P'*"]
 pub const WSA_PNRP_CLIENT_INVALID_COMPARTMENT_ID: u32 = 11506u32;
 #[doc = "*Required features: 'Win32_NetworkManagement_P2P'*"]

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/QoS/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/QoS/mod.rs
@@ -733,21 +733,53 @@ pub const GUAR_ADSPARM_Dsum: i32 = 136i32;
 #[doc = "*Required features: 'Win32_NetworkManagement_QoS'*"]
 pub const GUAR_ADSPARM_Dtot: i32 = 134i32;
 pub const GUID_QOS_BESTEFFORT_BANDWIDTH: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xed885290_40ec_11d1_2c91_00aa00574915);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_QOS_BESTEFFORT_BANDWIDTH ) , guid : :: windows :: core :: GUID::from_u128(0xed885290_40ec_11d1_2c91_00aa00574915) , } }
 pub const GUID_QOS_ENABLE_AVG_STATS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbafb6d11_27c4_4801_a46f_ef8080c188c8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_QOS_ENABLE_AVG_STATS ) , guid : :: windows :: core :: GUID::from_u128(0xbafb6d11_27c4_4801_a46f_ef8080c188c8) , } }
 pub const GUID_QOS_ENABLE_WINDOW_ADJUSTMENT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaa966725_d3e9_4c55_b335_2a00279a1e64);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_QOS_ENABLE_WINDOW_ADJUSTMENT ) , guid : :: windows :: core :: GUID::from_u128(0xaa966725_d3e9_4c55_b335_2a00279a1e64) , } }
 pub const GUID_QOS_FLOW_8021P_CONFORMING: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x08c1e013_fcd2_11d2_be1e_00a0c99ee63b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_QOS_FLOW_8021P_CONFORMING ) , guid : :: windows :: core :: GUID::from_u128(0x08c1e013_fcd2_11d2_be1e_00a0c99ee63b) , } }
 pub const GUID_QOS_FLOW_8021P_NONCONFORMING: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x09023f91_fcd2_11d2_be1e_00a0c99ee63b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_QOS_FLOW_8021P_NONCONFORMING ) , guid : :: windows :: core :: GUID::from_u128(0x09023f91_fcd2_11d2_be1e_00a0c99ee63b) , } }
 pub const GUID_QOS_FLOW_COUNT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1147f880_40ed_11d1_2c91_00aa00574915);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_QOS_FLOW_COUNT ) , guid : :: windows :: core :: GUID::from_u128(0x1147f880_40ed_11d1_2c91_00aa00574915) , } }
 pub const GUID_QOS_FLOW_IP_CONFORMING: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x07f99a8b_fcd2_11d2_be1e_00a0c99ee63b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_QOS_FLOW_IP_CONFORMING ) , guid : :: windows :: core :: GUID::from_u128(0x07f99a8b_fcd2_11d2_be1e_00a0c99ee63b) , } }
 pub const GUID_QOS_FLOW_IP_NONCONFORMING: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x087a5987_fcd2_11d2_be1e_00a0c99ee63b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_QOS_FLOW_IP_NONCONFORMING ) , guid : :: windows :: core :: GUID::from_u128(0x087a5987_fcd2_11d2_be1e_00a0c99ee63b) , } }
 pub const GUID_QOS_FLOW_MODE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5c82290a_515a_11d2_8e58_00c04fc9bfcb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_QOS_FLOW_MODE ) , guid : :: windows :: core :: GUID::from_u128(0x5c82290a_515a_11d2_8e58_00c04fc9bfcb) , } }
 pub const GUID_QOS_ISSLOW_FLOW: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xabf273a4_ee07_11d2_be1b_00a0c99ee63b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_QOS_ISSLOW_FLOW ) , guid : :: windows :: core :: GUID::from_u128(0xabf273a4_ee07_11d2_be1b_00a0c99ee63b) , } }
 pub const GUID_QOS_LATENCY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfc408ef0_40ec_11d1_2c91_00aa00574915);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_QOS_LATENCY ) , guid : :: windows :: core :: GUID::from_u128(0xfc408ef0_40ec_11d1_2c91_00aa00574915) , } }
 pub const GUID_QOS_MAX_OUTSTANDING_SENDS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x161ffa86_6120_11d1_2c91_00aa00574915);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_QOS_MAX_OUTSTANDING_SENDS ) , guid : :: windows :: core :: GUID::from_u128(0x161ffa86_6120_11d1_2c91_00aa00574915) , } }
 pub const GUID_QOS_NON_BESTEFFORT_LIMIT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x185c44e0_40ed_11d1_2c91_00aa00574915);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_QOS_NON_BESTEFFORT_LIMIT ) , guid : :: windows :: core :: GUID::from_u128(0x185c44e0_40ed_11d1_2c91_00aa00574915) , } }
 pub const GUID_QOS_REMAINING_BANDWIDTH: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc4c51720_40ec_11d1_2c91_00aa00574915);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_QOS_REMAINING_BANDWIDTH ) , guid : :: windows :: core :: GUID::from_u128(0xc4c51720_40ec_11d1_2c91_00aa00574915) , } }
 pub const GUID_QOS_STATISTICS_BUFFER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbb2c0980_e900_11d1_b07e_0080c71382bf);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_QOS_STATISTICS_BUFFER ) , guid : :: windows :: core :: GUID::from_u128(0xbb2c0980_e900_11d1_b07e_0080c71382bf) , } }
 pub const GUID_QOS_TIMER_RESOLUTION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xba10cc88_f13e_11d2_be1b_00a0c99ee63b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_QOS_TIMER_RESOLUTION ) , guid : :: windows :: core :: GUID::from_u128(0xba10cc88_f13e_11d2_be1b_00a0c99ee63b) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_NetworkManagement_QoS'*"]
 pub struct Gads_parms_t {

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WiFi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WiFi/mod.rs
@@ -10,120 +10,198 @@ pub const ch_description_type_phy_specific: CH_DESCRIPTION_TYPE = 3i32;
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_InfraCast_AccessPointBssid: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 19u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_InfraCast_AccessPointBssid ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_InfraCast_ChallengeAep: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 21u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_InfraCast_ChallengeAep ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_InfraCast_DevnodeAep: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 23u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_InfraCast_DevnodeAep ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_InfraCast_HostName_ResolutionMode: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 25u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_InfraCast_HostName_ResolutionMode ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_InfraCast_PinSupported: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 29u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_InfraCast_PinSupported ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_InfraCast_RtspTcpConnectionParametersSupported: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 30u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_InfraCast_RtspTcpConnectionParametersSupported ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_InfraCast_SinkHostName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 20u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_InfraCast_SinkHostName ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_InfraCast_SinkIpAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 26u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_InfraCast_SinkIpAddress ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_InfraCast_StreamSecuritySupported: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 18u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_InfraCast_StreamSecuritySupported ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_InfraCast_Supported: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 17u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_InfraCast_Supported ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WiFiDirectServices_AdvertisementId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x31b37743_7c5e_4005_93e6_e953f92b82e9), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WiFiDirectServices_AdvertisementId ) , guid : :: windows :: core :: GUID::from_u128(0x31b37743_7c5e_4005_93e6_e953f92b82e9) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WiFiDirectServices_RequestServiceInformation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x31b37743_7c5e_4005_93e6_e953f92b82e9), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WiFiDirectServices_RequestServiceInformation ) , guid : :: windows :: core :: GUID::from_u128(0x31b37743_7c5e_4005_93e6_e953f92b82e9) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WiFiDirectServices_ServiceAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x31b37743_7c5e_4005_93e6_e953f92b82e9), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WiFiDirectServices_ServiceAddress ) , guid : :: windows :: core :: GUID::from_u128(0x31b37743_7c5e_4005_93e6_e953f92b82e9) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WiFiDirectServices_ServiceConfigMethods: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x31b37743_7c5e_4005_93e6_e953f92b82e9), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WiFiDirectServices_ServiceConfigMethods ) , guid : :: windows :: core :: GUID::from_u128(0x31b37743_7c5e_4005_93e6_e953f92b82e9) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WiFiDirectServices_ServiceInformation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x31b37743_7c5e_4005_93e6_e953f92b82e9), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WiFiDirectServices_ServiceInformation ) , guid : :: windows :: core :: GUID::from_u128(0x31b37743_7c5e_4005_93e6_e953f92b82e9) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WiFiDirectServices_ServiceName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x31b37743_7c5e_4005_93e6_e953f92b82e9), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WiFiDirectServices_ServiceName ) , guid : :: windows :: core :: GUID::from_u128(0x31b37743_7c5e_4005_93e6_e953f92b82e9) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WiFiDirect_DeviceAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 1u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WiFiDirect_DeviceAddress ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WiFiDirect_DeviceAddressCopy: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WiFiDirect_DeviceAddressCopy ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WiFiDirect_FoundWsbService: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 24u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WiFiDirect_FoundWsbService ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WiFiDirect_GroupId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WiFiDirect_GroupId ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WiFiDirect_InformationElements: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WiFiDirect_InformationElements ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WiFiDirect_InterfaceAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WiFiDirect_InterfaceAddress ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WiFiDirect_InterfaceGuid: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WiFiDirect_InterfaceGuid ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WiFiDirect_IsConnected: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WiFiDirect_IsConnected ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WiFiDirect_IsDMGCapable: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 22u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WiFiDirect_IsDMGCapable ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WiFiDirect_IsLegacyDevice: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WiFiDirect_IsLegacyDevice ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WiFiDirect_IsMiracastLCPSupported: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WiFiDirect_IsMiracastLCPSupported ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WiFiDirect_IsRecentlyAssociated: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WiFiDirect_IsRecentlyAssociated ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WiFiDirect_IsVisible: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WiFiDirect_IsVisible ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WiFiDirect_LinkQuality: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 28u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WiFiDirect_LinkQuality ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WiFiDirect_MiracastVersion: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WiFiDirect_MiracastVersion ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WiFiDirect_Miracast_SessionMgmtControlPort: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 31u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WiFiDirect_Miracast_SessionMgmtControlPort ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WiFiDirect_NoMiracastAutoProject: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 16u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WiFiDirect_NoMiracastAutoProject ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WiFiDirect_RtspTcpConnectionParametersSupported: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 32u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WiFiDirect_RtspTcpConnectionParametersSupported ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WiFiDirect_Service_Aeps: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 15u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WiFiDirect_Service_Aeps ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WiFiDirect_Services: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WiFiDirect_Services ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WiFiDirect_SupportedChannelList: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WiFiDirect_SupportedChannelList ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WiFiDirect_TransientAssociation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 27u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WiFiDirect_TransientAssociation ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_WiFi_InterfaceGuid: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef1167eb_cbfc_4341_a568_a7c91a68982c), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_WiFi_InterfaceGuid ) , guid : :: windows :: core :: GUID::from_u128(0xef1167eb_cbfc_4341_a568_a7c91a68982c) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi'*"]
 pub const DISCOVERY_FILTER_BITMASK_ANY: u32 = 15u32;
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi'*"]
@@ -9909,8 +9987,14 @@ pub const DevProp_PciRootBus_SupportedSpeedsAndModes_Pci_X_533Mhz: u32 = 32u32;
 pub const DevProp_PciRootBus_SupportedSpeedsAndModes_Pci_X_66Mhz: u32 = 4u32;
 pub const Dot11AdHocManager: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdd06a84f_83bd_4d01_8ab9_2389fea0869e);
 pub const GUID_AEPSERVICE_WIFIDIRECT_DEVICE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcc29827c_9caf_4928_99a9_18f7c2381389);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_AEPSERVICE_WIFIDIRECT_DEVICE ) , guid : :: windows :: core :: GUID::from_u128(0xcc29827c_9caf_4928_99a9_18f7c2381389) , } }
 pub const GUID_DEVINTERFACE_ASP_INFRA_DEVICE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xff823995_7a72_4c80_8757_c67ee13d1a49);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_ASP_INFRA_DEVICE ) , guid : :: windows :: core :: GUID::from_u128(0xff823995_7a72_4c80_8757_c67ee13d1a49) , } }
 pub const GUID_DEVINTERFACE_WIFIDIRECT_DEVICE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x439b20af_8955_405b_99f0_a62af0c68d43);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_WIFIDIRECT_DEVICE ) , guid : :: windows :: core :: GUID::from_u128(0x439b20af_8955_405b_99f0_a62af0c68d43) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WiFi'*"]
 #[repr(transparent)]
 pub struct IDot11AdHocInterface(::windows::core::IUnknown);

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsConnectNow/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsConnectNow/mod.rs
@@ -178,16 +178,26 @@ pub struct IWCNDeviceVtbl(
 #[doc = "*Required features: 'Win32_NetworkManagement_WindowsConnectNow', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_WCN_DeviceType_Category: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x88190b8b_4684_11da_a26a_0002b3988e81), pid: 16u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_WCN_DeviceType_Category ) , guid : :: windows :: core :: GUID::from_u128(0x88190b8b_4684_11da_a26a_0002b3988e81) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WindowsConnectNow', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_WCN_DeviceType_SubCategory: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x88190b8b_4684_11da_a26a_0002b3988e81), pid: 18u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_WCN_DeviceType_SubCategory ) , guid : :: windows :: core :: GUID::from_u128(0x88190b8b_4684_11da_a26a_0002b3988e81) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WindowsConnectNow', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_WCN_DeviceType_SubCategoryOUI: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x88190b8b_4684_11da_a26a_0002b3988e81), pid: 17u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_WCN_DeviceType_SubCategoryOUI ) , guid : :: windows :: core :: GUID::from_u128(0x88190b8b_4684_11da_a26a_0002b3988e81) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WindowsConnectNow', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_WCN_SSID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x88190b8b_4684_11da_a26a_0002b3988e81), pid: 32u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_WCN_SSID ) , guid : :: windows :: core :: GUID::from_u128(0x88190b8b_4684_11da_a26a_0002b3988e81) , } }
 pub const SID_WcnProvider: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc100beca_d33a_4a4b_bf23_bbef4663d017);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SID_WcnProvider ) , guid : :: windows :: core :: GUID::from_u128(0xc100beca_d33a_4a4b_bf23_bbef4663d017) , } }
 pub const WCNDeviceObject: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc100bea7_d33a_4a4b_bf23_bbef4663d017);
 #[doc = "*Required features: 'Win32_NetworkManagement_WindowsConnectNow'*"]
 pub const WCN_API_MAX_BUFFER_SIZE: u32 = 2096u32;

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFilteringPlatform/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/WindowsFilteringPlatform/mod.rs
@@ -770,9 +770,17 @@ impl ::core::default::Default for FWPM_CALLOUT0 {
     }
 }
 pub const FWPM_CALLOUT_BUILT_IN_RESERVED_1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x779719a4_e695_47b6_a199_7999fec9163b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_BUILT_IN_RESERVED_1 ) , guid : :: windows :: core :: GUID::from_u128(0x779719a4_e695_47b6_a199_7999fec9163b) , } }
 pub const FWPM_CALLOUT_BUILT_IN_RESERVED_2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xef9661b6_7c5e_48fd_a130_96678ceacc41);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_BUILT_IN_RESERVED_2 ) , guid : :: windows :: core :: GUID::from_u128(0xef9661b6_7c5e_48fd_a130_96678ceacc41) , } }
 pub const FWPM_CALLOUT_BUILT_IN_RESERVED_3: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x18729c7a_2f62_4be0_966f_974b21b86df1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_BUILT_IN_RESERVED_3 ) , guid : :: windows :: core :: GUID::from_u128(0x18729c7a_2f62_4be0_966f_974b21b86df1) , } }
 pub const FWPM_CALLOUT_BUILT_IN_RESERVED_4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6c3fb801_daff_40e9_91e6_f7ff7e52f7d9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_BUILT_IN_RESERVED_4 ) , guid : :: windows :: core :: GUID::from_u128(0x6c3fb801_daff_40e9_91e6_f7ff7e52f7d9) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_NetworkManagement_WindowsFilteringPlatform'*"]
 pub struct FWPM_CALLOUT_CHANGE0 {
@@ -808,7 +816,11 @@ impl ::core::default::Default for FWPM_CALLOUT_CHANGE0 {
 #[doc = "*Required features: 'Win32_NetworkManagement_WindowsFilteringPlatform'*"]
 pub type FWPM_CALLOUT_CHANGE_CALLBACK0 = ::core::option::Option<unsafe extern "system" fn(context: *mut ::core::ffi::c_void, change: *const FWPM_CALLOUT_CHANGE0)>;
 pub const FWPM_CALLOUT_EDGE_TRAVERSAL_ALE_LISTEN_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x33486ab5_6d5e_4e65_a00b_a7afed0ba9a1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_EDGE_TRAVERSAL_ALE_LISTEN_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x33486ab5_6d5e_4e65_a00b_a7afed0ba9a1) , } }
 pub const FWPM_CALLOUT_EDGE_TRAVERSAL_ALE_RESOURCE_ASSIGNMENT_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x079b1010_f1c5_4fcd_ae05_da41107abd0b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_EDGE_TRAVERSAL_ALE_RESOURCE_ASSIGNMENT_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x079b1010_f1c5_4fcd_ae05_da41107abd0b) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_NetworkManagement_WindowsFilteringPlatform'*"]
 pub struct FWPM_CALLOUT_ENUM_TEMPLATE0 {
@@ -847,36 +859,98 @@ pub const FWPM_CALLOUT_FLAG_REGISTERED: u32 = 262144u32;
 #[doc = "*Required features: 'Win32_NetworkManagement_WindowsFilteringPlatform'*"]
 pub const FWPM_CALLOUT_FLAG_USES_PROVIDER_CONTEXT: u32 = 131072u32;
 pub const FWPM_CALLOUT_HTTP_TEMPLATE_SSL_HANDSHAKE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb3423249_8d09_4858_9210_95c7fda8e30f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_HTTP_TEMPLATE_SSL_HANDSHAKE ) , guid : :: windows :: core :: GUID::from_u128(0xb3423249_8d09_4858_9210_95c7fda8e30f) , } }
 pub const FWPM_CALLOUT_IPSEC_ALE_CONNECT_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6ac141fc_f75d_4203_b9c8_48e6149c2712);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_IPSEC_ALE_CONNECT_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x6ac141fc_f75d_4203_b9c8_48e6149c2712) , } }
 pub const FWPM_CALLOUT_IPSEC_ALE_CONNECT_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4c0dda05_e31f_4666_90b0_b3dfad34129a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_IPSEC_ALE_CONNECT_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x4c0dda05_e31f_4666_90b0_b3dfad34129a) , } }
 pub const FWPM_CALLOUT_IPSEC_DOSP_FORWARD_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2fcb56ec_cd37_4b4f_b108_62c2b1850a0c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_IPSEC_DOSP_FORWARD_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x2fcb56ec_cd37_4b4f_b108_62c2b1850a0c) , } }
 pub const FWPM_CALLOUT_IPSEC_DOSP_FORWARD_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6d08a342_db9e_4fbe_9ed2_57374ce89f79);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_IPSEC_DOSP_FORWARD_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x6d08a342_db9e_4fbe_9ed2_57374ce89f79) , } }
 pub const FWPM_CALLOUT_IPSEC_FORWARD_INBOUND_TUNNEL_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x28829633_c4f0_4e66_873f_844db2a899c7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_IPSEC_FORWARD_INBOUND_TUNNEL_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x28829633_c4f0_4e66_873f_844db2a899c7) , } }
 pub const FWPM_CALLOUT_IPSEC_FORWARD_INBOUND_TUNNEL_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaf50bec2_c686_429a_884d_b74443e7b0b4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_IPSEC_FORWARD_INBOUND_TUNNEL_V6 ) , guid : :: windows :: core :: GUID::from_u128(0xaf50bec2_c686_429a_884d_b74443e7b0b4) , } }
 pub const FWPM_CALLOUT_IPSEC_FORWARD_OUTBOUND_TUNNEL_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfb532136_15cb_440b_937c_1717ca320c40);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_IPSEC_FORWARD_OUTBOUND_TUNNEL_V4 ) , guid : :: windows :: core :: GUID::from_u128(0xfb532136_15cb_440b_937c_1717ca320c40) , } }
 pub const FWPM_CALLOUT_IPSEC_FORWARD_OUTBOUND_TUNNEL_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdae640cc_e021_4bee_9eb6_a48b275c8c1d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_IPSEC_FORWARD_OUTBOUND_TUNNEL_V6 ) , guid : :: windows :: core :: GUID::from_u128(0xdae640cc_e021_4bee_9eb6_a48b275c8c1d) , } }
 pub const FWPM_CALLOUT_IPSEC_INBOUND_INITIATE_SECURE_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7dff309b_ba7d_4aba_91aa_ae5c6640c944);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_IPSEC_INBOUND_INITIATE_SECURE_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x7dff309b_ba7d_4aba_91aa_ae5c6640c944) , } }
 pub const FWPM_CALLOUT_IPSEC_INBOUND_INITIATE_SECURE_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa9a0d6d9_c58c_474e_8aeb_3cfe99d6d53d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_IPSEC_INBOUND_INITIATE_SECURE_V6 ) , guid : :: windows :: core :: GUID::from_u128(0xa9a0d6d9_c58c_474e_8aeb_3cfe99d6d53d) , } }
 pub const FWPM_CALLOUT_IPSEC_INBOUND_TRANSPORT_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5132900d_5e84_4b5f_80e4_01741e81ff10);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_IPSEC_INBOUND_TRANSPORT_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x5132900d_5e84_4b5f_80e4_01741e81ff10) , } }
 pub const FWPM_CALLOUT_IPSEC_INBOUND_TRANSPORT_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x49d3ac92_2a6c_4dcf_955f_1c3be009dd99);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_IPSEC_INBOUND_TRANSPORT_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x49d3ac92_2a6c_4dcf_955f_1c3be009dd99) , } }
 pub const FWPM_CALLOUT_IPSEC_INBOUND_TUNNEL_ALE_ACCEPT_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3df6e7de_fd20_48f2_9f26_f854444cba79);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_IPSEC_INBOUND_TUNNEL_ALE_ACCEPT_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x3df6e7de_fd20_48f2_9f26_f854444cba79) , } }
 pub const FWPM_CALLOUT_IPSEC_INBOUND_TUNNEL_ALE_ACCEPT_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa1e392d3_72ac_47bb_87a7_0122c69434ab);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_IPSEC_INBOUND_TUNNEL_ALE_ACCEPT_V6 ) , guid : :: windows :: core :: GUID::from_u128(0xa1e392d3_72ac_47bb_87a7_0122c69434ab) , } }
 pub const FWPM_CALLOUT_IPSEC_INBOUND_TUNNEL_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x191a8a46_0bf8_46cf_b045_4b45dfa6a324);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_IPSEC_INBOUND_TUNNEL_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x191a8a46_0bf8_46cf_b045_4b45dfa6a324) , } }
 pub const FWPM_CALLOUT_IPSEC_INBOUND_TUNNEL_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x80c342e3_1e53_4d6f_9b44_03df5aeee154);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_IPSEC_INBOUND_TUNNEL_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x80c342e3_1e53_4d6f_9b44_03df5aeee154) , } }
 pub const FWPM_CALLOUT_IPSEC_OUTBOUND_TRANSPORT_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4b46bf0a_4523_4e57_aa38_a87987c910d9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_IPSEC_OUTBOUND_TRANSPORT_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x4b46bf0a_4523_4e57_aa38_a87987c910d9) , } }
 pub const FWPM_CALLOUT_IPSEC_OUTBOUND_TRANSPORT_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x38d87722_ad83_4f11_a91f_df0fb077225b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_IPSEC_OUTBOUND_TRANSPORT_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x38d87722_ad83_4f11_a91f_df0fb077225b) , } }
 pub const FWPM_CALLOUT_IPSEC_OUTBOUND_TUNNEL_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x70a4196c_835b_4fb0_98e8_075f4d977d46);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_IPSEC_OUTBOUND_TUNNEL_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x70a4196c_835b_4fb0_98e8_075f4d977d46) , } }
 pub const FWPM_CALLOUT_IPSEC_OUTBOUND_TUNNEL_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf1835363_a6a5_4e62_b180_23db789d8da6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_IPSEC_OUTBOUND_TUNNEL_V6 ) , guid : :: windows :: core :: GUID::from_u128(0xf1835363_a6a5_4e62_b180_23db789d8da6) , } }
 pub const FWPM_CALLOUT_POLICY_SILENT_MODE_AUTH_CONNECT_LAYER_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5fbfc31d_a51c_44dc_acb6_0624a030a700);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_POLICY_SILENT_MODE_AUTH_CONNECT_LAYER_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x5fbfc31d_a51c_44dc_acb6_0624a030a700) , } }
 pub const FWPM_CALLOUT_POLICY_SILENT_MODE_AUTH_CONNECT_LAYER_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5fbfc31d_a51c_44dc_acb6_0624a030a701);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_POLICY_SILENT_MODE_AUTH_CONNECT_LAYER_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x5fbfc31d_a51c_44dc_acb6_0624a030a701) , } }
 pub const FWPM_CALLOUT_POLICY_SILENT_MODE_AUTH_RECV_ACCEPT_LAYER_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5fbfc31d_a51c_44dc_acb6_0624a030a702);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_POLICY_SILENT_MODE_AUTH_RECV_ACCEPT_LAYER_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x5fbfc31d_a51c_44dc_acb6_0624a030a702) , } }
 pub const FWPM_CALLOUT_POLICY_SILENT_MODE_AUTH_RECV_ACCEPT_LAYER_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5fbfc31d_a51c_44dc_acb6_0624a030a703);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_POLICY_SILENT_MODE_AUTH_RECV_ACCEPT_LAYER_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x5fbfc31d_a51c_44dc_acb6_0624a030a703) , } }
 pub const FWPM_CALLOUT_RESERVED_AUTH_CONNECT_LAYER_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x288b524d_0566_4e19_b612_8f441a2e5949);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_RESERVED_AUTH_CONNECT_LAYER_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x288b524d_0566_4e19_b612_8f441a2e5949) , } }
 pub const FWPM_CALLOUT_RESERVED_AUTH_CONNECT_LAYER_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x00b84b92_2b5e_4b71_ab0e_aaca43e387e6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_RESERVED_AUTH_CONNECT_LAYER_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x00b84b92_2b5e_4b71_ab0e_aaca43e387e6) , } }
 pub const FWPM_CALLOUT_SET_OPTIONS_AUTH_CONNECT_LAYER_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbc582280_1677_41e9_94ab_c2fcb15c2eeb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_SET_OPTIONS_AUTH_CONNECT_LAYER_V4 ) , guid : :: windows :: core :: GUID::from_u128(0xbc582280_1677_41e9_94ab_c2fcb15c2eeb) , } }
 pub const FWPM_CALLOUT_SET_OPTIONS_AUTH_CONNECT_LAYER_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x98e5373c_b884_490f_b65f_2f6a4a575195);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_SET_OPTIONS_AUTH_CONNECT_LAYER_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x98e5373c_b884_490f_b65f_2f6a4a575195) , } }
 pub const FWPM_CALLOUT_SET_OPTIONS_AUTH_RECV_ACCEPT_LAYER_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2d55f008_0c01_4f92_b26e_a08a94569b8d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_SET_OPTIONS_AUTH_RECV_ACCEPT_LAYER_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x2d55f008_0c01_4f92_b26e_a08a94569b8d) , } }
 pub const FWPM_CALLOUT_SET_OPTIONS_AUTH_RECV_ACCEPT_LAYER_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x63018537_f281_4dc4_83d3_8dec18b7ade2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_SET_OPTIONS_AUTH_RECV_ACCEPT_LAYER_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x63018537_f281_4dc4_83d3_8dec18b7ade2) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_NetworkManagement_WindowsFilteringPlatform'*"]
 pub struct FWPM_CALLOUT_SUBSCRIPTION0 {
@@ -910,17 +984,41 @@ impl ::core::default::Default for FWPM_CALLOUT_SUBSCRIPTION0 {
     }
 }
 pub const FWPM_CALLOUT_TCP_CHIMNEY_ACCEPT_LAYER_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe183ecb2_3a7f_4b54_8ad9_76050ed880ca);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_TCP_CHIMNEY_ACCEPT_LAYER_V4 ) , guid : :: windows :: core :: GUID::from_u128(0xe183ecb2_3a7f_4b54_8ad9_76050ed880ca) , } }
 pub const FWPM_CALLOUT_TCP_CHIMNEY_ACCEPT_LAYER_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0378cf41_bf98_4603_81f2_7f12586079f6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_TCP_CHIMNEY_ACCEPT_LAYER_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x0378cf41_bf98_4603_81f2_7f12586079f6) , } }
 pub const FWPM_CALLOUT_TCP_CHIMNEY_CONNECT_LAYER_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf3e10ab3_2c25_4279_ac36_c30fc181bec4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_TCP_CHIMNEY_CONNECT_LAYER_V4 ) , guid : :: windows :: core :: GUID::from_u128(0xf3e10ab3_2c25_4279_ac36_c30fc181bec4) , } }
 pub const FWPM_CALLOUT_TCP_CHIMNEY_CONNECT_LAYER_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x39e22085_a341_42fc_a279_aec94e689c56);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_TCP_CHIMNEY_CONNECT_LAYER_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x39e22085_a341_42fc_a279_aec94e689c56) , } }
 pub const FWPM_CALLOUT_TCP_TEMPLATES_ACCEPT_LAYER_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2f23f5d0_40c4_4c41_a254_46d8dba8957c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_TCP_TEMPLATES_ACCEPT_LAYER_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x2f23f5d0_40c4_4c41_a254_46d8dba8957c) , } }
 pub const FWPM_CALLOUT_TCP_TEMPLATES_ACCEPT_LAYER_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb25152f0_991c_4f53_bbe7_d24b45fe632c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_TCP_TEMPLATES_ACCEPT_LAYER_V6 ) , guid : :: windows :: core :: GUID::from_u128(0xb25152f0_991c_4f53_bbe7_d24b45fe632c) , } }
 pub const FWPM_CALLOUT_TCP_TEMPLATES_CONNECT_LAYER_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x215a0b39_4b7e_4eda_8ce4_179679df6224);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_TCP_TEMPLATES_CONNECT_LAYER_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x215a0b39_4b7e_4eda_8ce4_179679df6224) , } }
 pub const FWPM_CALLOUT_TCP_TEMPLATES_CONNECT_LAYER_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x838b37a1_5c12_4d34_8b38_078728b2d25c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_TCP_TEMPLATES_CONNECT_LAYER_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x838b37a1_5c12_4d34_8b38_078728b2d25c) , } }
 pub const FWPM_CALLOUT_TEREDO_ALE_LISTEN_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x81a434e7_f60c_4378_bab8_c625a30f0197);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_TEREDO_ALE_LISTEN_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x81a434e7_f60c_4378_bab8_c625a30f0197) , } }
 pub const FWPM_CALLOUT_TEREDO_ALE_RESOURCE_ASSIGNMENT_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x31b95392_066e_42a2_b7db_92f8acdd56f9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_TEREDO_ALE_RESOURCE_ASSIGNMENT_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x31b95392_066e_42a2_b7db_92f8acdd56f9) , } }
 pub const FWPM_CALLOUT_WFP_TRANSPORT_LAYER_V4_SILENT_DROP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xeda08606_2494_4d78_89bc_67837c03b969);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_WFP_TRANSPORT_LAYER_V4_SILENT_DROP ) , guid : :: windows :: core :: GUID::from_u128(0xeda08606_2494_4d78_89bc_67837c03b969) , } }
 pub const FWPM_CALLOUT_WFP_TRANSPORT_LAYER_V6_SILENT_DROP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8693cc74_a075_4156_b476_9286eece814e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CALLOUT_WFP_TRANSPORT_LAYER_V6_SILENT_DROP ) , guid : :: windows :: core :: GUID::from_u128(0x8693cc74_a075_4156_b476_9286eece814e) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WindowsFilteringPlatform'*"]
 pub type FWPM_CHANGE_TYPE = i32;
 #[doc = "*Required features: 'Win32_NetworkManagement_WindowsFilteringPlatform'*"]
@@ -1002,141 +1100,413 @@ impl ::core::default::Default for FWPM_CLASSIFY_OPTIONS0 {
     }
 }
 pub const FWPM_CONDITION_ALE_APP_ID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd78e1e87_8644_4ea5_9437_d809ecefc971);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_ALE_APP_ID ) , guid : :: windows :: core :: GUID::from_u128(0xd78e1e87_8644_4ea5_9437_d809ecefc971) , } }
 pub const FWPM_CONDITION_ALE_EFFECTIVE_NAME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb1277b9a_b781_40fc_9671_e5f1b989f34e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_ALE_EFFECTIVE_NAME ) , guid : :: windows :: core :: GUID::from_u128(0xb1277b9a_b781_40fc_9671_e5f1b989f34e) , } }
 pub const FWPM_CONDITION_ALE_NAP_CONTEXT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x46275a9d_c03f_4d77_b784_1c57f4d02753);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_ALE_NAP_CONTEXT ) , guid : :: windows :: core :: GUID::from_u128(0x46275a9d_c03f_4d77_b784_1c57f4d02753) , } }
 pub const FWPM_CONDITION_ALE_ORIGINAL_APP_ID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0e6cd086_e1fb_4212_842f_8a9f993fb3f6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_ALE_ORIGINAL_APP_ID ) , guid : :: windows :: core :: GUID::from_u128(0x0e6cd086_e1fb_4212_842f_8a9f993fb3f6) , } }
 pub const FWPM_CONDITION_ALE_PACKAGE_ID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x71bc78fa_f17c_4997_a602_6abb261f351c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_ALE_PACKAGE_ID ) , guid : :: windows :: core :: GUID::from_u128(0x71bc78fa_f17c_4997_a602_6abb261f351c) , } }
 pub const FWPM_CONDITION_ALE_PROMISCUOUS_MODE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1c974776_7182_46e9_afd3_b02910e30334);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_ALE_PROMISCUOUS_MODE ) , guid : :: windows :: core :: GUID::from_u128(0x1c974776_7182_46e9_afd3_b02910e30334) , } }
 pub const FWPM_CONDITION_ALE_REAUTH_REASON: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb482d227_1979_4a98_8044_18bbe6237542);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_ALE_REAUTH_REASON ) , guid : :: windows :: core :: GUID::from_u128(0xb482d227_1979_4a98_8044_18bbe6237542) , } }
 pub const FWPM_CONDITION_ALE_REMOTE_MACHINE_ID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1aa47f51_7f93_4508_a271_81abb00c9cab);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_ALE_REMOTE_MACHINE_ID ) , guid : :: windows :: core :: GUID::from_u128(0x1aa47f51_7f93_4508_a271_81abb00c9cab) , } }
 pub const FWPM_CONDITION_ALE_REMOTE_USER_ID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf63073b7_0189_4ab0_95a4_6123cbfab862);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_ALE_REMOTE_USER_ID ) , guid : :: windows :: core :: GUID::from_u128(0xf63073b7_0189_4ab0_95a4_6123cbfab862) , } }
 pub const FWPM_CONDITION_ALE_SECURITY_ATTRIBUTE_FQBN_VALUE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x37a57699_5883_4963_92b8_3e704688b0ad);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_ALE_SECURITY_ATTRIBUTE_FQBN_VALUE ) , guid : :: windows :: core :: GUID::from_u128(0x37a57699_5883_4963_92b8_3e704688b0ad) , } }
 pub const FWPM_CONDITION_ALE_SIO_FIREWALL_SYSTEM_PORT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb9f4e088_cb98_4efb_a2c7_ad07332643db);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_ALE_SIO_FIREWALL_SYSTEM_PORT ) , guid : :: windows :: core :: GUID::from_u128(0xb9f4e088_cb98_4efb_a2c7_ad07332643db) , } }
 pub const FWPM_CONDITION_ALE_USER_ID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaf043a0a_b34d_4f86_979c_c90371af6e66);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_ALE_USER_ID ) , guid : :: windows :: core :: GUID::from_u128(0xaf043a0a_b34d_4f86_979c_c90371af6e66) , } }
 pub const FWPM_CONDITION_ARRIVAL_INTERFACE_INDEX: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcc088db3_1792_4a71_b0f9_037d21cd828b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_ARRIVAL_INTERFACE_INDEX ) , guid : :: windows :: core :: GUID::from_u128(0xcc088db3_1792_4a71_b0f9_037d21cd828b) , } }
 pub const FWPM_CONDITION_ARRIVAL_INTERFACE_PROFILE_ID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcdfe6aab_c083_4142_8679_c08f95329c61);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_ARRIVAL_INTERFACE_PROFILE_ID ) , guid : :: windows :: core :: GUID::from_u128(0xcdfe6aab_c083_4142_8679_c08f95329c61) , } }
 pub const FWPM_CONDITION_ARRIVAL_INTERFACE_TYPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x89f990de_e798_4e6d_ab76_7c9558292e6f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_ARRIVAL_INTERFACE_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x89f990de_e798_4e6d_ab76_7c9558292e6f) , } }
 pub const FWPM_CONDITION_ARRIVAL_TUNNEL_TYPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x511166dc_7a8c_4aa7_b533_95ab59fb0340);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_ARRIVAL_TUNNEL_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x511166dc_7a8c_4aa7_b533_95ab59fb0340) , } }
 pub const FWPM_CONDITION_AUTHENTICATION_TYPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xeb458cd5_da7b_4ef9_8d43_7b0a840332f2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_AUTHENTICATION_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0xeb458cd5_da7b_4ef9_8d43_7b0a840332f2) , } }
 pub const FWPM_CONDITION_CLIENT_CERT_KEY_LENGTH: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa3ec00c7_05f4_4df7_91f2_5f60d91ff443);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_CLIENT_CERT_KEY_LENGTH ) , guid : :: windows :: core :: GUID::from_u128(0xa3ec00c7_05f4_4df7_91f2_5f60d91ff443) , } }
 pub const FWPM_CONDITION_CLIENT_CERT_OID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc491ad5e_f882_4283_b916_436b103ff4ad);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_CLIENT_CERT_OID ) , guid : :: windows :: core :: GUID::from_u128(0xc491ad5e_f882_4283_b916_436b103ff4ad) , } }
 pub const FWPM_CONDITION_CLIENT_TOKEN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc228fc1e_403a_4478_be05_c9baa4c05ace);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_CLIENT_TOKEN ) , guid : :: windows :: core :: GUID::from_u128(0xc228fc1e_403a_4478_be05_c9baa4c05ace) , } }
 pub const FWPM_CONDITION_COMPARTMENT_ID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x35a791ab_04ac_4ff2_a6bb_da6cfac71806);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_COMPARTMENT_ID ) , guid : :: windows :: core :: GUID::from_u128(0x35a791ab_04ac_4ff2_a6bb_da6cfac71806) , } }
 pub const FWPM_CONDITION_CURRENT_PROFILE_ID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xab3033c9_c0e3_4759_937d_5758c65d4ae3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_CURRENT_PROFILE_ID ) , guid : :: windows :: core :: GUID::from_u128(0xab3033c9_c0e3_4759_937d_5758c65d4ae3) , } }
 pub const FWPM_CONDITION_DCOM_APP_ID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xff2e7b4d_3112_4770_b636_4d24ae3a6af2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_DCOM_APP_ID ) , guid : :: windows :: core :: GUID::from_u128(0xff2e7b4d_3112_4770_b636_4d24ae3a6af2) , } }
 pub const FWPM_CONDITION_DESTINATION_INTERFACE_INDEX: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x35cf6522_4139_45ee_a0d5_67b80949d879);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_DESTINATION_INTERFACE_INDEX ) , guid : :: windows :: core :: GUID::from_u128(0x35cf6522_4139_45ee_a0d5_67b80949d879) , } }
 pub const FWPM_CONDITION_DESTINATION_SUB_INTERFACE_INDEX: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2b7d4399_d4c7_4738_a2f5_e994b43da388);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_DESTINATION_SUB_INTERFACE_INDEX ) , guid : :: windows :: core :: GUID::from_u128(0x2b7d4399_d4c7_4738_a2f5_e994b43da388) , } }
 pub const FWPM_CONDITION_DIRECTION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8784c146_ca97_44d6_9fd1_19fb1840cbf7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_DIRECTION ) , guid : :: windows :: core :: GUID::from_u128(0x8784c146_ca97_44d6_9fd1_19fb1840cbf7) , } }
 pub const FWPM_CONDITION_EMBEDDED_LOCAL_ADDRESS_TYPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4672a468_8a0a_4202_abb4_849e92e66809);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_EMBEDDED_LOCAL_ADDRESS_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x4672a468_8a0a_4202_abb4_849e92e66809) , } }
 pub const FWPM_CONDITION_EMBEDDED_LOCAL_PORT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbfca394d_acdb_484e_b8e6_2aff79757345);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_EMBEDDED_LOCAL_PORT ) , guid : :: windows :: core :: GUID::from_u128(0xbfca394d_acdb_484e_b8e6_2aff79757345) , } }
 pub const FWPM_CONDITION_EMBEDDED_PROTOCOL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x07784107_a29e_4c7b_9ec7_29c44afafdbc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_EMBEDDED_PROTOCOL ) , guid : :: windows :: core :: GUID::from_u128(0x07784107_a29e_4c7b_9ec7_29c44afafdbc) , } }
 pub const FWPM_CONDITION_EMBEDDED_REMOTE_ADDRESS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x77ee4b39_3273_4671_b63b_ab6feb66eeb6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_EMBEDDED_REMOTE_ADDRESS ) , guid : :: windows :: core :: GUID::from_u128(0x77ee4b39_3273_4671_b63b_ab6feb66eeb6) , } }
 pub const FWPM_CONDITION_EMBEDDED_REMOTE_PORT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcae4d6a1_2968_40ed_a4ce_547160dda88d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_EMBEDDED_REMOTE_PORT ) , guid : :: windows :: core :: GUID::from_u128(0xcae4d6a1_2968_40ed_a4ce_547160dda88d) , } }
 pub const FWPM_CONDITION_ETHER_TYPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfd08948d_a219_4d52_bb98_1a5540ee7b4e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_ETHER_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0xfd08948d_a219_4d52_bb98_1a5540ee7b4e) , } }
 pub const FWPM_CONDITION_FLAGS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x632ce23b_5167_435c_86d7_e903684aa80c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_FLAGS ) , guid : :: windows :: core :: GUID::from_u128(0x632ce23b_5167_435c_86d7_e903684aa80c) , } }
 pub const FWPM_CONDITION_IMAGE_NAME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd024de4d_deaa_4317_9c85_e40ef6e140c3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_IMAGE_NAME ) , guid : :: windows :: core :: GUID::from_u128(0xd024de4d_deaa_4317_9c85_e40ef6e140c3) , } }
 pub const FWPM_CONDITION_INTERFACE_INDEX: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x667fd755_d695_434a_8af5_d3835a1259bc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_INTERFACE_INDEX ) , guid : :: windows :: core :: GUID::from_u128(0x667fd755_d695_434a_8af5_d3835a1259bc) , } }
 pub const FWPM_CONDITION_INTERFACE_MAC_ADDRESS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf6e63dce_1f4b_4c6b_b6ef_1165e71f8ee7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_INTERFACE_MAC_ADDRESS ) , guid : :: windows :: core :: GUID::from_u128(0xf6e63dce_1f4b_4c6b_b6ef_1165e71f8ee7) , } }
 pub const FWPM_CONDITION_INTERFACE_QUARANTINE_EPOCH: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcce68d5e_053b_43a8_9a6f_33384c28e4f6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_INTERFACE_QUARANTINE_EPOCH ) , guid : :: windows :: core :: GUID::from_u128(0xcce68d5e_053b_43a8_9a6f_33384c28e4f6) , } }
 pub const FWPM_CONDITION_INTERFACE_TYPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdaf8cd14_e09e_4c93_a5ae_c5c13b73ffca);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_INTERFACE_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0xdaf8cd14_e09e_4c93_a5ae_c5c13b73ffca) , } }
 pub const FWPM_CONDITION_IPSEC_POLICY_KEY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xad37dee3_722f_45cc_a4e3_068048124452);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_IPSEC_POLICY_KEY ) , guid : :: windows :: core :: GUID::from_u128(0xad37dee3_722f_45cc_a4e3_068048124452) , } }
 pub const FWPM_CONDITION_IPSEC_SECURITY_REALM_ID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x37a57700_5884_4964_92b8_3e704688b0ad);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_IPSEC_SECURITY_REALM_ID ) , guid : :: windows :: core :: GUID::from_u128(0x37a57700_5884_4964_92b8_3e704688b0ad) , } }
 pub const FWPM_CONDITION_IP_ARRIVAL_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x618a9b6d_386b_4136_ad6e_b51587cfb1cd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_IP_ARRIVAL_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0x618a9b6d_386b_4136_ad6e_b51587cfb1cd) , } }
 pub const FWPM_CONDITION_IP_DESTINATION_ADDRESS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2d79133b_b390_45c6_8699_acaceaafed33);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_IP_DESTINATION_ADDRESS ) , guid : :: windows :: core :: GUID::from_u128(0x2d79133b_b390_45c6_8699_acaceaafed33) , } }
 pub const FWPM_CONDITION_IP_DESTINATION_ADDRESS_TYPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1ec1b7c9_4eea_4f5e_b9ef_76beaaaf17ee);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_IP_DESTINATION_ADDRESS_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x1ec1b7c9_4eea_4f5e_b9ef_76beaaaf17ee) , } }
 pub const FWPM_CONDITION_IP_DESTINATION_PORT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xce6def45_60fb_4a7b_a304_af30a117000e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_IP_DESTINATION_PORT ) , guid : :: windows :: core :: GUID::from_u128(0xce6def45_60fb_4a7b_a304_af30a117000e) , } }
 pub const FWPM_CONDITION_IP_FORWARD_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1076b8a5_6323_4c5e_9810_e8d3fc9e6136);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_IP_FORWARD_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0x1076b8a5_6323_4c5e_9810_e8d3fc9e6136) , } }
 pub const FWPM_CONDITION_IP_LOCAL_ADDRESS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd9ee00de_c1ef_4617_bfe3_ffd8f5a08957);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_IP_LOCAL_ADDRESS ) , guid : :: windows :: core :: GUID::from_u128(0xd9ee00de_c1ef_4617_bfe3_ffd8f5a08957) , } }
 pub const FWPM_CONDITION_IP_LOCAL_ADDRESS_TYPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6ec7f6c4_376b_45d7_9e9c_d337cedcd237);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_IP_LOCAL_ADDRESS_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x6ec7f6c4_376b_45d7_9e9c_d337cedcd237) , } }
 pub const FWPM_CONDITION_IP_LOCAL_ADDRESS_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x03a629cb_6e52_49f8_9c41_5709633c09cf);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_IP_LOCAL_ADDRESS_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x03a629cb_6e52_49f8_9c41_5709633c09cf) , } }
 pub const FWPM_CONDITION_IP_LOCAL_ADDRESS_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2381be84_7524_45b3_a05b_1e637d9c7a6a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_IP_LOCAL_ADDRESS_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x2381be84_7524_45b3_a05b_1e637d9c7a6a) , } }
 pub const FWPM_CONDITION_IP_LOCAL_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4cd62a49_59c3_4969_b7f3_bda5d32890a4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_IP_LOCAL_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0x4cd62a49_59c3_4969_b7f3_bda5d32890a4) , } }
 pub const FWPM_CONDITION_IP_LOCAL_PORT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0c1ba1af_5765_453f_af22_a8f791ac775b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_IP_LOCAL_PORT ) , guid : :: windows :: core :: GUID::from_u128(0x0c1ba1af_5765_453f_af22_a8f791ac775b) , } }
 pub const FWPM_CONDITION_IP_NEXTHOP_ADDRESS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xeabe448a_a711_4d64_85b7_3f76b65299c7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_IP_NEXTHOP_ADDRESS ) , guid : :: windows :: core :: GUID::from_u128(0xeabe448a_a711_4d64_85b7_3f76b65299c7) , } }
 pub const FWPM_CONDITION_IP_NEXTHOP_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x93ae8f5b_7f6f_4719_98c8_14e97429ef04);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_IP_NEXTHOP_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0x93ae8f5b_7f6f_4719_98c8_14e97429ef04) , } }
 pub const FWPM_CONDITION_IP_PHYSICAL_ARRIVAL_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xda50d5c8_fa0d_4c89_b032_6e62136d1e96);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_IP_PHYSICAL_ARRIVAL_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0xda50d5c8_fa0d_4c89_b032_6e62136d1e96) , } }
 pub const FWPM_CONDITION_IP_PHYSICAL_NEXTHOP_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf09bd5ce_5150_48be_b098_c25152fb1f92);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_IP_PHYSICAL_NEXTHOP_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0xf09bd5ce_5150_48be_b098_c25152fb1f92) , } }
 pub const FWPM_CONDITION_IP_PROTOCOL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3971ef2b_623e_4f9a_8cb1_6e79b806b9a7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_IP_PROTOCOL ) , guid : :: windows :: core :: GUID::from_u128(0x3971ef2b_623e_4f9a_8cb1_6e79b806b9a7) , } }
 pub const FWPM_CONDITION_IP_REMOTE_ADDRESS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb235ae9a_1d64_49b8_a44c_5ff3d9095045);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_IP_REMOTE_ADDRESS ) , guid : :: windows :: core :: GUID::from_u128(0xb235ae9a_1d64_49b8_a44c_5ff3d9095045) , } }
 pub const FWPM_CONDITION_IP_REMOTE_ADDRESS_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1febb610_3bcc_45e1_bc36_2e067e2cb186);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_IP_REMOTE_ADDRESS_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x1febb610_3bcc_45e1_bc36_2e067e2cb186) , } }
 pub const FWPM_CONDITION_IP_REMOTE_ADDRESS_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x246e1d8c_8bee_4018_9b98_31d4582f3361);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_IP_REMOTE_ADDRESS_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x246e1d8c_8bee_4018_9b98_31d4582f3361) , } }
 pub const FWPM_CONDITION_IP_REMOTE_PORT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc35a604d_d22b_4e1a_91b4_68f674ee674b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_IP_REMOTE_PORT ) , guid : :: windows :: core :: GUID::from_u128(0xc35a604d_d22b_4e1a_91b4_68f674ee674b) , } }
 pub const FWPM_CONDITION_IP_SOURCE_ADDRESS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xae96897e_2e94_4bc9_b313_b27ee80e574d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_IP_SOURCE_ADDRESS ) , guid : :: windows :: core :: GUID::from_u128(0xae96897e_2e94_4bc9_b313_b27ee80e574d) , } }
 pub const FWPM_CONDITION_IP_SOURCE_PORT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa6afef91_3df4_4730_a214_f5426aebf821);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_IP_SOURCE_PORT ) , guid : :: windows :: core :: GUID::from_u128(0xa6afef91_3df4_4730_a214_f5426aebf821) , } }
 pub const FWPM_CONDITION_KM_AUTH_NAP_CONTEXT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x35d0ea0e_15ca_492b_900e_97fd46352cce);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_KM_AUTH_NAP_CONTEXT ) , guid : :: windows :: core :: GUID::from_u128(0x35d0ea0e_15ca_492b_900e_97fd46352cce) , } }
 pub const FWPM_CONDITION_KM_MODE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfeef4582_ef8f_4f7b_858b_9077d122de47);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_KM_MODE ) , guid : :: windows :: core :: GUID::from_u128(0xfeef4582_ef8f_4f7b_858b_9077d122de47) , } }
 pub const FWPM_CONDITION_KM_TYPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xff0f5f49_0ceb_481b_8638_1479791f3f2c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_KM_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0xff0f5f49_0ceb_481b_8638_1479791f3f2c) , } }
 pub const FWPM_CONDITION_L2_FLAGS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7bc43cbf_37ba_45f1_b74a_82ff518eeb10);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_L2_FLAGS ) , guid : :: windows :: core :: GUID::from_u128(0x7bc43cbf_37ba_45f1_b74a_82ff518eeb10) , } }
 pub const FWPM_CONDITION_LOCAL_INTERFACE_PROFILE_ID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4ebf7562_9f18_4d06_9941_a7a625744d71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_LOCAL_INTERFACE_PROFILE_ID ) , guid : :: windows :: core :: GUID::from_u128(0x4ebf7562_9f18_4d06_9941_a7a625744d71) , } }
 pub const FWPM_CONDITION_MAC_DESTINATION_ADDRESS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x04ea2a93_858c_4027_b613_b43180c7859e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_MAC_DESTINATION_ADDRESS ) , guid : :: windows :: core :: GUID::from_u128(0x04ea2a93_858c_4027_b613_b43180c7859e) , } }
 pub const FWPM_CONDITION_MAC_DESTINATION_ADDRESS_TYPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xae052932_ef42_4e99_b129_f3b3139e34f7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_MAC_DESTINATION_ADDRESS_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0xae052932_ef42_4e99_b129_f3b3139e34f7) , } }
 pub const FWPM_CONDITION_MAC_LOCAL_ADDRESS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd999e981_7948_4c83_b742_c84e3b678f8f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_MAC_LOCAL_ADDRESS ) , guid : :: windows :: core :: GUID::from_u128(0xd999e981_7948_4c83_b742_c84e3b678f8f) , } }
 pub const FWPM_CONDITION_MAC_LOCAL_ADDRESS_TYPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcc31355c_3073_4ffb_a14f_79415cb1ead1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_MAC_LOCAL_ADDRESS_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0xcc31355c_3073_4ffb_a14f_79415cb1ead1) , } }
 pub const FWPM_CONDITION_MAC_REMOTE_ADDRESS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x408f2ed4_3a70_4b4d_92a6_415ac20e2f12);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_MAC_REMOTE_ADDRESS ) , guid : :: windows :: core :: GUID::from_u128(0x408f2ed4_3a70_4b4d_92a6_415ac20e2f12) , } }
 pub const FWPM_CONDITION_MAC_REMOTE_ADDRESS_TYPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x027fedb4_f1c1_4030_b564_ee777fd867ea);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_MAC_REMOTE_ADDRESS_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x027fedb4_f1c1_4030_b564_ee777fd867ea) , } }
 pub const FWPM_CONDITION_MAC_SOURCE_ADDRESS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7b795451_f1f6_4d05_b7cb_21779d802336);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_MAC_SOURCE_ADDRESS ) , guid : :: windows :: core :: GUID::from_u128(0x7b795451_f1f6_4d05_b7cb_21779d802336) , } }
 pub const FWPM_CONDITION_MAC_SOURCE_ADDRESS_TYPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5c1b72e4_299e_4437_a298_bc3f014b3dc2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_MAC_SOURCE_ADDRESS_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x5c1b72e4_299e_4437_a298_bc3f014b3dc2) , } }
 pub const FWPM_CONDITION_NDIS_MEDIA_TYPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcb31cef1_791d_473b_89d1_61c5984304a0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_NDIS_MEDIA_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0xcb31cef1_791d_473b_89d1_61c5984304a0) , } }
 pub const FWPM_CONDITION_NDIS_PHYSICAL_MEDIA_TYPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x34c79823_c229_44f2_b83c_74020882ae77);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_NDIS_PHYSICAL_MEDIA_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x34c79823_c229_44f2_b83c_74020882ae77) , } }
 pub const FWPM_CONDITION_NDIS_PORT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdb7bb42b_2dac_4cd4_a59a_e0bdce1e6834);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_NDIS_PORT ) , guid : :: windows :: core :: GUID::from_u128(0xdb7bb42b_2dac_4cd4_a59a_e0bdce1e6834) , } }
 pub const FWPM_CONDITION_NET_EVENT_TYPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x206e9996_490e_40cf_b831_b38641eb6fcb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_NET_EVENT_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x206e9996_490e_40cf_b831_b38641eb6fcb) , } }
 pub const FWPM_CONDITION_NEXTHOP_INTERFACE_INDEX: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x138e6888_7ab8_4d65_9ee8_0591bcf6a494);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_NEXTHOP_INTERFACE_INDEX ) , guid : :: windows :: core :: GUID::from_u128(0x138e6888_7ab8_4d65_9ee8_0591bcf6a494) , } }
 pub const FWPM_CONDITION_NEXTHOP_INTERFACE_PROFILE_ID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd7ff9a56_cdaa_472b_84db_d23963c1d1bf);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_NEXTHOP_INTERFACE_PROFILE_ID ) , guid : :: windows :: core :: GUID::from_u128(0xd7ff9a56_cdaa_472b_84db_d23963c1d1bf) , } }
 pub const FWPM_CONDITION_NEXTHOP_INTERFACE_TYPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x97537c6c_d9a3_4767_a381_e942675cd920);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_NEXTHOP_INTERFACE_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x97537c6c_d9a3_4767_a381_e942675cd920) , } }
 pub const FWPM_CONDITION_NEXTHOP_SUB_INTERFACE_INDEX: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xef8a6122_0577_45a7_9aaf_825fbeb4fb95);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_NEXTHOP_SUB_INTERFACE_INDEX ) , guid : :: windows :: core :: GUID::from_u128(0xef8a6122_0577_45a7_9aaf_825fbeb4fb95) , } }
 pub const FWPM_CONDITION_NEXTHOP_TUNNEL_TYPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x72b1a111_987b_4720_99dd_c7c576fa2d4c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_NEXTHOP_TUNNEL_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x72b1a111_987b_4720_99dd_c7c576fa2d4c) , } }
 pub const FWPM_CONDITION_ORIGINAL_ICMP_TYPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x076dfdbe_c56c_4f72_ae8a_2cfe7e5c8286);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_ORIGINAL_ICMP_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x076dfdbe_c56c_4f72_ae8a_2cfe7e5c8286) , } }
 pub const FWPM_CONDITION_ORIGINAL_PROFILE_ID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x46ea1551_2255_492b_8019_aabeee349f40);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_ORIGINAL_PROFILE_ID ) , guid : :: windows :: core :: GUID::from_u128(0x46ea1551_2255_492b_8019_aabeee349f40) , } }
 pub const FWPM_CONDITION_PEER_NAME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9b539082_eb90_4186_a6cc_de5b63235016);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_PEER_NAME ) , guid : :: windows :: core :: GUID::from_u128(0x9b539082_eb90_4186_a6cc_de5b63235016) , } }
 pub const FWPM_CONDITION_PIPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1bd0741d_e3df_4e24_8634_762046eef6eb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_PIPE ) , guid : :: windows :: core :: GUID::from_u128(0x1bd0741d_e3df_4e24_8634_762046eef6eb) , } }
 pub const FWPM_CONDITION_PROCESS_WITH_RPC_IF_UUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe31180a8_bbbd_4d14_a65e_7157b06233bb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_PROCESS_WITH_RPC_IF_UUID ) , guid : :: windows :: core :: GUID::from_u128(0xe31180a8_bbbd_4d14_a65e_7157b06233bb) , } }
 pub const FWPM_CONDITION_QM_MODE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf64fc6d1_f9cb_43d2_8a5f_e13bc894f265);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_QM_MODE ) , guid : :: windows :: core :: GUID::from_u128(0xf64fc6d1_f9cb_43d2_8a5f_e13bc894f265) , } }
 pub const FWPM_CONDITION_REAUTHORIZE_REASON: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x11205e8c_11ae_457a_8a44_477026dd764a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_REAUTHORIZE_REASON ) , guid : :: windows :: core :: GUID::from_u128(0x11205e8c_11ae_457a_8a44_477026dd764a) , } }
 pub const FWPM_CONDITION_REMOTE_ID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf68166fd_0682_4c89_b8f5_86436c7ef9b7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_REMOTE_ID ) , guid : :: windows :: core :: GUID::from_u128(0xf68166fd_0682_4c89_b8f5_86436c7ef9b7) , } }
 pub const FWPM_CONDITION_REMOTE_USER_TOKEN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9bf0ee66_06c9_41b9_84da_288cb43af51f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_REMOTE_USER_TOKEN ) , guid : :: windows :: core :: GUID::from_u128(0x9bf0ee66_06c9_41b9_84da_288cb43af51f) , } }
 pub const FWPM_CONDITION_RESERVED0: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x678f4deb_45af_4882_93fe_19d4729d9834);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_RESERVED0 ) , guid : :: windows :: core :: GUID::from_u128(0x678f4deb_45af_4882_93fe_19d4729d9834) , } }
 pub const FWPM_CONDITION_RESERVED1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd818f827_5c69_48eb_bf80_d86b17755f97);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_RESERVED1 ) , guid : :: windows :: core :: GUID::from_u128(0xd818f827_5c69_48eb_bf80_d86b17755f97) , } }
 pub const FWPM_CONDITION_RESERVED10: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb979e282_d621_4c8c_b184_b105a61c36ce);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_RESERVED10 ) , guid : :: windows :: core :: GUID::from_u128(0xb979e282_d621_4c8c_b184_b105a61c36ce) , } }
 pub const FWPM_CONDITION_RESERVED11: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2d62ee4d_023d_411f_9582_43acbb795975);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_RESERVED11 ) , guid : :: windows :: core :: GUID::from_u128(0x2d62ee4d_023d_411f_9582_43acbb795975) , } }
 pub const FWPM_CONDITION_RESERVED12: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa3677c32_7e35_4ddc_93da_e8c33fc923c7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_RESERVED12 ) , guid : :: windows :: core :: GUID::from_u128(0xa3677c32_7e35_4ddc_93da_e8c33fc923c7) , } }
 pub const FWPM_CONDITION_RESERVED13: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x335a3e90_84aa_42f5_9e6f_59309536a44c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_RESERVED13 ) , guid : :: windows :: core :: GUID::from_u128(0x335a3e90_84aa_42f5_9e6f_59309536a44c) , } }
 pub const FWPM_CONDITION_RESERVED14: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x30e44da2_2f1a_4116_a559_f907de83604a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_RESERVED14 ) , guid : :: windows :: core :: GUID::from_u128(0x30e44da2_2f1a_4116_a559_f907de83604a) , } }
 pub const FWPM_CONDITION_RESERVED15: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbab8340f_afe0_43d1_80d8_5ca456962de3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_RESERVED15 ) , guid : :: windows :: core :: GUID::from_u128(0xbab8340f_afe0_43d1_80d8_5ca456962de3) , } }
 pub const FWPM_CONDITION_RESERVED2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x53d4123d_e15b_4e84_b7a8_dce16f7b62d9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_RESERVED2 ) , guid : :: windows :: core :: GUID::from_u128(0x53d4123d_e15b_4e84_b7a8_dce16f7b62d9) , } }
 pub const FWPM_CONDITION_RESERVED3: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7f6e8ca3_6606_4932_97c7_e1f20710af3b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_RESERVED3 ) , guid : :: windows :: core :: GUID::from_u128(0x7f6e8ca3_6606_4932_97c7_e1f20710af3b) , } }
 pub const FWPM_CONDITION_RESERVED4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5f58e642_b937_495e_a94b_f6b051a49250);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_RESERVED4 ) , guid : :: windows :: core :: GUID::from_u128(0x5f58e642_b937_495e_a94b_f6b051a49250) , } }
 pub const FWPM_CONDITION_RESERVED5: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9ba8f6cd_f77c_43e6_8847_11939dc5db5a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_RESERVED5 ) , guid : :: windows :: core :: GUID::from_u128(0x9ba8f6cd_f77c_43e6_8847_11939dc5db5a) , } }
 pub const FWPM_CONDITION_RESERVED6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf13d84bd_59d5_44c4_8817_5ecdae1805bd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_RESERVED6 ) , guid : :: windows :: core :: GUID::from_u128(0xf13d84bd_59d5_44c4_8817_5ecdae1805bd) , } }
 pub const FWPM_CONDITION_RESERVED7: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x65a0f930_45dd_4983_aa33_efc7b611af08);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_RESERVED7 ) , guid : :: windows :: core :: GUID::from_u128(0x65a0f930_45dd_4983_aa33_efc7b611af08) , } }
 pub const FWPM_CONDITION_RESERVED8: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4f424974_0c12_4816_9b47_9a547db39a32);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_RESERVED8 ) , guid : :: windows :: core :: GUID::from_u128(0x4f424974_0c12_4816_9b47_9a547db39a32) , } }
 pub const FWPM_CONDITION_RESERVED9: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xce78e10f_13ff_4c70_8643_36ad1879afa3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_RESERVED9 ) , guid : :: windows :: core :: GUID::from_u128(0xce78e10f_13ff_4c70_8643_36ad1879afa3) , } }
 pub const FWPM_CONDITION_RPC_AUTH_LEVEL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe5a0aed5_59ac_46ea_be05_a5f05ecf446e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_RPC_AUTH_LEVEL ) , guid : :: windows :: core :: GUID::from_u128(0xe5a0aed5_59ac_46ea_be05_a5f05ecf446e) , } }
 pub const FWPM_CONDITION_RPC_AUTH_TYPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdaba74ab_0d67_43e7_986e_75b84f82f594);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_RPC_AUTH_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0xdaba74ab_0d67_43e7_986e_75b84f82f594) , } }
 pub const FWPM_CONDITION_RPC_EP_FLAGS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x218b814a_0a39_49b8_8e71_c20c39c7dd2e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_RPC_EP_FLAGS ) , guid : :: windows :: core :: GUID::from_u128(0x218b814a_0a39_49b8_8e71_c20c39c7dd2e) , } }
 pub const FWPM_CONDITION_RPC_EP_VALUE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdccea0b9_0886_4360_9c6a_ab043a24fba9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_RPC_EP_VALUE ) , guid : :: windows :: core :: GUID::from_u128(0xdccea0b9_0886_4360_9c6a_ab043a24fba9) , } }
 pub const FWPM_CONDITION_RPC_IF_FLAG: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x238a8a32_3199_467d_871c_272621ab3896);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_RPC_IF_FLAG ) , guid : :: windows :: core :: GUID::from_u128(0x238a8a32_3199_467d_871c_272621ab3896) , } }
 pub const FWPM_CONDITION_RPC_IF_UUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7c9c7d9f_0075_4d35_a0d1_8311c4cf6af1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_RPC_IF_UUID ) , guid : :: windows :: core :: GUID::from_u128(0x7c9c7d9f_0075_4d35_a0d1_8311c4cf6af1) , } }
 pub const FWPM_CONDITION_RPC_IF_VERSION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xeabfd9b7_1262_4a2e_adaa_5f96f6fe326d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_RPC_IF_VERSION ) , guid : :: windows :: core :: GUID::from_u128(0xeabfd9b7_1262_4a2e_adaa_5f96f6fe326d) , } }
 pub const FWPM_CONDITION_RPC_PROTOCOL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2717bc74_3a35_4ce7_b7ef_c838fabdec45);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_RPC_PROTOCOL ) , guid : :: windows :: core :: GUID::from_u128(0x2717bc74_3a35_4ce7_b7ef_c838fabdec45) , } }
 pub const FWPM_CONDITION_RPC_PROXY_AUTH_TYPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x40953fe2_8565_4759_8488_1771b4b4b5db);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_RPC_PROXY_AUTH_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x40953fe2_8565_4759_8488_1771b4b4b5db) , } }
 pub const FWPM_CONDITION_RPC_SERVER_NAME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb605a225_c3b3_48c7_9833_7aefa9527546);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_RPC_SERVER_NAME ) , guid : :: windows :: core :: GUID::from_u128(0xb605a225_c3b3_48c7_9833_7aefa9527546) , } }
 pub const FWPM_CONDITION_RPC_SERVER_PORT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8090f645_9ad5_4e3b_9f9f_8023ca097909);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_RPC_SERVER_PORT ) , guid : :: windows :: core :: GUID::from_u128(0x8090f645_9ad5_4e3b_9f9f_8023ca097909) , } }
 pub const FWPM_CONDITION_SEC_ENCRYPT_ALGORITHM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0d306ef0_e974_4f74_b5c7_591b0da7d562);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_SEC_ENCRYPT_ALGORITHM ) , guid : :: windows :: core :: GUID::from_u128(0x0d306ef0_e974_4f74_b5c7_591b0da7d562) , } }
 pub const FWPM_CONDITION_SEC_KEY_SIZE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4772183b_ccf8_4aeb_bce1_c6c6161c8fe4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_SEC_KEY_SIZE ) , guid : :: windows :: core :: GUID::from_u128(0x4772183b_ccf8_4aeb_bce1_c6c6161c8fe4) , } }
 pub const FWPM_CONDITION_SOURCE_INTERFACE_INDEX: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2311334d_c92d_45bf_9496_edf447820e2d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_SOURCE_INTERFACE_INDEX ) , guid : :: windows :: core :: GUID::from_u128(0x2311334d_c92d_45bf_9496_edf447820e2d) , } }
 pub const FWPM_CONDITION_SOURCE_SUB_INTERFACE_INDEX: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x055edd9d_acd2_4361_8dab_f9525d97662f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_SOURCE_SUB_INTERFACE_INDEX ) , guid : :: windows :: core :: GUID::from_u128(0x055edd9d_acd2_4361_8dab_f9525d97662f) , } }
 pub const FWPM_CONDITION_SUB_INTERFACE_INDEX: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cd42473_d621_4be3_ae8c_72a348d283e1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_SUB_INTERFACE_INDEX ) , guid : :: windows :: core :: GUID::from_u128(0x0cd42473_d621_4be3_ae8c_72a348d283e1) , } }
 pub const FWPM_CONDITION_TUNNEL_TYPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x77a40437_8779_4868_a261_f5a902f1c0cd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_TUNNEL_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x77a40437_8779_4868_a261_f5a902f1c0cd) , } }
 pub const FWPM_CONDITION_VLAN_ID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x938eab21_3618_4e64_9ca5_2141ebda1ca2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_VLAN_ID ) , guid : :: windows :: core :: GUID::from_u128(0x938eab21_3618_4e64_9ca5_2141ebda1ca2) , } }
 pub const FWPM_CONDITION_VSWITCH_DESTINATION_INTERFACE_ID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8ed48be4_c926_49f6_a4f6_ef3030e3fc16);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_VSWITCH_DESTINATION_INTERFACE_ID ) , guid : :: windows :: core :: GUID::from_u128(0x8ed48be4_c926_49f6_a4f6_ef3030e3fc16) , } }
 pub const FWPM_CONDITION_VSWITCH_DESTINATION_INTERFACE_TYPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfa9b3f06_2f1a_4c57_9e68_a7098b28dbfe);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_VSWITCH_DESTINATION_INTERFACE_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0xfa9b3f06_2f1a_4c57_9e68_a7098b28dbfe) , } }
 pub const FWPM_CONDITION_VSWITCH_DESTINATION_VM_ID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6106aace_4de1_4c84_9671_3637f8bcf731);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_VSWITCH_DESTINATION_VM_ID ) , guid : :: windows :: core :: GUID::from_u128(0x6106aace_4de1_4c84_9671_3637f8bcf731) , } }
 pub const FWPM_CONDITION_VSWITCH_ID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc4a414ba_437b_4de6_9946_d99c1b95b312);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_VSWITCH_ID ) , guid : :: windows :: core :: GUID::from_u128(0xc4a414ba_437b_4de6_9946_d99c1b95b312) , } }
 pub const FWPM_CONDITION_VSWITCH_NETWORK_TYPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x11d48b4b_e77a_40b4_9155_392c906c2608);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_VSWITCH_NETWORK_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x11d48b4b_e77a_40b4_9155_392c906c2608) , } }
 pub const FWPM_CONDITION_VSWITCH_SOURCE_INTERFACE_ID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7f4ef24b_b2c1_4938_ba33_a1ecbed512ba);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_VSWITCH_SOURCE_INTERFACE_ID ) , guid : :: windows :: core :: GUID::from_u128(0x7f4ef24b_b2c1_4938_ba33_a1ecbed512ba) , } }
 pub const FWPM_CONDITION_VSWITCH_SOURCE_INTERFACE_TYPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe6b040a2_edaf_4c36_908b_f2f58ae43807);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_VSWITCH_SOURCE_INTERFACE_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0xe6b040a2_edaf_4c36_908b_f2f58ae43807) , } }
 pub const FWPM_CONDITION_VSWITCH_SOURCE_VM_ID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9c2a9ec2_9fc6_42bc_bdd8_406d4da0be64);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_VSWITCH_SOURCE_VM_ID ) , guid : :: windows :: core :: GUID::from_u128(0x9c2a9ec2_9fc6_42bc_bdd8_406d4da0be64) , } }
 pub const FWPM_CONDITION_VSWITCH_TENANT_NETWORK_ID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdc04843c_79e6_4e44_a025_65b9bb0f9f94);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_CONDITION_VSWITCH_TENANT_NETWORK_ID ) , guid : :: windows :: core :: GUID::from_u128(0xdc04843c_79e6_4e44_a025_65b9bb0f9f94) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_NetworkManagement_WindowsFilteringPlatform', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -1697,8 +2067,14 @@ impl ::core::default::Default for FWPM_FILTER_SUBSCRIPTION0 {
     }
 }
 pub const FWPM_KEYING_MODULE_AUTHIP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x11e3dae0_dd26_4590_857d_ab4b28d1a095);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_KEYING_MODULE_AUTHIP ) , guid : :: windows :: core :: GUID::from_u128(0x11e3dae0_dd26_4590_857d_ab4b28d1a095) , } }
 pub const FWPM_KEYING_MODULE_IKE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa9bbf787_82a8_45bb_a400_5d7e5952c7a9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_KEYING_MODULE_IKE ) , guid : :: windows :: core :: GUID::from_u128(0xa9bbf787_82a8_45bb_a400_5d7e5952c7a9) , } }
 pub const FWPM_KEYING_MODULE_IKEV2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x041792cc_8f07_419d_a394_716968cb1647);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_KEYING_MODULE_IKEV2 ) , guid : :: windows :: core :: GUID::from_u128(0x041792cc_8f07_419d_a394_716968cb1647) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_NetworkManagement_WindowsFilteringPlatform', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -1744,40 +2120,110 @@ impl ::core::default::Default for FWPM_LAYER0 {
     }
 }
 pub const FWPM_LAYER_ALE_AUTH_CONNECT_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc38d57d1_05a7_4c33_904f_7fbceee60e82);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_ALE_AUTH_CONNECT_V4 ) , guid : :: windows :: core :: GUID::from_u128(0xc38d57d1_05a7_4c33_904f_7fbceee60e82) , } }
 pub const FWPM_LAYER_ALE_AUTH_CONNECT_V4_DISCARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd632a801_f5ba_4ad6_96e3_607017d9836a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_ALE_AUTH_CONNECT_V4_DISCARD ) , guid : :: windows :: core :: GUID::from_u128(0xd632a801_f5ba_4ad6_96e3_607017d9836a) , } }
 pub const FWPM_LAYER_ALE_AUTH_CONNECT_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4a72393b_319f_44bc_84c3_ba54dcb3b6b4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_ALE_AUTH_CONNECT_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x4a72393b_319f_44bc_84c3_ba54dcb3b6b4) , } }
 pub const FWPM_LAYER_ALE_AUTH_CONNECT_V6_DISCARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc97bc3b8_c9a3_4e33_8695_8e17aad4de09);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_ALE_AUTH_CONNECT_V6_DISCARD ) , guid : :: windows :: core :: GUID::from_u128(0xc97bc3b8_c9a3_4e33_8695_8e17aad4de09) , } }
 pub const FWPM_LAYER_ALE_AUTH_LISTEN_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x88bb5dad_76d7_4227_9c71_df0a3ed7be7e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_ALE_AUTH_LISTEN_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x88bb5dad_76d7_4227_9c71_df0a3ed7be7e) , } }
 pub const FWPM_LAYER_ALE_AUTH_LISTEN_V4_DISCARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x371dfada_9f26_45fd_b4eb_c29eb212893f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_ALE_AUTH_LISTEN_V4_DISCARD ) , guid : :: windows :: core :: GUID::from_u128(0x371dfada_9f26_45fd_b4eb_c29eb212893f) , } }
 pub const FWPM_LAYER_ALE_AUTH_LISTEN_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7ac9de24_17dd_4814_b4bd_a9fbc95a321b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_ALE_AUTH_LISTEN_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x7ac9de24_17dd_4814_b4bd_a9fbc95a321b) , } }
 pub const FWPM_LAYER_ALE_AUTH_LISTEN_V6_DISCARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x60703b07_63c8_48e9_ada3_12b1af40a617);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_ALE_AUTH_LISTEN_V6_DISCARD ) , guid : :: windows :: core :: GUID::from_u128(0x60703b07_63c8_48e9_ada3_12b1af40a617) , } }
 pub const FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe1cd9fe7_f4b5_4273_96c0_592e487b8650);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4 ) , guid : :: windows :: core :: GUID::from_u128(0xe1cd9fe7_f4b5_4273_96c0_592e487b8650) , } }
 pub const FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4_DISCARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9eeaa99b_bd22_4227_919f_0073c63357b1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V4_DISCARD ) , guid : :: windows :: core :: GUID::from_u128(0x9eeaa99b_bd22_4227_919f_0073c63357b1) , } }
 pub const FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa3b42c97_9f04_4672_b87e_cee9c483257f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6 ) , guid : :: windows :: core :: GUID::from_u128(0xa3b42c97_9f04_4672_b87e_cee9c483257f) , } }
 pub const FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6_DISCARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x89455b97_dbe1_453f_a224_13da895af396);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_ALE_AUTH_RECV_ACCEPT_V6_DISCARD ) , guid : :: windows :: core :: GUID::from_u128(0x89455b97_dbe1_453f_a224_13da895af396) , } }
 pub const FWPM_LAYER_ALE_BIND_REDIRECT_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x66978cad_c704_42ac_86ac_7c1a231bd253);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_ALE_BIND_REDIRECT_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x66978cad_c704_42ac_86ac_7c1a231bd253) , } }
 pub const FWPM_LAYER_ALE_BIND_REDIRECT_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbef02c9c_606b_4536_8c26_1c2fc7b631d4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_ALE_BIND_REDIRECT_V6 ) , guid : :: windows :: core :: GUID::from_u128(0xbef02c9c_606b_4536_8c26_1c2fc7b631d4) , } }
 pub const FWPM_LAYER_ALE_CONNECT_REDIRECT_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc6e63c8c_b784_4562_aa7d_0a67cfcaf9a3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_ALE_CONNECT_REDIRECT_V4 ) , guid : :: windows :: core :: GUID::from_u128(0xc6e63c8c_b784_4562_aa7d_0a67cfcaf9a3) , } }
 pub const FWPM_LAYER_ALE_CONNECT_REDIRECT_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x587e54a7_8046_42ba_a0aa_b716250fc7fd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_ALE_CONNECT_REDIRECT_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x587e54a7_8046_42ba_a0aa_b716250fc7fd) , } }
 pub const FWPM_LAYER_ALE_ENDPOINT_CLOSURE_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb4766427_e2a2_467a_bd7e_dbcd1bd85a09);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_ALE_ENDPOINT_CLOSURE_V4 ) , guid : :: windows :: core :: GUID::from_u128(0xb4766427_e2a2_467a_bd7e_dbcd1bd85a09) , } }
 pub const FWPM_LAYER_ALE_ENDPOINT_CLOSURE_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbb536ccd_4755_4ba9_9ff7_f9edf8699c7b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_ALE_ENDPOINT_CLOSURE_V6 ) , guid : :: windows :: core :: GUID::from_u128(0xbb536ccd_4755_4ba9_9ff7_f9edf8699c7b) , } }
 pub const FWPM_LAYER_ALE_FLOW_ESTABLISHED_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaf80470a_5596_4c13_9992_539e6fe57967);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_ALE_FLOW_ESTABLISHED_V4 ) , guid : :: windows :: core :: GUID::from_u128(0xaf80470a_5596_4c13_9992_539e6fe57967) , } }
 pub const FWPM_LAYER_ALE_FLOW_ESTABLISHED_V4_DISCARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x146ae4a9_a1d2_4d43_a31a_4c42682b8e4f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_ALE_FLOW_ESTABLISHED_V4_DISCARD ) , guid : :: windows :: core :: GUID::from_u128(0x146ae4a9_a1d2_4d43_a31a_4c42682b8e4f) , } }
 pub const FWPM_LAYER_ALE_FLOW_ESTABLISHED_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7021d2b3_dfa4_406e_afeb_6afaf7e70efd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_ALE_FLOW_ESTABLISHED_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x7021d2b3_dfa4_406e_afeb_6afaf7e70efd) , } }
 pub const FWPM_LAYER_ALE_FLOW_ESTABLISHED_V6_DISCARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x46928636_bbca_4b76_941d_0fa7f5d7d372);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_ALE_FLOW_ESTABLISHED_V6_DISCARD ) , guid : :: windows :: core :: GUID::from_u128(0x46928636_bbca_4b76_941d_0fa7f5d7d372) , } }
 pub const FWPM_LAYER_ALE_RESOURCE_ASSIGNMENT_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1247d66d_0b60_4a15_8d44_7155d0f53a0c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_ALE_RESOURCE_ASSIGNMENT_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x1247d66d_0b60_4a15_8d44_7155d0f53a0c) , } }
 pub const FWPM_LAYER_ALE_RESOURCE_ASSIGNMENT_V4_DISCARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0b5812a2_c3ff_4eca_b88d_c79e20ac6322);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_ALE_RESOURCE_ASSIGNMENT_V4_DISCARD ) , guid : :: windows :: core :: GUID::from_u128(0x0b5812a2_c3ff_4eca_b88d_c79e20ac6322) , } }
 pub const FWPM_LAYER_ALE_RESOURCE_ASSIGNMENT_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x55a650e1_5f0a_4eca_a653_88f53b26aa8c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_ALE_RESOURCE_ASSIGNMENT_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x55a650e1_5f0a_4eca_a653_88f53b26aa8c) , } }
 pub const FWPM_LAYER_ALE_RESOURCE_ASSIGNMENT_V6_DISCARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcbc998bb_c51f_4c1a_bb4f_9775fcacab2f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_ALE_RESOURCE_ASSIGNMENT_V6_DISCARD ) , guid : :: windows :: core :: GUID::from_u128(0xcbc998bb_c51f_4c1a_bb4f_9775fcacab2f) , } }
 pub const FWPM_LAYER_ALE_RESOURCE_RELEASE_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x74365cce_ccb0_401a_bfc1_b89934ad7e15);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_ALE_RESOURCE_RELEASE_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x74365cce_ccb0_401a_bfc1_b89934ad7e15) , } }
 pub const FWPM_LAYER_ALE_RESOURCE_RELEASE_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf4e5ce80_edcc_4e13_8a2f_b91454bb057b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_ALE_RESOURCE_RELEASE_V6 ) , guid : :: windows :: core :: GUID::from_u128(0xf4e5ce80_edcc_4e13_8a2f_b91454bb057b) , } }
 pub const FWPM_LAYER_DATAGRAM_DATA_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3d08bf4e_45f6_4930_a922_417098e20027);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_DATAGRAM_DATA_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x3d08bf4e_45f6_4930_a922_417098e20027) , } }
 pub const FWPM_LAYER_DATAGRAM_DATA_V4_DISCARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x18e330c6_7248_4e52_aaab_472ed67704fd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_DATAGRAM_DATA_V4_DISCARD ) , guid : :: windows :: core :: GUID::from_u128(0x18e330c6_7248_4e52_aaab_472ed67704fd) , } }
 pub const FWPM_LAYER_DATAGRAM_DATA_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfa45fe2f_3cba_4427_87fc_57b9a4b10d00);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_DATAGRAM_DATA_V6 ) , guid : :: windows :: core :: GUID::from_u128(0xfa45fe2f_3cba_4427_87fc_57b9a4b10d00) , } }
 pub const FWPM_LAYER_DATAGRAM_DATA_V6_DISCARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x09d1dfe1_9b86_4a42_be9d_8c315b92a5d0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_DATAGRAM_DATA_V6_DISCARD ) , guid : :: windows :: core :: GUID::from_u128(0x09d1dfe1_9b86_4a42_be9d_8c315b92a5d0) , } }
 pub const FWPM_LAYER_EGRESS_VSWITCH_ETHERNET: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x86c872b0_76fa_4b79_93a4_0750530ae292);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_EGRESS_VSWITCH_ETHERNET ) , guid : :: windows :: core :: GUID::from_u128(0x86c872b0_76fa_4b79_93a4_0750530ae292) , } }
 pub const FWPM_LAYER_EGRESS_VSWITCH_TRANSPORT_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb92350b6_91f0_46b6_bdc4_871dfd4a7c98);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_EGRESS_VSWITCH_TRANSPORT_V4 ) , guid : :: windows :: core :: GUID::from_u128(0xb92350b6_91f0_46b6_bdc4_871dfd4a7c98) , } }
 pub const FWPM_LAYER_EGRESS_VSWITCH_TRANSPORT_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1b2def23_1881_40bd_82f4_4254e63141cb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_EGRESS_VSWITCH_TRANSPORT_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x1b2def23_1881_40bd_82f4_4254e63141cb) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_NetworkManagement_WindowsFilteringPlatform'*"]
 pub struct FWPM_LAYER_ENUM_TEMPLATE0 {
@@ -1817,59 +2263,167 @@ pub const FWPM_LAYER_FLAG_CLASSIFY_MOSTLY: u32 = 4u32;
 #[doc = "*Required features: 'Win32_NetworkManagement_WindowsFilteringPlatform'*"]
 pub const FWPM_LAYER_FLAG_KERNEL: u32 = 1u32;
 pub const FWPM_LAYER_IKEEXT_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb14b7bdb_dbbd_473e_bed4_8b4708d4f270);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_IKEEXT_V4 ) , guid : :: windows :: core :: GUID::from_u128(0xb14b7bdb_dbbd_473e_bed4_8b4708d4f270) , } }
 pub const FWPM_LAYER_IKEEXT_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb64786b3_f687_4eb9_89d2_8ef32acdabe2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_IKEEXT_V6 ) , guid : :: windows :: core :: GUID::from_u128(0xb64786b3_f687_4eb9_89d2_8ef32acdabe2) , } }
 pub const FWPM_LAYER_INBOUND_ICMP_ERROR_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x61499990_3cb6_4e84_b950_53b94b6964f3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_INBOUND_ICMP_ERROR_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x61499990_3cb6_4e84_b950_53b94b6964f3) , } }
 pub const FWPM_LAYER_INBOUND_ICMP_ERROR_V4_DISCARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa6b17075_ebaf_4053_a4e7_213c8121ede5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_INBOUND_ICMP_ERROR_V4_DISCARD ) , guid : :: windows :: core :: GUID::from_u128(0xa6b17075_ebaf_4053_a4e7_213c8121ede5) , } }
 pub const FWPM_LAYER_INBOUND_ICMP_ERROR_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x65f9bdff_3b2d_4e5d_b8c6_c720651fe898);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_INBOUND_ICMP_ERROR_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x65f9bdff_3b2d_4e5d_b8c6_c720651fe898) , } }
 pub const FWPM_LAYER_INBOUND_ICMP_ERROR_V6_DISCARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa6e7ccc0_08fb_468d_a472_9771d5595e09);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_INBOUND_ICMP_ERROR_V6_DISCARD ) , guid : :: windows :: core :: GUID::from_u128(0xa6e7ccc0_08fb_468d_a472_9771d5595e09) , } }
 pub const FWPM_LAYER_INBOUND_IPPACKET_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc86fd1bf_21cd_497e_a0bb_17425c885c58);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_INBOUND_IPPACKET_V4 ) , guid : :: windows :: core :: GUID::from_u128(0xc86fd1bf_21cd_497e_a0bb_17425c885c58) , } }
 pub const FWPM_LAYER_INBOUND_IPPACKET_V4_DISCARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb5a230d0_a8c0_44f2_916e_991b53ded1f7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_INBOUND_IPPACKET_V4_DISCARD ) , guid : :: windows :: core :: GUID::from_u128(0xb5a230d0_a8c0_44f2_916e_991b53ded1f7) , } }
 pub const FWPM_LAYER_INBOUND_IPPACKET_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf52032cb_991c_46e7_971d_2601459a91ca);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_INBOUND_IPPACKET_V6 ) , guid : :: windows :: core :: GUID::from_u128(0xf52032cb_991c_46e7_971d_2601459a91ca) , } }
 pub const FWPM_LAYER_INBOUND_IPPACKET_V6_DISCARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbb24c279_93b4_47a2_83ad_ae1698b50885);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_INBOUND_IPPACKET_V6_DISCARD ) , guid : :: windows :: core :: GUID::from_u128(0xbb24c279_93b4_47a2_83ad_ae1698b50885) , } }
 pub const FWPM_LAYER_INBOUND_MAC_FRAME_ETHERNET: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xeffb7edb_0055_4f9a_a231_4ff8131ad191);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_INBOUND_MAC_FRAME_ETHERNET ) , guid : :: windows :: core :: GUID::from_u128(0xeffb7edb_0055_4f9a_a231_4ff8131ad191) , } }
 pub const FWPM_LAYER_INBOUND_MAC_FRAME_NATIVE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd4220bd3_62ce_4f08_ae88_b56e8526df50);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_INBOUND_MAC_FRAME_NATIVE ) , guid : :: windows :: core :: GUID::from_u128(0xd4220bd3_62ce_4f08_ae88_b56e8526df50) , } }
 pub const FWPM_LAYER_INBOUND_MAC_FRAME_NATIVE_FAST: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x853aaa8e_2b78_4d24_a804_36db08b29711);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_INBOUND_MAC_FRAME_NATIVE_FAST ) , guid : :: windows :: core :: GUID::from_u128(0x853aaa8e_2b78_4d24_a804_36db08b29711) , } }
 pub const FWPM_LAYER_INBOUND_RESERVED2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf4fb8d55_c076_46d8_a2c7_6a4c722ca4ed);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_INBOUND_RESERVED2 ) , guid : :: windows :: core :: GUID::from_u128(0xf4fb8d55_c076_46d8_a2c7_6a4c722ca4ed) , } }
 pub const FWPM_LAYER_INBOUND_TRANSPORT_FAST: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe41d2719_05c7_40f0_8983_ea8d17bbc2f6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_INBOUND_TRANSPORT_FAST ) , guid : :: windows :: core :: GUID::from_u128(0xe41d2719_05c7_40f0_8983_ea8d17bbc2f6) , } }
 pub const FWPM_LAYER_INBOUND_TRANSPORT_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5926dfc8_e3cf_4426_a283_dc393f5d0f9d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_INBOUND_TRANSPORT_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x5926dfc8_e3cf_4426_a283_dc393f5d0f9d) , } }
 pub const FWPM_LAYER_INBOUND_TRANSPORT_V4_DISCARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xac4a9833_f69d_4648_b261_6dc84835ef39);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_INBOUND_TRANSPORT_V4_DISCARD ) , guid : :: windows :: core :: GUID::from_u128(0xac4a9833_f69d_4648_b261_6dc84835ef39) , } }
 pub const FWPM_LAYER_INBOUND_TRANSPORT_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x634a869f_fc23_4b90_b0c1_bf620a36ae6f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_INBOUND_TRANSPORT_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x634a869f_fc23_4b90_b0c1_bf620a36ae6f) , } }
 pub const FWPM_LAYER_INBOUND_TRANSPORT_V6_DISCARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2a6ff955_3b2b_49d2_9848_ad9d72dcaab7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_INBOUND_TRANSPORT_V6_DISCARD ) , guid : :: windows :: core :: GUID::from_u128(0x2a6ff955_3b2b_49d2_9848_ad9d72dcaab7) , } }
 pub const FWPM_LAYER_INGRESS_VSWITCH_ETHERNET: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7d98577a_9a87_41ec_9718_7cf589c9f32d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_INGRESS_VSWITCH_ETHERNET ) , guid : :: windows :: core :: GUID::from_u128(0x7d98577a_9a87_41ec_9718_7cf589c9f32d) , } }
 pub const FWPM_LAYER_INGRESS_VSWITCH_TRANSPORT_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb2696ff6_774f_4554_9f7d_3da3945f8e85);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_INGRESS_VSWITCH_TRANSPORT_V4 ) , guid : :: windows :: core :: GUID::from_u128(0xb2696ff6_774f_4554_9f7d_3da3945f8e85) , } }
 pub const FWPM_LAYER_INGRESS_VSWITCH_TRANSPORT_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5ee314fc_7d8a_47f4_b7e3_291a36da4e12);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_INGRESS_VSWITCH_TRANSPORT_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x5ee314fc_7d8a_47f4_b7e3_291a36da4e12) , } }
 pub const FWPM_LAYER_IPFORWARD_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa82acc24_4ee1_4ee1_b465_fd1d25cb10a4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_IPFORWARD_V4 ) , guid : :: windows :: core :: GUID::from_u128(0xa82acc24_4ee1_4ee1_b465_fd1d25cb10a4) , } }
 pub const FWPM_LAYER_IPFORWARD_V4_DISCARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9e9ea773_2fae_4210_8f17_34129ef369eb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_IPFORWARD_V4_DISCARD ) , guid : :: windows :: core :: GUID::from_u128(0x9e9ea773_2fae_4210_8f17_34129ef369eb) , } }
 pub const FWPM_LAYER_IPFORWARD_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7b964818_19c7_493a_b71f_832c3684d28c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_IPFORWARD_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x7b964818_19c7_493a_b71f_832c3684d28c) , } }
 pub const FWPM_LAYER_IPFORWARD_V6_DISCARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x31524a5d_1dfe_472f_bb93_518ee945d8a2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_IPFORWARD_V6_DISCARD ) , guid : :: windows :: core :: GUID::from_u128(0x31524a5d_1dfe_472f_bb93_518ee945d8a2) , } }
 pub const FWPM_LAYER_IPSEC_KM_DEMUX_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf02b1526_a459_4a51_b9e3_759de52b9d2c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_IPSEC_KM_DEMUX_V4 ) , guid : :: windows :: core :: GUID::from_u128(0xf02b1526_a459_4a51_b9e3_759de52b9d2c) , } }
 pub const FWPM_LAYER_IPSEC_KM_DEMUX_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2f755cf6_2fd4_4e88_b3e4_a91bca495235);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_IPSEC_KM_DEMUX_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x2f755cf6_2fd4_4e88_b3e4_a91bca495235) , } }
 pub const FWPM_LAYER_IPSEC_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xeda65c74_610d_4bc5_948f_3c4f89556867);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_IPSEC_V4 ) , guid : :: windows :: core :: GUID::from_u128(0xeda65c74_610d_4bc5_948f_3c4f89556867) , } }
 pub const FWPM_LAYER_IPSEC_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x13c48442_8d87_4261_9a29_59d2abc348b4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_IPSEC_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x13c48442_8d87_4261_9a29_59d2abc348b4) , } }
 pub const FWPM_LAYER_KM_AUTHORIZATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4aa226e9_9020_45fb_956a_c0249d841195);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_KM_AUTHORIZATION ) , guid : :: windows :: core :: GUID::from_u128(0x4aa226e9_9020_45fb_956a_c0249d841195) , } }
 pub const FWPM_LAYER_NAME_RESOLUTION_CACHE_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0c2aa681_905b_4ccd_a467_4dd811d07b7b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_NAME_RESOLUTION_CACHE_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x0c2aa681_905b_4ccd_a467_4dd811d07b7b) , } }
 pub const FWPM_LAYER_NAME_RESOLUTION_CACHE_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x92d592fa_6b01_434a_9dea_d1e96ea97da9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_NAME_RESOLUTION_CACHE_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x92d592fa_6b01_434a_9dea_d1e96ea97da9) , } }
 pub const FWPM_LAYER_OUTBOUND_ICMP_ERROR_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x41390100_564c_4b32_bc1d_718048354d7c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_OUTBOUND_ICMP_ERROR_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x41390100_564c_4b32_bc1d_718048354d7c) , } }
 pub const FWPM_LAYER_OUTBOUND_ICMP_ERROR_V4_DISCARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb3598d36_0561_4588_a6bf_e955e3f6264b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_OUTBOUND_ICMP_ERROR_V4_DISCARD ) , guid : :: windows :: core :: GUID::from_u128(0xb3598d36_0561_4588_a6bf_e955e3f6264b) , } }
 pub const FWPM_LAYER_OUTBOUND_ICMP_ERROR_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7fb03b60_7b8d_4dfa_badd_980176fc4e12);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_OUTBOUND_ICMP_ERROR_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x7fb03b60_7b8d_4dfa_badd_980176fc4e12) , } }
 pub const FWPM_LAYER_OUTBOUND_ICMP_ERROR_V6_DISCARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x65f2e647_8d0c_4f47_b19b_33a4d3f1357c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_OUTBOUND_ICMP_ERROR_V6_DISCARD ) , guid : :: windows :: core :: GUID::from_u128(0x65f2e647_8d0c_4f47_b19b_33a4d3f1357c) , } }
 pub const FWPM_LAYER_OUTBOUND_IPPACKET_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1e5c9fae_8a84_4135_a331_950b54229ecd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_OUTBOUND_IPPACKET_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x1e5c9fae_8a84_4135_a331_950b54229ecd) , } }
 pub const FWPM_LAYER_OUTBOUND_IPPACKET_V4_DISCARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x08e4bcb5_b647_48f3_953c_e5ddbd03937e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_OUTBOUND_IPPACKET_V4_DISCARD ) , guid : :: windows :: core :: GUID::from_u128(0x08e4bcb5_b647_48f3_953c_e5ddbd03937e) , } }
 pub const FWPM_LAYER_OUTBOUND_IPPACKET_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa3b3ab6b_3564_488c_9117_f34e82142763);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_OUTBOUND_IPPACKET_V6 ) , guid : :: windows :: core :: GUID::from_u128(0xa3b3ab6b_3564_488c_9117_f34e82142763) , } }
 pub const FWPM_LAYER_OUTBOUND_IPPACKET_V6_DISCARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9513d7c4_a934_49dc_91a7_6ccb80cc02e3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_OUTBOUND_IPPACKET_V6_DISCARD ) , guid : :: windows :: core :: GUID::from_u128(0x9513d7c4_a934_49dc_91a7_6ccb80cc02e3) , } }
 pub const FWPM_LAYER_OUTBOUND_MAC_FRAME_ETHERNET: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x694673bc_d6db_4870_adee_0acdbdb7f4b2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_OUTBOUND_MAC_FRAME_ETHERNET ) , guid : :: windows :: core :: GUID::from_u128(0x694673bc_d6db_4870_adee_0acdbdb7f4b2) , } }
 pub const FWPM_LAYER_OUTBOUND_MAC_FRAME_NATIVE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x94c44912_9d6f_4ebf_b995_05ab8a088d1b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_OUTBOUND_MAC_FRAME_NATIVE ) , guid : :: windows :: core :: GUID::from_u128(0x94c44912_9d6f_4ebf_b995_05ab8a088d1b) , } }
 pub const FWPM_LAYER_OUTBOUND_MAC_FRAME_NATIVE_FAST: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x470df946_c962_486f_9446_8293cbc75eb8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_OUTBOUND_MAC_FRAME_NATIVE_FAST ) , guid : :: windows :: core :: GUID::from_u128(0x470df946_c962_486f_9446_8293cbc75eb8) , } }
 pub const FWPM_LAYER_OUTBOUND_TRANSPORT_FAST: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x13ed4388_a070_4815_9935_7a9be6408b78);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_OUTBOUND_TRANSPORT_FAST ) , guid : :: windows :: core :: GUID::from_u128(0x13ed4388_a070_4815_9935_7a9be6408b78) , } }
 pub const FWPM_LAYER_OUTBOUND_TRANSPORT_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x09e61aea_d214_46e2_9b21_b26b0b2f28c8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_OUTBOUND_TRANSPORT_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x09e61aea_d214_46e2_9b21_b26b0b2f28c8) , } }
 pub const FWPM_LAYER_OUTBOUND_TRANSPORT_V4_DISCARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc5f10551_bdb0_43d7_a313_50e211f4d68a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_OUTBOUND_TRANSPORT_V4_DISCARD ) , guid : :: windows :: core :: GUID::from_u128(0xc5f10551_bdb0_43d7_a313_50e211f4d68a) , } }
 pub const FWPM_LAYER_OUTBOUND_TRANSPORT_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe1735bde_013f_4655_b351_a49e15762df0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_OUTBOUND_TRANSPORT_V6 ) , guid : :: windows :: core :: GUID::from_u128(0xe1735bde_013f_4655_b351_a49e15762df0) , } }
 pub const FWPM_LAYER_OUTBOUND_TRANSPORT_V6_DISCARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf433df69_ccbd_482e_b9b2_57165658c3b3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_OUTBOUND_TRANSPORT_V6_DISCARD ) , guid : :: windows :: core :: GUID::from_u128(0xf433df69_ccbd_482e_b9b2_57165658c3b3) , } }
 pub const FWPM_LAYER_RPC_EPMAP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9247bc61_eb07_47ee_872c_bfd78bfd1616);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_RPC_EPMAP ) , guid : :: windows :: core :: GUID::from_u128(0x9247bc61_eb07_47ee_872c_bfd78bfd1616) , } }
 pub const FWPM_LAYER_RPC_EP_ADD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x618dffc7_c450_4943_95db_99b4c16a55d4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_RPC_EP_ADD ) , guid : :: windows :: core :: GUID::from_u128(0x618dffc7_c450_4943_95db_99b4c16a55d4) , } }
 pub const FWPM_LAYER_RPC_PROXY_CONN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x94a4b50b_ba5c_4f27_907a_229fac0c2a7a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_RPC_PROXY_CONN ) , guid : :: windows :: core :: GUID::from_u128(0x94a4b50b_ba5c_4f27_907a_229fac0c2a7a) , } }
 pub const FWPM_LAYER_RPC_PROXY_IF: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf8a38615_e12c_41ac_98df_121ad981aade);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_RPC_PROXY_IF ) , guid : :: windows :: core :: GUID::from_u128(0xf8a38615_e12c_41ac_98df_121ad981aade) , } }
 pub const FWPM_LAYER_RPC_UM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x75a89dda_95e4_40f3_adc7_7688a9c847e1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_RPC_UM ) , guid : :: windows :: core :: GUID::from_u128(0x75a89dda_95e4_40f3_adc7_7688a9c847e1) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_NetworkManagement_WindowsFilteringPlatform'*"]
 pub struct FWPM_LAYER_STATISTICS0 {
@@ -1905,11 +2459,23 @@ impl ::core::default::Default for FWPM_LAYER_STATISTICS0 {
     }
 }
 pub const FWPM_LAYER_STREAM_PACKET_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaf52d8ec_cb2d_44e5_ad92_f8dc38d2eb29);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_STREAM_PACKET_V4 ) , guid : :: windows :: core :: GUID::from_u128(0xaf52d8ec_cb2d_44e5_ad92_f8dc38d2eb29) , } }
 pub const FWPM_LAYER_STREAM_PACKET_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x779a8ca3_f099_468f_b5d4_83535c461c02);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_STREAM_PACKET_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x779a8ca3_f099_468f_b5d4_83535c461c02) , } }
 pub const FWPM_LAYER_STREAM_V4: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3b89653c_c170_49e4_b1cd_e0eeeee19a3e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_STREAM_V4 ) , guid : :: windows :: core :: GUID::from_u128(0x3b89653c_c170_49e4_b1cd_e0eeeee19a3e) , } }
 pub const FWPM_LAYER_STREAM_V4_DISCARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x25c4c2c2_25ff_4352_82f9_c54a4a4726dc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_STREAM_V4_DISCARD ) , guid : :: windows :: core :: GUID::from_u128(0x25c4c2c2_25ff_4352_82f9_c54a4a4726dc) , } }
 pub const FWPM_LAYER_STREAM_V6: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x47c9137a_7ec4_46b3_b6e4_48e926b1eda4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_STREAM_V6 ) , guid : :: windows :: core :: GUID::from_u128(0x47c9137a_7ec4_46b3_b6e4_48e926b1eda4) , } }
 pub const FWPM_LAYER_STREAM_V6_DISCARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x10a59fc7_b628_4c41_9eb8_cf37d55103cf);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_LAYER_STREAM_V6_DISCARD ) , guid : :: windows :: core :: GUID::from_u128(0x10a59fc7_b628_4c41_9eb8_cf37d55103cf) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_NetworkManagement_WindowsFilteringPlatform', 'Win32_Foundation', 'Win32_Security'*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
@@ -4555,7 +5121,11 @@ pub const FWPM_PROVIDER_CONTEXT_FLAG_DOWNLEVEL: u32 = 2u32;
 #[doc = "*Required features: 'Win32_NetworkManagement_WindowsFilteringPlatform'*"]
 pub const FWPM_PROVIDER_CONTEXT_FLAG_PERSISTENT: u32 = 1u32;
 pub const FWPM_PROVIDER_CONTEXT_SECURE_SOCKET_AUTHIP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb25ea800_0d02_46ed_92bd_7fa84bb73e9d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_PROVIDER_CONTEXT_SECURE_SOCKET_AUTHIP ) , guid : :: windows :: core :: GUID::from_u128(0xb25ea800_0d02_46ed_92bd_7fa84bb73e9d) , } }
 pub const FWPM_PROVIDER_CONTEXT_SECURE_SOCKET_IPSEC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8c2d4144_f8e0_42c0_94ce_7ccfc63b2f9b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_PROVIDER_CONTEXT_SECURE_SOCKET_IPSEC ) , guid : :: windows :: core :: GUID::from_u128(0x8c2d4144_f8e0_42c0_94ce_7ccfc63b2f9b) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_NetworkManagement_WindowsFilteringPlatform'*"]
 pub struct FWPM_PROVIDER_CONTEXT_SUBSCRIPTION0 {
@@ -4653,11 +5223,23 @@ pub const FWPM_PROVIDER_FLAG_DISABLED: u32 = 16u32;
 #[doc = "*Required features: 'Win32_NetworkManagement_WindowsFilteringPlatform'*"]
 pub const FWPM_PROVIDER_FLAG_PERSISTENT: u32 = 1u32;
 pub const FWPM_PROVIDER_IKEEXT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x10ad9216_ccde_456c_8b16_e9f04e60a90b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_PROVIDER_IKEEXT ) , guid : :: windows :: core :: GUID::from_u128(0x10ad9216_ccde_456c_8b16_e9f04e60a90b) , } }
 pub const FWPM_PROVIDER_IPSEC_DOSP_CONFIG: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3c6c05a9_c05c_4bb9_8338_2327814ce8bf);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_PROVIDER_IPSEC_DOSP_CONFIG ) , guid : :: windows :: core :: GUID::from_u128(0x3c6c05a9_c05c_4bb9_8338_2327814ce8bf) , } }
 pub const FWPM_PROVIDER_MPSSVC_EDP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa90296f7_46b8_4457_8f84_b05e05d3c622);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_PROVIDER_MPSSVC_EDP ) , guid : :: windows :: core :: GUID::from_u128(0xa90296f7_46b8_4457_8f84_b05e05d3c622) , } }
 pub const FWPM_PROVIDER_MPSSVC_TENANT_RESTRICTIONS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd0718ff9_44da_4f50_9dc2_c963a4247613);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_PROVIDER_MPSSVC_TENANT_RESTRICTIONS ) , guid : :: windows :: core :: GUID::from_u128(0xd0718ff9_44da_4f50_9dc2_c963a4247613) , } }
 pub const FWPM_PROVIDER_MPSSVC_WF: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdecc16ca_3f33_4346_be1e_8fb4ae0f3d62);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_PROVIDER_MPSSVC_WF ) , guid : :: windows :: core :: GUID::from_u128(0xdecc16ca_3f33_4346_be1e_8fb4ae0f3d62) , } }
 pub const FWPM_PROVIDER_MPSSVC_WSH: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4b153735_1049_4480_aab4_d1b9bdc03710);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_PROVIDER_MPSSVC_WSH ) , guid : :: windows :: core :: GUID::from_u128(0x4b153735_1049_4480_aab4_d1b9bdc03710) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_NetworkManagement_WindowsFilteringPlatform'*"]
 pub struct FWPM_PROVIDER_SUBSCRIPTION0 {
@@ -4691,7 +5273,11 @@ impl ::core::default::Default for FWPM_PROVIDER_SUBSCRIPTION0 {
     }
 }
 pub const FWPM_PROVIDER_TCP_CHIMNEY_OFFLOAD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x896aa19e_9a34_4bcb_ae79_beb9127c84b9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_PROVIDER_TCP_CHIMNEY_OFFLOAD ) , guid : :: windows :: core :: GUID::from_u128(0x896aa19e_9a34_4bcb_ae79_beb9127c84b9) , } }
 pub const FWPM_PROVIDER_TCP_TEMPLATES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x76cfcd30_3394_432d_bed3_441ae50e63c3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_PROVIDER_TCP_TEMPLATES ) , guid : :: windows :: core :: GUID::from_u128(0x76cfcd30_3394_432d_bed3_441ae50e63c3) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WindowsFilteringPlatform'*"]
 pub type FWPM_SERVICE_STATE = i32;
 #[doc = "*Required features: 'Win32_NetworkManagement_WindowsFilteringPlatform'*"]
@@ -4994,18 +5580,44 @@ impl ::core::default::Default for FWPM_SUBLAYER_ENUM_TEMPLATE0 {
 #[doc = "*Required features: 'Win32_NetworkManagement_WindowsFilteringPlatform'*"]
 pub const FWPM_SUBLAYER_FLAG_PERSISTENT: u32 = 1u32;
 pub const FWPM_SUBLAYER_INSPECTION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x877519e1_e6a9_41a5_81b4_8c4f118e4a60);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_SUBLAYER_INSPECTION ) , guid : :: windows :: core :: GUID::from_u128(0x877519e1_e6a9_41a5_81b4_8c4f118e4a60) , } }
 pub const FWPM_SUBLAYER_IPSEC_DOSP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe076d572_5d3d_48ef_802b_909eddb098bd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_SUBLAYER_IPSEC_DOSP ) , guid : :: windows :: core :: GUID::from_u128(0xe076d572_5d3d_48ef_802b_909eddb098bd) , } }
 pub const FWPM_SUBLAYER_IPSEC_FORWARD_OUTBOUND_TUNNEL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa5082e73_8f71_4559_8a9a_101cea04ef87);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_SUBLAYER_IPSEC_FORWARD_OUTBOUND_TUNNEL ) , guid : :: windows :: core :: GUID::from_u128(0xa5082e73_8f71_4559_8a9a_101cea04ef87) , } }
 pub const FWPM_SUBLAYER_IPSEC_SECURITY_REALM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x37a57701_5884_4964_92b8_3e704688b0ad);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_SUBLAYER_IPSEC_SECURITY_REALM ) , guid : :: windows :: core :: GUID::from_u128(0x37a57701_5884_4964_92b8_3e704688b0ad) , } }
 pub const FWPM_SUBLAYER_IPSEC_TUNNEL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x83f299ed_9ff4_4967_aff4_c309f4dab827);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_SUBLAYER_IPSEC_TUNNEL ) , guid : :: windows :: core :: GUID::from_u128(0x83f299ed_9ff4_4967_aff4_c309f4dab827) , } }
 pub const FWPM_SUBLAYER_LIPS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1b75c0ce_ff60_4711_a70f_b4958cc3b2d0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_SUBLAYER_LIPS ) , guid : :: windows :: core :: GUID::from_u128(0x1b75c0ce_ff60_4711_a70f_b4958cc3b2d0) , } }
 pub const FWPM_SUBLAYER_MPSSVC_EDP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x09a47e38_fa97_471b_b123_18bcd7e65071);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_SUBLAYER_MPSSVC_EDP ) , guid : :: windows :: core :: GUID::from_u128(0x09a47e38_fa97_471b_b123_18bcd7e65071) , } }
 pub const FWPM_SUBLAYER_MPSSVC_QUARANTINE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb3cdd441_af90_41ba_a745_7c6008ff2302);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_SUBLAYER_MPSSVC_QUARANTINE ) , guid : :: windows :: core :: GUID::from_u128(0xb3cdd441_af90_41ba_a745_7c6008ff2302) , } }
 pub const FWPM_SUBLAYER_MPSSVC_TENANT_RESTRICTIONS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1ec6c7e1_fdd9_478a_b55f_ff8ba1d2c17d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_SUBLAYER_MPSSVC_TENANT_RESTRICTIONS ) , guid : :: windows :: core :: GUID::from_u128(0x1ec6c7e1_fdd9_478a_b55f_ff8ba1d2c17d) , } }
 pub const FWPM_SUBLAYER_MPSSVC_WF: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb3cdd441_af90_41ba_a745_7c6008ff2301);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_SUBLAYER_MPSSVC_WF ) , guid : :: windows :: core :: GUID::from_u128(0xb3cdd441_af90_41ba_a745_7c6008ff2301) , } }
 pub const FWPM_SUBLAYER_MPSSVC_WSH: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb3cdd441_af90_41ba_a745_7c6008ff2300);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_SUBLAYER_MPSSVC_WSH ) , guid : :: windows :: core :: GUID::from_u128(0xb3cdd441_af90_41ba_a745_7c6008ff2300) , } }
 pub const FWPM_SUBLAYER_RPC_AUDIT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x758c84f4_fb48_4de9_9aeb_3ed9551ab1fd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_SUBLAYER_RPC_AUDIT ) , guid : :: windows :: core :: GUID::from_u128(0x758c84f4_fb48_4de9_9aeb_3ed9551ab1fd) , } }
 pub const FWPM_SUBLAYER_SECURE_SOCKET: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x15a66e17_3f3c_4f7b_aa6c_812aa613dd82);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_SUBLAYER_SECURE_SOCKET ) , guid : :: windows :: core :: GUID::from_u128(0x15a66e17_3f3c_4f7b_aa6c_812aa613dd82) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_NetworkManagement_WindowsFilteringPlatform'*"]
 pub struct FWPM_SUBLAYER_SUBSCRIPTION0 {
@@ -5039,9 +5651,17 @@ impl ::core::default::Default for FWPM_SUBLAYER_SUBSCRIPTION0 {
     }
 }
 pub const FWPM_SUBLAYER_TCP_CHIMNEY_OFFLOAD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x337608b9_b7d5_4d5f_82f9_3618618bc058);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_SUBLAYER_TCP_CHIMNEY_OFFLOAD ) , guid : :: windows :: core :: GUID::from_u128(0x337608b9_b7d5_4d5f_82f9_3618618bc058) , } }
 pub const FWPM_SUBLAYER_TCP_TEMPLATES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x24421dcf_0ac5_4caa_9e14_50f6e3636af0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_SUBLAYER_TCP_TEMPLATES ) , guid : :: windows :: core :: GUID::from_u128(0x24421dcf_0ac5_4caa_9e14_50f6e3636af0) , } }
 pub const FWPM_SUBLAYER_TEREDO: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xba69dc66_5176_4979_9c89_26a7b46a8327);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_SUBLAYER_TEREDO ) , guid : :: windows :: core :: GUID::from_u128(0xba69dc66_5176_4979_9c89_26a7b46a8327) , } }
 pub const FWPM_SUBLAYER_UNIVERSAL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xeebecc03_ced4_4380_819a_2734397b2b74);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FWPM_SUBLAYER_UNIVERSAL ) , guid : :: windows :: core :: GUID::from_u128(0xeebecc03_ced4_4380_819a_2734397b2b74) , } }
 #[doc = "*Required features: 'Win32_NetworkManagement_WindowsFilteringPlatform'*"]
 pub type FWPM_SUBSCRIPTION_FLAGS = u32;
 #[doc = "*Required features: 'Win32_NetworkManagement_WindowsFilteringPlatform'*"]

--- a/crates/libs/windows/src/Windows/Win32/Networking/ActiveDirectory/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/ActiveDirectory/mod.rs
@@ -2008,24 +2008,62 @@ pub unsafe fn BinarySDToSecurityDescriptor<'a, Param2: ::windows::core::IntoPara
     unimplemented!("Unsupported target OS");
 }
 pub const CLSID_CommonQuery: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x83bc5ec0_6f2a_11d0_a1c4_00aa00c16e65);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_CommonQuery ) , guid : :: windows :: core :: GUID::from_u128(0x83bc5ec0_6f2a_11d0_a1c4_00aa00c16e65) , } }
 pub const CLSID_DsAdminCreateObj: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe301a009_f901_11d2_82b9_00c04f68928b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DsAdminCreateObj ) , guid : :: windows :: core :: GUID::from_u128(0xe301a009_f901_11d2_82b9_00c04f68928b) , } }
 pub const CLSID_DsDisplaySpecifier: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1ab4a8c0_6a0b_11d2_ad49_00c04fa31a86);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DsDisplaySpecifier ) , guid : :: windows :: core :: GUID::from_u128(0x1ab4a8c0_6a0b_11d2_ad49_00c04fa31a86) , } }
 pub const CLSID_DsDomainTreeBrowser: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1698790a_e2b4_11d0_b0b1_00c04fd8dca6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DsDomainTreeBrowser ) , guid : :: windows :: core :: GUID::from_u128(0x1698790a_e2b4_11d0_b0b1_00c04fd8dca6) , } }
 pub const CLSID_DsFindAdvanced: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x83ee3fe3_57d9_11d0_b932_00a024ab2dbb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DsFindAdvanced ) , guid : :: windows :: core :: GUID::from_u128(0x83ee3fe3_57d9_11d0_b932_00a024ab2dbb) , } }
 pub const CLSID_DsFindComputer: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x16006700_87ad_11d0_9140_00aa00c16e65);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DsFindComputer ) , guid : :: windows :: core :: GUID::from_u128(0x16006700_87ad_11d0_9140_00aa00c16e65) , } }
 pub const CLSID_DsFindContainer: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc1b3cbf2_886a_11d0_9140_00aa00c16e65);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DsFindContainer ) , guid : :: windows :: core :: GUID::from_u128(0xc1b3cbf2_886a_11d0_9140_00aa00c16e65) , } }
 pub const CLSID_DsFindDomainController: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x538c7b7e_d25e_11d0_9742_00a0c906af45);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DsFindDomainController ) , guid : :: windows :: core :: GUID::from_u128(0x538c7b7e_d25e_11d0_9742_00a0c906af45) , } }
 pub const CLSID_DsFindFrsMembers: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x94ce4b18_b3d3_11d1_b9b4_00c04fd8d5b0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DsFindFrsMembers ) , guid : :: windows :: core :: GUID::from_u128(0x94ce4b18_b3d3_11d1_b9b4_00c04fd8d5b0) , } }
 pub const CLSID_DsFindObjects: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x83ee3fe1_57d9_11d0_b932_00a024ab2dbb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DsFindObjects ) , guid : :: windows :: core :: GUID::from_u128(0x83ee3fe1_57d9_11d0_b932_00a024ab2dbb) , } }
 pub const CLSID_DsFindPeople: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x83ee3fe2_57d9_11d0_b932_00a024ab2dbb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DsFindPeople ) , guid : :: windows :: core :: GUID::from_u128(0x83ee3fe2_57d9_11d0_b932_00a024ab2dbb) , } }
 pub const CLSID_DsFindPrinter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb577f070_7ee2_11d0_913f_00aa00c16e65);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DsFindPrinter ) , guid : :: windows :: core :: GUID::from_u128(0xb577f070_7ee2_11d0_913f_00aa00c16e65) , } }
 pub const CLSID_DsFindVolume: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc1b3cbf1_886a_11d0_9140_00aa00c16e65);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DsFindVolume ) , guid : :: windows :: core :: GUID::from_u128(0xc1b3cbf1_886a_11d0_9140_00aa00c16e65) , } }
 pub const CLSID_DsFindWriteableDomainController: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7cbef079_aa84_444b_bc70_68e41283eabc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DsFindWriteableDomainController ) , guid : :: windows :: core :: GUID::from_u128(0x7cbef079_aa84_444b_bc70_68e41283eabc) , } }
 pub const CLSID_DsFolderProperties: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9e51e0d0_6e0f_11d2_9601_00c04fa31a86);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DsFolderProperties ) , guid : :: windows :: core :: GUID::from_u128(0x9e51e0d0_6e0f_11d2_9601_00c04fa31a86) , } }
 pub const CLSID_DsObjectPicker: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x17d6ccd8_3b7b_11d2_b9e0_00c04fd8dbf7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DsObjectPicker ) , guid : :: windows :: core :: GUID::from_u128(0x17d6ccd8_3b7b_11d2_b9e0_00c04fd8dbf7) , } }
 pub const CLSID_DsPropertyPages: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0d45d530_764b_11d0_a1ca_00aa00c16e65);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DsPropertyPages ) , guid : :: windows :: core :: GUID::from_u128(0x0d45d530_764b_11d0_a1ca_00aa00c16e65) , } }
 pub const CLSID_DsQuery: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8a23e65e_31c2_11d0_891c_00a024ab2dbb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DsQuery ) , guid : :: windows :: core :: GUID::from_u128(0x8a23e65e_31c2_11d0_891c_00a024ab2dbb) , } }
 pub const CLSID_MicrosoftDS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfe1290f0_cfbd_11cf_a330_00aa00c16e65);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_MicrosoftDS ) , guid : :: windows :: core :: GUID::from_u128(0xfe1290f0_cfbd_11cf_a330_00aa00c16e65) , } }
 #[doc = "*Required features: 'Win32_Networking_ActiveDirectory'*"]
 pub const CQFF_ISOPTIONAL: u32 = 2u32;
 #[doc = "*Required features: 'Win32_Networking_ActiveDirectory'*"]

--- a/crates/libs/windows/src/Windows/Win32/Networking/WinSock/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WinSock/mod.rs
@@ -341,6 +341,8 @@ pub const AI_SECURE_WITH_FALLBACK: u32 = 1048576u32;
 #[doc = "*Required features: 'Win32_Networking_WinSock'*"]
 pub const AI_V4MAPPED: u32 = 2048u32;
 pub const ASSOCIATE_NAMERES_CONTEXT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x59a38b67_d4fe_46e1_ba3c_87ea74ca3049);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ASSOCIATE_NAMERES_CONTEXT ) , guid : :: windows :: core :: GUID::from_u128(0x59a38b67_d4fe_46e1_ba3c_87ea74ca3049) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Networking_WinSock'*"]
 pub struct ASSOCIATE_NAMERES_CONTEXT_INPUT {
@@ -5204,7 +5206,11 @@ pub const RCVALL_SOCKETLEVELONLY: RCVALL_VALUE = 2i32;
 #[doc = "*Required features: 'Win32_Networking_WinSock'*"]
 pub const RCVALL_IPLEVEL: RCVALL_VALUE = 3i32;
 pub const REAL_TIME_NOTIFICATION_CAPABILITY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6b59819a_5cae_492d_a901_2a3c2c50164f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( REAL_TIME_NOTIFICATION_CAPABILITY ) , guid : :: windows :: core :: GUID::from_u128(0x6b59819a_5cae_492d_a901_2a3c2c50164f) , } }
 pub const REAL_TIME_NOTIFICATION_CAPABILITY_EX: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6843da03_154a_4616_a508_44371295f96b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( REAL_TIME_NOTIFICATION_CAPABILITY_EX ) , guid : :: windows :: core :: GUID::from_u128(0x6843da03_154a_4616_a508_44371295f96b) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Networking_WinSock'*"]
 pub struct REAL_TIME_NOTIFICATION_SETTING_INPUT {
@@ -7311,6 +7317,8 @@ impl ::core::default::Default for SOCKET_ADDRESS_LIST {
     }
 }
 pub const SOCKET_DEFAULT2_QM_POLICY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaec2ef9c_3a4d_4d3e_8842_239942e39a47);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SOCKET_DEFAULT2_QM_POLICY ) , guid : :: windows :: core :: GUID::from_u128(0xaec2ef9c_3a4d_4d3e_8842_239942e39a47) , } }
 #[doc = "*Required features: 'Win32_Networking_WinSock'*"]
 pub const SOCKET_ERROR: i32 = -1i32;
 #[doc = "*Required features: 'Win32_Networking_WinSock'*"]

--- a/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/Provider/mod.rs
@@ -1288,3 +1288,5 @@ pub const IDENTITY_CONNECTED: IdentityUpdateEvent = 64u32;
 #[doc = "*Required features: 'Win32_Security_Authentication_Identity_Provider'*"]
 pub const IDENTITY_DISCONNECTED: IdentityUpdateEvent = 128u32;
 pub const OID_OAssociatedIdentityProviderObject: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x98c5a3dd_db68_4f1a_8d2b_9079cdfeaf61);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( OID_OAssociatedIdentityProviderObject ) , guid : :: windows :: core :: GUID::from_u128(0x98c5a3dd_db68_4f1a_8d2b_9079cdfeaf61) , } }

--- a/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/mod.rs
@@ -651,73 +651,209 @@ pub unsafe fn AuditSetSystemPolicy(pauditpolicy: *const AUDIT_POLICY_INFORMATION
     unimplemented!("Unsupported target OS");
 }
 pub const Audit_AccountLogon: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x69979850_797a_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_AccountLogon ) , guid : :: windows :: core :: GUID::from_u128(0x69979850_797a_11d9_bed3_505054503030) , } }
 pub const Audit_AccountLogon_CredentialValidation: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce923f_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_AccountLogon_CredentialValidation ) , guid : :: windows :: core :: GUID::from_u128(0x0cce923f_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_AccountLogon_KerbCredentialValidation: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9242_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_AccountLogon_KerbCredentialValidation ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9242_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_AccountLogon_Kerberos: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9240_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_AccountLogon_Kerberos ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9240_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_AccountLogon_Others: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9241_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_AccountLogon_Others ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9241_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_AccountManagement: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6997984e_797a_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_AccountManagement ) , guid : :: windows :: core :: GUID::from_u128(0x6997984e_797a_11d9_bed3_505054503030) , } }
 pub const Audit_AccountManagement_ApplicationGroup: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9239_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_AccountManagement_ApplicationGroup ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9239_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_AccountManagement_ComputerAccount: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9236_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_AccountManagement_ComputerAccount ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9236_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_AccountManagement_DistributionGroup: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9238_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_AccountManagement_DistributionGroup ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9238_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_AccountManagement_Others: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce923a_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_AccountManagement_Others ) , guid : :: windows :: core :: GUID::from_u128(0x0cce923a_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_AccountManagement_SecurityGroup: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9237_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_AccountManagement_SecurityGroup ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9237_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_AccountManagement_UserAccount: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9235_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_AccountManagement_UserAccount ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9235_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_DSAccess_DSAccess: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce923b_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_DSAccess_DSAccess ) , guid : :: windows :: core :: GUID::from_u128(0x0cce923b_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_DetailedTracking: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6997984c_797a_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_DetailedTracking ) , guid : :: windows :: core :: GUID::from_u128(0x6997984c_797a_11d9_bed3_505054503030) , } }
 pub const Audit_DetailedTracking_DpapiActivity: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce922d_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_DetailedTracking_DpapiActivity ) , guid : :: windows :: core :: GUID::from_u128(0x0cce922d_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_DetailedTracking_PnpActivity: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9248_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_DetailedTracking_PnpActivity ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9248_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_DetailedTracking_ProcessCreation: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce922b_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_DetailedTracking_ProcessCreation ) , guid : :: windows :: core :: GUID::from_u128(0x0cce922b_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_DetailedTracking_ProcessTermination: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce922c_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_DetailedTracking_ProcessTermination ) , guid : :: windows :: core :: GUID::from_u128(0x0cce922c_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_DetailedTracking_RpcCall: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce922e_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_DetailedTracking_RpcCall ) , guid : :: windows :: core :: GUID::from_u128(0x0cce922e_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_DetailedTracking_TokenRightAdjusted: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce924a_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_DetailedTracking_TokenRightAdjusted ) , guid : :: windows :: core :: GUID::from_u128(0x0cce924a_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_DirectoryServiceAccess: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6997984f_797a_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_DirectoryServiceAccess ) , guid : :: windows :: core :: GUID::from_u128(0x6997984f_797a_11d9_bed3_505054503030) , } }
 pub const Audit_DsAccess_AdAuditChanges: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce923c_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_DsAccess_AdAuditChanges ) , guid : :: windows :: core :: GUID::from_u128(0x0cce923c_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_Ds_DetailedReplication: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce923e_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_Ds_DetailedReplication ) , guid : :: windows :: core :: GUID::from_u128(0x0cce923e_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_Ds_Replication: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce923d_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_Ds_Replication ) , guid : :: windows :: core :: GUID::from_u128(0x0cce923d_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_Logon: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x69979849_797a_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_Logon ) , guid : :: windows :: core :: GUID::from_u128(0x69979849_797a_11d9_bed3_505054503030) , } }
 pub const Audit_Logon_AccountLockout: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9217_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_Logon_AccountLockout ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9217_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_Logon_Claims: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9247_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_Logon_Claims ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9247_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_Logon_Groups: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9249_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_Logon_Groups ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9249_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_Logon_IPSecMainMode: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9218_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_Logon_IPSecMainMode ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9218_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_Logon_IPSecQuickMode: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9219_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_Logon_IPSecQuickMode ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9219_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_Logon_IPSecUserMode: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce921a_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_Logon_IPSecUserMode ) , guid : :: windows :: core :: GUID::from_u128(0x0cce921a_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_Logon_Logoff: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9216_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_Logon_Logoff ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9216_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_Logon_Logon: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9215_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_Logon_Logon ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9215_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_Logon_NPS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9243_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_Logon_NPS ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9243_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_Logon_Others: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce921c_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_Logon_Others ) , guid : :: windows :: core :: GUID::from_u128(0x0cce921c_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_Logon_SpecialLogon: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce921b_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_Logon_SpecialLogon ) , guid : :: windows :: core :: GUID::from_u128(0x0cce921b_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_ObjectAccess: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6997984a_797a_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_ObjectAccess ) , guid : :: windows :: core :: GUID::from_u128(0x6997984a_797a_11d9_bed3_505054503030) , } }
 pub const Audit_ObjectAccess_ApplicationGenerated: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9222_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_ObjectAccess_ApplicationGenerated ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9222_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_ObjectAccess_CbacStaging: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9246_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_ObjectAccess_CbacStaging ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9246_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_ObjectAccess_CertificationServices: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9221_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_ObjectAccess_CertificationServices ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9221_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_ObjectAccess_DetailedFileShare: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9244_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_ObjectAccess_DetailedFileShare ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9244_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_ObjectAccess_FileSystem: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce921d_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_ObjectAccess_FileSystem ) , guid : :: windows :: core :: GUID::from_u128(0x0cce921d_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_ObjectAccess_FirewallConnection: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9226_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_ObjectAccess_FirewallConnection ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9226_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_ObjectAccess_FirewallPacketDrops: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9225_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_ObjectAccess_FirewallPacketDrops ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9225_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_ObjectAccess_Handle: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9223_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_ObjectAccess_Handle ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9223_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_ObjectAccess_Kernel: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce921f_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_ObjectAccess_Kernel ) , guid : :: windows :: core :: GUID::from_u128(0x0cce921f_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_ObjectAccess_Other: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9227_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_ObjectAccess_Other ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9227_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_ObjectAccess_Registry: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce921e_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_ObjectAccess_Registry ) , guid : :: windows :: core :: GUID::from_u128(0x0cce921e_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_ObjectAccess_RemovableStorage: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9245_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_ObjectAccess_RemovableStorage ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9245_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_ObjectAccess_Sam: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9220_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_ObjectAccess_Sam ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9220_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_ObjectAccess_Share: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9224_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_ObjectAccess_Share ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9224_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_PolicyChange: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6997984d_797a_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_PolicyChange ) , guid : :: windows :: core :: GUID::from_u128(0x6997984d_797a_11d9_bed3_505054503030) , } }
 pub const Audit_PolicyChange_AuditPolicy: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce922f_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_PolicyChange_AuditPolicy ) , guid : :: windows :: core :: GUID::from_u128(0x0cce922f_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_PolicyChange_AuthenticationPolicy: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9230_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_PolicyChange_AuthenticationPolicy ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9230_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_PolicyChange_AuthorizationPolicy: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9231_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_PolicyChange_AuthorizationPolicy ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9231_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_PolicyChange_MpsscvRulePolicy: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9232_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_PolicyChange_MpsscvRulePolicy ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9232_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_PolicyChange_Others: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9234_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_PolicyChange_Others ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9234_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_PolicyChange_WfpIPSecPolicy: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9233_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_PolicyChange_WfpIPSecPolicy ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9233_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_PrivilegeUse: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6997984b_797a_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_PrivilegeUse ) , guid : :: windows :: core :: GUID::from_u128(0x6997984b_797a_11d9_bed3_505054503030) , } }
 pub const Audit_PrivilegeUse_NonSensitive: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9229_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_PrivilegeUse_NonSensitive ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9229_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_PrivilegeUse_Others: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce922a_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_PrivilegeUse_Others ) , guid : :: windows :: core :: GUID::from_u128(0x0cce922a_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_PrivilegeUse_Sensitive: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9228_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_PrivilegeUse_Sensitive ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9228_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_System: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x69979848_797a_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_System ) , guid : :: windows :: core :: GUID::from_u128(0x69979848_797a_11d9_bed3_505054503030) , } }
 pub const Audit_System_IPSecDriverEvents: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9213_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_System_IPSecDriverEvents ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9213_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_System_Integrity: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9212_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_System_Integrity ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9212_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_System_Others: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9214_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_System_Others ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9214_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_System_SecurityStateChange: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9210_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_System_SecurityStateChange ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9210_69ae_11d9_bed3_505054503030) , } }
 pub const Audit_System_SecuritySubsystemExtension: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cce9211_69ae_11d9_bed3_505054503030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Audit_System_SecuritySubsystemExtension ) , guid : :: windows :: core :: GUID::from_u128(0x0cce9211_69ae_11d9_bed3_505054503030) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Security_Authentication_Identity', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -20450,6 +20586,8 @@ pub unsafe fn VerifySignature(phcontext: *const super::super::Credentials::SecHa
     unimplemented!("Unsupported target OS");
 }
 pub const WINDOWS_SLID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x55c92734_d682_4d71_983e_d6ec3f16059f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WINDOWS_SLID ) , guid : :: windows :: core :: GUID::from_u128(0x55c92734_d682_4d71_983e_d6ec3f16059f) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Security_Authentication_Identity', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/Security/ConfigurationSnapin/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/ConfigurationSnapin/mod.rs
@@ -387,5 +387,11 @@ pub const SCE_LOG_LEVEL_DETAIL: SCE_LOG_ERR_LEVEL = 2u32;
 #[doc = "*Required features: 'Win32_Security_ConfigurationSnapin'*"]
 pub const SCE_LOG_LEVEL_DEBUG: SCE_LOG_ERR_LEVEL = 3u32;
 pub const cNodetypeSceAnalysisServices: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x678050c7_1ff8_11d1_affb_00c04fb984f9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( cNodetypeSceAnalysisServices ) , guid : :: windows :: core :: GUID::from_u128(0x678050c7_1ff8_11d1_affb_00c04fb984f9) , } }
 pub const cNodetypeSceEventLog: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2ce06698_4bf3_11d1_8c30_00c04fb984f9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( cNodetypeSceEventLog ) , guid : :: windows :: core :: GUID::from_u128(0x2ce06698_4bf3_11d1_8c30_00c04fb984f9) , } }
 pub const cNodetypeSceTemplateServices: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x24a7f717_1f0c_11d1_affb_00c04fb984f9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( cNodetypeSceTemplateServices ) , guid : :: windows :: core :: GUID::from_u128(0x24a7f717_1f0c_11d1_affb_00c04fb984f9) , } }

--- a/crates/libs/windows/src/Windows/Win32/Security/Credentials/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Credentials/mod.rs
@@ -1455,6 +1455,8 @@ pub unsafe fn CredWriteW(credential: *const CREDENTIALW, flags: u32) -> super::s
 #[doc = "*Required features: 'Win32_Security_Credentials'*"]
 pub const FILE_DEVICE_SMARTCARD: u32 = 49u32;
 pub const GUID_DEVINTERFACE_SMARTCARD_READER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x50dd5230_ba8a_11d1_bf5d_0000f805f530);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_SMARTCARD_READER ) , guid : :: windows :: core :: GUID::from_u128(0x50dd5230_ba8a_11d1_bf5d_0000f805f530) , } }
 #[doc = "*Required features: 'Win32_Security_Credentials', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]

--- a/crates/libs/windows/src/Windows/Win32/Security/ExtensibleAuthenticationProtocol/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/ExtensibleAuthenticationProtocol/mod.rs
@@ -2536,59 +2536,167 @@ impl ::core::default::Default for EapUsernamePasswordCredential {
 #[doc = "*Required features: 'Win32_Security_ExtensibleAuthenticationProtocol'*"]
 pub const FACILITY_EAP_MESSAGE: u32 = 2114u32;
 pub const GUID_EapHost_Cause_CertStoreInaccessible: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000004);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_CertStoreInaccessible ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000004) , } }
 pub const GUID_EapHost_Cause_EapNegotiationFailed: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000001c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_EapNegotiationFailed ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000001c) , } }
 pub const GUID_EapHost_Cause_EapQecInaccessible: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000312);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_EapQecInaccessible ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000312) , } }
 pub const GUID_EapHost_Cause_Generic_AuthFailure: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000104);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_Generic_AuthFailure ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000104) , } }
 pub const GUID_EapHost_Cause_IdentityUnknown: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000204);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_IdentityUnknown ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000204) , } }
 pub const GUID_EapHost_Cause_MethodDLLNotFound: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000001);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_MethodDLLNotFound ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000001) , } }
 pub const GUID_EapHost_Cause_MethodDoesNotSupportOperation: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000001e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_MethodDoesNotSupportOperation ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000001e) , } }
 pub const GUID_EapHost_Cause_Method_Config_Does_Not_Support_Sso: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xda18bd32_004f_41fa_ae08_0bc85e5845ac);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_Method_Config_Does_Not_Support_Sso ) , guid : :: windows :: core :: GUID::from_u128(0xda18bd32_004f_41fa_ae08_0bc85e5845ac) , } }
 pub const GUID_EapHost_Cause_No_SmartCardReader_Found: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000002b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_No_SmartCardReader_Found ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000002b) , } }
 pub const GUID_EapHost_Cause_Server_CertExpired: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000005);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_Server_CertExpired ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000005) , } }
 pub const GUID_EapHost_Cause_Server_CertInvalid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000006);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_Server_CertInvalid ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000006) , } }
 pub const GUID_EapHost_Cause_Server_CertNotFound: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000007);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_Server_CertNotFound ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000007) , } }
 pub const GUID_EapHost_Cause_Server_CertOtherError: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000108);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_Server_CertOtherError ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000108) , } }
 pub const GUID_EapHost_Cause_Server_CertRevoked: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000008);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_Server_CertRevoked ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000008) , } }
 pub const GUID_EapHost_Cause_Server_Root_CertNameRequired: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000012);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_Server_Root_CertNameRequired ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000012) , } }
 pub const GUID_EapHost_Cause_Server_Root_CertNotFound: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000112);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_Server_Root_CertNotFound ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000112) , } }
 pub const GUID_EapHost_Cause_SimNotValid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000304);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_SimNotValid ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000304) , } }
 pub const GUID_EapHost_Cause_ThirdPartyMethod_Host_Reset: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000212);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_ThirdPartyMethod_Host_Reset ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000212) , } }
 pub const GUID_EapHost_Cause_User_Account_OtherProblem: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000010e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_User_Account_OtherProblem ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000010e) , } }
 pub const GUID_EapHost_Cause_User_CertExpired: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000009);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_User_CertExpired ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000009) , } }
 pub const GUID_EapHost_Cause_User_CertInvalid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000000a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_User_CertInvalid ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000000a) , } }
 pub const GUID_EapHost_Cause_User_CertNotFound: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000000b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_User_CertNotFound ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000000b) , } }
 pub const GUID_EapHost_Cause_User_CertOtherError: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000000c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_User_CertOtherError ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000000c) , } }
 pub const GUID_EapHost_Cause_User_CertRejected: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000000d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_User_CertRejected ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000000d) , } }
 pub const GUID_EapHost_Cause_User_CertRevoked: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000000e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_User_CertRevoked ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000000e) , } }
 pub const GUID_EapHost_Cause_User_CredsRejected: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000020e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_User_CredsRejected ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000020e) , } }
 pub const GUID_EapHost_Cause_User_Root_CertExpired: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000000f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_User_Root_CertExpired ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000000f) , } }
 pub const GUID_EapHost_Cause_User_Root_CertInvalid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000010);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_User_Root_CertInvalid ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000010) , } }
 pub const GUID_EapHost_Cause_User_Root_CertNotFound: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000011);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_User_Root_CertNotFound ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000011) , } }
 pub const GUID_EapHost_Cause_XmlMalformed: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000001d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Cause_XmlMalformed ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000001d) , } }
 pub const GUID_EapHost_Default: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x00000000_0000_0000_0000_000000000000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Default ) , guid : :: windows :: core :: GUID::from_u128(0x00000000_0000_0000_0000_000000000000) , } }
 pub const GUID_EapHost_Help_ObtainingCerts: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf535eea3_1bdd_46ca_a2fc_a6655939b7e8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Help_ObtainingCerts ) , guid : :: windows :: core :: GUID::from_u128(0xf535eea3_1bdd_46ca_a2fc_a6655939b7e8) , } }
 pub const GUID_EapHost_Help_Troubleshooting: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x33307acf_0698_41ba_b014_ea0a2eb8d0a8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Help_Troubleshooting ) , guid : :: windows :: core :: GUID::from_u128(0x33307acf_0698_41ba_b014_ea0a2eb8d0a8) , } }
 pub const GUID_EapHost_Repair_ContactAdmin_AuthFailure: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000001f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Repair_ContactAdmin_AuthFailure ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000001f) , } }
 pub const GUID_EapHost_Repair_ContactAdmin_CertNameAbsent: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000029);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Repair_ContactAdmin_CertNameAbsent ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000029) , } }
 pub const GUID_EapHost_Repair_ContactAdmin_CertStoreInaccessible: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000024);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Repair_ContactAdmin_CertStoreInaccessible ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000024) , } }
 pub const GUID_EapHost_Repair_ContactAdmin_IdentityUnknown: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000020);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Repair_ContactAdmin_IdentityUnknown ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000020) , } }
 pub const GUID_EapHost_Repair_ContactAdmin_InvalidUserAccount: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000025);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Repair_ContactAdmin_InvalidUserAccount ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000025) , } }
 pub const GUID_EapHost_Repair_ContactAdmin_InvalidUserCert: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000002c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Repair_ContactAdmin_InvalidUserCert ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000002c) , } }
 pub const GUID_EapHost_Repair_ContactAdmin_MethodNotFound: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000022);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Repair_ContactAdmin_MethodNotFound ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000022) , } }
 pub const GUID_EapHost_Repair_ContactAdmin_NegotiationFailed: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000021);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Repair_ContactAdmin_NegotiationFailed ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000021) , } }
 pub const GUID_EapHost_Repair_ContactAdmin_NoSmartCardReader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000002a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Repair_ContactAdmin_NoSmartCardReader ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000002a) , } }
 pub const GUID_EapHost_Repair_ContactAdmin_RootCertInvalid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000026);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Repair_ContactAdmin_RootCertInvalid ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000026) , } }
 pub const GUID_EapHost_Repair_ContactAdmin_RootCertNotFound: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000027);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Repair_ContactAdmin_RootCertNotFound ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000027) , } }
 pub const GUID_EapHost_Repair_ContactAdmin_RootExpired: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000028);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Repair_ContactAdmin_RootExpired ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000028) , } }
 pub const GUID_EapHost_Repair_ContactSysadmin: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000002);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Repair_ContactSysadmin ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000002) , } }
 pub const GUID_EapHost_Repair_Method_Not_Support_Sso: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000002d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Repair_Method_Not_Support_Sso ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000002d) , } }
 pub const GUID_EapHost_Repair_No_ValidSim_Found: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000002e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Repair_No_ValidSim_Found ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000002e) , } }
 pub const GUID_EapHost_Repair_RestartNap: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000023);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Repair_RestartNap ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000023) , } }
 pub const GUID_EapHost_Repair_Retry_Authentication: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000011b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Repair_Retry_Authentication ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000011b) , } }
 pub const GUID_EapHost_Repair_Server_ClientSelectServerCert: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000018);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Repair_Server_ClientSelectServerCert ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000018) , } }
 pub const GUID_EapHost_Repair_User_AuthFailure: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000019);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Repair_User_AuthFailure ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d800000019) , } }
 pub const GUID_EapHost_Repair_User_GetNewCert: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000001a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Repair_User_GetNewCert ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000001a) , } }
 pub const GUID_EapHost_Repair_User_SelectValidCert: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000001b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EapHost_Repair_User_SelectValidCert ) , guid : :: windows :: core :: GUID::from_u128(0x9612fc67_6150_4209_a85e_a8d80000001b) , } }
 #[doc = "*Required features: 'Win32_Security_ExtensibleAuthenticationProtocol'*"]
 #[repr(transparent)]
 pub struct IAccountingProviderConfig(::windows::core::IUnknown);

--- a/crates/libs/windows/src/Windows/Win32/Storage/EnhancedStorage/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/EnhancedStorage/mod.rs
@@ -112,93 +112,153 @@ pub const ENHANCED_STORAGE_AUTHN_STATE_UNKNOWN: u32 = 0u32;
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_CAPABILITY_ASYMMETRIC_KEY_CRYPTOGRAPHY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 4002u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_CAPABILITY_ASYMMETRIC_KEY_CRYPTOGRAPHY ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_CAPABILITY_CERTIFICATE_EXTENSION_PARSING: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 4005u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_CAPABILITY_CERTIFICATE_EXTENSION_PARSING ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_CAPABILITY_HASH_ALGS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 4001u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_CAPABILITY_HASH_ALGS ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_CAPABILITY_RENDER_USER_DATA_UNUSABLE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 4004u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_CAPABILITY_RENDER_USER_DATA_UNUSABLE ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_CAPABILITY_SIGNING_ALGS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 4003u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_CAPABILITY_SIGNING_ALGS ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_COMMAND_CERT_ADMIN_CERTIFICATE_AUTHENTICATION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 103u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_COMMAND_CERT_ADMIN_CERTIFICATE_AUTHENTICATION ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_COMMAND_CERT_CREATE_CERTIFICATE_REQUEST: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 108u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_COMMAND_CERT_CREATE_CERTIFICATE_REQUEST ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_COMMAND_CERT_DEVICE_CERTIFICATE_AUTHENTICATION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 102u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_COMMAND_CERT_DEVICE_CERTIFICATE_AUTHENTICATION ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_COMMAND_CERT_GET_ACT_FRIENDLY_NAME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 113u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_COMMAND_CERT_GET_ACT_FRIENDLY_NAME ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_COMMAND_CERT_GET_CERTIFICATE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 106u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_COMMAND_CERT_GET_CERTIFICATE ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_COMMAND_CERT_GET_CERTIFICATE_COUNT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 105u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_COMMAND_CERT_GET_CERTIFICATE_COUNT ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_COMMAND_CERT_GET_SILO_CAPABILITIES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 112u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_COMMAND_CERT_GET_SILO_CAPABILITIES ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_COMMAND_CERT_GET_SILO_CAPABILITY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 111u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_COMMAND_CERT_GET_SILO_CAPABILITY ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_COMMAND_CERT_GET_SILO_GUID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 114u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_COMMAND_CERT_GET_SILO_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_COMMAND_CERT_HOST_CERTIFICATE_AUTHENTICATION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 101u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_COMMAND_CERT_HOST_CERTIFICATE_AUTHENTICATION ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_COMMAND_CERT_INITIALIZE_TO_MANUFACTURER_STATE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 104u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_COMMAND_CERT_INITIALIZE_TO_MANUFACTURER_STATE ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_COMMAND_CERT_SET_CERTIFICATE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 107u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_COMMAND_CERT_SET_CERTIFICATE ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_COMMAND_CERT_UNAUTHENTICATION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 110u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_COMMAND_CERT_UNAUTHENTICATION ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_COMMAND_PASSWORD_AUTHORIZE_ACT_ACCESS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 203u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_COMMAND_PASSWORD_AUTHORIZE_ACT_ACCESS ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_COMMAND_PASSWORD_CHANGE_PASSWORD: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 209u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_COMMAND_PASSWORD_CHANGE_PASSWORD ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_COMMAND_PASSWORD_CONFIG_ADMINISTRATOR: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 206u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_COMMAND_PASSWORD_CONFIG_ADMINISTRATOR ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_COMMAND_PASSWORD_CREATE_USER: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 207u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_COMMAND_PASSWORD_CREATE_USER ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_COMMAND_PASSWORD_DELETE_USER: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 208u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_COMMAND_PASSWORD_DELETE_USER ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_COMMAND_PASSWORD_INITIALIZE_USER_PASSWORD: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 210u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_COMMAND_PASSWORD_INITIALIZE_USER_PASSWORD ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_COMMAND_PASSWORD_QUERY_INFORMATION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 205u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_COMMAND_PASSWORD_QUERY_INFORMATION ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_COMMAND_PASSWORD_START_INITIALIZE_TO_MANUFACTURER_STATE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 211u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_COMMAND_PASSWORD_START_INITIALIZE_TO_MANUFACTURER_STATE ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_COMMAND_PASSWORD_UNAUTHORIZE_ACT_ACCESS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 204u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_COMMAND_PASSWORD_UNAUTHORIZE_ACT_ACCESS ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_COMMAND_SILO_ENUMERATE_SILOS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_COMMAND_SILO_ENUMERATE_SILOS ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_COMMAND_SILO_GET_AUTHENTICATION_STATE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_COMMAND_SILO_GET_AUTHENTICATION_STATE ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_COMMAND_SILO_IS_AUTHENTICATION_SILO: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_COMMAND_SILO_IS_AUTHENTICATION_SILO ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -292,105 +352,173 @@ impl ::core::default::Default for ENHANCED_STORAGE_PASSWORD_SILO_INFORMATION {
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_ADMIN_HINT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 2011u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_ADMIN_HINT ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_AUTHENTICATION_STATE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 1006u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_AUTHENTICATION_STATE ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_CERTIFICATE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 3009u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_CERTIFICATE ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_CERTIFICATE_ACT_FRIENDLY_NAME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 3014u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_CERTIFICATE_ACT_FRIENDLY_NAME ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_CERTIFICATE_CAPABILITY_TYPE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 3011u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_CERTIFICATE_CAPABILITY_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_CERTIFICATE_INDEX: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 3003u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_CERTIFICATE_INDEX ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_CERTIFICATE_LENGTH: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 3008u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_CERTIFICATE_LENGTH ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_CERTIFICATE_REQUEST: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 3010u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_CERTIFICATE_REQUEST ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_CERTIFICATE_SILO_CAPABILITIES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 3013u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_CERTIFICATE_SILO_CAPABILITIES ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_CERTIFICATE_SILO_CAPABILITY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 3012u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_CERTIFICATE_SILO_CAPABILITY ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_CERTIFICATE_SILO_GUID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 3015u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_CERTIFICATE_SILO_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_CERTIFICATE_TYPE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 3004u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_CERTIFICATE_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_IS_AUTHENTICATION_SILO: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 1009u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_IS_AUTHENTICATION_SILO ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_MAX_AUTH_FAILURES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 2001u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_MAX_AUTH_FAILURES ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_MAX_CERTIFICATE_COUNT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 3001u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_MAX_CERTIFICATE_COUNT ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_NEW_PASSWORD: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 2008u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_NEW_PASSWORD ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_NEW_PASSWORD_INDICATOR: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 2007u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_NEW_PASSWORD_INDICATOR ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_NEXT_CERTIFICATE_INDEX: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 3006u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_NEXT_CERTIFICATE_INDEX ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_NEXT_CERTIFICATE_OF_TYPE_INDEX: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 3007u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_NEXT_CERTIFICATE_OF_TYPE_INDEX ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_OLD_PASSWORD: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 2005u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_OLD_PASSWORD ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_PASSWORD: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 2004u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_PASSWORD ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_PASSWORD_INDICATOR: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 2006u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_PASSWORD_INDICATOR ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_PASSWORD_SILO_INFO: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 2014u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_PASSWORD_SILO_INFO ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_QUERY_SILO_RESULTS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 2017u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_QUERY_SILO_RESULTS ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_QUERY_SILO_TYPE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 2016u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_QUERY_SILO_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_SECURITY_IDENTIFIER: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 2015u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_SECURITY_IDENTIFIER ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_SIGNER_CERTIFICATE_INDEX: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 3016u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_SIGNER_CERTIFICATE_INDEX ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_SILO_FRIENDLYNAME_SPECIFIED: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 2013u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_SILO_FRIENDLYNAME_SPECIFIED ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_SILO_NAME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 2012u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_SILO_NAME ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_STORED_CERTIFICATE_COUNT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 3002u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_STORED_CERTIFICATE_COUNT ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_TEMPORARY_UNAUTHENTICATION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 1010u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_TEMPORARY_UNAUTHENTICATION ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_USER_HINT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 2009u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_USER_HINT ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_USER_NAME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 2010u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_USER_NAME ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const ENHANCED_STORAGE_PROPERTY_VALIDATION_POLICY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c), pid: 3005u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ENHANCED_STORAGE_PROPERTY_VALIDATION_POLICY ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage'*"]
 pub const ES_AUTHN_ERROR_END: u32 = 1279u32;
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage'*"]
@@ -444,6 +572,8 @@ pub const FLAGSTATUS_FOLLOWUP: i32 = 2i32;
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage'*"]
 pub const FLAGSTATUS_NOTFLAGGED: i32 = 0i32;
 pub const GUID_DEVINTERFACE_ENHANCED_STORAGE_SILO: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3897f6a4_fd35_4bc8_a0b7_5dbba36adafa);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_ENHANCED_STORAGE_SILO ) , guid : :: windows :: core :: GUID::from_u128(0x3897f6a4_fd35_4bc8_a0b7_5dbba36adafa) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage'*"]
 #[repr(transparent)]
 pub struct IEnhancedStorageACT(::windows::core::IUnknown);
@@ -1231,3117 +1361,5193 @@ pub const PHOTO_WHITEBALANCE_MANUAL: u32 = 1u32;
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AcquisitionID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x65a98875_3c80_40ab_abbc_efdaf77dbee2), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AcquisitionID ) , guid : :: windows :: core :: GUID::from_u128(0x65a98875_3c80_40ab_abbc_efdaf77dbee2) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Address_Country: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc07b4199_e1df_4493_b1e1_de5946fb58f8), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Address_Country ) , guid : :: windows :: core :: GUID::from_u128(0xc07b4199_e1df_4493_b1e1_de5946fb58f8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Address_CountryCode: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc07b4199_e1df_4493_b1e1_de5946fb58f8), pid: 101u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Address_CountryCode ) , guid : :: windows :: core :: GUID::from_u128(0xc07b4199_e1df_4493_b1e1_de5946fb58f8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Address_Region: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc07b4199_e1df_4493_b1e1_de5946fb58f8), pid: 102u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Address_Region ) , guid : :: windows :: core :: GUID::from_u128(0xc07b4199_e1df_4493_b1e1_de5946fb58f8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Address_RegionCode: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc07b4199_e1df_4493_b1e1_de5946fb58f8), pid: 103u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Address_RegionCode ) , guid : :: windows :: core :: GUID::from_u128(0xc07b4199_e1df_4493_b1e1_de5946fb58f8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Address_Town: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc07b4199_e1df_4493_b1e1_de5946fb58f8), pid: 104u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Address_Town ) , guid : :: windows :: core :: GUID::from_u128(0xc07b4199_e1df_4493_b1e1_de5946fb58f8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AppUserModel_ExcludeFromShowInNewInstall: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9f4c2855_9f79_4b39_a8d0_e1d42de1d5f3), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AppUserModel_ExcludeFromShowInNewInstall ) , guid : :: windows :: core :: GUID::from_u128(0x9f4c2855_9f79_4b39_a8d0_e1d42de1d5f3) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AppUserModel_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9f4c2855_9f79_4b39_a8d0_e1d42de1d5f3), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AppUserModel_ID ) , guid : :: windows :: core :: GUID::from_u128(0x9f4c2855_9f79_4b39_a8d0_e1d42de1d5f3) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AppUserModel_IsDestListSeparator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9f4c2855_9f79_4b39_a8d0_e1d42de1d5f3), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AppUserModel_IsDestListSeparator ) , guid : :: windows :: core :: GUID::from_u128(0x9f4c2855_9f79_4b39_a8d0_e1d42de1d5f3) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AppUserModel_IsDualMode: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9f4c2855_9f79_4b39_a8d0_e1d42de1d5f3), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AppUserModel_IsDualMode ) , guid : :: windows :: core :: GUID::from_u128(0x9f4c2855_9f79_4b39_a8d0_e1d42de1d5f3) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AppUserModel_PreventPinning: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9f4c2855_9f79_4b39_a8d0_e1d42de1d5f3), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AppUserModel_PreventPinning ) , guid : :: windows :: core :: GUID::from_u128(0x9f4c2855_9f79_4b39_a8d0_e1d42de1d5f3) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AppUserModel_RelaunchCommand: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9f4c2855_9f79_4b39_a8d0_e1d42de1d5f3), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AppUserModel_RelaunchCommand ) , guid : :: windows :: core :: GUID::from_u128(0x9f4c2855_9f79_4b39_a8d0_e1d42de1d5f3) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AppUserModel_RelaunchDisplayNameResource: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9f4c2855_9f79_4b39_a8d0_e1d42de1d5f3), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AppUserModel_RelaunchDisplayNameResource ) , guid : :: windows :: core :: GUID::from_u128(0x9f4c2855_9f79_4b39_a8d0_e1d42de1d5f3) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AppUserModel_RelaunchIconResource: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9f4c2855_9f79_4b39_a8d0_e1d42de1d5f3), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AppUserModel_RelaunchIconResource ) , guid : :: windows :: core :: GUID::from_u128(0x9f4c2855_9f79_4b39_a8d0_e1d42de1d5f3) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AppUserModel_SettingsCommand: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9f4c2855_9f79_4b39_a8d0_e1d42de1d5f3), pid: 38u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AppUserModel_SettingsCommand ) , guid : :: windows :: core :: GUID::from_u128(0x9f4c2855_9f79_4b39_a8d0_e1d42de1d5f3) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AppUserModel_StartPinOption: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9f4c2855_9f79_4b39_a8d0_e1d42de1d5f3), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AppUserModel_StartPinOption ) , guid : :: windows :: core :: GUID::from_u128(0x9f4c2855_9f79_4b39_a8d0_e1d42de1d5f3) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AppUserModel_ToastActivatorCLSID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9f4c2855_9f79_4b39_a8d0_e1d42de1d5f3), pid: 26u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AppUserModel_ToastActivatorCLSID ) , guid : :: windows :: core :: GUID::from_u128(0x9f4c2855_9f79_4b39_a8d0_e1d42de1d5f3) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AppUserModel_UninstallCommand: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9f4c2855_9f79_4b39_a8d0_e1d42de1d5f3), pid: 37u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AppUserModel_UninstallCommand ) , guid : :: windows :: core :: GUID::from_u128(0x9f4c2855_9f79_4b39_a8d0_e1d42de1d5f3) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AppUserModel_VisualElementsManifestHintPath: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9f4c2855_9f79_4b39_a8d0_e1d42de1d5f3), pid: 31u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AppUserModel_VisualElementsManifestHintPath ) , guid : :: windows :: core :: GUID::from_u128(0x9f4c2855_9f79_4b39_a8d0_e1d42de1d5f3) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_AppZoneIdentifier: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x502cfeab_47eb_459c_b960_e6d8728f7701), pid: 102u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_AppZoneIdentifier ) , guid : :: windows :: core :: GUID::from_u128(0x502cfeab_47eb_459c_b960_e6d8728f7701) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ApplicationDefinedProperties: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcdbfc167_337e_41d8_af7c_8c09205429c7), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ApplicationDefinedProperties ) , guid : :: windows :: core :: GUID::from_u128(0xcdbfc167_337e_41d8_af7c_8c09205429c7) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ApplicationName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9), pid: 18u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ApplicationName ) , guid : :: windows :: core :: GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Audio_ChannelCount: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440490_4c8b_11d1_8b70_080036b11a03), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Audio_ChannelCount ) , guid : :: windows :: core :: GUID::from_u128(0x64440490_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Audio_Compression: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440490_4c8b_11d1_8b70_080036b11a03), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Audio_Compression ) , guid : :: windows :: core :: GUID::from_u128(0x64440490_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Audio_EncodingBitrate: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440490_4c8b_11d1_8b70_080036b11a03), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Audio_EncodingBitrate ) , guid : :: windows :: core :: GUID::from_u128(0x64440490_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Audio_Format: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440490_4c8b_11d1_8b70_080036b11a03), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Audio_Format ) , guid : :: windows :: core :: GUID::from_u128(0x64440490_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Audio_IsVariableBitRate: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe6822fee_8c17_4d62_823c_8e9cfcbd1d5c), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Audio_IsVariableBitRate ) , guid : :: windows :: core :: GUID::from_u128(0xe6822fee_8c17_4d62_823c_8e9cfcbd1d5c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Audio_PeakValue: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2579e5d0_1116_4084_bd9a_9b4f7cb4df5e), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Audio_PeakValue ) , guid : :: windows :: core :: GUID::from_u128(0x2579e5d0_1116_4084_bd9a_9b4f7cb4df5e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Audio_SampleRate: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440490_4c8b_11d1_8b70_080036b11a03), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Audio_SampleRate ) , guid : :: windows :: core :: GUID::from_u128(0x64440490_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Audio_SampleSize: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440490_4c8b_11d1_8b70_080036b11a03), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Audio_SampleSize ) , guid : :: windows :: core :: GUID::from_u128(0x64440490_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Audio_StreamName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440490_4c8b_11d1_8b70_080036b11a03), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Audio_StreamName ) , guid : :: windows :: core :: GUID::from_u128(0x64440490_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Audio_StreamNumber: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440490_4c8b_11d1_8b70_080036b11a03), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Audio_StreamNumber ) , guid : :: windows :: core :: GUID::from_u128(0x64440490_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Author: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Author ) , guid : :: windows :: core :: GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_CachedFileUpdaterContentIdForConflictResolution: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8), pid: 114u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_CachedFileUpdaterContentIdForConflictResolution ) , guid : :: windows :: core :: GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_CachedFileUpdaterContentIdForStream: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8), pid: 113u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_CachedFileUpdaterContentIdForStream ) , guid : :: windows :: core :: GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Calendar_Duration: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x293ca35a_09aa_4dd2_b180_1fe245728a52), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Calendar_Duration ) , guid : :: windows :: core :: GUID::from_u128(0x293ca35a_09aa_4dd2_b180_1fe245728a52) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Calendar_IsOnline: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xbfee9149_e3e2_49a7_a862_c05988145cec), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Calendar_IsOnline ) , guid : :: windows :: core :: GUID::from_u128(0xbfee9149_e3e2_49a7_a862_c05988145cec) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Calendar_IsRecurring: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x315b9c8d_80a9_4ef9_ae16_8e746da51d70), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Calendar_IsRecurring ) , guid : :: windows :: core :: GUID::from_u128(0x315b9c8d_80a9_4ef9_ae16_8e746da51d70) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Calendar_Location: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf6272d18_cecc_40b1_b26a_3911717aa7bd), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Calendar_Location ) , guid : :: windows :: core :: GUID::from_u128(0xf6272d18_cecc_40b1_b26a_3911717aa7bd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Calendar_OptionalAttendeeAddresses: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd55bae5a_3892_417a_a649_c6ac5aaaeab3), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Calendar_OptionalAttendeeAddresses ) , guid : :: windows :: core :: GUID::from_u128(0xd55bae5a_3892_417a_a649_c6ac5aaaeab3) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Calendar_OptionalAttendeeNames: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x09429607_582d_437f_84c3_de93a2b24c3c), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Calendar_OptionalAttendeeNames ) , guid : :: windows :: core :: GUID::from_u128(0x09429607_582d_437f_84c3_de93a2b24c3c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Calendar_OrganizerAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x744c8242_4df5_456c_ab9e_014efb9021e3), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Calendar_OrganizerAddress ) , guid : :: windows :: core :: GUID::from_u128(0x744c8242_4df5_456c_ab9e_014efb9021e3) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Calendar_OrganizerName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xaaa660f9_9865_458e_b484_01bc7fe3973e), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Calendar_OrganizerName ) , guid : :: windows :: core :: GUID::from_u128(0xaaa660f9_9865_458e_b484_01bc7fe3973e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Calendar_ReminderTime: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x72fc5ba4_24f9_4011_9f3f_add27afad818), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Calendar_ReminderTime ) , guid : :: windows :: core :: GUID::from_u128(0x72fc5ba4_24f9_4011_9f3f_add27afad818) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Calendar_RequiredAttendeeAddresses: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0ba7d6c3_568d_4159_ab91_781a91fb71e5), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Calendar_RequiredAttendeeAddresses ) , guid : :: windows :: core :: GUID::from_u128(0x0ba7d6c3_568d_4159_ab91_781a91fb71e5) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Calendar_RequiredAttendeeNames: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb33af30b_f552_4584_936c_cb93e5cda29f), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Calendar_RequiredAttendeeNames ) , guid : :: windows :: core :: GUID::from_u128(0xb33af30b_f552_4584_936c_cb93e5cda29f) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Calendar_Resources: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f58a38_c54b_4c40_8696_97235980eae1), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Calendar_Resources ) , guid : :: windows :: core :: GUID::from_u128(0x00f58a38_c54b_4c40_8696_97235980eae1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Calendar_ResponseStatus: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x188c1f91_3c40_4132_9ec5_d8b03b72a8a2), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Calendar_ResponseStatus ) , guid : :: windows :: core :: GUID::from_u128(0x188c1f91_3c40_4132_9ec5_d8b03b72a8a2) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Calendar_ShowTimeAs: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5bf396d4_5eb2_466f_bde9_2fb3f2361d6e), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Calendar_ShowTimeAs ) , guid : :: windows :: core :: GUID::from_u128(0x5bf396d4_5eb2_466f_bde9_2fb3f2361d6e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Calendar_ShowTimeAsText: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x53da57cf_62c0_45c4_81de_7610bcefd7f5), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Calendar_ShowTimeAsText ) , guid : :: windows :: core :: GUID::from_u128(0x53da57cf_62c0_45c4_81de_7610bcefd7f5) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Capacity: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9b174b35_40ff_11d2_a27e_00c04fc30871), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Capacity ) , guid : :: windows :: core :: GUID::from_u128(0x9b174b35_40ff_11d2_a27e_00c04fc30871) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Category: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Category ) , guid : :: windows :: core :: GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Comment: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Comment ) , guid : :: windows :: core :: GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Communication_AccountName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Communication_AccountName ) , guid : :: windows :: core :: GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Communication_DateItemExpires: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x428040ac_a177_4c8a_9760_f6f761227f9a), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Communication_DateItemExpires ) , guid : :: windows :: core :: GUID::from_u128(0x428040ac_a177_4c8a_9760_f6f761227f9a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Communication_Direction: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8e531030_b960_4346_ae0d_66bc9a86fb94), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Communication_Direction ) , guid : :: windows :: core :: GUID::from_u128(0x8e531030_b960_4346_ae0d_66bc9a86fb94) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Communication_FollowupIconIndex: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x83a6347e_6fe4_4f40_ba9c_c4865240d1f4), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Communication_FollowupIconIndex ) , guid : :: windows :: core :: GUID::from_u128(0x83a6347e_6fe4_4f40_ba9c_c4865240d1f4) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Communication_HeaderItem: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc9c34f84_2241_4401_b607_bd20ed75ae7f), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Communication_HeaderItem ) , guid : :: windows :: core :: GUID::from_u128(0xc9c34f84_2241_4401_b607_bd20ed75ae7f) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Communication_PolicyTag: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xec0b4191_ab0b_4c66_90b6_c6637cdebbab), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Communication_PolicyTag ) , guid : :: windows :: core :: GUID::from_u128(0xec0b4191_ab0b_4c66_90b6_c6637cdebbab) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Communication_SecurityFlags: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8619a4b6_9f4d_4429_8c0f_b996ca59e335), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Communication_SecurityFlags ) , guid : :: windows :: core :: GUID::from_u128(0x8619a4b6_9f4d_4429_8c0f_b996ca59e335) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Communication_Suffix: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x807b653a_9e91_43ef_8f97_11ce04ee20c5), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Communication_Suffix ) , guid : :: windows :: core :: GUID::from_u128(0x807b653a_9e91_43ef_8f97_11ce04ee20c5) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Communication_TaskStatus: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xbe1a72c6_9a1d_46b7_afe7_afaf8cef4999), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Communication_TaskStatus ) , guid : :: windows :: core :: GUID::from_u128(0xbe1a72c6_9a1d_46b7_afe7_afaf8cef4999) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Communication_TaskStatusText: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa6744477_c237_475b_a075_54f34498292a), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Communication_TaskStatusText ) , guid : :: windows :: core :: GUID::from_u128(0xa6744477_c237_475b_a075_54f34498292a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Company: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae), pid: 15u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Company ) , guid : :: windows :: core :: GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ComputerName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ComputerName ) , guid : :: windows :: core :: GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Computer_DecoratedFreeSpace: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9b174b35_40ff_11d2_a27e_00c04fc30871), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Computer_DecoratedFreeSpace ) , guid : :: windows :: core :: GUID::from_u128(0x9b174b35_40ff_11d2_a27e_00c04fc30871) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_AccountPictureDynamicVideo: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0b8bb018_2725_4b44_92ba_7933aeb2dde7), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_AccountPictureDynamicVideo ) , guid : :: windows :: core :: GUID::from_u128(0x0b8bb018_2725_4b44_92ba_7933aeb2dde7) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_AccountPictureLarge: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0b8bb018_2725_4b44_92ba_7933aeb2dde7), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_AccountPictureLarge ) , guid : :: windows :: core :: GUID::from_u128(0x0b8bb018_2725_4b44_92ba_7933aeb2dde7) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_AccountPictureSmall: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0b8bb018_2725_4b44_92ba_7933aeb2dde7), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_AccountPictureSmall ) , guid : :: windows :: core :: GUID::from_u128(0x0b8bb018_2725_4b44_92ba_7933aeb2dde7) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_Anniversary: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9ad5badb_cea7_4470_a03d_b84e51b9949e), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_Anniversary ) , guid : :: windows :: core :: GUID::from_u128(0x9ad5badb_cea7_4470_a03d_b84e51b9949e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_AssistantName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcd102c9c_5540_4a88_a6f6_64e4981c8cd1), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_AssistantName ) , guid : :: windows :: core :: GUID::from_u128(0xcd102c9c_5540_4a88_a6f6_64e4981c8cd1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_AssistantTelephone: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9a93244d_a7ad_4ff8_9b99_45ee4cc09af6), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_AssistantTelephone ) , guid : :: windows :: core :: GUID::from_u128(0x9a93244d_a7ad_4ff8_9b99_45ee4cc09af6) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_Birthday: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x176dc63c_2688_4e89_8143_a347800f25e9), pid: 47u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_Birthday ) , guid : :: windows :: core :: GUID::from_u128(0x176dc63c_2688_4e89_8143_a347800f25e9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_BusinessAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x730fb6dd_cf7c_426b_a03f_bd166cc9ee24), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_BusinessAddress ) , guid : :: windows :: core :: GUID::from_u128(0x730fb6dd_cf7c_426b_a03f_bd166cc9ee24) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_BusinessAddress1Country: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 119u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_BusinessAddress1Country ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_BusinessAddress1Locality: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 117u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_BusinessAddress1Locality ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_BusinessAddress1PostalCode: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 120u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_BusinessAddress1PostalCode ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_BusinessAddress1Region: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 118u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_BusinessAddress1Region ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_BusinessAddress1Street: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 116u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_BusinessAddress1Street ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_BusinessAddress2Country: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 124u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_BusinessAddress2Country ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_BusinessAddress2Locality: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 122u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_BusinessAddress2Locality ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_BusinessAddress2PostalCode: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 125u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_BusinessAddress2PostalCode ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_BusinessAddress2Region: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 123u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_BusinessAddress2Region ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_BusinessAddress2Street: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 121u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_BusinessAddress2Street ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_BusinessAddress3Country: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 129u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_BusinessAddress3Country ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_BusinessAddress3Locality: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 127u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_BusinessAddress3Locality ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_BusinessAddress3PostalCode: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 130u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_BusinessAddress3PostalCode ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_BusinessAddress3Region: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 128u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_BusinessAddress3Region ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_BusinessAddress3Street: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 126u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_BusinessAddress3Street ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_BusinessAddressCity: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x402b5934_ec5a_48c3_93e6_85e86a2d934e), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_BusinessAddressCity ) , guid : :: windows :: core :: GUID::from_u128(0x402b5934_ec5a_48c3_93e6_85e86a2d934e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_BusinessAddressCountry: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb0b87314_fcf6_4feb_8dff_a50da6af561c), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_BusinessAddressCountry ) , guid : :: windows :: core :: GUID::from_u128(0xb0b87314_fcf6_4feb_8dff_a50da6af561c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_BusinessAddressPostOfficeBox: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xbc4e71ce_17f9_48d5_bee9_021df0ea5409), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_BusinessAddressPostOfficeBox ) , guid : :: windows :: core :: GUID::from_u128(0xbc4e71ce_17f9_48d5_bee9_021df0ea5409) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_BusinessAddressPostalCode: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe1d4a09e_d758_4cd1_b6ec_34a8b5a73f80), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_BusinessAddressPostalCode ) , guid : :: windows :: core :: GUID::from_u128(0xe1d4a09e_d758_4cd1_b6ec_34a8b5a73f80) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_BusinessAddressState: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x446f787f_10c4_41cb_a6c4_4d0343551597), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_BusinessAddressState ) , guid : :: windows :: core :: GUID::from_u128(0x446f787f_10c4_41cb_a6c4_4d0343551597) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_BusinessAddressStreet: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xddd1460f_c0bf_4553_8ce4_10433c908fb0), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_BusinessAddressStreet ) , guid : :: windows :: core :: GUID::from_u128(0xddd1460f_c0bf_4553_8ce4_10433c908fb0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_BusinessEmailAddresses: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf271c659_7e5e_471f_ba25_7f77b286f836), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_BusinessEmailAddresses ) , guid : :: windows :: core :: GUID::from_u128(0xf271c659_7e5e_471f_ba25_7f77b286f836) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_BusinessFaxNumber: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x91eff6f3_2e27_42ca_933e_7c999fbe310b), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_BusinessFaxNumber ) , guid : :: windows :: core :: GUID::from_u128(0x91eff6f3_2e27_42ca_933e_7c999fbe310b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_BusinessHomePage: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x56310920_2491_4919_99ce_eadb06fafdb2), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_BusinessHomePage ) , guid : :: windows :: core :: GUID::from_u128(0x56310920_2491_4919_99ce_eadb06fafdb2) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_BusinessTelephone: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6a15e5a0_0a1e_4cd7_bb8c_d2f1b0c929bc), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_BusinessTelephone ) , guid : :: windows :: core :: GUID::from_u128(0x6a15e5a0_0a1e_4cd7_bb8c_d2f1b0c929bc) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_CallbackTelephone: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xbf53d1c3_49e0_4f7f_8567_5a821d8ac542), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_CallbackTelephone ) , guid : :: windows :: core :: GUID::from_u128(0xbf53d1c3_49e0_4f7f_8567_5a821d8ac542) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_CarTelephone: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8fdc6dea_b929_412b_ba90_397a257465fe), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_CarTelephone ) , guid : :: windows :: core :: GUID::from_u128(0x8fdc6dea_b929_412b_ba90_397a257465fe) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_Children: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd4729704_8ef1_43ef_9024_2bd381187fd5), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_Children ) , guid : :: windows :: core :: GUID::from_u128(0xd4729704_8ef1_43ef_9024_2bd381187fd5) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_CompanyMainTelephone: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8589e481_6040_473d_b171_7fa89c2708ed), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_CompanyMainTelephone ) , guid : :: windows :: core :: GUID::from_u128(0x8589e481_6040_473d_b171_7fa89c2708ed) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_ConnectedServiceDisplayName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x39b77f4f_a104_4863_b395_2db2ad8f7bc1), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_ConnectedServiceDisplayName ) , guid : :: windows :: core :: GUID::from_u128(0x39b77f4f_a104_4863_b395_2db2ad8f7bc1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_ConnectedServiceIdentities: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x80f41eb8_afc4_4208_aa5f_cce21a627281), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_ConnectedServiceIdentities ) , guid : :: windows :: core :: GUID::from_u128(0x80f41eb8_afc4_4208_aa5f_cce21a627281) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_ConnectedServiceName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb5c84c9e_5927_46b5_a3cc_933c21b78469), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_ConnectedServiceName ) , guid : :: windows :: core :: GUID::from_u128(0xb5c84c9e_5927_46b5_a3cc_933c21b78469) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_ConnectedServiceSupportedActions: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa19fb7a9_024b_4371_a8bf_4d29c3e4e9c9), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_ConnectedServiceSupportedActions ) , guid : :: windows :: core :: GUID::from_u128(0xa19fb7a9_024b_4371_a8bf_4d29c3e4e9c9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_DataSuppliers: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9660c283_fc3a_4a08_a096_eed3aac46da2), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_DataSuppliers ) , guid : :: windows :: core :: GUID::from_u128(0x9660c283_fc3a_4a08_a096_eed3aac46da2) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_Department: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfc9f7306_ff8f_4d49_9fb6_3ffe5c0951ec), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_Department ) , guid : :: windows :: core :: GUID::from_u128(0xfc9f7306_ff8f_4d49_9fb6_3ffe5c0951ec) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_DisplayBusinessPhoneNumbers: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x364028da_d895_41fe_a584_302b1bb70a76), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_DisplayBusinessPhoneNumbers ) , guid : :: windows :: core :: GUID::from_u128(0x364028da_d895_41fe_a584_302b1bb70a76) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_DisplayHomePhoneNumbers: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5068bcdf_d697_4d85_8c53_1f1cdab01763), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_DisplayHomePhoneNumbers ) , guid : :: windows :: core :: GUID::from_u128(0x5068bcdf_d697_4d85_8c53_1f1cdab01763) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_DisplayMobilePhoneNumbers: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9cb0c358_9d7a_46b1_b466_dcc6f1a3d93d), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_DisplayMobilePhoneNumbers ) , guid : :: windows :: core :: GUID::from_u128(0x9cb0c358_9d7a_46b1_b466_dcc6f1a3d93d) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_DisplayOtherPhoneNumbers: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x03089873_8ee8_4191_bd60_d31f72b7900b), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_DisplayOtherPhoneNumbers ) , guid : :: windows :: core :: GUID::from_u128(0x03089873_8ee8_4191_bd60_d31f72b7900b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_EmailAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf8fa7fa3_d12b_4785_8a4e_691a94f7a3e7), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_EmailAddress ) , guid : :: windows :: core :: GUID::from_u128(0xf8fa7fa3_d12b_4785_8a4e_691a94f7a3e7) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_EmailAddress2: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x38965063_edc8_4268_8491_b7723172cf29), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_EmailAddress2 ) , guid : :: windows :: core :: GUID::from_u128(0x38965063_edc8_4268_8491_b7723172cf29) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_EmailAddress3: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x644d37b4_e1b3_4bad_b099_7e7c04966aca), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_EmailAddress3 ) , guid : :: windows :: core :: GUID::from_u128(0x644d37b4_e1b3_4bad_b099_7e7c04966aca) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_EmailAddresses: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x84d8f337_981d_44b3_9615_c7596dba17e3), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_EmailAddresses ) , guid : :: windows :: core :: GUID::from_u128(0x84d8f337_981d_44b3_9615_c7596dba17e3) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_EmailName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcc6f4f24_6083_4bd4_8754_674d0de87ab8), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_EmailName ) , guid : :: windows :: core :: GUID::from_u128(0xcc6f4f24_6083_4bd4_8754_674d0de87ab8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_FileAsName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf1a24aa7_9ca7_40f6_89ec_97def9ffe8db), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_FileAsName ) , guid : :: windows :: core :: GUID::from_u128(0xf1a24aa7_9ca7_40f6_89ec_97def9ffe8db) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_FirstName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x14977844_6b49_4aad_a714_a4513bf60460), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_FirstName ) , guid : :: windows :: core :: GUID::from_u128(0x14977844_6b49_4aad_a714_a4513bf60460) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_FullName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x635e9051_50a5_4ba2_b9db_4ed056c77296), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_FullName ) , guid : :: windows :: core :: GUID::from_u128(0x635e9051_50a5_4ba2_b9db_4ed056c77296) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_Gender: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x3c8cee58_d4f0_4cf9_b756_4e5d24447bcd), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_Gender ) , guid : :: windows :: core :: GUID::from_u128(0x3c8cee58_d4f0_4cf9_b756_4e5d24447bcd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_GenderValue: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x3c8cee58_d4f0_4cf9_b756_4e5d24447bcd), pid: 101u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_GenderValue ) , guid : :: windows :: core :: GUID::from_u128(0x3c8cee58_d4f0_4cf9_b756_4e5d24447bcd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_Hobbies: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5dc2253f_5e11_4adf_9cfe_910dd01e3e70), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_Hobbies ) , guid : :: windows :: core :: GUID::from_u128(0x5dc2253f_5e11_4adf_9cfe_910dd01e3e70) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_HomeAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x98f98354_617a_46b8_8560_5b1b64bf1f89), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_HomeAddress ) , guid : :: windows :: core :: GUID::from_u128(0x98f98354_617a_46b8_8560_5b1b64bf1f89) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_HomeAddress1Country: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 104u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_HomeAddress1Country ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_HomeAddress1Locality: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 102u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_HomeAddress1Locality ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_HomeAddress1PostalCode: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 105u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_HomeAddress1PostalCode ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_HomeAddress1Region: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 103u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_HomeAddress1Region ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_HomeAddress1Street: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 101u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_HomeAddress1Street ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_HomeAddress2Country: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 109u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_HomeAddress2Country ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_HomeAddress2Locality: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 107u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_HomeAddress2Locality ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_HomeAddress2PostalCode: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 110u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_HomeAddress2PostalCode ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_HomeAddress2Region: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 108u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_HomeAddress2Region ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_HomeAddress2Street: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 106u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_HomeAddress2Street ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_HomeAddress3Country: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 114u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_HomeAddress3Country ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_HomeAddress3Locality: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 112u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_HomeAddress3Locality ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_HomeAddress3PostalCode: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 115u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_HomeAddress3PostalCode ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_HomeAddress3Region: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 113u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_HomeAddress3Region ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_HomeAddress3Street: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 111u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_HomeAddress3Street ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_HomeAddressCity: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x176dc63c_2688_4e89_8143_a347800f25e9), pid: 65u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_HomeAddressCity ) , guid : :: windows :: core :: GUID::from_u128(0x176dc63c_2688_4e89_8143_a347800f25e9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_HomeAddressCountry: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x08a65aa1_f4c9_43dd_9ddf_a33d8e7ead85), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_HomeAddressCountry ) , guid : :: windows :: core :: GUID::from_u128(0x08a65aa1_f4c9_43dd_9ddf_a33d8e7ead85) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_HomeAddressPostOfficeBox: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7b9f6399_0a3f_4b12_89bd_4adc51c918af), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_HomeAddressPostOfficeBox ) , guid : :: windows :: core :: GUID::from_u128(0x7b9f6399_0a3f_4b12_89bd_4adc51c918af) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_HomeAddressPostalCode: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8afcc170_8a46_4b53_9eee_90bae7151e62), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_HomeAddressPostalCode ) , guid : :: windows :: core :: GUID::from_u128(0x8afcc170_8a46_4b53_9eee_90bae7151e62) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_HomeAddressState: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc89a23d0_7d6d_4eb8_87d4_776a82d493e5), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_HomeAddressState ) , guid : :: windows :: core :: GUID::from_u128(0xc89a23d0_7d6d_4eb8_87d4_776a82d493e5) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_HomeAddressStreet: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0adef160_db3f_4308_9a21_06237b16fa2a), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_HomeAddressStreet ) , guid : :: windows :: core :: GUID::from_u128(0x0adef160_db3f_4308_9a21_06237b16fa2a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_HomeEmailAddresses: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x56c90e9d_9d46_4963_886f_2e1cd9a694ef), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_HomeEmailAddresses ) , guid : :: windows :: core :: GUID::from_u128(0x56c90e9d_9d46_4963_886f_2e1cd9a694ef) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_HomeFaxNumber: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x660e04d6_81ab_4977_a09f_82313113ab26), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_HomeFaxNumber ) , guid : :: windows :: core :: GUID::from_u128(0x660e04d6_81ab_4977_a09f_82313113ab26) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_HomeTelephone: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x176dc63c_2688_4e89_8143_a347800f25e9), pid: 20u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_HomeTelephone ) , guid : :: windows :: core :: GUID::from_u128(0x176dc63c_2688_4e89_8143_a347800f25e9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_IMAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd68dbd8a_3374_4b81_9972_3ec30682db3d), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_IMAddress ) , guid : :: windows :: core :: GUID::from_u128(0xd68dbd8a_3374_4b81_9972_3ec30682db3d) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_Initials: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf3d8f40d_50cb_44a2_9718_40cb9119495d), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_Initials ) , guid : :: windows :: core :: GUID::from_u128(0xf3d8f40d_50cb_44a2_9718_40cb9119495d) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_JA_CompanyNamePhonetic: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x897b3694_fe9e_43e6_8066_260f590c0100), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_JA_CompanyNamePhonetic ) , guid : :: windows :: core :: GUID::from_u128(0x897b3694_fe9e_43e6_8066_260f590c0100) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_JA_FirstNamePhonetic: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x897b3694_fe9e_43e6_8066_260f590c0100), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_JA_FirstNamePhonetic ) , guid : :: windows :: core :: GUID::from_u128(0x897b3694_fe9e_43e6_8066_260f590c0100) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_JA_LastNamePhonetic: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x897b3694_fe9e_43e6_8066_260f590c0100), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_JA_LastNamePhonetic ) , guid : :: windows :: core :: GUID::from_u128(0x897b3694_fe9e_43e6_8066_260f590c0100) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_JobInfo1CompanyAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03), pid: 120u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_JobInfo1CompanyAddress ) , guid : :: windows :: core :: GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_JobInfo1CompanyName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03), pid: 102u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_JobInfo1CompanyName ) , guid : :: windows :: core :: GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_JobInfo1Department: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03), pid: 106u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_JobInfo1Department ) , guid : :: windows :: core :: GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_JobInfo1Manager: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03), pid: 105u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_JobInfo1Manager ) , guid : :: windows :: core :: GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_JobInfo1OfficeLocation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03), pid: 104u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_JobInfo1OfficeLocation ) , guid : :: windows :: core :: GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_JobInfo1Title: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03), pid: 103u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_JobInfo1Title ) , guid : :: windows :: core :: GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_JobInfo1YomiCompanyName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03), pid: 101u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_JobInfo1YomiCompanyName ) , guid : :: windows :: core :: GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_JobInfo2CompanyAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03), pid: 121u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_JobInfo2CompanyAddress ) , guid : :: windows :: core :: GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_JobInfo2CompanyName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03), pid: 108u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_JobInfo2CompanyName ) , guid : :: windows :: core :: GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_JobInfo2Department: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03), pid: 113u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_JobInfo2Department ) , guid : :: windows :: core :: GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_JobInfo2Manager: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03), pid: 112u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_JobInfo2Manager ) , guid : :: windows :: core :: GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_JobInfo2OfficeLocation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03), pid: 110u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_JobInfo2OfficeLocation ) , guid : :: windows :: core :: GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_JobInfo2Title: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03), pid: 109u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_JobInfo2Title ) , guid : :: windows :: core :: GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_JobInfo2YomiCompanyName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03), pid: 107u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_JobInfo2YomiCompanyName ) , guid : :: windows :: core :: GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_JobInfo3CompanyAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03), pid: 123u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_JobInfo3CompanyAddress ) , guid : :: windows :: core :: GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_JobInfo3CompanyName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03), pid: 115u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_JobInfo3CompanyName ) , guid : :: windows :: core :: GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_JobInfo3Department: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03), pid: 119u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_JobInfo3Department ) , guid : :: windows :: core :: GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_JobInfo3Manager: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03), pid: 118u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_JobInfo3Manager ) , guid : :: windows :: core :: GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_JobInfo3OfficeLocation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03), pid: 117u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_JobInfo3OfficeLocation ) , guid : :: windows :: core :: GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_JobInfo3Title: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03), pid: 116u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_JobInfo3Title ) , guid : :: windows :: core :: GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_JobInfo3YomiCompanyName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03), pid: 114u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_JobInfo3YomiCompanyName ) , guid : :: windows :: core :: GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_JobTitle: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x176dc63c_2688_4e89_8143_a347800f25e9), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_JobTitle ) , guid : :: windows :: core :: GUID::from_u128(0x176dc63c_2688_4e89_8143_a347800f25e9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_Label: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x97b0ad89_df49_49cc_834e_660974fd755b), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_Label ) , guid : :: windows :: core :: GUID::from_u128(0x97b0ad89_df49_49cc_834e_660974fd755b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_LastName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8f367200_c270_457c_b1d4_e07c5bcd90c7), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_LastName ) , guid : :: windows :: core :: GUID::from_u128(0x8f367200_c270_457c_b1d4_e07c5bcd90c7) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_MailingAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc0ac206a_827e_4650_95ae_77e2bb74fcc9), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_MailingAddress ) , guid : :: windows :: core :: GUID::from_u128(0xc0ac206a_827e_4650_95ae_77e2bb74fcc9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_MiddleName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x176dc63c_2688_4e89_8143_a347800f25e9), pid: 71u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_MiddleName ) , guid : :: windows :: core :: GUID::from_u128(0x176dc63c_2688_4e89_8143_a347800f25e9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_MobileTelephone: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x176dc63c_2688_4e89_8143_a347800f25e9), pid: 35u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_MobileTelephone ) , guid : :: windows :: core :: GUID::from_u128(0x176dc63c_2688_4e89_8143_a347800f25e9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_NickName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x176dc63c_2688_4e89_8143_a347800f25e9), pid: 74u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_NickName ) , guid : :: windows :: core :: GUID::from_u128(0x176dc63c_2688_4e89_8143_a347800f25e9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_OfficeLocation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x176dc63c_2688_4e89_8143_a347800f25e9), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_OfficeLocation ) , guid : :: windows :: core :: GUID::from_u128(0x176dc63c_2688_4e89_8143_a347800f25e9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_OtherAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x508161fa_313b_43d5_83a1_c1accf68622c), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_OtherAddress ) , guid : :: windows :: core :: GUID::from_u128(0x508161fa_313b_43d5_83a1_c1accf68622c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_OtherAddress1Country: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 134u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_OtherAddress1Country ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_OtherAddress1Locality: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 132u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_OtherAddress1Locality ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_OtherAddress1PostalCode: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 135u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_OtherAddress1PostalCode ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_OtherAddress1Region: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 133u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_OtherAddress1Region ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_OtherAddress1Street: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 131u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_OtherAddress1Street ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_OtherAddress2Country: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 139u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_OtherAddress2Country ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_OtherAddress2Locality: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 137u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_OtherAddress2Locality ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_OtherAddress2PostalCode: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 140u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_OtherAddress2PostalCode ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_OtherAddress2Region: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 138u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_OtherAddress2Region ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_OtherAddress2Street: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 136u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_OtherAddress2Street ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_OtherAddress3Country: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 144u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_OtherAddress3Country ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_OtherAddress3Locality: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 142u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_OtherAddress3Locality ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_OtherAddress3PostalCode: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 145u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_OtherAddress3PostalCode ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_OtherAddress3Region: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 143u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_OtherAddress3Region ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_OtherAddress3Street: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1), pid: 141u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_OtherAddress3Street ) , guid : :: windows :: core :: GUID::from_u128(0xa7b6f596_d678_4bc1_b05f_0203d27e8aa1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_OtherAddressCity: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6e682923_7f7b_4f0c_a337_cfca296687bf), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_OtherAddressCity ) , guid : :: windows :: core :: GUID::from_u128(0x6e682923_7f7b_4f0c_a337_cfca296687bf) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_OtherAddressCountry: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8f167568_0aae_4322_8ed9_6055b7b0e398), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_OtherAddressCountry ) , guid : :: windows :: core :: GUID::from_u128(0x8f167568_0aae_4322_8ed9_6055b7b0e398) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_OtherAddressPostOfficeBox: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8b26ea41_058f_43f6_aecc_4035681ce977), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_OtherAddressPostOfficeBox ) , guid : :: windows :: core :: GUID::from_u128(0x8b26ea41_058f_43f6_aecc_4035681ce977) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_OtherAddressPostalCode: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x95c656c1_2abf_4148_9ed3_9ec602e3b7cd), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_OtherAddressPostalCode ) , guid : :: windows :: core :: GUID::from_u128(0x95c656c1_2abf_4148_9ed3_9ec602e3b7cd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_OtherAddressState: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x71b377d6_e570_425f_a170_809fae73e54e), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_OtherAddressState ) , guid : :: windows :: core :: GUID::from_u128(0x71b377d6_e570_425f_a170_809fae73e54e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_OtherAddressStreet: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xff962609_b7d6_4999_862d_95180d529aea), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_OtherAddressStreet ) , guid : :: windows :: core :: GUID::from_u128(0xff962609_b7d6_4999_862d_95180d529aea) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_OtherEmailAddresses: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x11d6336b_38c4_4ec9_84d6_eb38d0b150af), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_OtherEmailAddresses ) , guid : :: windows :: core :: GUID::from_u128(0x11d6336b_38c4_4ec9_84d6_eb38d0b150af) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_PagerTelephone: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd6304e01_f8f5_4f45_8b15_d024a6296789), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_PagerTelephone ) , guid : :: windows :: core :: GUID::from_u128(0xd6304e01_f8f5_4f45_8b15_d024a6296789) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_PersonalTitle: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x176dc63c_2688_4e89_8143_a347800f25e9), pid: 69u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_PersonalTitle ) , guid : :: windows :: core :: GUID::from_u128(0x176dc63c_2688_4e89_8143_a347800f25e9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_PhoneNumbersCanonical: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd042d2a1_927e_40b5_a503_6edbd42a517e), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_PhoneNumbersCanonical ) , guid : :: windows :: core :: GUID::from_u128(0xd042d2a1_927e_40b5_a503_6edbd42a517e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_Prefix: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x176dc63c_2688_4e89_8143_a347800f25e9), pid: 75u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_Prefix ) , guid : :: windows :: core :: GUID::from_u128(0x176dc63c_2688_4e89_8143_a347800f25e9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_PrimaryAddressCity: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc8ea94f0_a9e3_4969_a94b_9c62a95324e0), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_PrimaryAddressCity ) , guid : :: windows :: core :: GUID::from_u128(0xc8ea94f0_a9e3_4969_a94b_9c62a95324e0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_PrimaryAddressCountry: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe53d799d_0f3f_466e_b2ff_74634a3cb7a4), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_PrimaryAddressCountry ) , guid : :: windows :: core :: GUID::from_u128(0xe53d799d_0f3f_466e_b2ff_74634a3cb7a4) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_PrimaryAddressPostOfficeBox: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xde5ef3c7_46e1_484e_9999_62c5308394c1), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_PrimaryAddressPostOfficeBox ) , guid : :: windows :: core :: GUID::from_u128(0xde5ef3c7_46e1_484e_9999_62c5308394c1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_PrimaryAddressPostalCode: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x18bbd425_ecfd_46ef_b612_7b4a6034eda0), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_PrimaryAddressPostalCode ) , guid : :: windows :: core :: GUID::from_u128(0x18bbd425_ecfd_46ef_b612_7b4a6034eda0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_PrimaryAddressState: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf1176dfe_7138_4640_8b4c_ae375dc70a6d), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_PrimaryAddressState ) , guid : :: windows :: core :: GUID::from_u128(0xf1176dfe_7138_4640_8b4c_ae375dc70a6d) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_PrimaryAddressStreet: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x63c25b20_96be_488f_8788_c09c407ad812), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_PrimaryAddressStreet ) , guid : :: windows :: core :: GUID::from_u128(0x63c25b20_96be_488f_8788_c09c407ad812) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_PrimaryEmailAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x176dc63c_2688_4e89_8143_a347800f25e9), pid: 48u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_PrimaryEmailAddress ) , guid : :: windows :: core :: GUID::from_u128(0x176dc63c_2688_4e89_8143_a347800f25e9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_PrimaryTelephone: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x176dc63c_2688_4e89_8143_a347800f25e9), pid: 25u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_PrimaryTelephone ) , guid : :: windows :: core :: GUID::from_u128(0x176dc63c_2688_4e89_8143_a347800f25e9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_Profession: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7268af55_1ce4_4f6e_a41f_b6e4ef10e4a9), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_Profession ) , guid : :: windows :: core :: GUID::from_u128(0x7268af55_1ce4_4f6e_a41f_b6e4ef10e4a9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_SpouseName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9d2408b6_3167_422b_82b0_f583b7a7cfe3), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_SpouseName ) , guid : :: windows :: core :: GUID::from_u128(0x9d2408b6_3167_422b_82b0_f583b7a7cfe3) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_Suffix: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x176dc63c_2688_4e89_8143_a347800f25e9), pid: 73u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_Suffix ) , guid : :: windows :: core :: GUID::from_u128(0x176dc63c_2688_4e89_8143_a347800f25e9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_TTYTDDTelephone: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xaaf16bac_2b55_45e6_9f6d_415eb94910df), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_TTYTDDTelephone ) , guid : :: windows :: core :: GUID::from_u128(0xaaf16bac_2b55_45e6_9f6d_415eb94910df) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_TelexNumber: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc554493c_c1f7_40c1_a76c_ef8c0614003e), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_TelexNumber ) , guid : :: windows :: core :: GUID::from_u128(0xc554493c_c1f7_40c1_a76c_ef8c0614003e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_WebPage: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd), pid: 18u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_WebPage ) , guid : :: windows :: core :: GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_Webpage2: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03), pid: 124u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_Webpage2 ) , guid : :: windows :: core :: GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Contact_Webpage3: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03), pid: 125u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Contact_Webpage3 ) , guid : :: windows :: core :: GUID::from_u128(0x00f63dd8_22bd_4a5d_ba34_5cb0b9bdcb03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ContainedItems: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0), pid: 29u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ContainedItems ) , guid : :: windows :: core :: GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ContentId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8), pid: 132u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ContentId ) , guid : :: windows :: core :: GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ContentStatus: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae), pid: 27u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ContentStatus ) , guid : :: windows :: core :: GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ContentType: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae), pid: 26u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ContentType ) , guid : :: windows :: core :: GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ContentUri: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8), pid: 131u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ContentUri ) , guid : :: windows :: core :: GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Copyright: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Copyright ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_CreatorAppId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc2ea046e_033c_4e91_bd5b_d4942f6bbe49), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_CreatorAppId ) , guid : :: windows :: core :: GUID::from_u128(0xc2ea046e_033c_4e91_bd5b_d4942f6bbe49) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_CreatorOpenWithUIOptions: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc2ea046e_033c_4e91_bd5b_d4942f6bbe49), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_CreatorOpenWithUIOptions ) , guid : :: windows :: core :: GUID::from_u128(0xc2ea046e_033c_4e91_bd5b_d4942f6bbe49) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DRM_DatePlayExpires: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xaeac19e4_89ae_4508_b9b7_bb867abee2ed), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DRM_DatePlayExpires ) , guid : :: windows :: core :: GUID::from_u128(0xaeac19e4_89ae_4508_b9b7_bb867abee2ed) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DRM_DatePlayStarts: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xaeac19e4_89ae_4508_b9b7_bb867abee2ed), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DRM_DatePlayStarts ) , guid : :: windows :: core :: GUID::from_u128(0xaeac19e4_89ae_4508_b9b7_bb867abee2ed) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DRM_Description: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xaeac19e4_89ae_4508_b9b7_bb867abee2ed), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DRM_Description ) , guid : :: windows :: core :: GUID::from_u128(0xaeac19e4_89ae_4508_b9b7_bb867abee2ed) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DRM_IsDisabled: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xaeac19e4_89ae_4508_b9b7_bb867abee2ed), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DRM_IsDisabled ) , guid : :: windows :: core :: GUID::from_u128(0xaeac19e4_89ae_4508_b9b7_bb867abee2ed) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DRM_IsProtected: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xaeac19e4_89ae_4508_b9b7_bb867abee2ed), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DRM_IsProtected ) , guid : :: windows :: core :: GUID::from_u128(0xaeac19e4_89ae_4508_b9b7_bb867abee2ed) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DRM_PlayCount: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xaeac19e4_89ae_4508_b9b7_bb867abee2ed), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DRM_PlayCount ) , guid : :: windows :: core :: GUID::from_u128(0xaeac19e4_89ae_4508_b9b7_bb867abee2ed) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DataObjectFormat: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1e81a3f8_a30f_4247_b9ee_1d0368a9425c), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DataObjectFormat ) , guid : :: windows :: core :: GUID::from_u128(0x1e81a3f8_a30f_4247_b9ee_1d0368a9425c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DateAccessed: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac), pid: 16u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DateAccessed ) , guid : :: windows :: core :: GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DateAcquired: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2cbaa8f5_d81f_47ca_b17a_f8d822300131), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DateAcquired ) , guid : :: windows :: core :: GUID::from_u128(0x2cbaa8f5_d81f_47ca_b17a_f8d822300131) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DateArchived: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x43f8d7b7_a444_4f87_9383_52271c9b915c), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DateArchived ) , guid : :: windows :: core :: GUID::from_u128(0x43f8d7b7_a444_4f87_9383_52271c9b915c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DateCompleted: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x72fab781_acda_43e5_b155_b2434f85e678), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DateCompleted ) , guid : :: windows :: core :: GUID::from_u128(0x72fab781_acda_43e5_b155_b2434f85e678) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DateCreated: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac), pid: 15u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DateCreated ) , guid : :: windows :: core :: GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DateImported: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99), pid: 18258u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DateImported ) , guid : :: windows :: core :: GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DateModified: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DateModified ) , guid : :: windows :: core :: GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DefaultSaveLocationDisplay: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5d76b67f_9b3d_44bb_b6ae_25da4f638a67), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DefaultSaveLocationDisplay ) , guid : :: windows :: core :: GUID::from_u128(0x5d76b67f_9b3d_44bb_b6ae_25da4f638a67) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DescriptionID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DescriptionID ) , guid : :: windows :: core :: GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_Bluetooth_DeviceAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2bd67d8b_8beb_48d5_87e0_6cda3428040a), pid: 1u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_Bluetooth_DeviceAddress ) , guid : :: windows :: core :: GUID::from_u128(0x2bd67d8b_8beb_48d5_87e0_6cda3428040a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_Bluetooth_Flags: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2bd67d8b_8beb_48d5_87e0_6cda3428040a), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_Bluetooth_Flags ) , guid : :: windows :: core :: GUID::from_u128(0x2bd67d8b_8beb_48d5_87e0_6cda3428040a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_Bluetooth_LastConnectedTime: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2bd67d8b_8beb_48d5_87e0_6cda3428040a), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_Bluetooth_LastConnectedTime ) , guid : :: windows :: core :: GUID::from_u128(0x2bd67d8b_8beb_48d5_87e0_6cda3428040a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_Bluetooth_Manufacturer: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2bd67d8b_8beb_48d5_87e0_6cda3428040a), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_Bluetooth_Manufacturer ) , guid : :: windows :: core :: GUID::from_u128(0x2bd67d8b_8beb_48d5_87e0_6cda3428040a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_Bluetooth_ModelNumber: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2bd67d8b_8beb_48d5_87e0_6cda3428040a), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_Bluetooth_ModelNumber ) , guid : :: windows :: core :: GUID::from_u128(0x2bd67d8b_8beb_48d5_87e0_6cda3428040a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_Bluetooth_ProductId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2bd67d8b_8beb_48d5_87e0_6cda3428040a), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_Bluetooth_ProductId ) , guid : :: windows :: core :: GUID::from_u128(0x2bd67d8b_8beb_48d5_87e0_6cda3428040a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_Bluetooth_ProductVersion: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2bd67d8b_8beb_48d5_87e0_6cda3428040a), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_Bluetooth_ProductVersion ) , guid : :: windows :: core :: GUID::from_u128(0x2bd67d8b_8beb_48d5_87e0_6cda3428040a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_Bluetooth_ServiceGuid: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2bd67d8b_8beb_48d5_87e0_6cda3428040a), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_Bluetooth_ServiceGuid ) , guid : :: windows :: core :: GUID::from_u128(0x2bd67d8b_8beb_48d5_87e0_6cda3428040a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_Bluetooth_VendorId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2bd67d8b_8beb_48d5_87e0_6cda3428040a), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_Bluetooth_VendorId ) , guid : :: windows :: core :: GUID::from_u128(0x2bd67d8b_8beb_48d5_87e0_6cda3428040a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_Bluetooth_VendorIdSource: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2bd67d8b_8beb_48d5_87e0_6cda3428040a), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_Bluetooth_VendorIdSource ) , guid : :: windows :: core :: GUID::from_u128(0x2bd67d8b_8beb_48d5_87e0_6cda3428040a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_Hid_IsReadOnly: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcbf38310_4a17_4310_a1eb_247f0b67593b), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_Hid_IsReadOnly ) , guid : :: windows :: core :: GUID::from_u128(0xcbf38310_4a17_4310_a1eb_247f0b67593b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_Hid_ProductId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcbf38310_4a17_4310_a1eb_247f0b67593b), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_Hid_ProductId ) , guid : :: windows :: core :: GUID::from_u128(0xcbf38310_4a17_4310_a1eb_247f0b67593b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_Hid_UsageId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcbf38310_4a17_4310_a1eb_247f0b67593b), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_Hid_UsageId ) , guid : :: windows :: core :: GUID::from_u128(0xcbf38310_4a17_4310_a1eb_247f0b67593b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_Hid_UsagePage: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcbf38310_4a17_4310_a1eb_247f0b67593b), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_Hid_UsagePage ) , guid : :: windows :: core :: GUID::from_u128(0xcbf38310_4a17_4310_a1eb_247f0b67593b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_Hid_VendorId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcbf38310_4a17_4310_a1eb_247f0b67593b), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_Hid_VendorId ) , guid : :: windows :: core :: GUID::from_u128(0xcbf38310_4a17_4310_a1eb_247f0b67593b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_Hid_VersionNumber: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcbf38310_4a17_4310_a1eb_247f0b67593b), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_Hid_VersionNumber ) , guid : :: windows :: core :: GUID::from_u128(0xcbf38310_4a17_4310_a1eb_247f0b67593b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_PrinterDriverDirectory: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x847c66de_b8d6_4af9_abc3_6f4f926bc039), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_PrinterDriverDirectory ) , guid : :: windows :: core :: GUID::from_u128(0x847c66de_b8d6_4af9_abc3_6f4f926bc039) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_PrinterDriverName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xafc47170_14f5_498c_8f30_b0d19be449c6), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_PrinterDriverName ) , guid : :: windows :: core :: GUID::from_u128(0xafc47170_14f5_498c_8f30_b0d19be449c6) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_PrinterEnumerationFlag: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa00742a1_cd8c_4b37_95ab_70755587767a), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_PrinterEnumerationFlag ) , guid : :: windows :: core :: GUID::from_u128(0xa00742a1_cd8c_4b37_95ab_70755587767a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_PrinterName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0a7b84ef_0c27_463f_84ef_06c5070001be), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_PrinterName ) , guid : :: windows :: core :: GUID::from_u128(0x0a7b84ef_0c27_463f_84ef_06c5070001be) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_PrinterPortName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xeec7b761_6f94_41b1_949f_c729720dd13c), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_PrinterPortName ) , guid : :: windows :: core :: GUID::from_u128(0xeec7b761_6f94_41b1_949f_c729720dd13c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_Proximity_SupportsNfc: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfb3842cd_9e2a_4f83_8fcc_4b0761139ae9), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_Proximity_SupportsNfc ) , guid : :: windows :: core :: GUID::from_u128(0xfb3842cd_9e2a_4f83_8fcc_4b0761139ae9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_Serial_PortName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4c6bf15c_4c03_4aac_91f5_64c0f852bcf4), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_Serial_PortName ) , guid : :: windows :: core :: GUID::from_u128(0x4c6bf15c_4c03_4aac_91f5_64c0f852bcf4) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_Serial_UsbProductId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4c6bf15c_4c03_4aac_91f5_64c0f852bcf4), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_Serial_UsbProductId ) , guid : :: windows :: core :: GUID::from_u128(0x4c6bf15c_4c03_4aac_91f5_64c0f852bcf4) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_Serial_UsbVendorId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4c6bf15c_4c03_4aac_91f5_64c0f852bcf4), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_Serial_UsbVendorId ) , guid : :: windows :: core :: GUID::from_u128(0x4c6bf15c_4c03_4aac_91f5_64c0f852bcf4) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_WinUsb_DeviceInterfaceClasses: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x95e127b5_79cc_4e83_9c9e_8422187b3e0e), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_WinUsb_DeviceInterfaceClasses ) , guid : :: windows :: core :: GUID::from_u128(0x95e127b5_79cc_4e83_9c9e_8422187b3e0e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_WinUsb_UsbClass: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x95e127b5_79cc_4e83_9c9e_8422187b3e0e), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_WinUsb_UsbClass ) , guid : :: windows :: core :: GUID::from_u128(0x95e127b5_79cc_4e83_9c9e_8422187b3e0e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_WinUsb_UsbProductId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x95e127b5_79cc_4e83_9c9e_8422187b3e0e), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_WinUsb_UsbProductId ) , guid : :: windows :: core :: GUID::from_u128(0x95e127b5_79cc_4e83_9c9e_8422187b3e0e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_WinUsb_UsbProtocol: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x95e127b5_79cc_4e83_9c9e_8422187b3e0e), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_WinUsb_UsbProtocol ) , guid : :: windows :: core :: GUID::from_u128(0x95e127b5_79cc_4e83_9c9e_8422187b3e0e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_WinUsb_UsbSubClass: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x95e127b5_79cc_4e83_9c9e_8422187b3e0e), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_WinUsb_UsbSubClass ) , guid : :: windows :: core :: GUID::from_u128(0x95e127b5_79cc_4e83_9c9e_8422187b3e0e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DeviceInterface_WinUsb_UsbVendorId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x95e127b5_79cc_4e83_9c9e_8422187b3e0e), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DeviceInterface_WinUsb_UsbVendorId ) , guid : :: windows :: core :: GUID::from_u128(0x95e127b5_79cc_4e83_9c9e_8422187b3e0e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Device_PrinterURL: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0b48f35a_be6e_4f17_b108_3c4073d1669a), pid: 15u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Device_PrinterURL ) , guid : :: windows :: core :: GUID::from_u128(0x0b48f35a_be6e_4f17_b108_3c4073d1669a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepContainer_CanPair: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0bba1ede_7566_4f47_90ec_25fc567ced2a), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepContainer_CanPair ) , guid : :: windows :: core :: GUID::from_u128(0x0bba1ede_7566_4f47_90ec_25fc567ced2a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepContainer_Categories: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0bba1ede_7566_4f47_90ec_25fc567ced2a), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepContainer_Categories ) , guid : :: windows :: core :: GUID::from_u128(0x0bba1ede_7566_4f47_90ec_25fc567ced2a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepContainer_Children: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0bba1ede_7566_4f47_90ec_25fc567ced2a), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepContainer_Children ) , guid : :: windows :: core :: GUID::from_u128(0x0bba1ede_7566_4f47_90ec_25fc567ced2a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepContainer_ContainerId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0bba1ede_7566_4f47_90ec_25fc567ced2a), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepContainer_ContainerId ) , guid : :: windows :: core :: GUID::from_u128(0x0bba1ede_7566_4f47_90ec_25fc567ced2a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepContainer_DialProtocol_InstalledApplications: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6af55d45_38db_4495_acb0_d4728a3b8314), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepContainer_DialProtocol_InstalledApplications ) , guid : :: windows :: core :: GUID::from_u128(0x6af55d45_38db_4495_acb0_d4728a3b8314) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepContainer_IsPaired: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0bba1ede_7566_4f47_90ec_25fc567ced2a), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepContainer_IsPaired ) , guid : :: windows :: core :: GUID::from_u128(0x0bba1ede_7566_4f47_90ec_25fc567ced2a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepContainer_IsPresent: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0bba1ede_7566_4f47_90ec_25fc567ced2a), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepContainer_IsPresent ) , guid : :: windows :: core :: GUID::from_u128(0x0bba1ede_7566_4f47_90ec_25fc567ced2a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepContainer_Manufacturer: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0bba1ede_7566_4f47_90ec_25fc567ced2a), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepContainer_Manufacturer ) , guid : :: windows :: core :: GUID::from_u128(0x0bba1ede_7566_4f47_90ec_25fc567ced2a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepContainer_ModelIds: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0bba1ede_7566_4f47_90ec_25fc567ced2a), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepContainer_ModelIds ) , guid : :: windows :: core :: GUID::from_u128(0x0bba1ede_7566_4f47_90ec_25fc567ced2a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepContainer_ModelName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0bba1ede_7566_4f47_90ec_25fc567ced2a), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepContainer_ModelName ) , guid : :: windows :: core :: GUID::from_u128(0x0bba1ede_7566_4f47_90ec_25fc567ced2a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepContainer_ProtocolIds: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0bba1ede_7566_4f47_90ec_25fc567ced2a), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepContainer_ProtocolIds ) , guid : :: windows :: core :: GUID::from_u128(0x0bba1ede_7566_4f47_90ec_25fc567ced2a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepContainer_SupportedUriSchemes: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6af55d45_38db_4495_acb0_d4728a3b8314), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepContainer_SupportedUriSchemes ) , guid : :: windows :: core :: GUID::from_u128(0x6af55d45_38db_4495_acb0_d4728a3b8314) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepContainer_SupportsAudio: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6af55d45_38db_4495_acb0_d4728a3b8314), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepContainer_SupportsAudio ) , guid : :: windows :: core :: GUID::from_u128(0x6af55d45_38db_4495_acb0_d4728a3b8314) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepContainer_SupportsCapturing: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6af55d45_38db_4495_acb0_d4728a3b8314), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepContainer_SupportsCapturing ) , guid : :: windows :: core :: GUID::from_u128(0x6af55d45_38db_4495_acb0_d4728a3b8314) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepContainer_SupportsImages: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6af55d45_38db_4495_acb0_d4728a3b8314), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepContainer_SupportsImages ) , guid : :: windows :: core :: GUID::from_u128(0x6af55d45_38db_4495_acb0_d4728a3b8314) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepContainer_SupportsInformation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6af55d45_38db_4495_acb0_d4728a3b8314), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepContainer_SupportsInformation ) , guid : :: windows :: core :: GUID::from_u128(0x6af55d45_38db_4495_acb0_d4728a3b8314) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepContainer_SupportsLimitedDiscovery: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6af55d45_38db_4495_acb0_d4728a3b8314), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepContainer_SupportsLimitedDiscovery ) , guid : :: windows :: core :: GUID::from_u128(0x6af55d45_38db_4495_acb0_d4728a3b8314) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepContainer_SupportsNetworking: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6af55d45_38db_4495_acb0_d4728a3b8314), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepContainer_SupportsNetworking ) , guid : :: windows :: core :: GUID::from_u128(0x6af55d45_38db_4495_acb0_d4728a3b8314) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepContainer_SupportsObjectTransfer: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6af55d45_38db_4495_acb0_d4728a3b8314), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepContainer_SupportsObjectTransfer ) , guid : :: windows :: core :: GUID::from_u128(0x6af55d45_38db_4495_acb0_d4728a3b8314) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepContainer_SupportsPositioning: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6af55d45_38db_4495_acb0_d4728a3b8314), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepContainer_SupportsPositioning ) , guid : :: windows :: core :: GUID::from_u128(0x6af55d45_38db_4495_acb0_d4728a3b8314) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepContainer_SupportsRendering: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6af55d45_38db_4495_acb0_d4728a3b8314), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepContainer_SupportsRendering ) , guid : :: windows :: core :: GUID::from_u128(0x6af55d45_38db_4495_acb0_d4728a3b8314) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepContainer_SupportsTelephony: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6af55d45_38db_4495_acb0_d4728a3b8314), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepContainer_SupportsTelephony ) , guid : :: windows :: core :: GUID::from_u128(0x6af55d45_38db_4495_acb0_d4728a3b8314) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepContainer_SupportsVideo: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6af55d45_38db_4495_acb0_d4728a3b8314), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepContainer_SupportsVideo ) , guid : :: windows :: core :: GUID::from_u128(0x6af55d45_38db_4495_acb0_d4728a3b8314) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepService_AepId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc9c141a9_1b4c_4f17_a9d1_f298538cadb8), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepService_AepId ) , guid : :: windows :: core :: GUID::from_u128(0xc9c141a9_1b4c_4f17_a9d1_f298538cadb8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepService_Bluetooth_CacheMode: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9744311e_7951_4b2e_b6f0_ecb293cac119), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepService_Bluetooth_CacheMode ) , guid : :: windows :: core :: GUID::from_u128(0x9744311e_7951_4b2e_b6f0_ecb293cac119) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepService_Bluetooth_ServiceGuid: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa399aac7_c265_474e_b073_ffce57721716), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepService_Bluetooth_ServiceGuid ) , guid : :: windows :: core :: GUID::from_u128(0xa399aac7_c265_474e_b073_ffce57721716) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepService_Bluetooth_TargetDevice: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9744311e_7951_4b2e_b6f0_ecb293cac119), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepService_Bluetooth_TargetDevice ) , guid : :: windows :: core :: GUID::from_u128(0x9744311e_7951_4b2e_b6f0_ecb293cac119) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepService_ContainerId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x71724756_3e74_4432_9b59_e7b2f668a593), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepService_ContainerId ) , guid : :: windows :: core :: GUID::from_u128(0x71724756_3e74_4432_9b59_e7b2f668a593) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepService_FriendlyName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x71724756_3e74_4432_9b59_e7b2f668a593), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepService_FriendlyName ) , guid : :: windows :: core :: GUID::from_u128(0x71724756_3e74_4432_9b59_e7b2f668a593) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepService_IoT_ServiceInterfaces: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x79d94e82_4d79_45aa_821a_74858b4e4ca6), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepService_IoT_ServiceInterfaces ) , guid : :: windows :: core :: GUID::from_u128(0x79d94e82_4d79_45aa_821a_74858b4e4ca6) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepService_ParentAepIsPaired: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc9c141a9_1b4c_4f17_a9d1_f298538cadb8), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepService_ParentAepIsPaired ) , guid : :: windows :: core :: GUID::from_u128(0xc9c141a9_1b4c_4f17_a9d1_f298538cadb8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepService_ProtocolId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc9c141a9_1b4c_4f17_a9d1_f298538cadb8), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepService_ProtocolId ) , guid : :: windows :: core :: GUID::from_u128(0xc9c141a9_1b4c_4f17_a9d1_f298538cadb8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepService_ServiceClassId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x71724756_3e74_4432_9b59_e7b2f668a593), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepService_ServiceClassId ) , guid : :: windows :: core :: GUID::from_u128(0x71724756_3e74_4432_9b59_e7b2f668a593) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AepService_ServiceId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc9c141a9_1b4c_4f17_a9d1_f298538cadb8), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AepService_ServiceId ) , guid : :: windows :: core :: GUID::from_u128(0xc9c141a9_1b4c_4f17_a9d1_f298538cadb8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_AepId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x3b2ce006_5e61_4fde_bab8_9b8aac9b26df), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_AepId ) , guid : :: windows :: core :: GUID::from_u128(0x3b2ce006_5e61_4fde_bab8_9b8aac9b26df) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_Bluetooth_Cod_Major: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5fbd34cd_561a_412e_ba98_478a6b0fef1d), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_Bluetooth_Cod_Major ) , guid : :: windows :: core :: GUID::from_u128(0x5fbd34cd_561a_412e_ba98_478a6b0fef1d) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_Bluetooth_Cod_Minor: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5fbd34cd_561a_412e_ba98_478a6b0fef1d), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_Bluetooth_Cod_Minor ) , guid : :: windows :: core :: GUID::from_u128(0x5fbd34cd_561a_412e_ba98_478a6b0fef1d) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_Bluetooth_Cod_Services_Audio: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5fbd34cd_561a_412e_ba98_478a6b0fef1d), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_Bluetooth_Cod_Services_Audio ) , guid : :: windows :: core :: GUID::from_u128(0x5fbd34cd_561a_412e_ba98_478a6b0fef1d) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_Bluetooth_Cod_Services_Capturing: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5fbd34cd_561a_412e_ba98_478a6b0fef1d), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_Bluetooth_Cod_Services_Capturing ) , guid : :: windows :: core :: GUID::from_u128(0x5fbd34cd_561a_412e_ba98_478a6b0fef1d) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_Bluetooth_Cod_Services_Information: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5fbd34cd_561a_412e_ba98_478a6b0fef1d), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_Bluetooth_Cod_Services_Information ) , guid : :: windows :: core :: GUID::from_u128(0x5fbd34cd_561a_412e_ba98_478a6b0fef1d) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_Bluetooth_Cod_Services_LimitedDiscovery: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5fbd34cd_561a_412e_ba98_478a6b0fef1d), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_Bluetooth_Cod_Services_LimitedDiscovery ) , guid : :: windows :: core :: GUID::from_u128(0x5fbd34cd_561a_412e_ba98_478a6b0fef1d) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_Bluetooth_Cod_Services_Networking: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5fbd34cd_561a_412e_ba98_478a6b0fef1d), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_Bluetooth_Cod_Services_Networking ) , guid : :: windows :: core :: GUID::from_u128(0x5fbd34cd_561a_412e_ba98_478a6b0fef1d) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_Bluetooth_Cod_Services_ObjectXfer: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5fbd34cd_561a_412e_ba98_478a6b0fef1d), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_Bluetooth_Cod_Services_ObjectXfer ) , guid : :: windows :: core :: GUID::from_u128(0x5fbd34cd_561a_412e_ba98_478a6b0fef1d) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_Bluetooth_Cod_Services_Positioning: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5fbd34cd_561a_412e_ba98_478a6b0fef1d), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_Bluetooth_Cod_Services_Positioning ) , guid : :: windows :: core :: GUID::from_u128(0x5fbd34cd_561a_412e_ba98_478a6b0fef1d) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_Bluetooth_Cod_Services_Rendering: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5fbd34cd_561a_412e_ba98_478a6b0fef1d), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_Bluetooth_Cod_Services_Rendering ) , guid : :: windows :: core :: GUID::from_u128(0x5fbd34cd_561a_412e_ba98_478a6b0fef1d) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_Bluetooth_Cod_Services_Telephony: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5fbd34cd_561a_412e_ba98_478a6b0fef1d), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_Bluetooth_Cod_Services_Telephony ) , guid : :: windows :: core :: GUID::from_u128(0x5fbd34cd_561a_412e_ba98_478a6b0fef1d) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_Bluetooth_LastSeenTime: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2bd67d8b_8beb_48d5_87e0_6cda3428040a), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_Bluetooth_LastSeenTime ) , guid : :: windows :: core :: GUID::from_u128(0x2bd67d8b_8beb_48d5_87e0_6cda3428040a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_Bluetooth_Le_AddressType: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x995ef0b0_7eb3_4a8b_b9ce_068bb3f4af69), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_Bluetooth_Le_AddressType ) , guid : :: windows :: core :: GUID::from_u128(0x995ef0b0_7eb3_4a8b_b9ce_068bb3f4af69) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_Bluetooth_Le_Appearance: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x995ef0b0_7eb3_4a8b_b9ce_068bb3f4af69), pid: 1u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_Bluetooth_Le_Appearance ) , guid : :: windows :: core :: GUID::from_u128(0x995ef0b0_7eb3_4a8b_b9ce_068bb3f4af69) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_Bluetooth_Le_Appearance_Category: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x995ef0b0_7eb3_4a8b_b9ce_068bb3f4af69), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_Bluetooth_Le_Appearance_Category ) , guid : :: windows :: core :: GUID::from_u128(0x995ef0b0_7eb3_4a8b_b9ce_068bb3f4af69) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_Bluetooth_Le_Appearance_Subcategory: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x995ef0b0_7eb3_4a8b_b9ce_068bb3f4af69), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_Bluetooth_Le_Appearance_Subcategory ) , guid : :: windows :: core :: GUID::from_u128(0x995ef0b0_7eb3_4a8b_b9ce_068bb3f4af69) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_Bluetooth_Le_IsConnectable: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x995ef0b0_7eb3_4a8b_b9ce_068bb3f4af69), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_Bluetooth_Le_IsConnectable ) , guid : :: windows :: core :: GUID::from_u128(0x995ef0b0_7eb3_4a8b_b9ce_068bb3f4af69) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_CanPair: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe7c3fb29_caa7_4f47_8c8b_be59b330d4c5), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_CanPair ) , guid : :: windows :: core :: GUID::from_u128(0xe7c3fb29_caa7_4f47_8c8b_be59b330d4c5) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_Category: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa35996ab_11cf_4935_8b61_a6761081ecdf), pid: 17u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_Category ) , guid : :: windows :: core :: GUID::from_u128(0xa35996ab_11cf_4935_8b61_a6761081ecdf) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_ContainerId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe7c3fb29_caa7_4f47_8c8b_be59b330d4c5), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_ContainerId ) , guid : :: windows :: core :: GUID::from_u128(0xe7c3fb29_caa7_4f47_8c8b_be59b330d4c5) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_DeviceAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa35996ab_11cf_4935_8b61_a6761081ecdf), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_DeviceAddress ) , guid : :: windows :: core :: GUID::from_u128(0xa35996ab_11cf_4935_8b61_a6761081ecdf) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_IsConnected: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa35996ab_11cf_4935_8b61_a6761081ecdf), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_IsConnected ) , guid : :: windows :: core :: GUID::from_u128(0xa35996ab_11cf_4935_8b61_a6761081ecdf) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_IsPaired: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa35996ab_11cf_4935_8b61_a6761081ecdf), pid: 16u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_IsPaired ) , guid : :: windows :: core :: GUID::from_u128(0xa35996ab_11cf_4935_8b61_a6761081ecdf) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_IsPresent: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa35996ab_11cf_4935_8b61_a6761081ecdf), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_IsPresent ) , guid : :: windows :: core :: GUID::from_u128(0xa35996ab_11cf_4935_8b61_a6761081ecdf) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_Manufacturer: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa35996ab_11cf_4935_8b61_a6761081ecdf), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_Manufacturer ) , guid : :: windows :: core :: GUID::from_u128(0xa35996ab_11cf_4935_8b61_a6761081ecdf) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_ModelId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa35996ab_11cf_4935_8b61_a6761081ecdf), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_ModelId ) , guid : :: windows :: core :: GUID::from_u128(0xa35996ab_11cf_4935_8b61_a6761081ecdf) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_ModelName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa35996ab_11cf_4935_8b61_a6761081ecdf), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_ModelName ) , guid : :: windows :: core :: GUID::from_u128(0xa35996ab_11cf_4935_8b61_a6761081ecdf) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_PointOfService_ConnectionTypes: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd4bf61b3_442e_4ada_882d_fa7b70c832d9), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_PointOfService_ConnectionTypes ) , guid : :: windows :: core :: GUID::from_u128(0xd4bf61b3_442e_4ada_882d_fa7b70c832d9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_ProtocolId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x3b2ce006_5e61_4fde_bab8_9b8aac9b26df), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_ProtocolId ) , guid : :: windows :: core :: GUID::from_u128(0x3b2ce006_5e61_4fde_bab8_9b8aac9b26df) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Aep_SignalStrength: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa35996ab_11cf_4935_8b61_a6761081ecdf), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Aep_SignalStrength ) , guid : :: windows :: core :: GUID::from_u128(0xa35996ab_11cf_4935_8b61_a6761081ecdf) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AppPackageFamilyName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x51236583_0c4a_4fe8_b81f_166aec13f510), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AppPackageFamilyName ) , guid : :: windows :: core :: GUID::from_u128(0x51236583_0c4a_4fe8_b81f_166aec13f510) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AudioDevice_Microphone_IsFarField: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8943b373_388c_4395_b557_bc6dbaffafdb), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AudioDevice_Microphone_IsFarField ) , guid : :: windows :: core :: GUID::from_u128(0x8943b373_388c_4395_b557_bc6dbaffafdb) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AudioDevice_Microphone_SensitivityInDbfs: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8943b373_388c_4395_b557_bc6dbaffafdb), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AudioDevice_Microphone_SensitivityInDbfs ) , guid : :: windows :: core :: GUID::from_u128(0x8943b373_388c_4395_b557_bc6dbaffafdb) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AudioDevice_Microphone_SensitivityInDbfs2: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8943b373_388c_4395_b557_bc6dbaffafdb), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AudioDevice_Microphone_SensitivityInDbfs2 ) , guid : :: windows :: core :: GUID::from_u128(0x8943b373_388c_4395_b557_bc6dbaffafdb) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AudioDevice_Microphone_SignalToNoiseRatioInDb: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8943b373_388c_4395_b557_bc6dbaffafdb), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AudioDevice_Microphone_SignalToNoiseRatioInDb ) , guid : :: windows :: core :: GUID::from_u128(0x8943b373_388c_4395_b557_bc6dbaffafdb) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AudioDevice_RawProcessingSupported: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8943b373_388c_4395_b557_bc6dbaffafdb), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AudioDevice_RawProcessingSupported ) , guid : :: windows :: core :: GUID::from_u128(0x8943b373_388c_4395_b557_bc6dbaffafdb) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_AudioDevice_SpeechProcessingSupported: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfb1de864_e06d_47f4_82a6_8a0aef44493c), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_AudioDevice_SpeechProcessingSupported ) , guid : :: windows :: core :: GUID::from_u128(0xfb1de864_e06d_47f4_82a6_8a0aef44493c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_BatteryLife: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_BatteryLife ) , guid : :: windows :: core :: GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_BatteryPlusCharging: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213), pid: 22u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_BatteryPlusCharging ) , guid : :: windows :: core :: GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_BatteryPlusChargingText: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213), pid: 23u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_BatteryPlusChargingText ) , guid : :: windows :: core :: GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Category: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 91u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Category ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_CategoryGroup: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 94u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_CategoryGroup ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_CategoryIds: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 90u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_CategoryIds ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_CategoryPlural: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 92u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_CategoryPlural ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_ChallengeAep: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0774315e_b714_48ec_8de8_8125c077ac11), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_ChallengeAep ) , guid : :: windows :: core :: GUID::from_u128(0x0774315e_b714_48ec_8de8_8125c077ac11) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_ChargingState: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_ChargingState ) , guid : :: windows :: core :: GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Children: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Children ) , guid : :: windows :: core :: GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_ClassGuid: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_ClassGuid ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_CompatibleIds: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_CompatibleIds ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Connected: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 55u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Connected ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_ContainerId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8c7ed206_3f8a_4827_b3ab_ae9e1faefc6c), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_ContainerId ) , guid : :: windows :: core :: GUID::from_u128(0x8c7ed206_3f8a_4827_b3ab_ae9e1faefc6c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_DefaultTooltip: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x880f70a2_6082_47ac_8aab_a739d1a300c3), pid: 153u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_DefaultTooltip ) , guid : :: windows :: core :: GUID::from_u128(0x880f70a2_6082_47ac_8aab_a739d1a300c3) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_DevObjectType: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x13673f42_a3d6_49f6_b4da_ae46e0c5237c), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_DevObjectType ) , guid : :: windows :: core :: GUID::from_u128(0x13673f42_a3d6_49f6_b4da_ae46e0c5237c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_DeviceCapabilities: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 17u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_DeviceCapabilities ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_DeviceCharacteristics: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 29u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_DeviceCharacteristics ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_DeviceDescription1: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 81u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_DeviceDescription1 ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_DeviceDescription2: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 82u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_DeviceDescription2 ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_DeviceHasProblem: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_DeviceHasProblem ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_DeviceInstanceId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 256u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_DeviceInstanceId ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_DeviceManufacturer: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_DeviceManufacturer ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_DialProtocol_InstalledApplications: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6845cc72_1b71_48c3_af86_b09171a19b14), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_DialProtocol_InstalledApplications ) , guid : :: windows :: core :: GUID::from_u128(0x6845cc72_1b71_48c3_af86_b09171a19b14) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_DiscoveryMethod: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 52u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_DiscoveryMethod ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Dnssd_Domain: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xbf79c0ab_bb74_4cee_b070_470b5ae202ea), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Dnssd_Domain ) , guid : :: windows :: core :: GUID::from_u128(0xbf79c0ab_bb74_4cee_b070_470b5ae202ea) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Dnssd_FullName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xbf79c0ab_bb74_4cee_b070_470b5ae202ea), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Dnssd_FullName ) , guid : :: windows :: core :: GUID::from_u128(0xbf79c0ab_bb74_4cee_b070_470b5ae202ea) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Dnssd_HostName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xbf79c0ab_bb74_4cee_b070_470b5ae202ea), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Dnssd_HostName ) , guid : :: windows :: core :: GUID::from_u128(0xbf79c0ab_bb74_4cee_b070_470b5ae202ea) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Dnssd_InstanceName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xbf79c0ab_bb74_4cee_b070_470b5ae202ea), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Dnssd_InstanceName ) , guid : :: windows :: core :: GUID::from_u128(0xbf79c0ab_bb74_4cee_b070_470b5ae202ea) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Dnssd_NetworkAdapterId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xbf79c0ab_bb74_4cee_b070_470b5ae202ea), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Dnssd_NetworkAdapterId ) , guid : :: windows :: core :: GUID::from_u128(0xbf79c0ab_bb74_4cee_b070_470b5ae202ea) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Dnssd_PortNumber: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xbf79c0ab_bb74_4cee_b070_470b5ae202ea), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Dnssd_PortNumber ) , guid : :: windows :: core :: GUID::from_u128(0xbf79c0ab_bb74_4cee_b070_470b5ae202ea) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Dnssd_Priority: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xbf79c0ab_bb74_4cee_b070_470b5ae202ea), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Dnssd_Priority ) , guid : :: windows :: core :: GUID::from_u128(0xbf79c0ab_bb74_4cee_b070_470b5ae202ea) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Dnssd_ServiceName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xbf79c0ab_bb74_4cee_b070_470b5ae202ea), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Dnssd_ServiceName ) , guid : :: windows :: core :: GUID::from_u128(0xbf79c0ab_bb74_4cee_b070_470b5ae202ea) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Dnssd_TextAttributes: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xbf79c0ab_bb74_4cee_b070_470b5ae202ea), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Dnssd_TextAttributes ) , guid : :: windows :: core :: GUID::from_u128(0xbf79c0ab_bb74_4cee_b070_470b5ae202ea) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Dnssd_Ttl: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xbf79c0ab_bb74_4cee_b070_470b5ae202ea), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Dnssd_Ttl ) , guid : :: windows :: core :: GUID::from_u128(0xbf79c0ab_bb74_4cee_b070_470b5ae202ea) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Dnssd_Weight: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xbf79c0ab_bb74_4cee_b070_470b5ae202ea), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Dnssd_Weight ) , guid : :: windows :: core :: GUID::from_u128(0xbf79c0ab_bb74_4cee_b070_470b5ae202ea) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_FriendlyName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 12288u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_FriendlyName ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_FunctionPaths: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd08dd4c0_3a9e_462e_8290_7b636b2576b9), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_FunctionPaths ) , guid : :: windows :: core :: GUID::from_u128(0xd08dd4c0_3a9e_462e_8290_7b636b2576b9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_GlyphIcon: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x51236583_0c4a_4fe8_b81f_166aec13f510), pid: 123u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_GlyphIcon ) , guid : :: windows :: core :: GUID::from_u128(0x51236583_0c4a_4fe8_b81f_166aec13f510) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_HardwareIds: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_HardwareIds ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Icon: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 57u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Icon ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_InLocalMachineContainer: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8c7ed206_3f8a_4827_b3ab_ae9e1faefc6c), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_InLocalMachineContainer ) , guid : :: windows :: core :: GUID::from_u128(0x8c7ed206_3f8a_4827_b3ab_ae9e1faefc6c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_InterfaceClassGuid: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x026e516e_b814_414b_83cd_856d6fef4822), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_InterfaceClassGuid ) , guid : :: windows :: core :: GUID::from_u128(0x026e516e_b814_414b_83cd_856d6fef4822) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_InterfaceEnabled: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x026e516e_b814_414b_83cd_856d6fef4822), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_InterfaceEnabled ) , guid : :: windows :: core :: GUID::from_u128(0x026e516e_b814_414b_83cd_856d6fef4822) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_InterfacePaths: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd08dd4c0_3a9e_462e_8290_7b636b2576b9), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_InterfacePaths ) , guid : :: windows :: core :: GUID::from_u128(0xd08dd4c0_3a9e_462e_8290_7b636b2576b9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_IpAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 12297u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_IpAddress ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_IsDefault: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 86u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_IsDefault ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_IsNetworkConnected: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 85u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_IsNetworkConnected ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_IsShared: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 84u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_IsShared ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_IsSoftwareInstalling: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x83da6326_97a6_4088_9453_a1923f573b29), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_IsSoftwareInstalling ) , guid : :: windows :: core :: GUID::from_u128(0x83da6326_97a6_4088_9453_a1923f573b29) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_LaunchDeviceStageFromExplorer: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 77u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_LaunchDeviceStageFromExplorer ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_LocalMachine: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 70u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_LocalMachine ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_LocationPaths: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0), pid: 37u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_LocationPaths ) , guid : :: windows :: core :: GUID::from_u128(0xa45c254e_df1c_4efd_8020_67d146a850e0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Manufacturer: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 8192u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Manufacturer ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_MetadataPath: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 71u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_MetadataPath ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_MicrophoneArray_Geometry: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa1829ea2_27eb_459e_935d_b2fad7b07762), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_MicrophoneArray_Geometry ) , guid : :: windows :: core :: GUID::from_u128(0xa1829ea2_27eb_459e_935d_b2fad7b07762) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_MissedCalls: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_MissedCalls ) , guid : :: windows :: core :: GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_ModelId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x80d81ea6_7473_4b0c_8216_efc11a2c4c8b), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_ModelId ) , guid : :: windows :: core :: GUID::from_u128(0x80d81ea6_7473_4b0c_8216_efc11a2c4c8b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_ModelName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 8194u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_ModelName ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_ModelNumber: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 8195u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_ModelNumber ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_NetworkName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_NetworkName ) , guid : :: windows :: core :: GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_NetworkType: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_NetworkType ) , guid : :: windows :: core :: GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_NetworkedTooltip: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x880f70a2_6082_47ac_8aab_a739d1a300c3), pid: 152u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_NetworkedTooltip ) , guid : :: windows :: core :: GUID::from_u128(0x880f70a2_6082_47ac_8aab_a739d1a300c3) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_NewPictures: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_NewPictures ) , guid : :: windows :: core :: GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_NotWorkingProperly: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 83u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_NotWorkingProperly ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Notification: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x06704b0c_e830_4c81_9178_91e4e95a80a0), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Notification ) , guid : :: windows :: core :: GUID::from_u128(0x06704b0c_e830_4c81_9178_91e4e95a80a0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_NotificationStore: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x06704b0c_e830_4c81_9178_91e4e95a80a0), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_NotificationStore ) , guid : :: windows :: core :: GUID::from_u128(0x06704b0c_e830_4c81_9178_91e4e95a80a0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Notifications_LowBattery: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc4c07f2b_8524_4e66_ae3a_a6235f103beb), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Notifications_LowBattery ) , guid : :: windows :: core :: GUID::from_u128(0xc4c07f2b_8524_4e66_ae3a_a6235f103beb) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Notifications_MissedCall: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6614ef48_4efe_4424_9eda_c79f404edf3e), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Notifications_MissedCall ) , guid : :: windows :: core :: GUID::from_u128(0x6614ef48_4efe_4424_9eda_c79f404edf3e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Notifications_NewMessage: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2be9260a_2012_4742_a555_f41b638b7dcb), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Notifications_NewMessage ) , guid : :: windows :: core :: GUID::from_u128(0x2be9260a_2012_4742_a555_f41b638b7dcb) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Notifications_NewVoicemail: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x59569556_0a08_4212_95b9_fae2ad6413db), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Notifications_NewVoicemail ) , guid : :: windows :: core :: GUID::from_u128(0x59569556_0a08_4212_95b9_fae2ad6413db) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Notifications_StorageFull: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa0e00ee1_f0c7_4d41_b8e7_26a7bd8d38b0), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Notifications_StorageFull ) , guid : :: windows :: core :: GUID::from_u128(0xa0e00ee1_f0c7_4d41_b8e7_26a7bd8d38b0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Notifications_StorageFullLinkText: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa0e00ee1_f0c7_4d41_b8e7_26a7bd8d38b0), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Notifications_StorageFullLinkText ) , guid : :: windows :: core :: GUID::from_u128(0xa0e00ee1_f0c7_4d41_b8e7_26a7bd8d38b0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Paired: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57), pid: 56u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Paired ) , guid : :: windows :: core :: GUID::from_u128(0x78c34fc8_104a_4aca_9ea4_524d52996e57) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Panel_PanelGroup: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8dbc9c86_97a9_4bff_9bc6_bfe95d3e6dad), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Panel_PanelGroup ) , guid : :: windows :: core :: GUID::from_u128(0x8dbc9c86_97a9_4bff_9bc6_bfe95d3e6dad) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Panel_PanelId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8dbc9c86_97a9_4bff_9bc6_bfe95d3e6dad), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Panel_PanelId ) , guid : :: windows :: core :: GUID::from_u128(0x8dbc9c86_97a9_4bff_9bc6_bfe95d3e6dad) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Parent: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Parent ) , guid : :: windows :: core :: GUID::from_u128(0x4340a6c5_93fa_4706_972c_7b648008a5a7) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_PhoneLineTransportDevice_Connected: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xaecf2fe8_1d00_4fee_8a6d_a70d719b772b), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_PhoneLineTransportDevice_Connected ) , guid : :: windows :: core :: GUID::from_u128(0xaecf2fe8_1d00_4fee_8a6d_a70d719b772b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_PhysicalDeviceLocation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_PhysicalDeviceLocation ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_PlaybackPositionPercent: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x3633de59_6825_4381_a49b_9f6ba13a1471), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_PlaybackPositionPercent ) , guid : :: windows :: core :: GUID::from_u128(0x3633de59_6825_4381_a49b_9f6ba13a1471) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_PlaybackState: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x3633de59_6825_4381_a49b_9f6ba13a1471), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_PlaybackState ) , guid : :: windows :: core :: GUID::from_u128(0x3633de59_6825_4381_a49b_9f6ba13a1471) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_PlaybackTitle: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x3633de59_6825_4381_a49b_9f6ba13a1471), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_PlaybackTitle ) , guid : :: windows :: core :: GUID::from_u128(0x3633de59_6825_4381_a49b_9f6ba13a1471) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Present: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Present ) , guid : :: windows :: core :: GUID::from_u128(0x540b947e_8b40_45bc_a8a2_6a0b894cbda2) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_PresentationUrl: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 8198u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_PresentationUrl ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_PrimaryCategory: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd08dd4c0_3a9e_462e_8290_7b636b2576b9), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_PrimaryCategory ) , guid : :: windows :: core :: GUID::from_u128(0xd08dd4c0_3a9e_462e_8290_7b636b2576b9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_RemainingDuration: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x3633de59_6825_4381_a49b_9f6ba13a1471), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_RemainingDuration ) , guid : :: windows :: core :: GUID::from_u128(0x3633de59_6825_4381_a49b_9f6ba13a1471) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_RestrictedInterface: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x026e516e_b814_414b_83cd_856d6fef4822), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_RestrictedInterface ) , guid : :: windows :: core :: GUID::from_u128(0x026e516e_b814_414b_83cd_856d6fef4822) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Roaming: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Roaming ) , guid : :: windows :: core :: GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_SafeRemovalRequired: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xafd97640_86a3_4210_b67c_289c41aabe55), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_SafeRemovalRequired ) , guid : :: windows :: core :: GUID::from_u128(0xafd97640_86a3_4210_b67c_289c41aabe55) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_SchematicName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x026e516e_b814_414b_83cd_856d6fef4822), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_SchematicName ) , guid : :: windows :: core :: GUID::from_u128(0x026e516e_b814_414b_83cd_856d6fef4822) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_ServiceAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 16384u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_ServiceAddress ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_ServiceId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd), pid: 16385u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_ServiceId ) , guid : :: windows :: core :: GUID::from_u128(0x656a3bb3_ecc0_43fd_8477_4ae0404a96cd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_SharedTooltip: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x880f70a2_6082_47ac_8aab_a739d1a300c3), pid: 151u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_SharedTooltip ) , guid : :: windows :: core :: GUID::from_u128(0x880f70a2_6082_47ac_8aab_a739d1a300c3) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_SignalStrength: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_SignalStrength ) , guid : :: windows :: core :: GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_SmartCards_ReaderKind: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd6b5b883_18bd_4b4d_b2ec_9e38affeda82), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_SmartCards_ReaderKind ) , guid : :: windows :: core :: GUID::from_u128(0xd6b5b883_18bd_4b4d_b2ec_9e38affeda82) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Status: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd08dd4c0_3a9e_462e_8290_7b636b2576b9), pid: 259u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Status ) , guid : :: windows :: core :: GUID::from_u128(0xd08dd4c0_3a9e_462e_8290_7b636b2576b9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Status1: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd08dd4c0_3a9e_462e_8290_7b636b2576b9), pid: 257u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Status1 ) , guid : :: windows :: core :: GUID::from_u128(0xd08dd4c0_3a9e_462e_8290_7b636b2576b9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Status2: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd08dd4c0_3a9e_462e_8290_7b636b2576b9), pid: 258u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Status2 ) , guid : :: windows :: core :: GUID::from_u128(0xd08dd4c0_3a9e_462e_8290_7b636b2576b9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_StorageCapacity: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_StorageCapacity ) , guid : :: windows :: core :: GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_StorageFreeSpace: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_StorageFreeSpace ) , guid : :: windows :: core :: GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_StorageFreeSpacePercent: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_StorageFreeSpacePercent ) , guid : :: windows :: core :: GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_TextMessages: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_TextMessages ) , guid : :: windows :: core :: GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Voicemail: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Voicemail ) , guid : :: windows :: core :: GUID::from_u128(0x49cd1f76_5626_4b17_a4e8_18b4aa1a2213) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_WiFiDirectServices_AdvertisementId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x31b37743_7c5e_4005_93e6_e953f92b82e9), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_WiFiDirectServices_AdvertisementId ) , guid : :: windows :: core :: GUID::from_u128(0x31b37743_7c5e_4005_93e6_e953f92b82e9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_WiFiDirectServices_RequestServiceInformation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x31b37743_7c5e_4005_93e6_e953f92b82e9), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_WiFiDirectServices_RequestServiceInformation ) , guid : :: windows :: core :: GUID::from_u128(0x31b37743_7c5e_4005_93e6_e953f92b82e9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_WiFiDirectServices_ServiceAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x31b37743_7c5e_4005_93e6_e953f92b82e9), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_WiFiDirectServices_ServiceAddress ) , guid : :: windows :: core :: GUID::from_u128(0x31b37743_7c5e_4005_93e6_e953f92b82e9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_WiFiDirectServices_ServiceConfigMethods: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x31b37743_7c5e_4005_93e6_e953f92b82e9), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_WiFiDirectServices_ServiceConfigMethods ) , guid : :: windows :: core :: GUID::from_u128(0x31b37743_7c5e_4005_93e6_e953f92b82e9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_WiFiDirectServices_ServiceInformation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x31b37743_7c5e_4005_93e6_e953f92b82e9), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_WiFiDirectServices_ServiceInformation ) , guid : :: windows :: core :: GUID::from_u128(0x31b37743_7c5e_4005_93e6_e953f92b82e9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_WiFiDirectServices_ServiceName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x31b37743_7c5e_4005_93e6_e953f92b82e9), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_WiFiDirectServices_ServiceName ) , guid : :: windows :: core :: GUID::from_u128(0x31b37743_7c5e_4005_93e6_e953f92b82e9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_WiFiDirect_DeviceAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_WiFiDirect_DeviceAddress ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_WiFiDirect_GroupId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_WiFiDirect_GroupId ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_WiFiDirect_InformationElements: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_WiFiDirect_InformationElements ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_WiFiDirect_InterfaceAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_WiFiDirect_InterfaceAddress ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_WiFiDirect_InterfaceGuid: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_WiFiDirect_InterfaceGuid ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_WiFiDirect_IsConnected: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_WiFiDirect_IsConnected ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_WiFiDirect_IsLegacyDevice: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_WiFiDirect_IsLegacyDevice ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_WiFiDirect_IsMiracastLcpSupported: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_WiFiDirect_IsMiracastLcpSupported ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_WiFiDirect_IsVisible: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_WiFiDirect_IsVisible ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_WiFiDirect_MiracastVersion: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_WiFiDirect_MiracastVersion ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_WiFiDirect_Services: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_WiFiDirect_Services ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_WiFiDirect_SupportedChannelList: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_WiFiDirect_SupportedChannelList ) , guid : :: windows :: core :: GUID::from_u128(0x1506935d_e3e7_450f_8637_82233ebe5f6e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_WiFi_InterfaceGuid: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef1167eb_cbfc_4341_a568_a7c91a68982c), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_WiFi_InterfaceGuid ) , guid : :: windows :: core :: GUID::from_u128(0xef1167eb_cbfc_4341_a568_a7c91a68982c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_WiaDeviceType: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6bdd1fc6_810f_11d0_bec7_08002be2092f), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_WiaDeviceType ) , guid : :: windows :: core :: GUID::from_u128(0x6bdd1fc6_810f_11d0_bec7_08002be2092f) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_WinPhone8CameraFlags: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb7b4d61c_5a64_4187_a52e_b1539f359099), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_WinPhone8CameraFlags ) , guid : :: windows :: core :: GUID::from_u128(0xb7b4d61c_5a64_4187_a52e_b1539f359099) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Devices_Wwan_InterfaceGuid: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xff1167eb_cbfc_4341_a568_a7c91a68982c), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Devices_Wwan_InterfaceGuid ) , guid : :: windows :: core :: GUID::from_u128(0xff1167eb_cbfc_4341_a568_a7c91a68982c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Document_ByteCount: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Document_ByteCount ) , guid : :: windows :: core :: GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Document_CharacterCount: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9), pid: 16u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Document_CharacterCount ) , guid : :: windows :: core :: GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Document_ClientID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x276d7bb0_5b34_4fb0_aa4b_158ed12a1809), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Document_ClientID ) , guid : :: windows :: core :: GUID::from_u128(0x276d7bb0_5b34_4fb0_aa4b_158ed12a1809) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Document_Contributor: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf334115e_da1b_4509_9b3d_119504dc7abb), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Document_Contributor ) , guid : :: windows :: core :: GUID::from_u128(0xf334115e_da1b_4509_9b3d_119504dc7abb) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Document_DateCreated: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Document_DateCreated ) , guid : :: windows :: core :: GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Document_DatePrinted: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Document_DatePrinted ) , guid : :: windows :: core :: GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Document_DateSaved: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Document_DateSaved ) , guid : :: windows :: core :: GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Document_Division: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1e005ee6_bf27_428b_b01c_79676acd2870), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Document_Division ) , guid : :: windows :: core :: GUID::from_u128(0x1e005ee6_bf27_428b_b01c_79676acd2870) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Document_DocumentID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe08805c8_e395_40df_80d2_54f0d6c43154), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Document_DocumentID ) , guid : :: windows :: core :: GUID::from_u128(0xe08805c8_e395_40df_80d2_54f0d6c43154) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Document_HiddenSlideCount: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Document_HiddenSlideCount ) , guid : :: windows :: core :: GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Document_LastAuthor: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Document_LastAuthor ) , guid : :: windows :: core :: GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Document_LineCount: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Document_LineCount ) , guid : :: windows :: core :: GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Document_Manager: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Document_Manager ) , guid : :: windows :: core :: GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Document_MultimediaClipCount: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Document_MultimediaClipCount ) , guid : :: windows :: core :: GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Document_NoteCount: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Document_NoteCount ) , guid : :: windows :: core :: GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Document_PageCount: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Document_PageCount ) , guid : :: windows :: core :: GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Document_ParagraphCount: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Document_ParagraphCount ) , guid : :: windows :: core :: GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Document_PresentationFormat: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Document_PresentationFormat ) , guid : :: windows :: core :: GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Document_RevisionNumber: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Document_RevisionNumber ) , guid : :: windows :: core :: GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Document_Security: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9), pid: 19u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Document_Security ) , guid : :: windows :: core :: GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Document_SlideCount: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Document_SlideCount ) , guid : :: windows :: core :: GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Document_Template: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Document_Template ) , guid : :: windows :: core :: GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Document_TotalEditingTime: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Document_TotalEditingTime ) , guid : :: windows :: core :: GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Document_Version: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae), pid: 29u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Document_Version ) , guid : :: windows :: core :: GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Document_WordCount: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9), pid: 15u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Document_WordCount ) , guid : :: windows :: core :: GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_DueDate: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x3f8472b5_e0af_4db2_8071_c53fe76ae7ce), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_DueDate ) , guid : :: windows :: core :: GUID::from_u128(0x3f8472b5_e0af_4db2_8071_c53fe76ae7ce) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_EdgeGesture_DisableTouchWhenFullscreen: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x32ce38b2_2c9a_41b1_9bc5_b3784394aa44), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_EdgeGesture_DisableTouchWhenFullscreen ) , guid : :: windows :: core :: GUID::from_u128(0x32ce38b2_2c9a_41b1_9bc5_b3784394aa44) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_EndDate: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc75faa05_96fd_49e7_9cb4_9f601082d553), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_EndDate ) , guid : :: windows :: core :: GUID::from_u128(0xc75faa05_96fd_49e7_9cb4_9f601082d553) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ExpandoProperties: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6fa20de6_d11c_4d9d_a154_64317628c12d), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ExpandoProperties ) , guid : :: windows :: core :: GUID::from_u128(0x6fa20de6_d11c_4d9d_a154_64317628c12d) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FileAllocationSize: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac), pid: 18u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FileAllocationSize ) , guid : :: windows :: core :: GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FileAttributes: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FileAttributes ) , guid : :: windows :: core :: GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FileCount: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FileCount ) , guid : :: windows :: core :: GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FileDescription: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cef7d53_fa64_11d1_a203_0000f81fedee), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FileDescription ) , guid : :: windows :: core :: GUID::from_u128(0x0cef7d53_fa64_11d1_a203_0000f81fedee) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FileExtension: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe4f10a3c_49e6_405d_8288_a23bd4eeaa6c), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FileExtension ) , guid : :: windows :: core :: GUID::from_u128(0xe4f10a3c_49e6_405d_8288_a23bd4eeaa6c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FileFRN: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac), pid: 21u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FileFRN ) , guid : :: windows :: core :: GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FileName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x41cf5ae0_f75a_4806_bd87_59c7d9248eb9), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FileName ) , guid : :: windows :: core :: GUID::from_u128(0x41cf5ae0_f75a_4806_bd87_59c7d9248eb9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FileOfflineAvailabilityStatus: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FileOfflineAvailabilityStatus ) , guid : :: windows :: core :: GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FileOwner: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9b174b34_40ff_11d2_a27e_00c04fc30871), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FileOwner ) , guid : :: windows :: core :: GUID::from_u128(0x9b174b34_40ff_11d2_a27e_00c04fc30871) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FilePlaceholderStatus: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb2f9b9d6_fec4_4dd5_94d7_8957488c807b), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FilePlaceholderStatus ) , guid : :: windows :: core :: GUID::from_u128(0xb2f9b9d6_fec4_4dd5_94d7_8957488c807b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FileVersion: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cef7d53_fa64_11d1_a203_0000f81fedee), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FileVersion ) , guid : :: windows :: core :: GUID::from_u128(0x0cef7d53_fa64_11d1_a203_0000f81fedee) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FindData: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0), pid: 0u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FindData ) , guid : :: windows :: core :: GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FlagColor: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x67df94de_0ca7_4d6f_b792_053a3e4f03cf), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FlagColor ) , guid : :: windows :: core :: GUID::from_u128(0x67df94de_0ca7_4d6f_b792_053a3e4f03cf) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FlagColorText: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x45eae747_8e2a_40ae_8cbf_ca52aba6152a), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FlagColorText ) , guid : :: windows :: core :: GUID::from_u128(0x45eae747_8e2a_40ae_8cbf_ca52aba6152a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FlagStatus: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FlagStatus ) , guid : :: windows :: core :: GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FlagStatusText: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xdc54fd2e_189d_4871_aa01_08c2f57a4abc), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FlagStatusText ) , guid : :: windows :: core :: GUID::from_u128(0xdc54fd2e_189d_4871_aa01_08c2f57a4abc) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FolderKind: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8), pid: 101u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FolderKind ) , guid : :: windows :: core :: GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FolderNameDisplay: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac), pid: 25u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FolderNameDisplay ) , guid : :: windows :: core :: GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FreeSpace: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9b174b35_40ff_11d2_a27e_00c04fc30871), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FreeSpace ) , guid : :: windows :: core :: GUID::from_u128(0x9b174b35_40ff_11d2_a27e_00c04fc30871) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_FullText: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1e3ee840_bc2b_476c_8237_2acd1a839b22), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_FullText ) , guid : :: windows :: core :: GUID::from_u128(0x1e3ee840_bc2b_476c_8237_2acd1a839b22) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_Altitude: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x827edb4f_5b73_44a7_891d_fdffabea35ca), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_Altitude ) , guid : :: windows :: core :: GUID::from_u128(0x827edb4f_5b73_44a7_891d_fdffabea35ca) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_AltitudeDenominator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x78342dcb_e358_4145_ae9a_6bfe4e0f9f51), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_AltitudeDenominator ) , guid : :: windows :: core :: GUID::from_u128(0x78342dcb_e358_4145_ae9a_6bfe4e0f9f51) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_AltitudeNumerator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2dad1eb7_816d_40d3_9ec3_c9773be2aade), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_AltitudeNumerator ) , guid : :: windows :: core :: GUID::from_u128(0x2dad1eb7_816d_40d3_9ec3_c9773be2aade) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_AltitudeRef: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x46ac629d_75ea_4515_867f_6dc4321c5844), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_AltitudeRef ) , guid : :: windows :: core :: GUID::from_u128(0x46ac629d_75ea_4515_867f_6dc4321c5844) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_AreaInformation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x972e333e_ac7e_49f1_8adf_a70d07a9bcab), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_AreaInformation ) , guid : :: windows :: core :: GUID::from_u128(0x972e333e_ac7e_49f1_8adf_a70d07a9bcab) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_DOP: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cf8fb02_1837_42f1_a697_a7017aa289b9), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_DOP ) , guid : :: windows :: core :: GUID::from_u128(0x0cf8fb02_1837_42f1_a697_a7017aa289b9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_DOPDenominator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa0be94c5_50ba_487b_bd35_0654be8881ed), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_DOPDenominator ) , guid : :: windows :: core :: GUID::from_u128(0xa0be94c5_50ba_487b_bd35_0654be8881ed) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_DOPNumerator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x47166b16_364f_4aa0_9f31_e2ab3df449c3), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_DOPNumerator ) , guid : :: windows :: core :: GUID::from_u128(0x47166b16_364f_4aa0_9f31_e2ab3df449c3) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_Date: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x3602c812_0f3b_45f0_85ad_603468d69423), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_Date ) , guid : :: windows :: core :: GUID::from_u128(0x3602c812_0f3b_45f0_85ad_603468d69423) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_DestBearing: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc66d4b3c_e888_47cc_b99f_9dca3ee34dea), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_DestBearing ) , guid : :: windows :: core :: GUID::from_u128(0xc66d4b3c_e888_47cc_b99f_9dca3ee34dea) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_DestBearingDenominator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7abcf4f8_7c3f_4988_ac91_8d2c2e97eca5), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_DestBearingDenominator ) , guid : :: windows :: core :: GUID::from_u128(0x7abcf4f8_7c3f_4988_ac91_8d2c2e97eca5) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_DestBearingNumerator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xba3b1da9_86ee_4b5d_a2a4_a271a429f0cf), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_DestBearingNumerator ) , guid : :: windows :: core :: GUID::from_u128(0xba3b1da9_86ee_4b5d_a2a4_a271a429f0cf) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_DestBearingRef: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9ab84393_2a0f_4b75_bb22_7279786977cb), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_DestBearingRef ) , guid : :: windows :: core :: GUID::from_u128(0x9ab84393_2a0f_4b75_bb22_7279786977cb) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_DestDistance: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa93eae04_6804_4f24_ac81_09b266452118), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_DestDistance ) , guid : :: windows :: core :: GUID::from_u128(0xa93eae04_6804_4f24_ac81_09b266452118) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_DestDistanceDenominator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9bc2c99b_ac71_4127_9d1c_2596d0d7dcb7), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_DestDistanceDenominator ) , guid : :: windows :: core :: GUID::from_u128(0x9bc2c99b_ac71_4127_9d1c_2596d0d7dcb7) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_DestDistanceNumerator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2bda47da_08c6_4fe1_80bc_a72fc517c5d0), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_DestDistanceNumerator ) , guid : :: windows :: core :: GUID::from_u128(0x2bda47da_08c6_4fe1_80bc_a72fc517c5d0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_DestDistanceRef: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xed4df2d3_8695_450b_856f_f5c1c53acb66), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_DestDistanceRef ) , guid : :: windows :: core :: GUID::from_u128(0xed4df2d3_8695_450b_856f_f5c1c53acb66) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_DestLatitude: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9d1d7cc5_5c39_451c_86b3_928e2d18cc47), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_DestLatitude ) , guid : :: windows :: core :: GUID::from_u128(0x9d1d7cc5_5c39_451c_86b3_928e2d18cc47) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_DestLatitudeDenominator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x3a372292_7fca_49a7_99d5_e47bb2d4e7ab), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_DestLatitudeDenominator ) , guid : :: windows :: core :: GUID::from_u128(0x3a372292_7fca_49a7_99d5_e47bb2d4e7ab) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_DestLatitudeNumerator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xecf4b6f6_d5a6_433c_bb92_4076650fc890), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_DestLatitudeNumerator ) , guid : :: windows :: core :: GUID::from_u128(0xecf4b6f6_d5a6_433c_bb92_4076650fc890) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_DestLatitudeRef: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcea820b9_ce61_4885_a128_005d9087c192), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_DestLatitudeRef ) , guid : :: windows :: core :: GUID::from_u128(0xcea820b9_ce61_4885_a128_005d9087c192) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_DestLongitude: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x47a96261_cb4c_4807_8ad3_40b9d9dbc6bc), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_DestLongitude ) , guid : :: windows :: core :: GUID::from_u128(0x47a96261_cb4c_4807_8ad3_40b9d9dbc6bc) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_DestLongitudeDenominator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x425d69e5_48ad_4900_8d80_6eb6b8d0ac86), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_DestLongitudeDenominator ) , guid : :: windows :: core :: GUID::from_u128(0x425d69e5_48ad_4900_8d80_6eb6b8d0ac86) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_DestLongitudeNumerator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa3250282_fb6d_48d5_9a89_dbcace75cccf), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_DestLongitudeNumerator ) , guid : :: windows :: core :: GUID::from_u128(0xa3250282_fb6d_48d5_9a89_dbcace75cccf) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_DestLongitudeRef: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x182c1ea6_7c1c_4083_ab4b_ac6c9f4ed128), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_DestLongitudeRef ) , guid : :: windows :: core :: GUID::from_u128(0x182c1ea6_7c1c_4083_ab4b_ac6c9f4ed128) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_Differential: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xaaf4ee25_bd3b_4dd7_bfc4_47f77bb00f6d), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_Differential ) , guid : :: windows :: core :: GUID::from_u128(0xaaf4ee25_bd3b_4dd7_bfc4_47f77bb00f6d) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_ImgDirection: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x16473c91_d017_4ed9_ba4d_b6baa55dbcf8), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_ImgDirection ) , guid : :: windows :: core :: GUID::from_u128(0x16473c91_d017_4ed9_ba4d_b6baa55dbcf8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_ImgDirectionDenominator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x10b24595_41a2_4e20_93c2_5761c1395f32), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_ImgDirectionDenominator ) , guid : :: windows :: core :: GUID::from_u128(0x10b24595_41a2_4e20_93c2_5761c1395f32) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_ImgDirectionNumerator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xdc5877c7_225f_45f7_bac7_e81334b6130a), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_ImgDirectionNumerator ) , guid : :: windows :: core :: GUID::from_u128(0xdc5877c7_225f_45f7_bac7_e81334b6130a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_ImgDirectionRef: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa4aaa5b7_1ad0_445f_811a_0f8f6e67f6b5), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_ImgDirectionRef ) , guid : :: windows :: core :: GUID::from_u128(0xa4aaa5b7_1ad0_445f_811a_0f8f6e67f6b5) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_Latitude: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8727cfff_4868_4ec6_ad5b_81b98521d1ab), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_Latitude ) , guid : :: windows :: core :: GUID::from_u128(0x8727cfff_4868_4ec6_ad5b_81b98521d1ab) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_LatitudeDecimal: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0f55cde2_4f49_450d_92c1_dcd16301b1b7), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_LatitudeDecimal ) , guid : :: windows :: core :: GUID::from_u128(0x0f55cde2_4f49_450d_92c1_dcd16301b1b7) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_LatitudeDenominator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x16e634ee_2bff_497b_bd8a_4341ad39eeb9), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_LatitudeDenominator ) , guid : :: windows :: core :: GUID::from_u128(0x16e634ee_2bff_497b_bd8a_4341ad39eeb9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_LatitudeNumerator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7ddaaad1_ccc8_41ae_b750_b2cb8031aea2), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_LatitudeNumerator ) , guid : :: windows :: core :: GUID::from_u128(0x7ddaaad1_ccc8_41ae_b750_b2cb8031aea2) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_LatitudeRef: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x029c0252_5b86_46c7_aca0_2769ffc8e3d4), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_LatitudeRef ) , guid : :: windows :: core :: GUID::from_u128(0x029c0252_5b86_46c7_aca0_2769ffc8e3d4) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_Longitude: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc4c4dbb2_b593_466b_bbda_d03d27d5e43a), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_Longitude ) , guid : :: windows :: core :: GUID::from_u128(0xc4c4dbb2_b593_466b_bbda_d03d27d5e43a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_LongitudeDecimal: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4679c1b5_844d_4590_baf5_f322231f1b81), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_LongitudeDecimal ) , guid : :: windows :: core :: GUID::from_u128(0x4679c1b5_844d_4590_baf5_f322231f1b81) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_LongitudeDenominator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xbe6e176c_4534_4d2c_ace5_31dedac1606b), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_LongitudeDenominator ) , guid : :: windows :: core :: GUID::from_u128(0xbe6e176c_4534_4d2c_ace5_31dedac1606b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_LongitudeNumerator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x02b0f689_a914_4e45_821d_1dda452ed2c4), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_LongitudeNumerator ) , guid : :: windows :: core :: GUID::from_u128(0x02b0f689_a914_4e45_821d_1dda452ed2c4) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_LongitudeRef: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x33dcf22b_28d5_464c_8035_1ee9efd25278), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_LongitudeRef ) , guid : :: windows :: core :: GUID::from_u128(0x33dcf22b_28d5_464c_8035_1ee9efd25278) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_MapDatum: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2ca2dae6_eddc_407d_bef1_773942abfa95), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_MapDatum ) , guid : :: windows :: core :: GUID::from_u128(0x2ca2dae6_eddc_407d_bef1_773942abfa95) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_MeasureMode: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa015ed5d_aaea_4d58_8a86_3c586920ea0b), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_MeasureMode ) , guid : :: windows :: core :: GUID::from_u128(0xa015ed5d_aaea_4d58_8a86_3c586920ea0b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_ProcessingMethod: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x59d49e61_840f_4aa9_a939_e2099b7f6399), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_ProcessingMethod ) , guid : :: windows :: core :: GUID::from_u128(0x59d49e61_840f_4aa9_a939_e2099b7f6399) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_Satellites: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x467ee575_1f25_4557_ad4e_b8b58b0d9c15), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_Satellites ) , guid : :: windows :: core :: GUID::from_u128(0x467ee575_1f25_4557_ad4e_b8b58b0d9c15) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_Speed: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xda5d0862_6e76_4e1b_babd_70021bd25494), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_Speed ) , guid : :: windows :: core :: GUID::from_u128(0xda5d0862_6e76_4e1b_babd_70021bd25494) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_SpeedDenominator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7d122d5a_ae5e_4335_8841_d71e7ce72f53), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_SpeedDenominator ) , guid : :: windows :: core :: GUID::from_u128(0x7d122d5a_ae5e_4335_8841_d71e7ce72f53) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_SpeedNumerator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xacc9ce3d_c213_4942_8b48_6d0820f21c6d), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_SpeedNumerator ) , guid : :: windows :: core :: GUID::from_u128(0xacc9ce3d_c213_4942_8b48_6d0820f21c6d) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_SpeedRef: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xecf7f4c9_544f_4d6d_9d98_8ad79adaf453), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_SpeedRef ) , guid : :: windows :: core :: GUID::from_u128(0xecf7f4c9_544f_4d6d_9d98_8ad79adaf453) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_Status: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x125491f4_818f_46b2_91b5_d537753617b2), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_Status ) , guid : :: windows :: core :: GUID::from_u128(0x125491f4_818f_46b2_91b5_d537753617b2) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_Track: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x76c09943_7c33_49e3_9e7e_cdba872cfada), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_Track ) , guid : :: windows :: core :: GUID::from_u128(0x76c09943_7c33_49e3_9e7e_cdba872cfada) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_TrackDenominator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc8d1920c_01f6_40c0_ac86_2f3a4ad00770), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_TrackDenominator ) , guid : :: windows :: core :: GUID::from_u128(0xc8d1920c_01f6_40c0_ac86_2f3a4ad00770) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_TrackNumerator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x702926f4_44a6_43e1_ae71_45627116893b), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_TrackNumerator ) , guid : :: windows :: core :: GUID::from_u128(0x702926f4_44a6_43e1_ae71_45627116893b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_TrackRef: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x35dbe6fe_44c3_4400_aaae_d2c799c407e8), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_TrackRef ) , guid : :: windows :: core :: GUID::from_u128(0x35dbe6fe_44c3_4400_aaae_d2c799c407e8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_GPS_VersionID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x22704da4_c6b2_4a99_8e56_f16df8c92599), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_GPS_VersionID ) , guid : :: windows :: core :: GUID::from_u128(0x22704da4_c6b2_4a99_8e56_f16df8c92599) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_HighKeywords: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9), pid: 24u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_HighKeywords ) , guid : :: windows :: core :: GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_History_SelectionCount: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1ce0d6bc_536c_4600_b0dd_7e0c66b350d5), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_History_SelectionCount ) , guid : :: windows :: core :: GUID::from_u128(0x1ce0d6bc_536c_4600_b0dd_7e0c66b350d5) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_History_TargetUrlHostName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1ce0d6bc_536c_4600_b0dd_7e0c66b350d5), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_History_TargetUrlHostName ) , guid : :: windows :: core :: GUID::from_u128(0x1ce0d6bc_536c_4600_b0dd_7e0c66b350d5) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_History_VisitCount: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5cbf2787_48cf_4208_b90e_ee5e5d420294), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_History_VisitCount ) , guid : :: windows :: core :: GUID::from_u128(0x5cbf2787_48cf_4208_b90e_ee5e5d420294) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Identity: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa26f4afc_7346_4299_be47_eb1ae613139f), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Identity ) , guid : :: windows :: core :: GUID::from_u128(0xa26f4afc_7346_4299_be47_eb1ae613139f) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_IdentityProvider_Name: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb96eff7b_35ca_4a35_8607_29e3a54c46ea), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_IdentityProvider_Name ) , guid : :: windows :: core :: GUID::from_u128(0xb96eff7b_35ca_4a35_8607_29e3a54c46ea) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_IdentityProvider_Picture: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2425166f_5642_4864_992f_98fd98f294c3), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_IdentityProvider_Picture ) , guid : :: windows :: core :: GUID::from_u128(0x2425166f_5642_4864_992f_98fd98f294c3) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Identity_Blob: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8c3b93a4_baed_1a83_9a32_102ee313f6eb), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Identity_Blob ) , guid : :: windows :: core :: GUID::from_u128(0x8c3b93a4_baed_1a83_9a32_102ee313f6eb) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Identity_DisplayName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7d683fc9_d155_45a8_bb1f_89d19bcb792f), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Identity_DisplayName ) , guid : :: windows :: core :: GUID::from_u128(0x7d683fc9_d155_45a8_bb1f_89d19bcb792f) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Identity_InternetSid: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6d6d5d49_265d_4688_9f4e_1fdd33e7cc83), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Identity_InternetSid ) , guid : :: windows :: core :: GUID::from_u128(0x6d6d5d49_265d_4688_9f4e_1fdd33e7cc83) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Identity_IsMeIdentity: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa4108708_09df_4377_9dfc_6d99986d5a67), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Identity_IsMeIdentity ) , guid : :: windows :: core :: GUID::from_u128(0xa4108708_09df_4377_9dfc_6d99986d5a67) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Identity_KeyProviderContext: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa26f4afc_7346_4299_be47_eb1ae613139f), pid: 17u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Identity_KeyProviderContext ) , guid : :: windows :: core :: GUID::from_u128(0xa26f4afc_7346_4299_be47_eb1ae613139f) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Identity_KeyProviderName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa26f4afc_7346_4299_be47_eb1ae613139f), pid: 16u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Identity_KeyProviderName ) , guid : :: windows :: core :: GUID::from_u128(0xa26f4afc_7346_4299_be47_eb1ae613139f) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Identity_LogonStatusString: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf18dedf3_337f_42c0_9e03_cee08708a8c3), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Identity_LogonStatusString ) , guid : :: windows :: core :: GUID::from_u128(0xf18dedf3_337f_42c0_9e03_cee08708a8c3) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Identity_PrimaryEmailAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfcc16823_baed_4f24_9b32_a0982117f7fa), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Identity_PrimaryEmailAddress ) , guid : :: windows :: core :: GUID::from_u128(0xfcc16823_baed_4f24_9b32_a0982117f7fa) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Identity_PrimarySid: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2b1b801e_c0c1_4987_9ec5_72fa89814787), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Identity_PrimarySid ) , guid : :: windows :: core :: GUID::from_u128(0x2b1b801e_c0c1_4987_9ec5_72fa89814787) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Identity_ProviderData: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa8a74b92_361b_4e9a_b722_7c4a7330a312), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Identity_ProviderData ) , guid : :: windows :: core :: GUID::from_u128(0xa8a74b92_361b_4e9a_b722_7c4a7330a312) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Identity_ProviderID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x74a7de49_fa11_4d3d_a006_db7e08675916), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Identity_ProviderID ) , guid : :: windows :: core :: GUID::from_u128(0x74a7de49_fa11_4d3d_a006_db7e08675916) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Identity_QualifiedUserName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xda520e51_f4e9_4739_ac82_02e0a95c9030), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Identity_QualifiedUserName ) , guid : :: windows :: core :: GUID::from_u128(0xda520e51_f4e9_4739_ac82_02e0a95c9030) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Identity_UniqueID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe55fc3b0_2b60_4220_918e_b21e8bf16016), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Identity_UniqueID ) , guid : :: windows :: core :: GUID::from_u128(0xe55fc3b0_2b60_4220_918e_b21e8bf16016) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Identity_UserName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc4322503_78ca_49c6_9acc_a68e2afd7b6b), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Identity_UserName ) , guid : :: windows :: core :: GUID::from_u128(0xc4322503_78ca_49c6_9acc_a68e2afd7b6b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ImageParsingName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd7750ee0_c6a4_48ec_b53e_b87b52e6d073), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ImageParsingName ) , guid : :: windows :: core :: GUID::from_u128(0xd7750ee0_c6a4_48ec_b53e_b87b52e6d073) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Image_BitDepth: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6444048f_4c8b_11d1_8b70_080036b11a03), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Image_BitDepth ) , guid : :: windows :: core :: GUID::from_u128(0x6444048f_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Image_ColorSpace: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99), pid: 40961u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Image_ColorSpace ) , guid : :: windows :: core :: GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Image_CompressedBitsPerPixel: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x364b6fa9_37ab_482a_be2b_ae02f60d4318), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Image_CompressedBitsPerPixel ) , guid : :: windows :: core :: GUID::from_u128(0x364b6fa9_37ab_482a_be2b_ae02f60d4318) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Image_CompressedBitsPerPixelDenominator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1f8844e1_24ad_4508_9dfd_5326a415ce02), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Image_CompressedBitsPerPixelDenominator ) , guid : :: windows :: core :: GUID::from_u128(0x1f8844e1_24ad_4508_9dfd_5326a415ce02) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Image_CompressedBitsPerPixelNumerator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd21a7148_d32c_4624_8900_277210f79c0f), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Image_CompressedBitsPerPixelNumerator ) , guid : :: windows :: core :: GUID::from_u128(0xd21a7148_d32c_4624_8900_277210f79c0f) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Image_Compression: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99), pid: 259u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Image_Compression ) , guid : :: windows :: core :: GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Image_CompressionText: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x3f08e66f_2f44_4bb9_a682_ac35d2562322), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Image_CompressionText ) , guid : :: windows :: core :: GUID::from_u128(0x3f08e66f_2f44_4bb9_a682_ac35d2562322) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Image_Dimensions: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6444048f_4c8b_11d1_8b70_080036b11a03), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Image_Dimensions ) , guid : :: windows :: core :: GUID::from_u128(0x6444048f_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Image_HorizontalResolution: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6444048f_4c8b_11d1_8b70_080036b11a03), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Image_HorizontalResolution ) , guid : :: windows :: core :: GUID::from_u128(0x6444048f_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Image_HorizontalSize: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6444048f_4c8b_11d1_8b70_080036b11a03), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Image_HorizontalSize ) , guid : :: windows :: core :: GUID::from_u128(0x6444048f_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Image_ImageID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x10dabe05_32aa_4c29_bf1a_63e2d220587f), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Image_ImageID ) , guid : :: windows :: core :: GUID::from_u128(0x10dabe05_32aa_4c29_bf1a_63e2d220587f) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Image_ResolutionUnit: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x19b51fa6_1f92_4a5c_ab48_7df0abd67444), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Image_ResolutionUnit ) , guid : :: windows :: core :: GUID::from_u128(0x19b51fa6_1f92_4a5c_ab48_7df0abd67444) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Image_VerticalResolution: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6444048f_4c8b_11d1_8b70_080036b11a03), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Image_VerticalResolution ) , guid : :: windows :: core :: GUID::from_u128(0x6444048f_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Image_VerticalSize: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6444048f_4c8b_11d1_8b70_080036b11a03), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Image_VerticalSize ) , guid : :: windows :: core :: GUID::from_u128(0x6444048f_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Importance: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Importance ) , guid : :: windows :: core :: GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ImportanceText: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa3b29791_7713_4e1d_bb40_17db85f01831), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ImportanceText ) , guid : :: windows :: core :: GUID::from_u128(0xa3b29791_7713_4e1d_bb40_17db85f01831) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_InfoTipText: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc9944a21_a406_48fe_8225_aec7e24c211b), pid: 17u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_InfoTipText ) , guid : :: windows :: core :: GUID::from_u128(0xc9944a21_a406_48fe_8225_aec7e24c211b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_InternalName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cef7d53_fa64_11d1_a203_0000f81fedee), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_InternalName ) , guid : :: windows :: core :: GUID::from_u128(0x0cef7d53_fa64_11d1_a203_0000f81fedee) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_IsAttachment: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf23f425c_71a1_4fa8_922f_678ea4a60408), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_IsAttachment ) , guid : :: windows :: core :: GUID::from_u128(0xf23f425c_71a1_4fa8_922f_678ea4a60408) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_IsDefaultNonOwnerSaveLocation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5d76b67f_9b3d_44bb_b6ae_25da4f638a67), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_IsDefaultNonOwnerSaveLocation ) , guid : :: windows :: core :: GUID::from_u128(0x5d76b67f_9b3d_44bb_b6ae_25da4f638a67) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_IsDefaultSaveLocation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5d76b67f_9b3d_44bb_b6ae_25da4f638a67), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_IsDefaultSaveLocation ) , guid : :: windows :: core :: GUID::from_u128(0x5d76b67f_9b3d_44bb_b6ae_25da4f638a67) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_IsDeleted: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5cda5fc8_33ee_4ff3_9094_ae7bd8868c4d), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_IsDeleted ) , guid : :: windows :: core :: GUID::from_u128(0x5cda5fc8_33ee_4ff3_9094_ae7bd8868c4d) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_IsEncrypted: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x90e5e14e_648b_4826_b2aa_acaf790e3513), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_IsEncrypted ) , guid : :: windows :: core :: GUID::from_u128(0x90e5e14e_648b_4826_b2aa_acaf790e3513) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_IsFlagged: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5da84765_e3ff_4278_86b0_a27967fbdd03), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_IsFlagged ) , guid : :: windows :: core :: GUID::from_u128(0x5da84765_e3ff_4278_86b0_a27967fbdd03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_IsFlaggedComplete: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa6f360d2_55f9_48de_b909_620e090a647c), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_IsFlaggedComplete ) , guid : :: windows :: core :: GUID::from_u128(0xa6f360d2_55f9_48de_b909_620e090a647c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_IsIncomplete: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x346c8bd1_2e6a_4c45_89a4_61b78e8e700f), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_IsIncomplete ) , guid : :: windows :: core :: GUID::from_u128(0x346c8bd1_2e6a_4c45_89a4_61b78e8e700f) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_IsLocationSupported: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5d76b67f_9b3d_44bb_b6ae_25da4f638a67), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_IsLocationSupported ) , guid : :: windows :: core :: GUID::from_u128(0x5d76b67f_9b3d_44bb_b6ae_25da4f638a67) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_IsPinnedToNameSpaceTree: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5d76b67f_9b3d_44bb_b6ae_25da4f638a67), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_IsPinnedToNameSpaceTree ) , guid : :: windows :: core :: GUID::from_u128(0x5d76b67f_9b3d_44bb_b6ae_25da4f638a67) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_IsRead: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_IsRead ) , guid : :: windows :: core :: GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_IsSearchOnlyItem: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5d76b67f_9b3d_44bb_b6ae_25da4f638a67), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_IsSearchOnlyItem ) , guid : :: windows :: core :: GUID::from_u128(0x5d76b67f_9b3d_44bb_b6ae_25da4f638a67) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_IsSendToTarget: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0), pid: 33u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_IsSendToTarget ) , guid : :: windows :: core :: GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_IsShared: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef884c5b_2bfe_41bb_aae5_76eedf4f9902), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_IsShared ) , guid : :: windows :: core :: GUID::from_u128(0xef884c5b_2bfe_41bb_aae5_76eedf4f9902) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ItemAuthors: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd0a04f0a_462a_48a4_bb2f_3706e88dbd7d), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ItemAuthors ) , guid : :: windows :: core :: GUID::from_u128(0xd0a04f0a_462a_48a4_bb2f_3706e88dbd7d) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ItemClassType: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x048658ad_2db8_41a4_bbb6_ac1ef1207eb1), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ItemClassType ) , guid : :: windows :: core :: GUID::from_u128(0x048658ad_2db8_41a4_bbb6_ac1ef1207eb1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ItemDate: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf7db74b4_4287_4103_afba_f1b13dcd75cf), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ItemDate ) , guid : :: windows :: core :: GUID::from_u128(0xf7db74b4_4287_4103_afba_f1b13dcd75cf) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ItemFolderNameDisplay: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ItemFolderNameDisplay ) , guid : :: windows :: core :: GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ItemFolderPathDisplay: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ItemFolderPathDisplay ) , guid : :: windows :: core :: GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ItemFolderPathDisplayNarrow: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xdabd30ed_0043_4789_a7f8_d013a4736622), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ItemFolderPathDisplayNarrow ) , guid : :: windows :: core :: GUID::from_u128(0xdabd30ed_0043_4789_a7f8_d013a4736622) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ItemName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6b8da074_3b5c_43bc_886f_0a2cdce00b6f), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ItemName ) , guid : :: windows :: core :: GUID::from_u128(0x6b8da074_3b5c_43bc_886f_0a2cdce00b6f) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ItemNameDisplay: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ItemNameDisplay ) , guid : :: windows :: core :: GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ItemNameDisplayWithoutExtension: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac), pid: 24u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ItemNameDisplayWithoutExtension ) , guid : :: windows :: core :: GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ItemNamePrefix: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd7313ff1_a77a_401c_8c99_3dbdd68add36), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ItemNamePrefix ) , guid : :: windows :: core :: GUID::from_u128(0xd7313ff1_a77a_401c_8c99_3dbdd68add36) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ItemNameSortOverride: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac), pid: 23u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ItemNameSortOverride ) , guid : :: windows :: core :: GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ItemParticipants: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd4d0aa16_9948_41a4_aa85_d97ff9646993), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ItemParticipants ) , guid : :: windows :: core :: GUID::from_u128(0xd4d0aa16_9948_41a4_aa85_d97ff9646993) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ItemPathDisplay: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ItemPathDisplay ) , guid : :: windows :: core :: GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ItemPathDisplayNarrow: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ItemPathDisplayNarrow ) , guid : :: windows :: core :: GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ItemSubType: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0), pid: 37u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ItemSubType ) , guid : :: windows :: core :: GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ItemType: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ItemType ) , guid : :: windows :: core :: GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ItemTypeText: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ItemTypeText ) , guid : :: windows :: core :: GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ItemUrl: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x49691c90_7e17_101a_a91c_08002b2ecda9), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ItemUrl ) , guid : :: windows :: core :: GUID::from_u128(0x49691c90_7e17_101a_a91c_08002b2ecda9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Journal_Contacts: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xdea7c82c_1d89_4a66_9427_a4e3debabcb1), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Journal_Contacts ) , guid : :: windows :: core :: GUID::from_u128(0xdea7c82c_1d89_4a66_9427_a4e3debabcb1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Journal_EntryType: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x95beb1fc_326d_4644_b396_cd3ed90e6ddf), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Journal_EntryType ) , guid : :: windows :: core :: GUID::from_u128(0x95beb1fc_326d_4644_b396_cd3ed90e6ddf) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Keywords: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Keywords ) , guid : :: windows :: core :: GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Kind: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1e3ee840_bc2b_476c_8237_2acd1a839b22), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Kind ) , guid : :: windows :: core :: GUID::from_u128(0x1e3ee840_bc2b_476c_8237_2acd1a839b22) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_KindText: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf04bef95_c585_4197_a2b7_df46fdc9ee6d), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_KindText ) , guid : :: windows :: core :: GUID::from_u128(0xf04bef95_c585_4197_a2b7_df46fdc9ee6d) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Language: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae), pid: 28u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Language ) , guid : :: windows :: core :: GUID::from_u128(0xd5cdd502_2e9c_101b_9397_08002b2cf9ae) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_LastSyncError: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8), pid: 107u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_LastSyncError ) , guid : :: windows :: core :: GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_LastSyncWarning: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8), pid: 128u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_LastSyncWarning ) , guid : :: windows :: core :: GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_LastWriterPackageFamilyName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x502cfeab_47eb_459c_b960_e6d8728f7701), pid: 101u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_LastWriterPackageFamilyName ) , guid : :: windows :: core :: GUID::from_u128(0x502cfeab_47eb_459c_b960_e6d8728f7701) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_LayoutPattern_ContentViewModeForBrowse: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc9944a21_a406_48fe_8225_aec7e24c211b), pid: 500u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_LayoutPattern_ContentViewModeForBrowse ) , guid : :: windows :: core :: GUID::from_u128(0xc9944a21_a406_48fe_8225_aec7e24c211b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_LayoutPattern_ContentViewModeForSearch: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc9944a21_a406_48fe_8225_aec7e24c211b), pid: 501u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_LayoutPattern_ContentViewModeForSearch ) , guid : :: windows :: core :: GUID::from_u128(0xc9944a21_a406_48fe_8225_aec7e24c211b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_LibraryLocationsCount: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x908696c7_8f87_44f2_80ed_a8c1c6894575), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_LibraryLocationsCount ) , guid : :: windows :: core :: GUID::from_u128(0x908696c7_8f87_44f2_80ed_a8c1c6894575) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Link_Arguments: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x436f2667_14e2_4feb_b30a_146c53b5b674), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Link_Arguments ) , guid : :: windows :: core :: GUID::from_u128(0x436f2667_14e2_4feb_b30a_146c53b5b674) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Link_Comment: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb9b4b3fc_2b51_4a42_b5d8_324146afcf25), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Link_Comment ) , guid : :: windows :: core :: GUID::from_u128(0xb9b4b3fc_2b51_4a42_b5d8_324146afcf25) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Link_DateVisited: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5cbf2787_48cf_4208_b90e_ee5e5d420294), pid: 23u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Link_DateVisited ) , guid : :: windows :: core :: GUID::from_u128(0x5cbf2787_48cf_4208_b90e_ee5e5d420294) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Link_Description: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5cbf2787_48cf_4208_b90e_ee5e5d420294), pid: 21u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Link_Description ) , guid : :: windows :: core :: GUID::from_u128(0x5cbf2787_48cf_4208_b90e_ee5e5d420294) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Link_FeedItemLocalId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8a2f99f9_3c37_465d_a8d7_69777a246d0c), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Link_FeedItemLocalId ) , guid : :: windows :: core :: GUID::from_u128(0x8a2f99f9_3c37_465d_a8d7_69777a246d0c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Link_Status: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb9b4b3fc_2b51_4a42_b5d8_324146afcf25), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Link_Status ) , guid : :: windows :: core :: GUID::from_u128(0xb9b4b3fc_2b51_4a42_b5d8_324146afcf25) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Link_TargetExtension: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7a7d76f4_b630_4bd7_95ff_37cc51a975c9), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Link_TargetExtension ) , guid : :: windows :: core :: GUID::from_u128(0x7a7d76f4_b630_4bd7_95ff_37cc51a975c9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Link_TargetParsingPath: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb9b4b3fc_2b51_4a42_b5d8_324146afcf25), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Link_TargetParsingPath ) , guid : :: windows :: core :: GUID::from_u128(0xb9b4b3fc_2b51_4a42_b5d8_324146afcf25) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Link_TargetSFGAOFlags: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb9b4b3fc_2b51_4a42_b5d8_324146afcf25), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Link_TargetSFGAOFlags ) , guid : :: windows :: core :: GUID::from_u128(0xb9b4b3fc_2b51_4a42_b5d8_324146afcf25) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Link_TargetSFGAOFlagsStrings: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd6942081_d53b_443d_ad47_5e059d9cd27a), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Link_TargetSFGAOFlagsStrings ) , guid : :: windows :: core :: GUID::from_u128(0xd6942081_d53b_443d_ad47_5e059d9cd27a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Link_TargetUrl: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5cbf2787_48cf_4208_b90e_ee5e5d420294), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Link_TargetUrl ) , guid : :: windows :: core :: GUID::from_u128(0x5cbf2787_48cf_4208_b90e_ee5e5d420294) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Link_TargetUrlHostName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8a2f99f9_3c37_465d_a8d7_69777a246d0c), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Link_TargetUrlHostName ) , guid : :: windows :: core :: GUID::from_u128(0x8a2f99f9_3c37_465d_a8d7_69777a246d0c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Link_TargetUrlPath: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8a2f99f9_3c37_465d_a8d7_69777a246d0c), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Link_TargetUrlPath ) , guid : :: windows :: core :: GUID::from_u128(0x8a2f99f9_3c37_465d_a8d7_69777a246d0c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_LowKeywords: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9), pid: 25u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_LowKeywords ) , guid : :: windows :: core :: GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_MIMEType: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0b63e350_9ccc_11d0_bcdb_00805fccce04), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_MIMEType ) , guid : :: windows :: core :: GUID::from_u128(0x0b63e350_9ccc_11d0_bcdb_00805fccce04) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_AuthorUrl: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 32u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_AuthorUrl ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_AverageLevel: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x09edd5b6_b301_43c5_9990_d00302effd46), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_AverageLevel ) , guid : :: windows :: core :: GUID::from_u128(0x09edd5b6_b301_43c5_9990_d00302effd46) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_ClassPrimaryID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_ClassPrimaryID ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_ClassSecondaryID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_ClassSecondaryID ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_CollectionGroupID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 24u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_CollectionGroupID ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_CollectionID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 25u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_CollectionID ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_ContentDistributor: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 18u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_ContentDistributor ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_ContentID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 26u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_ContentID ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_CreatorApplication: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 27u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_CreatorApplication ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_CreatorApplicationVersion: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 28u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_CreatorApplicationVersion ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_DVDID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 15u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_DVDID ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_DateEncoded: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2e4b640d_5019_46d8_8881_55414cc5caa0), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_DateEncoded ) , guid : :: windows :: core :: GUID::from_u128(0x2e4b640d_5019_46d8_8881_55414cc5caa0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_DateReleased: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xde41cc29_6971_4290_b472_f59f2e2f31e2), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_DateReleased ) , guid : :: windows :: core :: GUID::from_u128(0xde41cc29_6971_4290_b472_f59f2e2f31e2) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_DlnaProfileID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcfa31b45_525d_4998_bb44_3f7d81542fa4), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_DlnaProfileID ) , guid : :: windows :: core :: GUID::from_u128(0xcfa31b45_525d_4998_bb44_3f7d81542fa4) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_Duration: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440490_4c8b_11d1_8b70_080036b11a03), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_Duration ) , guid : :: windows :: core :: GUID::from_u128(0x64440490_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_EncodedBy: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 36u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_EncodedBy ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_EncodingSettings: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 37u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_EncodingSettings ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_EpisodeNumber: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_EpisodeNumber ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_FrameCount: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6444048f_4c8b_11d1_8b70_080036b11a03), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_FrameCount ) , guid : :: windows :: core :: GUID::from_u128(0x6444048f_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_MCDI: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 16u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_MCDI ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_MetadataContentProvider: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 17u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_MetadataContentProvider ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_Producer: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 22u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_Producer ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_PromotionUrl: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 33u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_PromotionUrl ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_ProtectionType: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 38u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_ProtectionType ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_ProviderRating: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 39u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_ProviderRating ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_ProviderStyle: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 40u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_ProviderStyle ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_Publisher: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 30u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_Publisher ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_SeasonNumber: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 101u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_SeasonNumber ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_SeriesName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 42u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_SeriesName ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_SubTitle: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6), pid: 38u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_SubTitle ) , guid : :: windows :: core :: GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_SubscriptionContentId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9aebae7a_9644_487d_a92c_657585ed751a), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_SubscriptionContentId ) , guid : :: windows :: core :: GUID::from_u128(0x9aebae7a_9644_487d_a92c_657585ed751a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_ThumbnailLargePath: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 47u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_ThumbnailLargePath ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_ThumbnailLargeUri: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 48u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_ThumbnailLargeUri ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_ThumbnailSmallPath: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 49u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_ThumbnailSmallPath ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_ThumbnailSmallUri: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 50u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_ThumbnailSmallUri ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_UniqueFileIdentifier: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 35u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_UniqueFileIdentifier ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_UserNoAutoInfo: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 41u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_UserNoAutoInfo ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_UserWebUrl: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 34u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_UserWebUrl ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_Writer: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 23u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_Writer ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Media_Year: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Media_Year ) , guid : :: windows :: core :: GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_MediumKeywords: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9), pid: 26u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_MediumKeywords ) , guid : :: windows :: core :: GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Message_AttachmentContents: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x3143bf7c_80a8_4854_8880_e2e40189bdd0), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Message_AttachmentContents ) , guid : :: windows :: core :: GUID::from_u128(0x3143bf7c_80a8_4854_8880_e2e40189bdd0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Message_AttachmentNames: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd), pid: 21u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Message_AttachmentNames ) , guid : :: windows :: core :: GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Message_BccAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Message_BccAddress ) , guid : :: windows :: core :: GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Message_BccName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Message_BccName ) , guid : :: windows :: core :: GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Message_CcAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Message_CcAddress ) , guid : :: windows :: core :: GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Message_CcName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Message_CcName ) , guid : :: windows :: core :: GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Message_ConversationID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xdc8f80bd_af1e_4289_85b6_3dfc1b493992), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Message_ConversationID ) , guid : :: windows :: core :: GUID::from_u128(0xdc8f80bd_af1e_4289_85b6_3dfc1b493992) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Message_ConversationIndex: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xdc8f80bd_af1e_4289_85b6_3dfc1b493992), pid: 101u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Message_ConversationIndex ) , guid : :: windows :: core :: GUID::from_u128(0xdc8f80bd_af1e_4289_85b6_3dfc1b493992) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Message_DateReceived: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd), pid: 20u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Message_DateReceived ) , guid : :: windows :: core :: GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Message_DateSent: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd), pid: 19u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Message_DateSent ) , guid : :: windows :: core :: GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Message_Flags: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa82d9ee7_ca67_4312_965e_226bcea85023), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Message_Flags ) , guid : :: windows :: core :: GUID::from_u128(0xa82d9ee7_ca67_4312_965e_226bcea85023) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Message_FromAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Message_FromAddress ) , guid : :: windows :: core :: GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Message_FromName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Message_FromName ) , guid : :: windows :: core :: GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Message_HasAttachments: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9c1fcf74_2d97_41ba_b4ae_cb2e3661a6e4), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Message_HasAttachments ) , guid : :: windows :: core :: GUID::from_u128(0x9c1fcf74_2d97_41ba_b4ae_cb2e3661a6e4) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Message_IsFwdOrReply: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9a9bc088_4f6d_469e_9919_e705412040f9), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Message_IsFwdOrReply ) , guid : :: windows :: core :: GUID::from_u128(0x9a9bc088_4f6d_469e_9919_e705412040f9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Message_MessageClass: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcd9ed458_08ce_418f_a70e_f912c7bb9c5c), pid: 103u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Message_MessageClass ) , guid : :: windows :: core :: GUID::from_u128(0xcd9ed458_08ce_418f_a70e_f912c7bb9c5c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Message_Participants: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1a9ba605_8e7c_4d11_ad7d_a50ada18ba1b), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Message_Participants ) , guid : :: windows :: core :: GUID::from_u128(0x1a9ba605_8e7c_4d11_ad7d_a50ada18ba1b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Message_ProofInProgress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9098f33c_9a7d_48a8_8de5_2e1227a64e91), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Message_ProofInProgress ) , guid : :: windows :: core :: GUID::from_u128(0x9098f33c_9a7d_48a8_8de5_2e1227a64e91) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Message_SenderAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0be1c8e7_1981_4676_ae14_fdd78f05a6e7), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Message_SenderAddress ) , guid : :: windows :: core :: GUID::from_u128(0x0be1c8e7_1981_4676_ae14_fdd78f05a6e7) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Message_SenderName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0da41cfa_d224_4a18_ae2f_596158db4b3a), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Message_SenderName ) , guid : :: windows :: core :: GUID::from_u128(0x0da41cfa_d224_4a18_ae2f_596158db4b3a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Message_Store: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd), pid: 15u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Message_Store ) , guid : :: windows :: core :: GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Message_ToAddress: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd), pid: 16u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Message_ToAddress ) , guid : :: windows :: core :: GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Message_ToDoFlags: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1f856a9f_6900_4aba_9505_2d5f1b4d66cb), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Message_ToDoFlags ) , guid : :: windows :: core :: GUID::from_u128(0x1f856a9f_6900_4aba_9505_2d5f1b4d66cb) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Message_ToDoTitle: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xbccc8a3c_8cef_42e5_9b1c_c69079398bc7), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Message_ToDoTitle ) , guid : :: windows :: core :: GUID::from_u128(0xbccc8a3c_8cef_42e5_9b1c_c69079398bc7) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Message_ToName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd), pid: 17u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Message_ToName ) , guid : :: windows :: core :: GUID::from_u128(0xe3e0584c_b788_4a5a_bb20_7f5a44c9acdd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_MileageInformation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfdf84370_031a_4add_9e91_0d775f1c6605), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_MileageInformation ) , guid : :: windows :: core :: GUID::from_u128(0xfdf84370_031a_4add_9e91_0d775f1c6605) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Music_AlbumArtist: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Music_AlbumArtist ) , guid : :: windows :: core :: GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Music_AlbumArtistSortOverride: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf1fdb4af_f78c_466c_bb05_56e92db0b8ec), pid: 103u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Music_AlbumArtistSortOverride ) , guid : :: windows :: core :: GUID::from_u128(0xf1fdb4af_f78c_466c_bb05_56e92db0b8ec) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Music_AlbumID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Music_AlbumID ) , guid : :: windows :: core :: GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Music_AlbumTitle: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Music_AlbumTitle ) , guid : :: windows :: core :: GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Music_AlbumTitleSortOverride: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x13eb7ffc_ec89_4346_b19d_ccc6f1784223), pid: 101u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Music_AlbumTitleSortOverride ) , guid : :: windows :: core :: GUID::from_u128(0x13eb7ffc_ec89_4346_b19d_ccc6f1784223) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Music_Artist: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Music_Artist ) , guid : :: windows :: core :: GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Music_ArtistSortOverride: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xdeeb2db5_0696_4ce0_94fe_a01f77a45fb5), pid: 102u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Music_ArtistSortOverride ) , guid : :: windows :: core :: GUID::from_u128(0xdeeb2db5_0696_4ce0_94fe_a01f77a45fb5) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Music_BeatsPerMinute: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6), pid: 35u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Music_BeatsPerMinute ) , guid : :: windows :: core :: GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Music_Composer: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 19u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Music_Composer ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Music_ComposerSortOverride: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00bc20a3_bd48_4085_872c_a88d77f5097e), pid: 105u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Music_ComposerSortOverride ) , guid : :: windows :: core :: GUID::from_u128(0x00bc20a3_bd48_4085_872c_a88d77f5097e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Music_Conductor: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6), pid: 36u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Music_Conductor ) , guid : :: windows :: core :: GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Music_ContentGroupDescription: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6), pid: 33u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Music_ContentGroupDescription ) , guid : :: windows :: core :: GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Music_DiscNumber: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6afe7437_9bcd_49c7_80fe_4a5c65fa5874), pid: 104u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Music_DiscNumber ) , guid : :: windows :: core :: GUID::from_u128(0x6afe7437_9bcd_49c7_80fe_4a5c65fa5874) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Music_DisplayArtist: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfd122953_fa93_4ef7_92c3_04c946b2f7c8), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Music_DisplayArtist ) , guid : :: windows :: core :: GUID::from_u128(0xfd122953_fa93_4ef7_92c3_04c946b2f7c8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Music_Genre: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Music_Genre ) , guid : :: windows :: core :: GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Music_InitialKey: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6), pid: 34u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Music_InitialKey ) , guid : :: windows :: core :: GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Music_IsCompilation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc449d5cb_9ea4_4809_82e8_af9d59ded6d1), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Music_IsCompilation ) , guid : :: windows :: core :: GUID::from_u128(0xc449d5cb_9ea4_4809_82e8_af9d59ded6d1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Music_Lyrics: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Music_Lyrics ) , guid : :: windows :: core :: GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Music_Mood: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6), pid: 39u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Music_Mood ) , guid : :: windows :: core :: GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Music_PartOfSet: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6), pid: 37u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Music_PartOfSet ) , guid : :: windows :: core :: GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Music_Period: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 31u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Music_Period ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Music_SynchronizedLyrics: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6b223b6a_162e_4aa9_b39f_05d678fc6d77), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Music_SynchronizedLyrics ) , guid : :: windows :: core :: GUID::from_u128(0x6b223b6a_162e_4aa9_b39f_05d678fc6d77) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Music_TrackNumber: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Music_TrackNumber ) , guid : :: windows :: core :: GUID::from_u128(0x56a3372e_ce9c_11d2_9f0e_006097c686f6) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_NamespaceCLSID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_NamespaceCLSID ) , guid : :: windows :: core :: GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Note_Color: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4776cafa_bce4_4cb1_a23e_265e76d8eb11), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Note_Color ) , guid : :: windows :: core :: GUID::from_u128(0x4776cafa_bce4_4cb1_a23e_265e76d8eb11) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Note_ColorText: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x46b4e8de_cdb2_440d_885c_1658eb65b914), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Note_ColorText ) , guid : :: windows :: core :: GUID::from_u128(0x46b4e8de_cdb2_440d_885c_1658eb65b914) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Null: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x00000000_0000_0000_0000_000000000000), pid: 0u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Null ) , guid : :: windows :: core :: GUID::from_u128(0x00000000_0000_0000_0000_000000000000) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_OfflineAvailability: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa94688b6_7d9f_4570_a648_e3dfc0ab2b3f), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_OfflineAvailability ) , guid : :: windows :: core :: GUID::from_u128(0xa94688b6_7d9f_4570_a648_e3dfc0ab2b3f) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_OfflineStatus: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6d24888f_4718_4bda_afed_ea0fb4386cd8), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_OfflineStatus ) , guid : :: windows :: core :: GUID::from_u128(0x6d24888f_4718_4bda_afed_ea0fb4386cd8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_OriginalFileName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cef7d53_fa64_11d1_a203_0000f81fedee), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_OriginalFileName ) , guid : :: windows :: core :: GUID::from_u128(0x0cef7d53_fa64_11d1_a203_0000f81fedee) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_OwnerSID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5d76b67f_9b3d_44bb_b6ae_25da4f638a67), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_OwnerSID ) , guid : :: windows :: core :: GUID::from_u128(0x5d76b67f_9b3d_44bb_b6ae_25da4f638a67) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ParentalRating: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 21u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ParentalRating ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ParentalRatingReason: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x10984e0a_f9f2_4321_b7ef_baf195af4319), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ParentalRatingReason ) , guid : :: windows :: core :: GUID::from_u128(0x10984e0a_f9f2_4321_b7ef_baf195af4319) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ParentalRatingsOrganization: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa7fe0840_1344_46f0_8d37_52ed712a4bf9), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ParentalRatingsOrganization ) , guid : :: windows :: core :: GUID::from_u128(0xa7fe0840_1344_46f0_8d37_52ed712a4bf9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ParsingBindContext: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xdfb9a04d_362f_4ca3_b30b_0254b17b5b84), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ParsingBindContext ) , guid : :: windows :: core :: GUID::from_u128(0xdfb9a04d_362f_4ca3_b30b_0254b17b5b84) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ParsingName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0), pid: 24u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ParsingName ) , guid : :: windows :: core :: GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ParsingPath: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0), pid: 30u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ParsingPath ) , guid : :: windows :: core :: GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PerceivedType: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PerceivedType ) , guid : :: windows :: core :: GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PercentFull: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9b174b35_40ff_11d2_a27e_00c04fc30871), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PercentFull ) , guid : :: windows :: core :: GUID::from_u128(0x9b174b35_40ff_11d2_a27e_00c04fc30871) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_Aperture: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99), pid: 37378u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_Aperture ) , guid : :: windows :: core :: GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_ApertureDenominator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe1a9a38b_6685_46bd_875e_570dc7ad7320), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_ApertureDenominator ) , guid : :: windows :: core :: GUID::from_u128(0xe1a9a38b_6685_46bd_875e_570dc7ad7320) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_ApertureNumerator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0337ecec_39fb_4581_a0bd_4c4cc51e9914), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_ApertureNumerator ) , guid : :: windows :: core :: GUID::from_u128(0x0337ecec_39fb_4581_a0bd_4c4cc51e9914) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_Brightness: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1a701bf6_478c_4361_83ab_3701bb053c58), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_Brightness ) , guid : :: windows :: core :: GUID::from_u128(0x1a701bf6_478c_4361_83ab_3701bb053c58) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_BrightnessDenominator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6ebe6946_2321_440a_90f0_c043efd32476), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_BrightnessDenominator ) , guid : :: windows :: core :: GUID::from_u128(0x6ebe6946_2321_440a_90f0_c043efd32476) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_BrightnessNumerator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9e7d118f_b314_45a0_8cfb_d654b917c9e9), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_BrightnessNumerator ) , guid : :: windows :: core :: GUID::from_u128(0x9e7d118f_b314_45a0_8cfb_d654b917c9e9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_CameraManufacturer: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99), pid: 271u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_CameraManufacturer ) , guid : :: windows :: core :: GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_CameraModel: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99), pid: 272u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_CameraModel ) , guid : :: windows :: core :: GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_CameraSerialNumber: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99), pid: 273u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_CameraSerialNumber ) , guid : :: windows :: core :: GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_Contrast: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2a785ba9_8d23_4ded_82e6_60a350c86a10), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_Contrast ) , guid : :: windows :: core :: GUID::from_u128(0x2a785ba9_8d23_4ded_82e6_60a350c86a10) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_ContrastText: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x59dde9f2_5253_40ea_9a8b_479e96c6249a), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_ContrastText ) , guid : :: windows :: core :: GUID::from_u128(0x59dde9f2_5253_40ea_9a8b_479e96c6249a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_DateTaken: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99), pid: 36867u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_DateTaken ) , guid : :: windows :: core :: GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_DigitalZoom: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf85bf840_a925_4bc2_b0c4_8e36b598679e), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_DigitalZoom ) , guid : :: windows :: core :: GUID::from_u128(0xf85bf840_a925_4bc2_b0c4_8e36b598679e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_DigitalZoomDenominator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x745baf0e_e5c1_4cfb_8a1b_d031a0a52393), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_DigitalZoomDenominator ) , guid : :: windows :: core :: GUID::from_u128(0x745baf0e_e5c1_4cfb_8a1b_d031a0a52393) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_DigitalZoomNumerator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x16cbb924_6500_473b_a5be_f1599bcbe413), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_DigitalZoomNumerator ) , guid : :: windows :: core :: GUID::from_u128(0x16cbb924_6500_473b_a5be_f1599bcbe413) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_EXIFVersion: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd35f743a_eb2e_47f2_a286_844132cb1427), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_EXIFVersion ) , guid : :: windows :: core :: GUID::from_u128(0xd35f743a_eb2e_47f2_a286_844132cb1427) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_Event: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99), pid: 18248u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_Event ) , guid : :: windows :: core :: GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_ExposureBias: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99), pid: 37380u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_ExposureBias ) , guid : :: windows :: core :: GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_ExposureBiasDenominator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xab205e50_04b7_461c_a18c_2f233836e627), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_ExposureBiasDenominator ) , guid : :: windows :: core :: GUID::from_u128(0xab205e50_04b7_461c_a18c_2f233836e627) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_ExposureBiasNumerator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x738bf284_1d87_420b_92cf_5834bf6ef9ed), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_ExposureBiasNumerator ) , guid : :: windows :: core :: GUID::from_u128(0x738bf284_1d87_420b_92cf_5834bf6ef9ed) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_ExposureIndex: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x967b5af8_995a_46ed_9e11_35b3c5b9782d), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_ExposureIndex ) , guid : :: windows :: core :: GUID::from_u128(0x967b5af8_995a_46ed_9e11_35b3c5b9782d) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_ExposureIndexDenominator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x93112f89_c28b_492f_8a9d_4be2062cee8a), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_ExposureIndexDenominator ) , guid : :: windows :: core :: GUID::from_u128(0x93112f89_c28b_492f_8a9d_4be2062cee8a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_ExposureIndexNumerator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcdedcf30_8919_44df_8f4c_4eb2ffdb8d89), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_ExposureIndexNumerator ) , guid : :: windows :: core :: GUID::from_u128(0xcdedcf30_8919_44df_8f4c_4eb2ffdb8d89) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_ExposureProgram: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99), pid: 34850u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_ExposureProgram ) , guid : :: windows :: core :: GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_ExposureProgramText: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfec690b7_5f30_4646_ae47_4caafba884a3), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_ExposureProgramText ) , guid : :: windows :: core :: GUID::from_u128(0xfec690b7_5f30_4646_ae47_4caafba884a3) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_ExposureTime: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99), pid: 33434u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_ExposureTime ) , guid : :: windows :: core :: GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_ExposureTimeDenominator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x55e98597_ad16_42e0_b624_21599a199838), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_ExposureTimeDenominator ) , guid : :: windows :: core :: GUID::from_u128(0x55e98597_ad16_42e0_b624_21599a199838) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_ExposureTimeNumerator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x257e44e2_9031_4323_ac38_85c552871b2e), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_ExposureTimeNumerator ) , guid : :: windows :: core :: GUID::from_u128(0x257e44e2_9031_4323_ac38_85c552871b2e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_FNumber: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99), pid: 33437u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_FNumber ) , guid : :: windows :: core :: GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_FNumberDenominator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe92a2496_223b_4463_a4e3_30eabba79d80), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_FNumberDenominator ) , guid : :: windows :: core :: GUID::from_u128(0xe92a2496_223b_4463_a4e3_30eabba79d80) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_FNumberNumerator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1b97738a_fdfc_462f_9d93_1957e08be90c), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_FNumberNumerator ) , guid : :: windows :: core :: GUID::from_u128(0x1b97738a_fdfc_462f_9d93_1957e08be90c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_Flash: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99), pid: 37385u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_Flash ) , guid : :: windows :: core :: GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_FlashEnergy: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99), pid: 41483u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_FlashEnergy ) , guid : :: windows :: core :: GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_FlashEnergyDenominator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd7b61c70_6323_49cd_a5fc_c84277162c97), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_FlashEnergyDenominator ) , guid : :: windows :: core :: GUID::from_u128(0xd7b61c70_6323_49cd_a5fc_c84277162c97) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_FlashEnergyNumerator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfcad3d3d_0858_400f_aaa3_2f66cce2a6bc), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_FlashEnergyNumerator ) , guid : :: windows :: core :: GUID::from_u128(0xfcad3d3d_0858_400f_aaa3_2f66cce2a6bc) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_FlashManufacturer: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xaabaf6c9_e0c5_4719_8585_57b103e584fe), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_FlashManufacturer ) , guid : :: windows :: core :: GUID::from_u128(0xaabaf6c9_e0c5_4719_8585_57b103e584fe) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_FlashModel: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfe83bb35_4d1a_42e2_916b_06f3e1af719e), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_FlashModel ) , guid : :: windows :: core :: GUID::from_u128(0xfe83bb35_4d1a_42e2_916b_06f3e1af719e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_FlashText: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6b8b68f6_200b_47ea_8d25_d8050f57339f), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_FlashText ) , guid : :: windows :: core :: GUID::from_u128(0x6b8b68f6_200b_47ea_8d25_d8050f57339f) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_FocalLength: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99), pid: 37386u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_FocalLength ) , guid : :: windows :: core :: GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_FocalLengthDenominator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x305bc615_dca1_44a5_9fd4_10c0ba79412e), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_FocalLengthDenominator ) , guid : :: windows :: core :: GUID::from_u128(0x305bc615_dca1_44a5_9fd4_10c0ba79412e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_FocalLengthInFilm: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa0e74609_b84d_4f49_b860_462bd9971f98), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_FocalLengthInFilm ) , guid : :: windows :: core :: GUID::from_u128(0xa0e74609_b84d_4f49_b860_462bd9971f98) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_FocalLengthNumerator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x776b6b3b_1e3d_4b0c_9a0e_8fbaf2a8492a), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_FocalLengthNumerator ) , guid : :: windows :: core :: GUID::from_u128(0x776b6b3b_1e3d_4b0c_9a0e_8fbaf2a8492a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_FocalPlaneXResolution: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcfc08d97_c6f7_4484_89dd_ebef4356fe76), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_FocalPlaneXResolution ) , guid : :: windows :: core :: GUID::from_u128(0xcfc08d97_c6f7_4484_89dd_ebef4356fe76) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_FocalPlaneXResolutionDenominator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0933f3f5_4786_4f46_a8e8_d64dd37fa521), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_FocalPlaneXResolutionDenominator ) , guid : :: windows :: core :: GUID::from_u128(0x0933f3f5_4786_4f46_a8e8_d64dd37fa521) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_FocalPlaneXResolutionNumerator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xdccb10af_b4e2_4b88_95f9_031b4d5ab490), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_FocalPlaneXResolutionNumerator ) , guid : :: windows :: core :: GUID::from_u128(0xdccb10af_b4e2_4b88_95f9_031b4d5ab490) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_FocalPlaneYResolution: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4fffe4d0_914f_4ac4_8d6f_c9c61de169b1), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_FocalPlaneYResolution ) , guid : :: windows :: core :: GUID::from_u128(0x4fffe4d0_914f_4ac4_8d6f_c9c61de169b1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_FocalPlaneYResolutionDenominator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1d6179a6_a876_4031_b013_3347b2b64dc8), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_FocalPlaneYResolutionDenominator ) , guid : :: windows :: core :: GUID::from_u128(0x1d6179a6_a876_4031_b013_3347b2b64dc8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_FocalPlaneYResolutionNumerator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa2e541c5_4440_4ba8_867e_75cfc06828cd), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_FocalPlaneYResolutionNumerator ) , guid : :: windows :: core :: GUID::from_u128(0xa2e541c5_4440_4ba8_867e_75cfc06828cd) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_GainControl: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfa304789_00c7_4d80_904a_1e4dcc7265aa), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_GainControl ) , guid : :: windows :: core :: GUID::from_u128(0xfa304789_00c7_4d80_904a_1e4dcc7265aa) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_GainControlDenominator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x42864dfd_9da4_4f77_bded_4aad7b256735), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_GainControlDenominator ) , guid : :: windows :: core :: GUID::from_u128(0x42864dfd_9da4_4f77_bded_4aad7b256735) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_GainControlNumerator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8e8ecf7c_b7b8_4eb8_a63f_0ee715c96f9e), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_GainControlNumerator ) , guid : :: windows :: core :: GUID::from_u128(0x8e8ecf7c_b7b8_4eb8_a63f_0ee715c96f9e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_GainControlText: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc06238b2_0bf9_4279_a723_25856715cb9d), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_GainControlText ) , guid : :: windows :: core :: GUID::from_u128(0xc06238b2_0bf9_4279_a723_25856715cb9d) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_ISOSpeed: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99), pid: 34855u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_ISOSpeed ) , guid : :: windows :: core :: GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_LensManufacturer: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe6ddcaf7_29c5_4f0a_9a68_d19412ec7090), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_LensManufacturer ) , guid : :: windows :: core :: GUID::from_u128(0xe6ddcaf7_29c5_4f0a_9a68_d19412ec7090) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_LensModel: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe1277516_2b5f_4869_89b1_2e585bd38b7a), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_LensModel ) , guid : :: windows :: core :: GUID::from_u128(0xe1277516_2b5f_4869_89b1_2e585bd38b7a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_LightSource: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99), pid: 37384u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_LightSource ) , guid : :: windows :: core :: GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_MakerNote: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfa303353_b659_4052_85e9_bcac79549b84), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_MakerNote ) , guid : :: windows :: core :: GUID::from_u128(0xfa303353_b659_4052_85e9_bcac79549b84) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_MakerNoteOffset: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x813f4124_34e6_4d17_ab3e_6b1f3c2247a1), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_MakerNoteOffset ) , guid : :: windows :: core :: GUID::from_u128(0x813f4124_34e6_4d17_ab3e_6b1f3c2247a1) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_MaxAperture: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x08f6d7c2_e3f2_44fc_af1e_5aa5c81a2d3e), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_MaxAperture ) , guid : :: windows :: core :: GUID::from_u128(0x08f6d7c2_e3f2_44fc_af1e_5aa5c81a2d3e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_MaxApertureDenominator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc77724d4_601f_46c5_9b89_c53f93bceb77), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_MaxApertureDenominator ) , guid : :: windows :: core :: GUID::from_u128(0xc77724d4_601f_46c5_9b89_c53f93bceb77) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_MaxApertureNumerator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc107e191_a459_44c5_9ae6_b952ad4b906d), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_MaxApertureNumerator ) , guid : :: windows :: core :: GUID::from_u128(0xc107e191_a459_44c5_9ae6_b952ad4b906d) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_MeteringMode: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99), pid: 37383u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_MeteringMode ) , guid : :: windows :: core :: GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_MeteringModeText: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf628fd8c_7ba8_465a_a65b_c5aa79263a9e), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_MeteringModeText ) , guid : :: windows :: core :: GUID::from_u128(0xf628fd8c_7ba8_465a_a65b_c5aa79263a9e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_Orientation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99), pid: 274u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_Orientation ) , guid : :: windows :: core :: GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_OrientationText: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa9ea193c_c511_498a_a06b_58e2776dcc28), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_OrientationText ) , guid : :: windows :: core :: GUID::from_u128(0xa9ea193c_c511_498a_a06b_58e2776dcc28) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_PeopleNames: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe8309b6e_084c_49b4_b1fc_90a80331b638), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_PeopleNames ) , guid : :: windows :: core :: GUID::from_u128(0xe8309b6e_084c_49b4_b1fc_90a80331b638) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_PhotometricInterpretation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x341796f1_1df9_4b1c_a564_91bdefa43877), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_PhotometricInterpretation ) , guid : :: windows :: core :: GUID::from_u128(0x341796f1_1df9_4b1c_a564_91bdefa43877) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_PhotometricInterpretationText: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x821437d6_9eab_4765_a589_3b1cbbd22a61), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_PhotometricInterpretationText ) , guid : :: windows :: core :: GUID::from_u128(0x821437d6_9eab_4765_a589_3b1cbbd22a61) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_ProgramMode: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6d217f6d_3f6a_4825_b470_5f03ca2fbe9b), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_ProgramMode ) , guid : :: windows :: core :: GUID::from_u128(0x6d217f6d_3f6a_4825_b470_5f03ca2fbe9b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_ProgramModeText: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7fe3aa27_2648_42f3_89b0_454e5cb150c3), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_ProgramModeText ) , guid : :: windows :: core :: GUID::from_u128(0x7fe3aa27_2648_42f3_89b0_454e5cb150c3) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_RelatedSoundFile: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x318a6b45_087f_4dc2_b8cc_05359551fc9e), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_RelatedSoundFile ) , guid : :: windows :: core :: GUID::from_u128(0x318a6b45_087f_4dc2_b8cc_05359551fc9e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_Saturation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x49237325_a95a_4f67_b211_816b2d45d2e0), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_Saturation ) , guid : :: windows :: core :: GUID::from_u128(0x49237325_a95a_4f67_b211_816b2d45d2e0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_SaturationText: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x61478c08_b600_4a84_bbe4_e99c45f0a072), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_SaturationText ) , guid : :: windows :: core :: GUID::from_u128(0x61478c08_b600_4a84_bbe4_e99c45f0a072) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_Sharpness: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfc6976db_8349_4970_ae97_b3c5316a08f0), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_Sharpness ) , guid : :: windows :: core :: GUID::from_u128(0xfc6976db_8349_4970_ae97_b3c5316a08f0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_SharpnessText: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x51ec3f47_dd50_421d_8769_334f50424b1e), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_SharpnessText ) , guid : :: windows :: core :: GUID::from_u128(0x51ec3f47_dd50_421d_8769_334f50424b1e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_ShutterSpeed: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99), pid: 37377u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_ShutterSpeed ) , guid : :: windows :: core :: GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_ShutterSpeedDenominator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe13d8975_81c7_4948_ae3f_37cae11e8ff7), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_ShutterSpeedDenominator ) , guid : :: windows :: core :: GUID::from_u128(0xe13d8975_81c7_4948_ae3f_37cae11e8ff7) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_ShutterSpeedNumerator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x16ea4042_d6f4_4bca_8349_7c78d30fb333), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_ShutterSpeedNumerator ) , guid : :: windows :: core :: GUID::from_u128(0x16ea4042_d6f4_4bca_8349_7c78d30fb333) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_SubjectDistance: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99), pid: 37382u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_SubjectDistance ) , guid : :: windows :: core :: GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_SubjectDistanceDenominator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0c840a88_b043_466d_9766_d4b26da3fa77), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_SubjectDistanceDenominator ) , guid : :: windows :: core :: GUID::from_u128(0x0c840a88_b043_466d_9766_d4b26da3fa77) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_SubjectDistanceNumerator: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8af4961c_f526_43e5_aa81_db768219178d), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_SubjectDistanceNumerator ) , guid : :: windows :: core :: GUID::from_u128(0x8af4961c_f526_43e5_aa81_db768219178d) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_TagViewAggregate: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb812f15d_c2d8_4bbf_bacd_79744346113f), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_TagViewAggregate ) , guid : :: windows :: core :: GUID::from_u128(0xb812f15d_c2d8_4bbf_bacd_79744346113f) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_TranscodedForSync: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9a8ebb75_6458_4e82_bacb_35c0095b03bb), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_TranscodedForSync ) , guid : :: windows :: core :: GUID::from_u128(0x9a8ebb75_6458_4e82_bacb_35c0095b03bb) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_WhiteBalance: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xee3d3d8a_5381_4cfa_b13b_aaf66b5f4ec9), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_WhiteBalance ) , guid : :: windows :: core :: GUID::from_u128(0xee3d3d8a_5381_4cfa_b13b_aaf66b5f4ec9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Photo_WhiteBalanceText: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6336b95e_c7a7_426d_86fd_7ae3d39c84b4), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Photo_WhiteBalanceText ) , guid : :: windows :: core :: GUID::from_u128(0x6336b95e_c7a7_426d_86fd_7ae3d39c84b4) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Priority: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9c1fcf74_2d97_41ba_b4ae_cb2e3661a6e4), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Priority ) , guid : :: windows :: core :: GUID::from_u128(0x9c1fcf74_2d97_41ba_b4ae_cb2e3661a6e4) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PriorityText: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd98be98b_b86b_4095_bf52_9d23b2e0a752), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PriorityText ) , guid : :: windows :: core :: GUID::from_u128(0xd98be98b_b86b_4095_bf52_9d23b2e0a752) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Project: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x39a7f922_477c_48de_8bc8_b28441e342e3), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Project ) , guid : :: windows :: core :: GUID::from_u128(0x39a7f922_477c_48de_8bc8_b28441e342e3) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropGroup_Advanced: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x900a403b_097b_4b95_8ae2_071fdaeeb118), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropGroup_Advanced ) , guid : :: windows :: core :: GUID::from_u128(0x900a403b_097b_4b95_8ae2_071fdaeeb118) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropGroup_Audio: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2804d469_788f_48aa_8570_71b9c187e138), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropGroup_Audio ) , guid : :: windows :: core :: GUID::from_u128(0x2804d469_788f_48aa_8570_71b9c187e138) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropGroup_Calendar: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9973d2b5_bfd8_438a_ba94_5349b293181a), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropGroup_Calendar ) , guid : :: windows :: core :: GUID::from_u128(0x9973d2b5_bfd8_438a_ba94_5349b293181a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropGroup_Camera: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xde00de32_547e_4981_ad4b_542f2e9007d8), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropGroup_Camera ) , guid : :: windows :: core :: GUID::from_u128(0xde00de32_547e_4981_ad4b_542f2e9007d8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropGroup_Contact: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xdf975fd3_250a_4004_858f_34e29a3e37aa), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropGroup_Contact ) , guid : :: windows :: core :: GUID::from_u128(0xdf975fd3_250a_4004_858f_34e29a3e37aa) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropGroup_Content: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd0dab0ba_368a_4050_a882_6c010fd19a4f), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropGroup_Content ) , guid : :: windows :: core :: GUID::from_u128(0xd0dab0ba_368a_4050_a882_6c010fd19a4f) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropGroup_Description: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8969b275_9475_4e00_a887_ff93b8b41e44), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropGroup_Description ) , guid : :: windows :: core :: GUID::from_u128(0x8969b275_9475_4e00_a887_ff93b8b41e44) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropGroup_FileSystem: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe3a7d2c1_80fc_4b40_8f34_30ea111bdc2e), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropGroup_FileSystem ) , guid : :: windows :: core :: GUID::from_u128(0xe3a7d2c1_80fc_4b40_8f34_30ea111bdc2e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropGroup_GPS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf3713ada_90e3_4e11_aae5_fdc17685b9be), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropGroup_GPS ) , guid : :: windows :: core :: GUID::from_u128(0xf3713ada_90e3_4e11_aae5_fdc17685b9be) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropGroup_General: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xcc301630_b192_4c22_b372_9f4c6d338e07), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropGroup_General ) , guid : :: windows :: core :: GUID::from_u128(0xcc301630_b192_4c22_b372_9f4c6d338e07) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropGroup_Image: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe3690a87_0fa8_4a2a_9a9f_fce8827055ac), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropGroup_Image ) , guid : :: windows :: core :: GUID::from_u128(0xe3690a87_0fa8_4a2a_9a9f_fce8827055ac) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropGroup_Media: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x61872cf7_6b5e_4b4b_ac2d_59da84459248), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropGroup_Media ) , guid : :: windows :: core :: GUID::from_u128(0x61872cf7_6b5e_4b4b_ac2d_59da84459248) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropGroup_MediaAdvanced: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8859a284_de7e_4642_99ba_d431d044b1ec), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropGroup_MediaAdvanced ) , guid : :: windows :: core :: GUID::from_u128(0x8859a284_de7e_4642_99ba_d431d044b1ec) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropGroup_Message: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7fd7259d_16b4_4135_9f97_7c96ecd2fa9e), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropGroup_Message ) , guid : :: windows :: core :: GUID::from_u128(0x7fd7259d_16b4_4135_9f97_7c96ecd2fa9e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropGroup_Music: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x68dd6094_7216_40f1_a029_43fe7127043f), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropGroup_Music ) , guid : :: windows :: core :: GUID::from_u128(0x68dd6094_7216_40f1_a029_43fe7127043f) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropGroup_Origin: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2598d2fb_5569_4367_95df_5cd3a177e1a5), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropGroup_Origin ) , guid : :: windows :: core :: GUID::from_u128(0x2598d2fb_5569_4367_95df_5cd3a177e1a5) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropGroup_PhotoAdvanced: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cb2bf5a_9ee7_4a86_8222_f01e07fdadaf), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropGroup_PhotoAdvanced ) , guid : :: windows :: core :: GUID::from_u128(0x0cb2bf5a_9ee7_4a86_8222_f01e07fdadaf) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropGroup_RecordedTV: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xe7b33238_6584_4170_a5c0_ac25efd9da56), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropGroup_RecordedTV ) , guid : :: windows :: core :: GUID::from_u128(0xe7b33238_6584_4170_a5c0_ac25efd9da56) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropGroup_Video: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xbebe0920_7671_4c54_a3eb_49fddfc191ee), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropGroup_Video ) , guid : :: windows :: core :: GUID::from_u128(0xbebe0920_7671_4c54_a3eb_49fddfc191ee) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropList_ConflictPrompt: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc9944a21_a406_48fe_8225_aec7e24c211b), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropList_ConflictPrompt ) , guid : :: windows :: core :: GUID::from_u128(0xc9944a21_a406_48fe_8225_aec7e24c211b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropList_ContentViewModeForBrowse: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc9944a21_a406_48fe_8225_aec7e24c211b), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropList_ContentViewModeForBrowse ) , guid : :: windows :: core :: GUID::from_u128(0xc9944a21_a406_48fe_8225_aec7e24c211b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropList_ContentViewModeForSearch: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc9944a21_a406_48fe_8225_aec7e24c211b), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropList_ContentViewModeForSearch ) , guid : :: windows :: core :: GUID::from_u128(0xc9944a21_a406_48fe_8225_aec7e24c211b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropList_ExtendedTileInfo: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc9944a21_a406_48fe_8225_aec7e24c211b), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropList_ExtendedTileInfo ) , guid : :: windows :: core :: GUID::from_u128(0xc9944a21_a406_48fe_8225_aec7e24c211b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropList_FileOperationPrompt: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc9944a21_a406_48fe_8225_aec7e24c211b), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropList_FileOperationPrompt ) , guid : :: windows :: core :: GUID::from_u128(0xc9944a21_a406_48fe_8225_aec7e24c211b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropList_FullDetails: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc9944a21_a406_48fe_8225_aec7e24c211b), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropList_FullDetails ) , guid : :: windows :: core :: GUID::from_u128(0xc9944a21_a406_48fe_8225_aec7e24c211b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropList_InfoTip: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc9944a21_a406_48fe_8225_aec7e24c211b), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropList_InfoTip ) , guid : :: windows :: core :: GUID::from_u128(0xc9944a21_a406_48fe_8225_aec7e24c211b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropList_NonPersonal: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x49d1091f_082e_493f_b23f_d2308aa9668c), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropList_NonPersonal ) , guid : :: windows :: core :: GUID::from_u128(0x49d1091f_082e_493f_b23f_d2308aa9668c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropList_PreviewDetails: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc9944a21_a406_48fe_8225_aec7e24c211b), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropList_PreviewDetails ) , guid : :: windows :: core :: GUID::from_u128(0xc9944a21_a406_48fe_8225_aec7e24c211b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropList_PreviewTitle: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc9944a21_a406_48fe_8225_aec7e24c211b), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropList_PreviewTitle ) , guid : :: windows :: core :: GUID::from_u128(0xc9944a21_a406_48fe_8225_aec7e24c211b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropList_QuickTip: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc9944a21_a406_48fe_8225_aec7e24c211b), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropList_QuickTip ) , guid : :: windows :: core :: GUID::from_u128(0xc9944a21_a406_48fe_8225_aec7e24c211b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropList_TileInfo: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xc9944a21_a406_48fe_8225_aec7e24c211b), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropList_TileInfo ) , guid : :: windows :: core :: GUID::from_u128(0xc9944a21_a406_48fe_8225_aec7e24c211b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PropList_XPDetailsPanel: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf2275480_f782_4291_bd94_f13693513aec), pid: 0u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PropList_XPDetailsPanel ) , guid : :: windows :: core :: GUID::from_u128(0xf2275480_f782_4291_bd94_f13693513aec) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ProviderItemID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf21d9941_81f0_471a_adee_4e74b49217ed), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ProviderItemID ) , guid : :: windows :: core :: GUID::from_u128(0xf21d9941_81f0_471a_adee_4e74b49217ed) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Rating: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Rating ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_RatingText: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x90197ca7_fd8f_4e8c_9da3_b57e1e609295), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_RatingText ) , guid : :: windows :: core :: GUID::from_u128(0x90197ca7_fd8f_4e8c_9da3_b57e1e609295) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_RecordedTV_ChannelNumber: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6d748de2_8d38_4cc3_ac60_f009b057c557), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_RecordedTV_ChannelNumber ) , guid : :: windows :: core :: GUID::from_u128(0x6d748de2_8d38_4cc3_ac60_f009b057c557) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_RecordedTV_Credits: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6d748de2_8d38_4cc3_ac60_f009b057c557), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_RecordedTV_Credits ) , guid : :: windows :: core :: GUID::from_u128(0x6d748de2_8d38_4cc3_ac60_f009b057c557) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_RecordedTV_DateContentExpires: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6d748de2_8d38_4cc3_ac60_f009b057c557), pid: 15u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_RecordedTV_DateContentExpires ) , guid : :: windows :: core :: GUID::from_u128(0x6d748de2_8d38_4cc3_ac60_f009b057c557) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_RecordedTV_EpisodeName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6d748de2_8d38_4cc3_ac60_f009b057c557), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_RecordedTV_EpisodeName ) , guid : :: windows :: core :: GUID::from_u128(0x6d748de2_8d38_4cc3_ac60_f009b057c557) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_RecordedTV_IsATSCContent: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6d748de2_8d38_4cc3_ac60_f009b057c557), pid: 16u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_RecordedTV_IsATSCContent ) , guid : :: windows :: core :: GUID::from_u128(0x6d748de2_8d38_4cc3_ac60_f009b057c557) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_RecordedTV_IsClosedCaptioningAvailable: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6d748de2_8d38_4cc3_ac60_f009b057c557), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_RecordedTV_IsClosedCaptioningAvailable ) , guid : :: windows :: core :: GUID::from_u128(0x6d748de2_8d38_4cc3_ac60_f009b057c557) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_RecordedTV_IsDTVContent: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6d748de2_8d38_4cc3_ac60_f009b057c557), pid: 17u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_RecordedTV_IsDTVContent ) , guid : :: windows :: core :: GUID::from_u128(0x6d748de2_8d38_4cc3_ac60_f009b057c557) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_RecordedTV_IsHDContent: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6d748de2_8d38_4cc3_ac60_f009b057c557), pid: 18u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_RecordedTV_IsHDContent ) , guid : :: windows :: core :: GUID::from_u128(0x6d748de2_8d38_4cc3_ac60_f009b057c557) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_RecordedTV_IsRepeatBroadcast: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6d748de2_8d38_4cc3_ac60_f009b057c557), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_RecordedTV_IsRepeatBroadcast ) , guid : :: windows :: core :: GUID::from_u128(0x6d748de2_8d38_4cc3_ac60_f009b057c557) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_RecordedTV_IsSAP: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6d748de2_8d38_4cc3_ac60_f009b057c557), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_RecordedTV_IsSAP ) , guid : :: windows :: core :: GUID::from_u128(0x6d748de2_8d38_4cc3_ac60_f009b057c557) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_RecordedTV_NetworkAffiliation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x2c53c813_fb63_4e22_a1ab_0b331ca1e273), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_RecordedTV_NetworkAffiliation ) , guid : :: windows :: core :: GUID::from_u128(0x2c53c813_fb63_4e22_a1ab_0b331ca1e273) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_RecordedTV_OriginalBroadcastDate: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4684fe97_8765_4842_9c13_f006447b178c), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_RecordedTV_OriginalBroadcastDate ) , guid : :: windows :: core :: GUID::from_u128(0x4684fe97_8765_4842_9c13_f006447b178c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_RecordedTV_ProgramDescription: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6d748de2_8d38_4cc3_ac60_f009b057c557), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_RecordedTV_ProgramDescription ) , guid : :: windows :: core :: GUID::from_u128(0x6d748de2_8d38_4cc3_ac60_f009b057c557) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_RecordedTV_RecordingTime: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa5477f61_7a82_4eca_9dde_98b69b2479b3), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_RecordedTV_RecordingTime ) , guid : :: windows :: core :: GUID::from_u128(0xa5477f61_7a82_4eca_9dde_98b69b2479b3) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_RecordedTV_StationCallSign: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x6d748de2_8d38_4cc3_ac60_f009b057c557), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_RecordedTV_StationCallSign ) , guid : :: windows :: core :: GUID::from_u128(0x6d748de2_8d38_4cc3_ac60_f009b057c557) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_RecordedTV_StationName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x1b5439e7_eba1_4af8_bdd7_7af1d4549493), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_RecordedTV_StationName ) , guid : :: windows :: core :: GUID::from_u128(0x1b5439e7_eba1_4af8_bdd7_7af1d4549493) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_RemoteConflictingFile: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8), pid: 115u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_RemoteConflictingFile ) , guid : :: windows :: core :: GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_SFGAOFlags: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0), pid: 25u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_SFGAOFlags ) , guid : :: windows :: core :: GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Search_AutoSummary: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x560c36c0_503a_11cf_baa1_00004c752a9a), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Search_AutoSummary ) , guid : :: windows :: core :: GUID::from_u128(0x560c36c0_503a_11cf_baa1_00004c752a9a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Search_ContainerHash: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xbceee283_35df_4d53_826a_f36a3eefc6be), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Search_ContainerHash ) , guid : :: windows :: core :: GUID::from_u128(0xbceee283_35df_4d53_826a_f36a3eefc6be) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Search_Contents: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac), pid: 19u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Search_Contents ) , guid : :: windows :: core :: GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Search_EntryID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x49691c90_7e17_101a_a91c_08002b2ecda9), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Search_EntryID ) , guid : :: windows :: core :: GUID::from_u128(0x49691c90_7e17_101a_a91c_08002b2ecda9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Search_ExtendedProperties: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7b03b546_fa4f_4a52_a2fe_03d5311e5865), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Search_ExtendedProperties ) , guid : :: windows :: core :: GUID::from_u128(0x7b03b546_fa4f_4a52_a2fe_03d5311e5865) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Search_GatherTime: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0b63e350_9ccc_11d0_bcdb_00805fccce04), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Search_GatherTime ) , guid : :: windows :: core :: GUID::from_u128(0x0b63e350_9ccc_11d0_bcdb_00805fccce04) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Search_HitCount: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x49691c90_7e17_101a_a91c_08002b2ecda9), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Search_HitCount ) , guid : :: windows :: core :: GUID::from_u128(0x49691c90_7e17_101a_a91c_08002b2ecda9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Search_IsClosedDirectory: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0b63e343_9ccc_11d0_bcdb_00805fccce04), pid: 23u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Search_IsClosedDirectory ) , guid : :: windows :: core :: GUID::from_u128(0x0b63e343_9ccc_11d0_bcdb_00805fccce04) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Search_IsFullyContained: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0b63e343_9ccc_11d0_bcdb_00805fccce04), pid: 24u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Search_IsFullyContained ) , guid : :: windows :: core :: GUID::from_u128(0x0b63e343_9ccc_11d0_bcdb_00805fccce04) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Search_QueryFocusedSummary: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x560c36c0_503a_11cf_baa1_00004c752a9a), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Search_QueryFocusedSummary ) , guid : :: windows :: core :: GUID::from_u128(0x560c36c0_503a_11cf_baa1_00004c752a9a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Search_QueryFocusedSummaryWithFallback: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x560c36c0_503a_11cf_baa1_00004c752a9a), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Search_QueryFocusedSummaryWithFallback ) , guid : :: windows :: core :: GUID::from_u128(0x560c36c0_503a_11cf_baa1_00004c752a9a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Search_QueryPropertyHits: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x49691c90_7e17_101a_a91c_08002b2ecda9), pid: 21u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Search_QueryPropertyHits ) , guid : :: windows :: core :: GUID::from_u128(0x49691c90_7e17_101a_a91c_08002b2ecda9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Search_Rank: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x49691c90_7e17_101a_a91c_08002b2ecda9), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Search_Rank ) , guid : :: windows :: core :: GUID::from_u128(0x49691c90_7e17_101a_a91c_08002b2ecda9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Search_Store: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa06992b3_8caf_4ed7_a547_b259e32ac9fc), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Search_Store ) , guid : :: windows :: core :: GUID::from_u128(0xa06992b3_8caf_4ed7_a547_b259e32ac9fc) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Search_UrlToIndex: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0b63e343_9ccc_11d0_bcdb_00805fccce04), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Search_UrlToIndex ) , guid : :: windows :: core :: GUID::from_u128(0x0b63e343_9ccc_11d0_bcdb_00805fccce04) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Search_UrlToIndexWithModificationTime: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0b63e343_9ccc_11d0_bcdb_00805fccce04), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Search_UrlToIndexWithModificationTime ) , guid : :: windows :: core :: GUID::from_u128(0x0b63e343_9ccc_11d0_bcdb_00805fccce04) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Security_AllowedEnterpriseDataProtectionIdentities: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x38d43380_d418_4830_84d5_46935a81c5c6), pid: 32u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Security_AllowedEnterpriseDataProtectionIdentities ) , guid : :: windows :: core :: GUID::from_u128(0x38d43380_d418_4830_84d5_46935a81c5c6) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Security_EncryptionOwners: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5f5aff6a_37e5_4780_97ea_80c7565cf535), pid: 34u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Security_EncryptionOwners ) , guid : :: windows :: core :: GUID::from_u128(0x5f5aff6a_37e5_4780_97ea_80c7565cf535) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Security_EncryptionOwnersDisplay: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xde621b8f_e125_43a3_a32d_5665446d632a), pid: 25u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Security_EncryptionOwnersDisplay ) , guid : :: windows :: core :: GUID::from_u128(0xde621b8f_e125_43a3_a32d_5665446d632a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Sensitivity: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf8d3f6ac_4874_42cb_be59_ab454b30716a), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Sensitivity ) , guid : :: windows :: core :: GUID::from_u128(0xf8d3f6ac_4874_42cb_be59_ab454b30716a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_SensitivityText: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd0c7f054_3f72_4725_8527_129a577cb269), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_SensitivityText ) , guid : :: windows :: core :: GUID::from_u128(0xd0c7f054_3f72_4725_8527_129a577cb269) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ShareUserRating: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ShareUserRating ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_SharedWith: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef884c5b_2bfe_41bb_aae5_76eedf4f9902), pid: 200u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_SharedWith ) , guid : :: windows :: core :: GUID::from_u128(0xef884c5b_2bfe_41bb_aae5_76eedf4f9902) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_SharingStatus: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xef884c5b_2bfe_41bb_aae5_76eedf4f9902), pid: 300u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_SharingStatus ) , guid : :: windows :: core :: GUID::from_u128(0xef884c5b_2bfe_41bb_aae5_76eedf4f9902) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Shell_OmitFromView: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xde35258c_c695_4cbc_b982_38b0ad24ced0), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Shell_OmitFromView ) , guid : :: windows :: core :: GUID::from_u128(0xde35258c_c695_4cbc_b982_38b0ad24ced0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Shell_SFGAOFlagsStrings: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd6942081_d53b_443d_ad47_5e059d9cd27a), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Shell_SFGAOFlagsStrings ) , guid : :: windows :: core :: GUID::from_u128(0xd6942081_d53b_443d_ad47_5e059d9cd27a) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_SimpleRating: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xa09f084e_ad41_489f_8076_aa5be3082bca), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_SimpleRating ) , guid : :: windows :: core :: GUID::from_u128(0xa09f084e_ad41_489f_8076_aa5be3082bca) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Size: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Size ) , guid : :: windows :: core :: GUID::from_u128(0xb725f130_47ef_101a_a5f1_02608c9eebac) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_SoftwareUsed: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99), pid: 305u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_SoftwareUsed ) , guid : :: windows :: core :: GUID::from_u128(0x14b81da1_0135_4d31_96d9_6cbfc9671a99) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Software_DateLastUsed: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x841e4f90_ff59_4d16_8947_e81bbffab36d), pid: 16u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Software_DateLastUsed ) , guid : :: windows :: core :: GUID::from_u128(0x841e4f90_ff59_4d16_8947_e81bbffab36d) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Software_ProductName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cef7d53_fa64_11d1_a203_0000f81fedee), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Software_ProductName ) , guid : :: windows :: core :: GUID::from_u128(0x0cef7d53_fa64_11d1_a203_0000f81fedee) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_SourceItem: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x668cdfa5_7a1b_4323_ae4b_e527393a1d81), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_SourceItem ) , guid : :: windows :: core :: GUID::from_u128(0x668cdfa5_7a1b_4323_ae4b_e527393a1d81) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_SourcePackageFamilyName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xffae9db7_1c8d_43ff_818c_84403aa3732d), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_SourcePackageFamilyName ) , guid : :: windows :: core :: GUID::from_u128(0xffae9db7_1c8d_43ff_818c_84403aa3732d) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_StartDate: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x48fd6ec8_8a12_4cdf_a03e_4ec5a511edde), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_StartDate ) , guid : :: windows :: core :: GUID::from_u128(0x48fd6ec8_8a12_4cdf_a03e_4ec5a511edde) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Status: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x000214a1_0000_0000_c000_000000000046), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Status ) , guid : :: windows :: core :: GUID::from_u128(0x000214a1_0000_0000_c000_000000000046) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_StatusBarSelectedItemCount: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x26dc287c_6e3d_4bd3_b2b0_6a26ba2e346d), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_StatusBarSelectedItemCount ) , guid : :: windows :: core :: GUID::from_u128(0x26dc287c_6e3d_4bd3_b2b0_6a26ba2e346d) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_StatusBarViewItemCount: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x26dc287c_6e3d_4bd3_b2b0_6a26ba2e346d), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_StatusBarViewItemCount ) , guid : :: windows :: core :: GUID::from_u128(0x26dc287c_6e3d_4bd3_b2b0_6a26ba2e346d) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_StorageProviderCallerVersionInformation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb2f9b9d6_fec4_4dd5_94d7_8957488c807b), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_StorageProviderCallerVersionInformation ) , guid : :: windows :: core :: GUID::from_u128(0xb2f9b9d6_fec4_4dd5_94d7_8957488c807b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_StorageProviderError: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8), pid: 109u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_StorageProviderError ) , guid : :: windows :: core :: GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_StorageProviderFileChecksum: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb2f9b9d6_fec4_4dd5_94d7_8957488c807b), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_StorageProviderFileChecksum ) , guid : :: windows :: core :: GUID::from_u128(0xb2f9b9d6_fec4_4dd5_94d7_8957488c807b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_StorageProviderFileFlags: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb2f9b9d6_fec4_4dd5_94d7_8957488c807b), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_StorageProviderFileFlags ) , guid : :: windows :: core :: GUID::from_u128(0xb2f9b9d6_fec4_4dd5_94d7_8957488c807b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_StorageProviderFileHasConflict: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb2f9b9d6_fec4_4dd5_94d7_8957488c807b), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_StorageProviderFileHasConflict ) , guid : :: windows :: core :: GUID::from_u128(0xb2f9b9d6_fec4_4dd5_94d7_8957488c807b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_StorageProviderFileIdentifier: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb2f9b9d6_fec4_4dd5_94d7_8957488c807b), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_StorageProviderFileIdentifier ) , guid : :: windows :: core :: GUID::from_u128(0xb2f9b9d6_fec4_4dd5_94d7_8957488c807b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_StorageProviderFileRemoteUri: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8), pid: 112u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_StorageProviderFileRemoteUri ) , guid : :: windows :: core :: GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_StorageProviderFileVersion: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb2f9b9d6_fec4_4dd5_94d7_8957488c807b), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_StorageProviderFileVersion ) , guid : :: windows :: core :: GUID::from_u128(0xb2f9b9d6_fec4_4dd5_94d7_8957488c807b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_StorageProviderFileVersionWaterline: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xb2f9b9d6_fec4_4dd5_94d7_8957488c807b), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_StorageProviderFileVersionWaterline ) , guid : :: windows :: core :: GUID::from_u128(0xb2f9b9d6_fec4_4dd5_94d7_8957488c807b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_StorageProviderId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8), pid: 108u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_StorageProviderId ) , guid : :: windows :: core :: GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_StorageProviderShareStatuses: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8), pid: 111u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_StorageProviderShareStatuses ) , guid : :: windows :: core :: GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_StorageProviderSharingStatus: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8), pid: 117u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_StorageProviderSharingStatus ) , guid : :: windows :: core :: GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_StorageProviderStatus: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8), pid: 110u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_StorageProviderStatus ) , guid : :: windows :: core :: GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Storage_Portable: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d1ebee8_0803_4774_9842_b77db50265e9), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Storage_Portable ) , guid : :: windows :: core :: GUID::from_u128(0x4d1ebee8_0803_4774_9842_b77db50265e9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Storage_RemovableMedia: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d1ebee8_0803_4774_9842_b77db50265e9), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Storage_RemovableMedia ) , guid : :: windows :: core :: GUID::from_u128(0x4d1ebee8_0803_4774_9842_b77db50265e9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Storage_SystemCritical: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d1ebee8_0803_4774_9842_b77db50265e9), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Storage_SystemCritical ) , guid : :: windows :: core :: GUID::from_u128(0x4d1ebee8_0803_4774_9842_b77db50265e9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Subject: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Subject ) , guid : :: windows :: core :: GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Supplemental_Album: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0c73b141_39d6_4653_a683_cab291eaf95b), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Supplemental_Album ) , guid : :: windows :: core :: GUID::from_u128(0x0c73b141_39d6_4653_a683_cab291eaf95b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Supplemental_AlbumID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0c73b141_39d6_4653_a683_cab291eaf95b), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Supplemental_AlbumID ) , guid : :: windows :: core :: GUID::from_u128(0x0c73b141_39d6_4653_a683_cab291eaf95b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Supplemental_Location: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0c73b141_39d6_4653_a683_cab291eaf95b), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Supplemental_Location ) , guid : :: windows :: core :: GUID::from_u128(0x0c73b141_39d6_4653_a683_cab291eaf95b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Supplemental_Person: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0c73b141_39d6_4653_a683_cab291eaf95b), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Supplemental_Person ) , guid : :: windows :: core :: GUID::from_u128(0x0c73b141_39d6_4653_a683_cab291eaf95b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Supplemental_ResourceId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0c73b141_39d6_4653_a683_cab291eaf95b), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Supplemental_ResourceId ) , guid : :: windows :: core :: GUID::from_u128(0x0c73b141_39d6_4653_a683_cab291eaf95b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Supplemental_Tag: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0c73b141_39d6_4653_a683_cab291eaf95b), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Supplemental_Tag ) , guid : :: windows :: core :: GUID::from_u128(0x0c73b141_39d6_4653_a683_cab291eaf95b) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_SyncTransferStatus: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8), pid: 103u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_SyncTransferStatus ) , guid : :: windows :: core :: GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Sync_Comments: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7bd5533e_af15_44db_b8c8_bd6624e1d032), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Sync_Comments ) , guid : :: windows :: core :: GUID::from_u128(0x7bd5533e_af15_44db_b8c8_bd6624e1d032) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Sync_ConflictDescription: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xce50c159_2fb8_41fd_be68_d3e042e274bc), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Sync_ConflictDescription ) , guid : :: windows :: core :: GUID::from_u128(0xce50c159_2fb8_41fd_be68_d3e042e274bc) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Sync_ConflictFirstLocation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xce50c159_2fb8_41fd_be68_d3e042e274bc), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Sync_ConflictFirstLocation ) , guid : :: windows :: core :: GUID::from_u128(0xce50c159_2fb8_41fd_be68_d3e042e274bc) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Sync_ConflictSecondLocation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xce50c159_2fb8_41fd_be68_d3e042e274bc), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Sync_ConflictSecondLocation ) , guid : :: windows :: core :: GUID::from_u128(0xce50c159_2fb8_41fd_be68_d3e042e274bc) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Sync_HandlerCollectionID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7bd5533e_af15_44db_b8c8_bd6624e1d032), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Sync_HandlerCollectionID ) , guid : :: windows :: core :: GUID::from_u128(0x7bd5533e_af15_44db_b8c8_bd6624e1d032) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Sync_HandlerID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7bd5533e_af15_44db_b8c8_bd6624e1d032), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Sync_HandlerID ) , guid : :: windows :: core :: GUID::from_u128(0x7bd5533e_af15_44db_b8c8_bd6624e1d032) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Sync_HandlerName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xce50c159_2fb8_41fd_be68_d3e042e274bc), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Sync_HandlerName ) , guid : :: windows :: core :: GUID::from_u128(0xce50c159_2fb8_41fd_be68_d3e042e274bc) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Sync_HandlerType: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7bd5533e_af15_44db_b8c8_bd6624e1d032), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Sync_HandlerType ) , guid : :: windows :: core :: GUID::from_u128(0x7bd5533e_af15_44db_b8c8_bd6624e1d032) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Sync_HandlerTypeLabel: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7bd5533e_af15_44db_b8c8_bd6624e1d032), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Sync_HandlerTypeLabel ) , guid : :: windows :: core :: GUID::from_u128(0x7bd5533e_af15_44db_b8c8_bd6624e1d032) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Sync_ItemID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7bd5533e_af15_44db_b8c8_bd6624e1d032), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Sync_ItemID ) , guid : :: windows :: core :: GUID::from_u128(0x7bd5533e_af15_44db_b8c8_bd6624e1d032) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Sync_ItemName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xce50c159_2fb8_41fd_be68_d3e042e274bc), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Sync_ItemName ) , guid : :: windows :: core :: GUID::from_u128(0xce50c159_2fb8_41fd_be68_d3e042e274bc) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Sync_ProgressPercentage: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7bd5533e_af15_44db_b8c8_bd6624e1d032), pid: 23u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Sync_ProgressPercentage ) , guid : :: windows :: core :: GUID::from_u128(0x7bd5533e_af15_44db_b8c8_bd6624e1d032) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Sync_State: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7bd5533e_af15_44db_b8c8_bd6624e1d032), pid: 24u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Sync_State ) , guid : :: windows :: core :: GUID::from_u128(0x7bd5533e_af15_44db_b8c8_bd6624e1d032) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Sync_Status: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x7bd5533e_af15_44db_b8c8_bd6624e1d032), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Sync_Status ) , guid : :: windows :: core :: GUID::from_u128(0x7bd5533e_af15_44db_b8c8_bd6624e1d032) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Task_BillingInformation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xd37d52c6_261c_4303_82b3_08b926ac6f12), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Task_BillingInformation ) , guid : :: windows :: core :: GUID::from_u128(0xd37d52c6_261c_4303_82b3_08b926ac6f12) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Task_CompletionStatus: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x084d8a0a_e6d5_40de_bf1f_c8820e7c877c), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Task_CompletionStatus ) , guid : :: windows :: core :: GUID::from_u128(0x084d8a0a_e6d5_40de_bf1f_c8820e7c877c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Task_Owner: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x08c7cc5f_60f2_4494_ad75_55e3e0b5add0), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Task_Owner ) , guid : :: windows :: core :: GUID::from_u128(0x08c7cc5f_60f2_4494_ad75_55e3e0b5add0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Thumbnail: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9), pid: 17u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Thumbnail ) , guid : :: windows :: core :: GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ThumbnailCacheId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x446d16b1_8dad_4870_a748_402ea43d788c), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ThumbnailCacheId ) , guid : :: windows :: core :: GUID::from_u128(0x446d16b1_8dad_4870_a748_402ea43d788c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ThumbnailStream: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9), pid: 27u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ThumbnailStream ) , guid : :: windows :: core :: GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Title: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Title ) , guid : :: windows :: core :: GUID::from_u128(0xf29f85e0_4ff9_1068_ab91_08002b27b3d9) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_TitleSortOverride: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xf0f7984d_222e_4ad2_82ab_1dd8ea40e57e), pid: 300u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_TitleSortOverride ) , guid : :: windows :: core :: GUID::from_u128(0xf0f7984d_222e_4ad2_82ab_1dd8ea40e57e) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_TotalFileSize: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_TotalFileSize ) , guid : :: windows :: core :: GUID::from_u128(0x28636aa6_953d_11d2_b5d6_00c04fd918d0) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Trademarks: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x0cef7d53_fa64_11d1_a203_0000f81fedee), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Trademarks ) , guid : :: windows :: core :: GUID::from_u128(0x0cef7d53_fa64_11d1_a203_0000f81fedee) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_TransferOrder: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8), pid: 106u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_TransferOrder ) , guid : :: windows :: core :: GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_TransferPosition: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8), pid: 104u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_TransferPosition ) , guid : :: windows :: core :: GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_TransferSize: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8), pid: 105u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_TransferSize ) , guid : :: windows :: core :: GUID::from_u128(0xfceff153_e839_4cf3_a9e7_ea22832094b8) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Video_Compression: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Video_Compression ) , guid : :: windows :: core :: GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Video_Director: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03), pid: 20u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Video_Director ) , guid : :: windows :: core :: GUID::from_u128(0x64440492_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Video_EncodingBitrate: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Video_EncodingBitrate ) , guid : :: windows :: core :: GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Video_FourCC: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03), pid: 44u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Video_FourCC ) , guid : :: windows :: core :: GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Video_FrameHeight: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Video_FrameHeight ) , guid : :: windows :: core :: GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Video_FrameRate: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Video_FrameRate ) , guid : :: windows :: core :: GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Video_FrameWidth: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Video_FrameWidth ) , guid : :: windows :: core :: GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Video_HorizontalAspectRatio: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03), pid: 42u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Video_HorizontalAspectRatio ) , guid : :: windows :: core :: GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Video_IsSpherical: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Video_IsSpherical ) , guid : :: windows :: core :: GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Video_IsStereo: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03), pid: 98u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Video_IsStereo ) , guid : :: windows :: core :: GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Video_Orientation: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03), pid: 99u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Video_Orientation ) , guid : :: windows :: core :: GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Video_SampleSize: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Video_SampleSize ) , guid : :: windows :: core :: GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Video_StreamName: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Video_StreamName ) , guid : :: windows :: core :: GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Video_StreamNumber: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Video_StreamNumber ) , guid : :: windows :: core :: GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Video_TotalBitrate: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03), pid: 43u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Video_TotalBitrate ) , guid : :: windows :: core :: GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Video_TranscodedForSync: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03), pid: 46u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Video_TranscodedForSync ) , guid : :: windows :: core :: GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Video_VerticalAspectRatio: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03), pid: 45u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Video_VerticalAspectRatio ) , guid : :: windows :: core :: GUID::from_u128(0x64440491_4c8b_11d1_8b70_080036b11a03) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_VolumeId: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x446d16b1_8dad_4870_a748_402ea43d788c), pid: 104u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_VolumeId ) , guid : :: windows :: core :: GUID::from_u128(0x446d16b1_8dad_4870_a748_402ea43d788c) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Volume_FileSystem: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9b174b35_40ff_11d2_a27e_00c04fc30871), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Volume_FileSystem ) , guid : :: windows :: core :: GUID::from_u128(0x9b174b35_40ff_11d2_a27e_00c04fc30871) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Volume_IsMappedDrive: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x149c0b69_2c2d_48fc_808f_d318d78c4636), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Volume_IsMappedDrive ) , guid : :: windows :: core :: GUID::from_u128(0x149c0b69_2c2d_48fc_808f_d318d78c4636) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_Volume_IsRoot: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x9b174b35_40ff_11d2_a27e_00c04fc30871), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_Volume_IsRoot ) , guid : :: windows :: core :: GUID::from_u128(0x9b174b35_40ff_11d2_a27e_00c04fc30871) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_ZoneIdentifier: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x502cfeab_47eb_459c_b960_e6d8728f7701), pid: 100u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_ZoneIdentifier ) , guid : :: windows :: core :: GUID::from_u128(0x502cfeab_47eb_459c_b960_e6d8728f7701) , } }
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage'*"]
 pub const PLAYBACKSTATE_NOMEDIA: u32 = 7u32;
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage'*"]
@@ -4471,3 +6677,5 @@ pub const SYNC_STATE_SYNCING: u32 = 5u32;
 #[doc = "*Required features: 'Win32_Storage_EnhancedStorage'*"]
 pub const SYNC_STATE_SYNCNOTRUN: u32 = 1u32;
 pub const WPD_CATEGORY_ENHANCED_STORAGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPD_CATEGORY_ENHANCED_STORAGE ) , guid : :: windows :: core :: GUID::from_u128(0x91248166_b832_4ad4_baa4_7ca0b6b2798c) , } }

--- a/crates/libs/windows/src/Windows/Win32/Storage/FileSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/FileSystem/mod.rs
@@ -931,6 +931,8 @@ impl ::core::default::Default for CLFS_STREAM_ID_INFORMATION {
     }
 }
 pub const CLSID_DiskQuotaControl: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7988b571_ec89_11cf_9c00_00aa00a14f56);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DiskQuotaControl ) , guid : :: windows :: core :: GUID::from_u128(0x7988b571_ec89_11cf_9c00_00aa00a14f56) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_Storage_FileSystem'*"]
 pub struct CLS_ARCHIVE_DESCRIPTOR {
@@ -12270,29 +12272,77 @@ pub unsafe fn OpenTransactionManagerById(transactionmanagerid: *const ::windows:
     unimplemented!("Unsupported target OS");
 }
 pub const PARTITION_BASIC_DATA_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xebd0a0a2_b9e5_4433_87c0_68b6b72699c7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PARTITION_BASIC_DATA_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xebd0a0a2_b9e5_4433_87c0_68b6b72699c7) , } }
 pub const PARTITION_BSP_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x57434f53_4df9_45b9_8e9e_2370f006457c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PARTITION_BSP_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x57434f53_4df9_45b9_8e9e_2370f006457c) , } }
 pub const PARTITION_CLUSTER_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdb97dba9_0840_4bae_97f0_ffb9a327c7e1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PARTITION_CLUSTER_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xdb97dba9_0840_4bae_97f0_ffb9a327c7e1) , } }
 pub const PARTITION_DPP_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x57434f53_94cb_43f0_a533_d73c10cfa57d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PARTITION_DPP_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x57434f53_94cb_43f0_a533_d73c10cfa57d) , } }
 pub const PARTITION_ENTRY_UNUSED_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x00000000_0000_0000_0000_000000000000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PARTITION_ENTRY_UNUSED_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x00000000_0000_0000_0000_000000000000) , } }
 pub const PARTITION_LDM_DATA_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaf9b60a0_1431_4f62_bc68_3311714a69ad);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PARTITION_LDM_DATA_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xaf9b60a0_1431_4f62_bc68_3311714a69ad) , } }
 pub const PARTITION_LDM_METADATA_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5808c8aa_7e8f_42e0_85d2_e1e90434cfb3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PARTITION_LDM_METADATA_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x5808c8aa_7e8f_42e0_85d2_e1e90434cfb3) , } }
 pub const PARTITION_LEGACY_BL_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x424ca0e2_7cb2_4fb9_8143_c52a99398bc6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PARTITION_LEGACY_BL_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x424ca0e2_7cb2_4fb9_8143_c52a99398bc6) , } }
 pub const PARTITION_LEGACY_BL_GUID_BACKUP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x424c3e6c_d79f_49cb_935d_36d71467a288);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PARTITION_LEGACY_BL_GUID_BACKUP ) , guid : :: windows :: core :: GUID::from_u128(0x424c3e6c_d79f_49cb_935d_36d71467a288) , } }
 pub const PARTITION_MAIN_OS_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x57434f53_8f45_405e_8a23_186d8a4330d3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PARTITION_MAIN_OS_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x57434f53_8f45_405e_8a23_186d8a4330d3) , } }
 pub const PARTITION_MSFT_RECOVERY_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xde94bba4_06d1_4d40_a16a_bfd50179d6ac);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PARTITION_MSFT_RECOVERY_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xde94bba4_06d1_4d40_a16a_bfd50179d6ac) , } }
 pub const PARTITION_MSFT_RESERVED_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe3c9e316_0b5c_4db8_817d_f92df00215ae);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PARTITION_MSFT_RESERVED_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xe3c9e316_0b5c_4db8_817d_f92df00215ae) , } }
 pub const PARTITION_MSFT_SNAPSHOT_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcaddebf1_4400_4de8_b103_12117dcf3ccf);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PARTITION_MSFT_SNAPSHOT_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xcaddebf1_4400_4de8_b103_12117dcf3ccf) , } }
 pub const PARTITION_OS_DATA_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x57434f53_23f2_44d5_a830_67bbdaa609f9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PARTITION_OS_DATA_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x57434f53_23f2_44d5_a830_67bbdaa609f9) , } }
 pub const PARTITION_PATCH_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8967a686_96aa_6aa8_9589_a84256541090);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PARTITION_PATCH_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x8967a686_96aa_6aa8_9589_a84256541090) , } }
 pub const PARTITION_PRE_INSTALLED_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x57434f53_7fe0_4196_9b42_427b51643484);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PARTITION_PRE_INSTALLED_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x57434f53_7fe0_4196_9b42_427b51643484) , } }
 pub const PARTITION_SERVICING_FILES_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x57434f53_432e_4014_ae4c_8deaa9c0006a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PARTITION_SERVICING_FILES_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x57434f53_432e_4014_ae4c_8deaa9c0006a) , } }
 pub const PARTITION_SERVICING_METADATA_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x57434f53_c691_4a05_bb4e_703dafd229ce);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PARTITION_SERVICING_METADATA_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x57434f53_c691_4a05_bb4e_703dafd229ce) , } }
 pub const PARTITION_SERVICING_RESERVE_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x57434f53_4b81_460b_a319_ffb6fe136d14);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PARTITION_SERVICING_RESERVE_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x57434f53_4b81_460b_a319_ffb6fe136d14) , } }
 pub const PARTITION_SERVICING_STAGING_ROOT_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x57434f53_e84d_4e84_aaf3_ecbbbd04b9df);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PARTITION_SERVICING_STAGING_ROOT_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x57434f53_e84d_4e84_aaf3_ecbbbd04b9df) , } }
 pub const PARTITION_SPACES_DATA_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe7addcb4_dc34_4539_9a76_ebbd07be6f7e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PARTITION_SPACES_DATA_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xe7addcb4_dc34_4539_9a76_ebbd07be6f7e) , } }
 pub const PARTITION_SPACES_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe75caf8f_f680_4cee_afa3_b001e56efc2d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PARTITION_SPACES_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xe75caf8f_f680_4cee_afa3_b001e56efc2d) , } }
 pub const PARTITION_SYSTEM_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc12a7328_f81f_11d2_ba4b_00a0c93ec93b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PARTITION_SYSTEM_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xc12a7328_f81f_11d2_ba4b_00a0c93ec93b) , } }
 pub const PARTITION_WINDOWS_SYSTEM_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x57434f53_e3e3_4631_a5c5_26d2243873aa);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PARTITION_WINDOWS_SYSTEM_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x57434f53_e3e3_4631_a5c5_26d2243873aa) , } }
 #[doc = "*Required features: 'Win32_Storage_FileSystem'*"]
 pub type PCLFS_COMPLETION_ROUTINE = ::core::option::Option<unsafe extern "system" fn(pvoverlapped: *mut ::core::ffi::c_void, ulreserved: u32)>;
 #[doc = "*Required features: 'Win32_Storage_FileSystem', 'Win32_Foundation'*"]

--- a/crates/libs/windows/src/Windows/Win32/Storage/Imapi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Imapi/mod.rs
@@ -3,25 +3,65 @@ pub const BlockRange: ::windows::core::GUID = ::windows::core::GUID::from_u128(0
 pub const BlockRangeList: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb507ca28_2204_11dd_966a_001aa01bbc58);
 pub const BootOptions: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2c941fce_975b_59be_a960_9a2a262853a5);
 pub const CATID_SMTP_DNSRESOLVERRECORDSINK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbd0b4366_8e03_11d2_94f6_00c04f79f1d6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_SMTP_DNSRESOLVERRECORDSINK ) , guid : :: windows :: core :: GUID::from_u128(0xbd0b4366_8e03_11d2_94f6_00c04f79f1d6) , } }
 pub const CATID_SMTP_DSN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x22b55731_f5f8_4d23_bd8f_87b52371a73a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_SMTP_DSN ) , guid : :: windows :: core :: GUID::from_u128(0x22b55731_f5f8_4d23_bd8f_87b52371a73a) , } }
 pub const CATID_SMTP_GET_AUX_DOMAIN_INFO_FLAGS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x84ff368a_fab3_43d7_bcdf_692c5b46e6b1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_SMTP_GET_AUX_DOMAIN_INFO_FLAGS ) , guid : :: windows :: core :: GUID::from_u128(0x84ff368a_fab3_43d7_bcdf_692c5b46e6b1) , } }
 pub const CATID_SMTP_LOG: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x93d0a538_2c1e_4b68_a7c9_d73a8aa6ee97);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_SMTP_LOG ) , guid : :: windows :: core :: GUID::from_u128(0x93d0a538_2c1e_4b68_a7c9_d73a8aa6ee97) , } }
 pub const CATID_SMTP_MAXMSGSIZE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xebf159de_a67e_11d2_94f7_00c04f79f1d6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_SMTP_MAXMSGSIZE ) , guid : :: windows :: core :: GUID::from_u128(0xebf159de_a67e_11d2_94f7_00c04f79f1d6) , } }
 pub const CATID_SMTP_MSGTRACKLOG: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc6df52aa_7db0_11d2_94f4_00c04f79f1d6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_SMTP_MSGTRACKLOG ) , guid : :: windows :: core :: GUID::from_u128(0xc6df52aa_7db0_11d2_94f4_00c04f79f1d6) , } }
 pub const CATID_SMTP_ON_BEFORE_DATA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf6628c92_0d5e_11d2_aa68_00c04fa35b82);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_SMTP_ON_BEFORE_DATA ) , guid : :: windows :: core :: GUID::from_u128(0xf6628c92_0d5e_11d2_aa68_00c04fa35b82) , } }
 pub const CATID_SMTP_ON_INBOUND_COMMAND: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf6628c8d_0d5e_11d2_aa68_00c04fa35b82);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_SMTP_ON_INBOUND_COMMAND ) , guid : :: windows :: core :: GUID::from_u128(0xf6628c8d_0d5e_11d2_aa68_00c04fa35b82) , } }
 pub const CATID_SMTP_ON_MESSAGE_START: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf6628c90_0d5e_11d2_aa68_00c04fa35b82);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_SMTP_ON_MESSAGE_START ) , guid : :: windows :: core :: GUID::from_u128(0xf6628c90_0d5e_11d2_aa68_00c04fa35b82) , } }
 pub const CATID_SMTP_ON_PER_RECIPIENT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf6628c91_0d5e_11d2_aa68_00c04fa35b82);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_SMTP_ON_PER_RECIPIENT ) , guid : :: windows :: core :: GUID::from_u128(0xf6628c91_0d5e_11d2_aa68_00c04fa35b82) , } }
 pub const CATID_SMTP_ON_SERVER_RESPONSE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf6628c8e_0d5e_11d2_aa68_00c04fa35b82);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_SMTP_ON_SERVER_RESPONSE ) , guid : :: windows :: core :: GUID::from_u128(0xf6628c8e_0d5e_11d2_aa68_00c04fa35b82) , } }
 pub const CATID_SMTP_ON_SESSION_END: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf6628c93_0d5e_11d2_aa68_00c04fa35b82);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_SMTP_ON_SESSION_END ) , guid : :: windows :: core :: GUID::from_u128(0xf6628c93_0d5e_11d2_aa68_00c04fa35b82) , } }
 pub const CATID_SMTP_ON_SESSION_START: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf6628c8f_0d5e_11d2_aa68_00c04fa35b82);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_SMTP_ON_SESSION_START ) , guid : :: windows :: core :: GUID::from_u128(0xf6628c8f_0d5e_11d2_aa68_00c04fa35b82) , } }
 pub const CATID_SMTP_STORE_DRIVER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x59175850_e533_11d1_aa67_00c04fa345f6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_SMTP_STORE_DRIVER ) , guid : :: windows :: core :: GUID::from_u128(0x59175850_e533_11d1_aa67_00c04fa345f6) , } }
 pub const CATID_SMTP_TRANSPORT_CATEGORIZE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x960252a3_0a3a_11d2_9e00_00c04fa322ba);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_SMTP_TRANSPORT_CATEGORIZE ) , guid : :: windows :: core :: GUID::from_u128(0x960252a3_0a3a_11d2_9e00_00c04fa322ba) , } }
 pub const CATID_SMTP_TRANSPORT_POSTCATEGORIZE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x76719654_05a6_11d2_9dfd_00c04fa322ba);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_SMTP_TRANSPORT_POSTCATEGORIZE ) , guid : :: windows :: core :: GUID::from_u128(0x76719654_05a6_11d2_9dfd_00c04fa322ba) , } }
 pub const CATID_SMTP_TRANSPORT_PRECATEGORIZE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa3acfb0d_83ff_11d2_9e14_00c04fa322ba);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_SMTP_TRANSPORT_PRECATEGORIZE ) , guid : :: windows :: core :: GUID::from_u128(0xa3acfb0d_83ff_11d2_9e14_00c04fa322ba) , } }
 pub const CATID_SMTP_TRANSPORT_ROUTER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x283430c9_1850_11d2_9e03_00c04fa322ba);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_SMTP_TRANSPORT_ROUTER ) , guid : :: windows :: core :: GUID::from_u128(0x283430c9_1850_11d2_9e03_00c04fa322ba) , } }
 pub const CATID_SMTP_TRANSPORT_SUBMISSION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xff3caa23_00b9_11d2_9dfb_00c04fa322ba);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_SMTP_TRANSPORT_SUBMISSION ) , guid : :: windows :: core :: GUID::from_u128(0xff3caa23_00b9_11d2_9dfb_00c04fa322ba) , } }
 pub const CLSID_SmtpCat: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb23c35b7_9219_11d2_9e17_00c04fa322ba);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_SmtpCat ) , guid : :: windows :: core :: GUID::from_u128(0xb23c35b7_9219_11d2_9e17_00c04fa322ba) , } }
 #[doc = "*Required features: 'Win32_Storage_Imapi'*"]
 #[inline]
 pub unsafe fn CloseIMsgSession(lpmsgsess: *mut _MSGSESS) {
@@ -1339,7 +1379,11 @@ pub const FsiItemFile: FsiItemType = 2i32;
 pub const FsiNamedStreams: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc6b6f8ed_6d19_44b4_b539_b159b793a32d);
 pub const FsiStream: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2c941fcd_975b_59be_a960_9a2a262853a5);
 pub const GUID_SMTPSVC_SOURCE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1b3c0666_e470_11d1_aa67_00c04fa345f6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SMTPSVC_SOURCE ) , guid : :: windows :: core :: GUID::from_u128(0x1b3c0666_e470_11d1_aa67_00c04fa345f6) , } }
 pub const GUID_SMTP_SOURCE_TYPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfb65c4dc_e468_11d1_aa67_00c04fa345f6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SMTP_SOURCE_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0xfb65c4dc_e468_11d1_aa67_00c04fa345f6) , } }
 #[doc = "*Required features: 'Win32_Storage_Imapi', 'Win32_System_AddressBook'*"]
 #[cfg(feature = "Win32_System_AddressBook")]
 #[inline]

--- a/crates/libs/windows/src/Windows/Win32/Storage/IscsiDisc/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/IscsiDisc/mod.rs
@@ -5173,6 +5173,8 @@ impl ::core::default::Default for STORAGE_FIRMWARE_SLOT_INFO_V2 {
 #[doc = "*Required features: 'Win32_Storage_IscsiDisc'*"]
 pub const STORAGE_FIRMWARE_SLOT_INFO_V2_REVISION_LENGTH: u32 = 16u32;
 pub const ScsiRawInterfaceGuid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x53f56309_b6bf_11d0_94f2_00a0c91efb8b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ScsiRawInterfaceGuid ) , guid : :: windows :: core :: GUID::from_u128(0x53f56309_b6bf_11d0_94f2_00a0c91efb8b) , } }
 #[doc = "*Required features: 'Win32_Storage_IscsiDisc'*"]
 #[inline]
 pub unsafe fn SendScsiInquiry(uniquesessionid: *mut ISCSI_UNIQUE_SESSION_ID, lun: u64, evpdcmddt: u8, pagecode: u8, scsistatus: *mut u8, responsesize: *mut u32, responsebuffer: *mut u8, sensesize: *mut u32, sensebuffer: *mut u8) -> u32 {
@@ -5399,5 +5401,7 @@ pub const TargetFlags: TARGET_INFORMATION_CLASS = 6i32;
 #[doc = "*Required features: 'Win32_Storage_IscsiDisc'*"]
 pub const LoginOptions: TARGET_INFORMATION_CLASS = 7i32;
 pub const WmiScsiAddressGuid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x53f5630f_b6bf_11d0_94f2_00a0c91efb8b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WmiScsiAddressGuid ) , guid : :: windows :: core :: GUID::from_u128(0x53f5630f_b6bf_11d0_94f2_00a0c91efb8b) , } }
 #[repr(C)]
 pub struct _ADAPTER_OBJECT(pub u8);

--- a/crates/libs/windows/src/Windows/Win32/Storage/Vhd/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Vhd/mod.rs
@@ -3181,4 +3181,8 @@ pub const VIRTUAL_STORAGE_TYPE_DEVICE_VHDSET: u32 = 4u32;
 #[doc = "*Required features: 'Win32_Storage_Vhd'*"]
 pub const VIRTUAL_STORAGE_TYPE_DEVICE_VHDX: u32 = 3u32;
 pub const VIRTUAL_STORAGE_TYPE_VENDOR_MICROSOFT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xec984aec_a0f9_47e9_901f_71415a66345b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( VIRTUAL_STORAGE_TYPE_VENDOR_MICROSOFT ) , guid : :: windows :: core :: GUID::from_u128(0xec984aec_a0f9_47e9_901f_71415a66345b) , } }
 pub const VIRTUAL_STORAGE_TYPE_VENDOR_UNKNOWN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x00000000_0000_0000_0000_000000000000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( VIRTUAL_STORAGE_TYPE_VENDOR_UNKNOWN ) , guid : :: windows :: core :: GUID::from_u128(0x00000000_0000_0000_0000_000000000000) , } }

--- a/crates/libs/windows/src/Windows/Win32/Storage/VirtualDiskService/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/VirtualDiskService/mod.rs
@@ -1,6 +1,10 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 pub const CLSID_VdsLoader: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9c38ed61_d565_4728_aeee_c80952f0ecde);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_VdsLoader ) , guid : :: windows :: core :: GUID::from_u128(0x9c38ed61_d565_4728_aeee_c80952f0ecde) , } }
 pub const CLSID_VdsService: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7d1933cb_86f6_4a98_8628_01be94c9a575);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_VdsService ) , guid : :: windows :: core :: GUID::from_u128(0x7d1933cb_86f6_4a98_8628_01be94c9a575) , } }
 #[doc = "*Required features: 'Win32_Storage_VirtualDiskService'*"]
 pub const GPT_PARTITION_NAME_LENGTH: u32 = 36u32;
 #[doc = "*Required features: 'Win32_Storage_VirtualDiskService'*"]

--- a/crates/libs/windows/src/Windows/Win32/Storage/Xps/Printing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Xps/Printing/mod.rs
@@ -1,7 +1,13 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 pub const ID_DOCUMENTPACKAGETARGET_MSXPS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9cae40a8_ded1_41c9_a9fd_d735ef33aeda);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ID_DOCUMENTPACKAGETARGET_MSXPS ) , guid : :: windows :: core :: GUID::from_u128(0x9cae40a8_ded1_41c9_a9fd_d735ef33aeda) , } }
 pub const ID_DOCUMENTPACKAGETARGET_OPENXPS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0056bb72_8c9c_4612_bd0f_93012a87099d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ID_DOCUMENTPACKAGETARGET_OPENXPS ) , guid : :: windows :: core :: GUID::from_u128(0x0056bb72_8c9c_4612_bd0f_93012a87099d) , } }
 pub const ID_DOCUMENTPACKAGETARGET_OPENXPS_WITH_3D: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x63dbd720_8b14_4577_b074_7bb11b596d28);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ID_DOCUMENTPACKAGETARGET_OPENXPS_WITH_3D ) , guid : :: windows :: core :: GUID::from_u128(0x63dbd720_8b14_4577_b074_7bb11b596d28) , } }
 #[doc = "*Required features: 'Win32_Storage_Xps_Printing'*"]
 #[repr(transparent)]
 pub struct IPrintDocumentPackageStatusEvent(::windows::core::IUnknown);

--- a/crates/libs/windows/src/Windows/Win32/System/ApplicationInstallationAndServicing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ApplicationInstallationAndServicing/mod.rs
@@ -816,7 +816,11 @@ pub unsafe fn ApplyPatchToFileW<'a, Param0: ::windows::core::IntoParam<'a, super
     unimplemented!("Unsupported target OS");
 }
 pub const CLSID_EvalCom2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6e5e1910_8053_4660_b795_6b612e29bc58);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_EvalCom2 ) , guid : :: windows :: core :: GUID::from_u128(0x6e5e1910_8053_4660_b795_6b612e29bc58) , } }
 pub const CLSID_MsmMerge2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf94985d5_29f9_4743_9805_99bc3f35b678);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_MsmMerge2 ) , guid : :: windows :: core :: GUID::from_u128(0xf94985d5_29f9_4743_9805_99bc3f35b678) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_System_ApplicationInstallationAndServicing'*"]
 pub struct COMPATIBILITY_CONTEXT_ELEMENT {
@@ -1696,8 +1700,14 @@ impl ::core::default::Default for FUSION_INSTALL_REFERENCE {
     }
 }
 pub const FUSION_REFCOUNT_FILEPATH_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb02f9d65_fb77_4f7a_afa5_b391309f11c9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FUSION_REFCOUNT_FILEPATH_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xb02f9d65_fb77_4f7a_afa5_b391309f11c9) , } }
 pub const FUSION_REFCOUNT_OPAQUE_STRING_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2ec93463_b0c3_45e1_8364_327e96aea856);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FUSION_REFCOUNT_OPAQUE_STRING_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x2ec93463_b0c3_45e1_8364_327e96aea856) , } }
 pub const FUSION_REFCOUNT_UNINSTALL_SUBKEY_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8cedc215_ac4b_488b_93c0_a50a49cb2fb8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FUSION_REFCOUNT_UNINSTALL_SUBKEY_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x8cedc215_ac4b_488b_93c0_a50a49cb2fb8) , } }
 #[doc = "*Required features: 'Win32_System_ApplicationInstallationAndServicing', 'Win32_Foundation', 'Win32_System_WindowsProgramming'*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_WindowsProgramming"))]
 #[inline]
@@ -6498,6 +6508,8 @@ pub struct IValidateVtbl(
     #[cfg(not(feature = "Win32_Foundation"))] usize,
 );
 pub const LIBID_MsmMergeTypeLib: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0adda82f_2c26_11d2_ad65_00a0c9af11a6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( LIBID_MsmMergeTypeLib ) , guid : :: windows :: core :: GUID::from_u128(0x0adda82f_2c26_11d2_ad65_00a0c9af11a6) , } }
 #[doc = "*Required features: 'Win32_System_ApplicationInstallationAndServicing'*"]
 pub const LOGALL: u32 = 15u32;
 #[doc = "*Required features: 'Win32_System_ApplicationInstallationAndServicing'*"]

--- a/crates/libs/windows/src/Windows/Win32/System/Contacts/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Contacts/mod.rs
@@ -12,6 +12,8 @@ pub const CGD_STRING_PROPERTY: u32 = 1u32;
 #[doc = "*Required features: 'Win32_System_Contacts'*"]
 pub const CGD_UNKNOWN_PROPERTY: u32 = 0u32;
 pub const CLSID_ContactAggregationManager: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x96c8ad95_c199_44de_b34e_ac33c442df39);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_ContactAggregationManager ) , guid : :: windows :: core :: GUID::from_u128(0x96c8ad95_c199_44de_b34e_ac33c442df39) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_System_Contacts'*"]
 pub struct CONTACT_AGGREGATION_BLOB {

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/mod.rs
@@ -32,6 +32,8 @@ impl ::core::default::Default for CLASSIC_EVENT_ID {
     }
 }
 pub const CLSID_TraceRelogger: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7b40792d_05ff_44c4_9058_f440c71f17d4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_TraceRelogger ) , guid : :: windows :: core :: GUID::from_u128(0x7b40792d_05ff_44c4_9058_f440c71f17d4) , } }
 pub const CTraceRelogger: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7b40792d_05ff_44c4_9058_f440c71f17d4);
 #[doc = "*Required features: 'Win32_System_Diagnostics_Etw'*"]
 #[inline]
@@ -120,6 +122,8 @@ pub const DecodingSourceTlg: DECODING_SOURCE = 3i32;
 #[doc = "*Required features: 'Win32_System_Diagnostics_Etw'*"]
 pub const DecodingSourceMax: DECODING_SOURCE = 4i32;
 pub const DefaultTraceSecurityGuid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0811c1af_7a07_4a06_82ed_869455cdf713);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DefaultTraceSecurityGuid ) , guid : :: windows :: core :: GUID::from_u128(0x0811c1af_7a07_4a06_82ed_869455cdf713) , } }
 #[doc = "*Required features: 'Win32_System_Diagnostics_Etw'*"]
 pub type ENABLECALLBACK_ENABLED_STATE = u32;
 #[doc = "*Required features: 'Win32_System_Diagnostics_Etw'*"]
@@ -3590,7 +3594,11 @@ pub unsafe fn EventSetInformation(reghandle: u64, informationclass: EVENT_INFO_C
     unimplemented!("Unsupported target OS");
 }
 pub const EventTraceConfigGuid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x01853a65_418f_4f36_aefc_dc0f1d2fd235);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( EventTraceConfigGuid ) , guid : :: windows :: core :: GUID::from_u128(0x01853a65_418f_4f36_aefc_dc0f1d2fd235) , } }
 pub const EventTraceGuid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x68fdd900_4a3e_11d1_84f4_0000f80464e3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( EventTraceGuid ) , guid : :: windows :: core :: GUID::from_u128(0x68fdd900_4a3e_11d1_84f4_0000f80464e3) , } }
 #[doc = "*Required features: 'Win32_System_Diagnostics_Etw'*"]
 #[inline]
 pub unsafe fn EventUnregister(reghandle: u64) -> u32 {
@@ -4488,6 +4496,8 @@ impl ::core::default::Default for PROVIDER_FILTER_INFO {
     }
 }
 pub const PrivateLoggerNotificationGuid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3595ab5c_042a_4c8e_b942_2d059bfeb1b1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PrivateLoggerNotificationGuid ) , guid : :: windows :: core :: GUID::from_u128(0x3595ab5c_042a_4c8e_b942_2d059bfeb1b1) , } }
 #[doc = "*Required features: 'Win32_System_Diagnostics_Etw', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
@@ -4886,23 +4896,59 @@ pub unsafe fn StopTraceW<'a, Param1: ::windows::core::IntoParam<'a, super::super
     unimplemented!("Unsupported target OS");
 }
 pub const SystemAlpcProviderGuid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfcb9baaf_e529_4980_92e9_ced1a6aadfdf);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SystemAlpcProviderGuid ) , guid : :: windows :: core :: GUID::from_u128(0xfcb9baaf_e529_4980_92e9_ced1a6aadfdf) , } }
 pub const SystemConfigProviderGuid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfef3a8b6_318d_4b67_a96a_3b0f6b8f18fe);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SystemConfigProviderGuid ) , guid : :: windows :: core :: GUID::from_u128(0xfef3a8b6_318d_4b67_a96a_3b0f6b8f18fe) , } }
 pub const SystemCpuProviderGuid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc6c5265f_eae8_4650_aae4_9d48603d8510);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SystemCpuProviderGuid ) , guid : :: windows :: core :: GUID::from_u128(0xc6c5265f_eae8_4650_aae4_9d48603d8510) , } }
 pub const SystemHypervisorProviderGuid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbafa072a_918a_4bed_b622_bc152097098f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SystemHypervisorProviderGuid ) , guid : :: windows :: core :: GUID::from_u128(0xbafa072a_918a_4bed_b622_bc152097098f) , } }
 pub const SystemInterruptProviderGuid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd4bbee17_b545_4888_858b_744169015b25);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SystemInterruptProviderGuid ) , guid : :: windows :: core :: GUID::from_u128(0xd4bbee17_b545_4888_858b_744169015b25) , } }
 pub const SystemIoFilterProviderGuid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfbd09363_9e22_4661_b8bf_e7a34b535b8c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SystemIoFilterProviderGuid ) , guid : :: windows :: core :: GUID::from_u128(0xfbd09363_9e22_4661_b8bf_e7a34b535b8c) , } }
 pub const SystemIoProviderGuid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3d5c43e3_0f1c_4202_b817_174c0070dc79);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SystemIoProviderGuid ) , guid : :: windows :: core :: GUID::from_u128(0x3d5c43e3_0f1c_4202_b817_174c0070dc79) , } }
 pub const SystemLockProviderGuid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x721ddfd3_dacc_4e1e_b26a_a2cb31d4705a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SystemLockProviderGuid ) , guid : :: windows :: core :: GUID::from_u128(0x721ddfd3_dacc_4e1e_b26a_a2cb31d4705a) , } }
 pub const SystemMemoryProviderGuid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x82958ca9_b6cd_47f8_a3a8_03ae85a4bc24);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SystemMemoryProviderGuid ) , guid : :: windows :: core :: GUID::from_u128(0x82958ca9_b6cd_47f8_a3a8_03ae85a4bc24) , } }
 pub const SystemObjectProviderGuid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfebd7460_3d1d_47eb_af49_c9eeb1e146f2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SystemObjectProviderGuid ) , guid : :: windows :: core :: GUID::from_u128(0xfebd7460_3d1d_47eb_af49_c9eeb1e146f2) , } }
 pub const SystemPowerProviderGuid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc134884a_32d5_4488_80e5_14ed7abb8269);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SystemPowerProviderGuid ) , guid : :: windows :: core :: GUID::from_u128(0xc134884a_32d5_4488_80e5_14ed7abb8269) , } }
 pub const SystemProcessProviderGuid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x151f55dc_467d_471f_83b5_5f889d46ff66);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SystemProcessProviderGuid ) , guid : :: windows :: core :: GUID::from_u128(0x151f55dc_467d_471f_83b5_5f889d46ff66) , } }
 pub const SystemProfileProviderGuid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbfeb0324_1cee_496f_a409_2ac2b48a6322);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SystemProfileProviderGuid ) , guid : :: windows :: core :: GUID::from_u128(0xbfeb0324_1cee_496f_a409_2ac2b48a6322) , } }
 pub const SystemRegistryProviderGuid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x16156bd9_fab4_4cfa_a232_89d1099058e3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SystemRegistryProviderGuid ) , guid : :: windows :: core :: GUID::from_u128(0x16156bd9_fab4_4cfa_a232_89d1099058e3) , } }
 pub const SystemSchedulerProviderGuid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x599a2a76_4d91_4910_9ac7_7d33f2e97a6c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SystemSchedulerProviderGuid ) , guid : :: windows :: core :: GUID::from_u128(0x599a2a76_4d91_4910_9ac7_7d33f2e97a6c) , } }
 pub const SystemSyscallProviderGuid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x434286f7_6f1b_45bb_b37e_95f623046c7c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SystemSyscallProviderGuid ) , guid : :: windows :: core :: GUID::from_u128(0x434286f7_6f1b_45bb_b37e_95f623046c7c) , } }
 pub const SystemTimerProviderGuid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4f061568_e215_499f_ab2e_eda0ae890a5b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SystemTimerProviderGuid ) , guid : :: windows :: core :: GUID::from_u128(0x4f061568_e215_499f_ab2e_eda0ae890a5b) , } }
 pub const SystemTraceControlGuid: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9e814aad_3204_11d2_9a82_006008a86939);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SystemTraceControlGuid ) , guid : :: windows :: core :: GUID::from_u128(0x9e814aad_3204_11d2_9a82_006008a86939) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_System_Diagnostics_Etw'*"]
 pub struct TDH_CONTEXT {

--- a/crates/libs/windows/src/Windows/Win32/System/DistributedTransactionCoordinator/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/DistributedTransactionCoordinator/mod.rs
@@ -44,7 +44,11 @@ impl ::core::default::Default for BOID {
     }
 }
 pub const CLSID_MSDtcTransaction: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x39f8d76b_0928_11d1_97df_00c04fb9618a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_MSDtcTransaction ) , guid : :: windows :: core :: GUID::from_u128(0x39f8d76b_0928_11d1_97df_00c04fb9618a) , } }
 pub const CLSID_MSDtcTransactionManager: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5b18ab61_091d_11d1_97df_00c04fb9618a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_MSDtcTransactionManager ) , guid : :: windows :: core :: GUID::from_u128(0x5b18ab61_091d_11d1_97df_00c04fb9618a) , } }
 #[doc = "*Required features: 'Win32_System_DistributedTransactionCoordinator'*"]
 pub const DTCINSTALL_E_CLIENT_ALREADY_INSTALLED: i32 = 384i32;
 #[doc = "*Required features: 'Win32_System_DistributedTransactionCoordinator'*"]

--- a/crates/libs/windows/src/Windows/Win32/System/EventNotificationService/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/EventNotificationService/mod.rs
@@ -647,12 +647,26 @@ impl ::core::default::Default for QOCINFO {
 }
 pub const SENS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd597cafe_5b9f_11d1_8dd2_00aa004abd5e);
 pub const SENSGUID_EVENTCLASS_LOGON: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd5978630_5b9f_11d1_8dd2_00aa004abd5e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSGUID_EVENTCLASS_LOGON ) , guid : :: windows :: core :: GUID::from_u128(0xd5978630_5b9f_11d1_8dd2_00aa004abd5e) , } }
 pub const SENSGUID_EVENTCLASS_LOGON2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd5978650_5b9f_11d1_8dd2_00aa004abd5e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSGUID_EVENTCLASS_LOGON2 ) , guid : :: windows :: core :: GUID::from_u128(0xd5978650_5b9f_11d1_8dd2_00aa004abd5e) , } }
 pub const SENSGUID_EVENTCLASS_NETWORK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd5978620_5b9f_11d1_8dd2_00aa004abd5e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSGUID_EVENTCLASS_NETWORK ) , guid : :: windows :: core :: GUID::from_u128(0xd5978620_5b9f_11d1_8dd2_00aa004abd5e) , } }
 pub const SENSGUID_EVENTCLASS_ONNOW: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd5978640_5b9f_11d1_8dd2_00aa004abd5e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSGUID_EVENTCLASS_ONNOW ) , guid : :: windows :: core :: GUID::from_u128(0xd5978640_5b9f_11d1_8dd2_00aa004abd5e) , } }
 pub const SENSGUID_PUBLISHER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5fee1bd6_5b9b_11d1_8dd2_00aa004abd5e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSGUID_PUBLISHER ) , guid : :: windows :: core :: GUID::from_u128(0x5fee1bd6_5b9b_11d1_8dd2_00aa004abd5e) , } }
 pub const SENSGUID_SUBSCRIBER_LCE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd3938ab0_5b9d_11d1_8dd2_00aa004abd5e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSGUID_SUBSCRIBER_LCE ) , guid : :: windows :: core :: GUID::from_u128(0xd3938ab0_5b9d_11d1_8dd2_00aa004abd5e) , } }
 pub const SENSGUID_SUBSCRIBER_WININET: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd3938ab5_5b9d_11d1_8dd2_00aa004abd5e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SENSGUID_SUBSCRIBER_WININET ) , guid : :: windows :: core :: GUID::from_u128(0xd3938ab5_5b9d_11d1_8dd2_00aa004abd5e) , } }
 #[doc = "*Required features: 'Win32_System_EventNotificationService'*"]
 pub type SENS_CONNECTION_TYPE = u32;
 #[doc = "*Required features: 'Win32_System_EventNotificationService'*"]

--- a/crates/libs/windows/src/Windows/Win32/System/GroupPolicy/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/GroupPolicy/mod.rs
@@ -23,8 +23,14 @@ pub unsafe fn BrowseForGPO(lpbrowseinfo: *mut GPOBROWSEINFO) -> ::windows::core:
     unimplemented!("Unsupported target OS");
 }
 pub const CLSID_GPESnapIn: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8fc0b734_a0e1_11d1_a7d3_0000f87571e3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_GPESnapIn ) , guid : :: windows :: core :: GUID::from_u128(0x8fc0b734_a0e1_11d1_a7d3_0000f87571e3) , } }
 pub const CLSID_GroupPolicyObject: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xea502722_a23d_11d1_a7d3_0000f87571e3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_GroupPolicyObject ) , guid : :: windows :: core :: GUID::from_u128(0xea502722_a23d_11d1_a7d3_0000f87571e3) , } }
 pub const CLSID_RSOPSnapIn: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6dc3804b_7212_458d_adb0_9a07e2ae1fa2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_RSOPSnapIn ) , guid : :: windows :: core :: GUID::from_u128(0x6dc3804b_7212_458d_adb0_9a07e2ae1fa2) , } }
 #[doc = "*Required features: 'Win32_System_GroupPolicy', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
@@ -9233,13 +9239,29 @@ pub const MANAGED_APPTYPE_UNSUPPORTED: u32 = 3u32;
 #[doc = "*Required features: 'Win32_System_GroupPolicy'*"]
 pub const MANAGED_APPTYPE_WINDOWSINSTALLER: u32 = 1u32;
 pub const NODEID_Machine: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8fc0b737_a0e1_11d1_a7d3_0000f87571e3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( NODEID_Machine ) , guid : :: windows :: core :: GUID::from_u128(0x8fc0b737_a0e1_11d1_a7d3_0000f87571e3) , } }
 pub const NODEID_MachineSWSettings: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8fc0b73a_a0e1_11d1_a7d3_0000f87571e3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( NODEID_MachineSWSettings ) , guid : :: windows :: core :: GUID::from_u128(0x8fc0b73a_a0e1_11d1_a7d3_0000f87571e3) , } }
 pub const NODEID_RSOPMachine: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbd4c1a2e_0b7a_4a62_a6b0_c0577539c97e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( NODEID_RSOPMachine ) , guid : :: windows :: core :: GUID::from_u128(0xbd4c1a2e_0b7a_4a62_a6b0_c0577539c97e) , } }
 pub const NODEID_RSOPMachineSWSettings: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6a76273e_eb8e_45db_94c5_25663a5f2c1a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( NODEID_RSOPMachineSWSettings ) , guid : :: windows :: core :: GUID::from_u128(0x6a76273e_eb8e_45db_94c5_25663a5f2c1a) , } }
 pub const NODEID_RSOPUser: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xab87364f_0cec_4cd8_9bf8_898f34628fb8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( NODEID_RSOPUser ) , guid : :: windows :: core :: GUID::from_u128(0xab87364f_0cec_4cd8_9bf8_898f34628fb8) , } }
 pub const NODEID_RSOPUserSWSettings: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe52c5ce3_fd27_4402_84de_d9a5f2858910);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( NODEID_RSOPUserSWSettings ) , guid : :: windows :: core :: GUID::from_u128(0xe52c5ce3_fd27_4402_84de_d9a5f2858910) , } }
 pub const NODEID_User: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8fc0b738_a0e1_11d1_a7d3_0000f87571e3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( NODEID_User ) , guid : :: windows :: core :: GUID::from_u128(0x8fc0b738_a0e1_11d1_a7d3_0000f87571e3) , } }
 pub const NODEID_UserSWSettings: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8fc0b73c_a0e1_11d1_a7d3_0000f87571e3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( NODEID_UserSWSettings ) , guid : :: windows :: core :: GUID::from_u128(0x8fc0b73c_a0e1_11d1_a7d3_0000f87571e3) , } }
 #[doc = "*Required features: 'Win32_System_GroupPolicy', 'Win32_Foundation', 'Win32_System_Com', 'Win32_System_Wmi'*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Wmi"))]
 pub type PFNGENERATEGROUPPOLICY = ::core::option::Option<unsafe extern "system" fn(dwflags: u32, pbabort: *mut super::super::Foundation::BOOL, pwszsite: super::super::Foundation::PWSTR, pcomputertarget: *const RSOP_TARGET, pusertarget: *const RSOP_TARGET) -> u32>;

--- a/crates/libs/windows/src/Windows/Win32/System/Hypervisor/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Hypervisor/mod.rs
@@ -317,6 +317,8 @@ pub const GuestOsVendorLANCOM: GUEST_OS_VENDOR = 512i32;
 #[cfg(feature = "Win32_Foundation")]
 pub type GUEST_SYMBOLS_PROVIDER_DEBUG_INFO_CALLBACK = ::core::option::Option<unsafe extern "system" fn(infomessage: super::super::Foundation::PSTR)>;
 pub const GUID_DEVINTERFACE_VM_GENCOUNTER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3ff2c92b_6598_4e60_8e1c_0ccf4927e319);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_VM_GENCOUNTER ) , guid : :: windows :: core :: GUID::from_u128(0x3ff2c92b_6598_4e60_8e1c_0ccf4927e319) , } }
 #[doc = "*Required features: 'Win32_System_Hypervisor'*"]
 #[inline]
 pub unsafe fn GetActiveVirtualTrustLevel(vmsavedstatedumphandle: *mut ::core::ffi::c_void, vpid: u32, virtualtrustlevel: *mut u8) -> ::windows::core::Result<()> {
@@ -771,12 +773,26 @@ pub const HVSOCKET_CONNECT_TIMEOUT_MAX: u32 = 300000u32;
 #[doc = "*Required features: 'Win32_System_Hypervisor'*"]
 pub const HVSOCKET_CONTAINER_PASSTHRU: u32 = 2u32;
 pub const HV_GUID_BROADCAST: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xffffffff_ffff_ffff_ffff_ffffffffffff);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( HV_GUID_BROADCAST ) , guid : :: windows :: core :: GUID::from_u128(0xffffffff_ffff_ffff_ffff_ffffffffffff) , } }
 pub const HV_GUID_CHILDREN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x90db8b89_0d35_4f79_8ce9_49ea0ac8b7cd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( HV_GUID_CHILDREN ) , guid : :: windows :: core :: GUID::from_u128(0x90db8b89_0d35_4f79_8ce9_49ea0ac8b7cd) , } }
 pub const HV_GUID_LOOPBACK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe0e16197_dd56_4a10_9195_5ee7a155a838);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( HV_GUID_LOOPBACK ) , guid : :: windows :: core :: GUID::from_u128(0xe0e16197_dd56_4a10_9195_5ee7a155a838) , } }
 pub const HV_GUID_PARENT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa42e7cda_d03f_480c_9cc2_a4de20abb878);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( HV_GUID_PARENT ) , guid : :: windows :: core :: GUID::from_u128(0xa42e7cda_d03f_480c_9cc2_a4de20abb878) , } }
 pub const HV_GUID_SILOHOST: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x36bd0c5c_7276_4223_88ba_7d03b654c568);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( HV_GUID_SILOHOST ) , guid : :: windows :: core :: GUID::from_u128(0x36bd0c5c_7276_4223_88ba_7d03b654c568) , } }
 pub const HV_GUID_VSOCK_TEMPLATE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x00000000_facb_11e6_bd58_64006a7986d3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( HV_GUID_VSOCK_TEMPLATE ) , guid : :: windows :: core :: GUID::from_u128(0x00000000_facb_11e6_bd58_64006a7986d3) , } }
 pub const HV_GUID_ZERO: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x00000000_0000_0000_0000_000000000000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( HV_GUID_ZERO ) , guid : :: windows :: core :: GUID::from_u128(0x00000000_0000_0000_0000_000000000000) , } }
 #[doc = "*Required features: 'Win32_System_Hypervisor'*"]
 pub const HV_PROTOCOL_RAW: u32 = 1u32;
 #[doc = "*Required features: 'Win32_System_Hypervisor'*"]

--- a/crates/libs/windows/src/Windows/Win32/System/Iis/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Iis/mod.rs
@@ -593,14 +593,32 @@ impl ::core::default::Default for CERT_CONTEXT_EX {
     }
 }
 pub const CLSID_IImgCtx: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3050f3d6_98b5_11cf_bb82_00aa00bdce0b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_IImgCtx ) , guid : :: windows :: core :: GUID::from_u128(0x3050f3d6_98b5_11cf_bb82_00aa00bdce0b) , } }
 pub const CLSID_IisServiceControl: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe8fb8621_588f_11d2_9d61_00c04f79c5fe);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_IisServiceControl ) , guid : :: windows :: core :: GUID::from_u128(0xe8fb8621_588f_11d2_9d61_00c04f79c5fe) , } }
 pub const CLSID_MSAdminBase_W: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa9e69610_b80d_11d0_b9b9_00a0c922e750);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_MSAdminBase_W ) , guid : :: windows :: core :: GUID::from_u128(0xa9e69610_b80d_11d0_b9b9_00a0c922e750) , } }
 pub const CLSID_Request: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x920c25d0_25d9_11d0_a55f_00a0c90c2091);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_Request ) , guid : :: windows :: core :: GUID::from_u128(0x920c25d0_25d9_11d0_a55f_00a0c90c2091) , } }
 pub const CLSID_Response: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x46e19ba0_25dd_11d0_a55f_00a0c90c2091);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_Response ) , guid : :: windows :: core :: GUID::from_u128(0x46e19ba0_25dd_11d0_a55f_00a0c90c2091) , } }
 pub const CLSID_ScriptingContext: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd97a6da0_a868_11cf_83ae_11b0c90c2bd8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_ScriptingContext ) , guid : :: windows :: core :: GUID::from_u128(0xd97a6da0_a868_11cf_83ae_11b0c90c2bd8) , } }
 pub const CLSID_Server: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa506d160_25e0_11d0_a55f_00a0c90c2091);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_Server ) , guid : :: windows :: core :: GUID::from_u128(0xa506d160_25e0_11d0_a55f_00a0c90c2091) , } }
 pub const CLSID_Session: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x509f8f20_25de_11d0_a55f_00a0c90c2091);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_Session ) , guid : :: windows :: core :: GUID::from_u128(0x509f8f20_25de_11d0_a55f_00a0c90c2091) , } }
 pub const CLSID_WamAdmin: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x61738644_f196_11d0_9953_00c04fd919c1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_WamAdmin ) , guid : :: windows :: core :: GUID::from_u128(0x61738644_f196_11d0_9953_00c04fd919c1) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_System_Iis', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -784,12 +802,26 @@ pub const FTP_PROCESS_TERMINATE_SESSION: FTP_PROCESS_STATUS = 2i32;
 pub const FTP_PROCESS_REJECT_COMMAND: FTP_PROCESS_STATUS = 3i32;
 pub const FtpProvider: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x70bdc667_33b2_45f0_ac52_c3ca46f7a656);
 pub const GUID_IIS_ALL_TRACE_PROVIDERS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x00000000_0000_0000_0000_000000000000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IIS_ALL_TRACE_PROVIDERS ) , guid : :: windows :: core :: GUID::from_u128(0x00000000_0000_0000_0000_000000000000) , } }
 pub const GUID_IIS_ASPNET_TRACE_PROVIDER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaff081fe_0247_4275_9c4e_021f3dc1da35);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IIS_ASPNET_TRACE_PROVIDER ) , guid : :: windows :: core :: GUID::from_u128(0xaff081fe_0247_4275_9c4e_021f3dc1da35) , } }
 pub const GUID_IIS_ASP_TRACE_TRACE_PROVIDER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x06b94d9a_b15e_456e_a4ef_37c984a2cb4b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IIS_ASP_TRACE_TRACE_PROVIDER ) , guid : :: windows :: core :: GUID::from_u128(0x06b94d9a_b15e_456e_a4ef_37c984a2cb4b) , } }
 pub const GUID_IIS_ISAPI_TRACE_PROVIDER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa1c2040e_8840_4c31_ba11_9871031a19ea);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IIS_ISAPI_TRACE_PROVIDER ) , guid : :: windows :: core :: GUID::from_u128(0xa1c2040e_8840_4c31_ba11_9871031a19ea) , } }
 pub const GUID_IIS_WWW_GLOBAL_TRACE_PROVIDER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd55d3bc9_cba9_44df_827e_132d3a4596c2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IIS_WWW_GLOBAL_TRACE_PROVIDER ) , guid : :: windows :: core :: GUID::from_u128(0xd55d3bc9_cba9_44df_827e_132d3a4596c2) , } }
 pub const GUID_IIS_WWW_SERVER_TRACE_PROVIDER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3a2a4e84_4c21_4981_ae10_3fda0d9b0f83);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IIS_WWW_SERVER_TRACE_PROVIDER ) , guid : :: windows :: core :: GUID::from_u128(0x3a2a4e84_4c21_4981_ae10_3fda0d9b0f83) , } }
 pub const GUID_IIS_WWW_SERVER_V2_TRACE_PROVIDER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xde4649c9_15e8_4fea_9d85_1cdda520c334);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IIS_WWW_SERVER_V2_TRACE_PROVIDER ) , guid : :: windows :: core :: GUID::from_u128(0xde4649c9_15e8_4fea_9d85_1cdda520c334) , } }
 #[doc = "*Required features: 'Win32_System_Iis', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
@@ -3891,8 +3923,14 @@ pub struct IMSImpExpHelpWVtbl(
     #[cfg(not(feature = "Win32_Foundation"))] usize,
 );
 pub const LIBID_ASPTypeLibrary: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd97a6da0_a85c_11cf_83ae_00a0c90c2bd8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( LIBID_ASPTypeLibrary ) , guid : :: windows :: core :: GUID::from_u128(0xd97a6da0_a85c_11cf_83ae_00a0c90c2bd8) , } }
 pub const LIBID_IISRSTALib: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe8fb8614_588f_11d2_9d61_00c04f79c5fe);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( LIBID_IISRSTALib ) , guid : :: windows :: core :: GUID::from_u128(0xe8fb8614_588f_11d2_9d61_00c04f79c5fe) , } }
 pub const LIBID_WAMREGLib: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x29822aa8_f302_11d0_9953_00c04fd919c1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( LIBID_WAMREGLib ) , guid : :: windows :: core :: GUID::from_u128(0x29822aa8_f302_11d0_9953_00c04fd919c1) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_System_Iis', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/System/Ioctl/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Ioctl/mod.rs
@@ -3885,27 +3885,43 @@ impl ::core::default::Default for DEVICE_WRITE_AGGREGATION_DESCRIPTOR {
 #[doc = "*Required features: 'Win32_System_Ioctl', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Storage_Disk_Number: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d1ebee8_0803_4774_9842_b77db50265e9), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Storage_Disk_Number ) , guid : :: windows :: core :: GUID::from_u128(0x4d1ebee8_0803_4774_9842_b77db50265e9) , } }
 #[doc = "*Required features: 'Win32_System_Ioctl', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Storage_Gpt_Name: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d1ebee8_0803_4774_9842_b77db50265e9), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Storage_Gpt_Name ) , guid : :: windows :: core :: GUID::from_u128(0x4d1ebee8_0803_4774_9842_b77db50265e9) , } }
 #[doc = "*Required features: 'Win32_System_Ioctl', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Storage_Gpt_Type: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d1ebee8_0803_4774_9842_b77db50265e9), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Storage_Gpt_Type ) , guid : :: windows :: core :: GUID::from_u128(0x4d1ebee8_0803_4774_9842_b77db50265e9) , } }
 #[doc = "*Required features: 'Win32_System_Ioctl', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Storage_Mbr_Type: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d1ebee8_0803_4774_9842_b77db50265e9), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Storage_Mbr_Type ) , guid : :: windows :: core :: GUID::from_u128(0x4d1ebee8_0803_4774_9842_b77db50265e9) , } }
 #[doc = "*Required features: 'Win32_System_Ioctl', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Storage_Partition_Number: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d1ebee8_0803_4774_9842_b77db50265e9), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Storage_Partition_Number ) , guid : :: windows :: core :: GUID::from_u128(0x4d1ebee8_0803_4774_9842_b77db50265e9) , } }
 #[doc = "*Required features: 'Win32_System_Ioctl', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Storage_Portable: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d1ebee8_0803_4774_9842_b77db50265e9), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Storage_Portable ) , guid : :: windows :: core :: GUID::from_u128(0x4d1ebee8_0803_4774_9842_b77db50265e9) , } }
 #[doc = "*Required features: 'Win32_System_Ioctl', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Storage_Removable_Media: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d1ebee8_0803_4774_9842_b77db50265e9), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Storage_Removable_Media ) , guid : :: windows :: core :: GUID::from_u128(0x4d1ebee8_0803_4774_9842_b77db50265e9) , } }
 #[doc = "*Required features: 'Win32_System_Ioctl', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const DEVPKEY_Storage_System_Critical: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x4d1ebee8_0803_4774_9842_b77db50265e9), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DEVPKEY_Storage_System_Critical ) , guid : :: windows :: core :: GUID::from_u128(0x4d1ebee8_0803_4774_9842_b77db50265e9) , } }
 #[doc = "*Required features: 'Win32_System_Ioctl'*"]
 pub const DISABLE_SMART: u32 = 217u32;
 #[doc = "*Required features: 'Win32_System_Ioctl'*"]
@@ -6845,8 +6861,14 @@ pub const FILE_TYPE_NOTIFICATION_FLAG_USAGE_BEGIN: u32 = 1u32;
 #[doc = "*Required features: 'Win32_System_Ioctl'*"]
 pub const FILE_TYPE_NOTIFICATION_FLAG_USAGE_END: u32 = 2u32;
 pub const FILE_TYPE_NOTIFICATION_GUID_CRASHDUMP_FILE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9d453eb7_d2a6_4dbd_a2e3_fbd0ed9109a9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FILE_TYPE_NOTIFICATION_GUID_CRASHDUMP_FILE ) , guid : :: windows :: core :: GUID::from_u128(0x9d453eb7_d2a6_4dbd_a2e3_fbd0ed9109a9) , } }
 pub const FILE_TYPE_NOTIFICATION_GUID_HIBERNATION_FILE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb7624d64_b9a3_4cf8_8011_5b86c940e7b7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FILE_TYPE_NOTIFICATION_GUID_HIBERNATION_FILE ) , guid : :: windows :: core :: GUID::from_u128(0xb7624d64_b9a3_4cf8_8011_5b86c940e7b7) , } }
 pub const FILE_TYPE_NOTIFICATION_GUID_PAGE_FILE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0d0a64a1_38fc_4db8_9fe7_3f4352cd7c5c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FILE_TYPE_NOTIFICATION_GUID_PAGE_FILE ) , guid : :: windows :: core :: GUID::from_u128(0x0d0a64a1_38fc_4db8_9fe7_3f4352cd7c5c) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_System_Ioctl'*"]
 pub struct FILE_TYPE_NOTIFICATION_INPUT {
@@ -8460,28 +8482,74 @@ impl ::core::default::Default for GP_LOG_PAGE_DESCRIPTOR {
     }
 }
 pub const GUID_DEVICEDUMP_DRIVER_STORAGE_PORT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xda82441d_7142_4bc1_b844_0807c5a4b67f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVICEDUMP_DRIVER_STORAGE_PORT ) , guid : :: windows :: core :: GUID::from_u128(0xda82441d_7142_4bc1_b844_0807c5a4b67f) , } }
 pub const GUID_DEVICEDUMP_STORAGE_DEVICE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd8e2592f_1aab_4d56_a746_1f7585df40f4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVICEDUMP_STORAGE_DEVICE ) , guid : :: windows :: core :: GUID::from_u128(0xd8e2592f_1aab_4d56_a746_1f7585df40f4) , } }
 pub const GUID_DEVINTERFACE_CDCHANGER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x53f56312_b6bf_11d0_94f2_00a0c91efb8b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_CDCHANGER ) , guid : :: windows :: core :: GUID::from_u128(0x53f56312_b6bf_11d0_94f2_00a0c91efb8b) , } }
 pub const GUID_DEVINTERFACE_CDROM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x53f56308_b6bf_11d0_94f2_00a0c91efb8b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_CDROM ) , guid : :: windows :: core :: GUID::from_u128(0x53f56308_b6bf_11d0_94f2_00a0c91efb8b) , } }
 pub const GUID_DEVINTERFACE_COMPORT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x86e0d1e0_8089_11d0_9ce4_08003e301f73);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_COMPORT ) , guid : :: windows :: core :: GUID::from_u128(0x86e0d1e0_8089_11d0_9ce4_08003e301f73) , } }
 pub const GUID_DEVINTERFACE_DISK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x53f56307_b6bf_11d0_94f2_00a0c91efb8b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_DISK ) , guid : :: windows :: core :: GUID::from_u128(0x53f56307_b6bf_11d0_94f2_00a0c91efb8b) , } }
 pub const GUID_DEVINTERFACE_FLOPPY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x53f56311_b6bf_11d0_94f2_00a0c91efb8b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_FLOPPY ) , guid : :: windows :: core :: GUID::from_u128(0x53f56311_b6bf_11d0_94f2_00a0c91efb8b) , } }
 pub const GUID_DEVINTERFACE_HIDDEN_VOLUME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7f108a28_9833_4b3b_b780_2c6b5fa5c062);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_HIDDEN_VOLUME ) , guid : :: windows :: core :: GUID::from_u128(0x7f108a28_9833_4b3b_b780_2c6b5fa5c062) , } }
 pub const GUID_DEVINTERFACE_MEDIUMCHANGER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x53f56310_b6bf_11d0_94f2_00a0c91efb8b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_MEDIUMCHANGER ) , guid : :: windows :: core :: GUID::from_u128(0x53f56310_b6bf_11d0_94f2_00a0c91efb8b) , } }
 pub const GUID_DEVINTERFACE_PARTITION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x53f5630a_b6bf_11d0_94f2_00a0c91efb8b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_PARTITION ) , guid : :: windows :: core :: GUID::from_u128(0x53f5630a_b6bf_11d0_94f2_00a0c91efb8b) , } }
 pub const GUID_DEVINTERFACE_SCM_PHYSICAL_DEVICE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4283609d_4dc2_43be_bbb4_4f15dfce2c61);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_SCM_PHYSICAL_DEVICE ) , guid : :: windows :: core :: GUID::from_u128(0x4283609d_4dc2_43be_bbb4_4f15dfce2c61) , } }
 pub const GUID_DEVINTERFACE_SERENUM_BUS_ENUMERATOR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d36e978_e325_11ce_bfc1_08002be10318);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_SERENUM_BUS_ENUMERATOR ) , guid : :: windows :: core :: GUID::from_u128(0x4d36e978_e325_11ce_bfc1_08002be10318) , } }
 pub const GUID_DEVINTERFACE_SERVICE_VOLUME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6ead3d82_25ec_46bc_b7fd_c1f0df8f5037);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_SERVICE_VOLUME ) , guid : :: windows :: core :: GUID::from_u128(0x6ead3d82_25ec_46bc_b7fd_c1f0df8f5037) , } }
 pub const GUID_DEVINTERFACE_SES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1790c9ec_47d5_4df3_b5af_9adf3cf23e48);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_SES ) , guid : :: windows :: core :: GUID::from_u128(0x1790c9ec_47d5_4df3_b5af_9adf3cf23e48) , } }
 pub const GUID_DEVINTERFACE_STORAGEPORT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2accfe60_c130_11d2_b082_00a0c91efb8b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_STORAGEPORT ) , guid : :: windows :: core :: GUID::from_u128(0x2accfe60_c130_11d2_b082_00a0c91efb8b) , } }
 pub const GUID_DEVINTERFACE_TAPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x53f5630b_b6bf_11d0_94f2_00a0c91efb8b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_TAPE ) , guid : :: windows :: core :: GUID::from_u128(0x53f5630b_b6bf_11d0_94f2_00a0c91efb8b) , } }
 pub const GUID_DEVINTERFACE_UNIFIED_ACCESS_RPMB: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x27447c21_bcc3_4d07_a05b_a3395bb4eee7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_UNIFIED_ACCESS_RPMB ) , guid : :: windows :: core :: GUID::from_u128(0x27447c21_bcc3_4d07_a05b_a3395bb4eee7) , } }
 pub const GUID_DEVINTERFACE_VMLUN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6f416619_9f29_42a5_b20b_37e219ca02b0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_VMLUN ) , guid : :: windows :: core :: GUID::from_u128(0x6f416619_9f29_42a5_b20b_37e219ca02b0) , } }
 pub const GUID_DEVINTERFACE_VOLUME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x53f5630d_b6bf_11d0_94f2_00a0c91efb8b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_VOLUME ) , guid : :: windows :: core :: GUID::from_u128(0x53f5630d_b6bf_11d0_94f2_00a0c91efb8b) , } }
 pub const GUID_DEVINTERFACE_WRITEONCEDISK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x53f5630c_b6bf_11d0_94f2_00a0c91efb8b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_WRITEONCEDISK ) , guid : :: windows :: core :: GUID::from_u128(0x53f5630c_b6bf_11d0_94f2_00a0c91efb8b) , } }
 pub const GUID_DEVINTERFACE_ZNSDISK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb87941c5_ffdb_43c7_b6b1_20b632f0b109);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_ZNSDISK ) , guid : :: windows :: core :: GUID::from_u128(0xb87941c5_ffdb_43c7_b6b1_20b632f0b109) , } }
 pub const GUID_SCM_PD_HEALTH_NOTIFICATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9da2d386_72f5_4ee3_8155_eca0678e3b06);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SCM_PD_HEALTH_NOTIFICATION ) , guid : :: windows :: core :: GUID::from_u128(0x9da2d386_72f5_4ee3_8155_eca0678e3b06) , } }
 pub const GUID_SCM_PD_PASSTHROUGH_INVDIMM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4309ac30_0d11_11e4_9191_0800200c9a66);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SCM_PD_PASSTHROUGH_INVDIMM ) , guid : :: windows :: core :: GUID::from_u128(0x4309ac30_0d11_11e4_9191_0800200c9a66) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_System_Ioctl'*"]
 pub struct HISTOGRAM_BUCKET {

--- a/crates/libs/windows/src/Windows/Win32/System/MixedReality/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/MixedReality/mod.rs
@@ -1,5 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 pub const PERCEPTIONFIELD_StateStream_TimeStamps: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaa886119_f32f_49bf_92ca_f9ddf784d297);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PERCEPTIONFIELD_StateStream_TimeStamps ) , guid : :: windows :: core :: GUID::from_u128(0xaa886119_f32f_49bf_92ca_f9ddf784d297) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_System_MixedReality'*"]
 pub struct PERCEPTION_PAYLOAD_FIELD {

--- a/crates/libs/windows/src/Windows/Win32/System/Ole/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Ole/mod.rs
@@ -287,12 +287,26 @@ impl ::core::default::Default for CLEANLOCALSTORAGE {
     }
 }
 pub const CLSID_CColorPropPage: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0be35201_8f91_11ce_9de3_00aa004bb851);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_CColorPropPage ) , guid : :: windows :: core :: GUID::from_u128(0x0be35201_8f91_11ce_9de3_00aa004bb851) , } }
 pub const CLSID_CFontPropPage: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0be35200_8f91_11ce_9de3_00aa004bb851);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_CFontPropPage ) , guid : :: windows :: core :: GUID::from_u128(0x0be35200_8f91_11ce_9de3_00aa004bb851) , } }
 pub const CLSID_CPicturePropPage: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0be35202_8f91_11ce_9de3_00aa004bb851);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_CPicturePropPage ) , guid : :: windows :: core :: GUID::from_u128(0x0be35202_8f91_11ce_9de3_00aa004bb851) , } }
 pub const CLSID_ConvertVBX: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfb8f0822_0164_101b_84ed_08002b2ec713);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_ConvertVBX ) , guid : :: windows :: core :: GUID::from_u128(0xfb8f0822_0164_101b_84ed_08002b2ec713) , } }
 pub const CLSID_PersistPropset: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfb8f0821_0164_101b_84ed_08002b2ec713);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_PersistPropset ) , guid : :: windows :: core :: GUID::from_u128(0xfb8f0821_0164_101b_84ed_08002b2ec713) , } }
 pub const CLSID_StdFont: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0be35203_8f91_11ce_9de3_00aa004bb851);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_StdFont ) , guid : :: windows :: core :: GUID::from_u128(0x0be35203_8f91_11ce_9de3_00aa004bb851) , } }
 pub const CLSID_StdPicture: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0be35204_8f91_11ce_9de3_00aa004bb851);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_StdPicture ) , guid : :: windows :: core :: GUID::from_u128(0x0be35204_8f91_11ce_9de3_00aa004bb851) , } }
 #[doc = "*Required features: 'Win32_System_Ole'*"]
 pub const CONNECT_E_ADVISELIMIT: ::windows::core::HRESULT = ::windows::core::HRESULT(-2147220991i32);
 #[doc = "*Required features: 'Win32_System_Ole'*"]
@@ -1029,25 +1043,65 @@ pub type GUIDKIND = i32;
 #[doc = "*Required features: 'Win32_System_Ole'*"]
 pub const GUIDKIND_DEFAULT_SOURCE_DISP_IID: GUIDKIND = 1i32;
 pub const GUID_CHECKVALUEEXCLUSIVE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6650430c_be0f_101a_8bbb_00aa00300cab);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_CHECKVALUEEXCLUSIVE ) , guid : :: windows :: core :: GUID::from_u128(0x6650430c_be0f_101a_8bbb_00aa00300cab) , } }
 pub const GUID_COLOR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x66504301_be0f_101a_8bbb_00aa00300cab);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_COLOR ) , guid : :: windows :: core :: GUID::from_u128(0x66504301_be0f_101a_8bbb_00aa00300cab) , } }
 pub const GUID_FONTBOLD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6650430f_be0f_101a_8bbb_00aa00300cab);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_FONTBOLD ) , guid : :: windows :: core :: GUID::from_u128(0x6650430f_be0f_101a_8bbb_00aa00300cab) , } }
 pub const GUID_FONTITALIC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x66504310_be0f_101a_8bbb_00aa00300cab);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_FONTITALIC ) , guid : :: windows :: core :: GUID::from_u128(0x66504310_be0f_101a_8bbb_00aa00300cab) , } }
 pub const GUID_FONTNAME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6650430d_be0f_101a_8bbb_00aa00300cab);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_FONTNAME ) , guid : :: windows :: core :: GUID::from_u128(0x6650430d_be0f_101a_8bbb_00aa00300cab) , } }
 pub const GUID_FONTSIZE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6650430e_be0f_101a_8bbb_00aa00300cab);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_FONTSIZE ) , guid : :: windows :: core :: GUID::from_u128(0x6650430e_be0f_101a_8bbb_00aa00300cab) , } }
 pub const GUID_FONTSTRIKETHROUGH: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x66504312_be0f_101a_8bbb_00aa00300cab);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_FONTSTRIKETHROUGH ) , guid : :: windows :: core :: GUID::from_u128(0x66504312_be0f_101a_8bbb_00aa00300cab) , } }
 pub const GUID_FONTUNDERSCORE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x66504311_be0f_101a_8bbb_00aa00300cab);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_FONTUNDERSCORE ) , guid : :: windows :: core :: GUID::from_u128(0x66504311_be0f_101a_8bbb_00aa00300cab) , } }
 pub const GUID_HANDLE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x66504313_be0f_101a_8bbb_00aa00300cab);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_HANDLE ) , guid : :: windows :: core :: GUID::from_u128(0x66504313_be0f_101a_8bbb_00aa00300cab) , } }
 pub const GUID_HIMETRIC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x66504300_be0f_101a_8bbb_00aa00300cab);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_HIMETRIC ) , guid : :: windows :: core :: GUID::from_u128(0x66504300_be0f_101a_8bbb_00aa00300cab) , } }
 pub const GUID_OPTIONVALUEEXCLUSIVE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6650430b_be0f_101a_8bbb_00aa00300cab);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_OPTIONVALUEEXCLUSIVE ) , guid : :: windows :: core :: GUID::from_u128(0x6650430b_be0f_101a_8bbb_00aa00300cab) , } }
 pub const GUID_TRISTATE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6650430a_be0f_101a_8bbb_00aa00300cab);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TRISTATE ) , guid : :: windows :: core :: GUID::from_u128(0x6650430a_be0f_101a_8bbb_00aa00300cab) , } }
 pub const GUID_XPOS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x66504306_be0f_101a_8bbb_00aa00300cab);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_XPOS ) , guid : :: windows :: core :: GUID::from_u128(0x66504306_be0f_101a_8bbb_00aa00300cab) , } }
 pub const GUID_XPOSPIXEL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x66504302_be0f_101a_8bbb_00aa00300cab);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_XPOSPIXEL ) , guid : :: windows :: core :: GUID::from_u128(0x66504302_be0f_101a_8bbb_00aa00300cab) , } }
 pub const GUID_XSIZE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x66504308_be0f_101a_8bbb_00aa00300cab);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_XSIZE ) , guid : :: windows :: core :: GUID::from_u128(0x66504308_be0f_101a_8bbb_00aa00300cab) , } }
 pub const GUID_XSIZEPIXEL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x66504304_be0f_101a_8bbb_00aa00300cab);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_XSIZEPIXEL ) , guid : :: windows :: core :: GUID::from_u128(0x66504304_be0f_101a_8bbb_00aa00300cab) , } }
 pub const GUID_YPOS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x66504307_be0f_101a_8bbb_00aa00300cab);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_YPOS ) , guid : :: windows :: core :: GUID::from_u128(0x66504307_be0f_101a_8bbb_00aa00300cab) , } }
 pub const GUID_YPOSPIXEL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x66504303_be0f_101a_8bbb_00aa00300cab);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_YPOSPIXEL ) , guid : :: windows :: core :: GUID::from_u128(0x66504303_be0f_101a_8bbb_00aa00300cab) , } }
 pub const GUID_YSIZE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x66504309_be0f_101a_8bbb_00aa00300cab);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_YSIZE ) , guid : :: windows :: core :: GUID::from_u128(0x66504309_be0f_101a_8bbb_00aa00300cab) , } }
 pub const GUID_YSIZEPIXEL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x66504305_be0f_101a_8bbb_00aa00300cab);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_YSIZEPIXEL ) , guid : :: windows :: core :: GUID::from_u128(0x66504305_be0f_101a_8bbb_00aa00300cab) , } }
 #[doc = "*Required features: 'Win32_System_Ole'*"]
 #[inline]
 pub unsafe fn GetActiveObject(rclsid: *const ::windows::core::GUID, pvreserved: *mut ::core::ffi::c_void, ppunk: *mut ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()> {
@@ -16161,8 +16215,14 @@ pub const SF_RECORD: SF_TYPE = 36i32;
 #[doc = "*Required features: 'Win32_System_Ole'*"]
 pub const SF_HAVEIID: SF_TYPE = 32781i32;
 pub const SID_GetCaller: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4717cc40_bcb9_11d0_9336_00a0c90dcaa9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SID_GetCaller ) , guid : :: windows :: core :: GUID::from_u128(0x4717cc40_bcb9_11d0_9336_00a0c90dcaa9) , } }
 pub const SID_ProvideRuntimeContext: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x74a5040c_dd0c_48f0_ac85_194c3259180a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SID_ProvideRuntimeContext ) , guid : :: windows :: core :: GUID::from_u128(0x74a5040c_dd0c_48f0_ac85_194c3259180a) , } }
 pub const SID_VariantConversion: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1f101481_bccd_11d0_9336_00a0c90dcaa9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SID_VariantConversion ) , guid : :: windows :: core :: GUID::from_u128(0x1f101481_bccd_11d0_9336_00a0c90dcaa9) , } }
 #[doc = "*Required features: 'Win32_System_Ole'*"]
 pub const STDOLE2_LCID: u32 = 0u32;
 #[doc = "*Required features: 'Win32_System_Ole'*"]

--- a/crates/libs/windows/src/Windows/Win32/System/ParentalControls/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ParentalControls/mod.rs
@@ -939,6 +939,8 @@ pub const WPCFLAG_WEB_SETTING_NOTBLOCKED: WPCFLAG_WEB_SETTING = 0i32;
 #[doc = "*Required features: 'Win32_System_ParentalControls'*"]
 pub const WPCFLAG_WEB_SETTING_DOWNLOADSBLOCKED: WPCFLAG_WEB_SETTING = 1i32;
 pub const WPCPROV: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x01090065_b467_4503_9b28_533766761087);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WPCPROV ) , guid : :: windows :: core :: GUID::from_u128(0x01090065_b467_4503_9b28_533766761087) , } }
 #[doc = "*Required features: 'Win32_System_ParentalControls'*"]
 pub const WPCPROV_KEYWORD_ThirdParty: u32 = 32u32;
 #[doc = "*Required features: 'Win32_System_ParentalControls'*"]

--- a/crates/libs/windows/src/Windows/Win32/System/Performance/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Performance/mod.rs
@@ -178,10 +178,20 @@ pub struct DICounterItemVtbl(
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole")))] usize,
 );
 pub const DIID_DICounterItem: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc08c4ff2_0e2e_11cf_942c_008029004347);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DIID_DICounterItem ) , guid : :: windows :: core :: GUID::from_u128(0xc08c4ff2_0e2e_11cf_942c_008029004347) , } }
 pub const DIID_DILogFileItem: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8d093ffc_f777_4917_82d1_833fbc54c58f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DIID_DILogFileItem ) , guid : :: windows :: core :: GUID::from_u128(0x8d093ffc_f777_4917_82d1_833fbc54c58f) , } }
 pub const DIID_DISystemMonitor: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x13d73d81_c32e_11cf_9398_00aa00a3ddea);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DIID_DISystemMonitor ) , guid : :: windows :: core :: GUID::from_u128(0x13d73d81_c32e_11cf_9398_00aa00a3ddea) , } }
 pub const DIID_DISystemMonitorEvents: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x84979930_4ab3_11cf_943a_008029004347);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DIID_DISystemMonitorEvents ) , guid : :: windows :: core :: GUID::from_u128(0x84979930_4ab3_11cf_943a_008029004347) , } }
 pub const DIID_DISystemMonitorInternal: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x194eb242_c32c_11cf_9398_00aa00a3ddea);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DIID_DISystemMonitorInternal ) , guid : :: windows :: core :: GUID::from_u128(0x194eb242_c32c_11cf_9398_00aa00a3ddea) , } }
 #[doc = "*Required features: 'Win32_System_Performance'*"]
 #[repr(transparent)]
 pub struct DILogFileItem(::windows::core::IUnknown);
@@ -7365,6 +7375,8 @@ pub unsafe fn InstallPerfDllW<'a, Param0: ::windows::core::IntoParam<'a, super::
     unimplemented!("Unsupported target OS");
 }
 pub const LIBID_SystemMonitor: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1b773e42_2509_11cf_942f_008029004347);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( LIBID_SystemMonitor ) , guid : :: windows :: core :: GUID::from_u128(0x1b773e42_2509_11cf_942f_008029004347) , } }
 pub const LegacyDataCollectorSet: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x03837526_098b_11d8_9414_505054503030);
 pub const LegacyDataCollectorSetCollection: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x03837527_098b_11d8_9414_505054503030);
 pub const LegacyTraceSession: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x03837528_098b_11d8_9414_505054503030);
@@ -12033,6 +12045,8 @@ pub unsafe fn RestorePerfRegistryFromFileW<'a, Param0: ::windows::core::IntoPara
     unimplemented!("Unsupported target OS");
 }
 pub const S_PDH: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x04d66358_c4a1_419b_8023_23b73902de2c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( S_PDH ) , guid : :: windows :: core :: GUID::from_u128(0x04d66358_c4a1_419b_8023_23b73902de2c) , } }
 pub const ServerDataCollectorSet: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x03837531_098b_11d8_9414_505054503030);
 pub const ServerDataCollectorSetCollection: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x03837532_098b_11d8_9414_505054503030);
 #[doc = "*Required features: 'Win32_System_Performance', 'Win32_Foundation'*"]

--- a/crates/libs/windows/src/Windows/Win32/System/Power/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Power/mod.rs
@@ -206,9 +206,13 @@ pub const BATTERY_CLASS_MINOR_VERSION_1: u32 = 1u32;
 #[doc = "*Required features: 'Win32_System_Power'*"]
 pub const BATTERY_CRITICAL: u32 = 8u32;
 pub const BATTERY_CYCLE_COUNT_WMI_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xef98db24_0014_4c25_a50b_c724ae5cd371);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( BATTERY_CYCLE_COUNT_WMI_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xef98db24_0014_4c25_a50b_c724ae5cd371) , } }
 #[doc = "*Required features: 'Win32_System_Power'*"]
 pub const BATTERY_DISCHARGING: u32 = 2u32;
 pub const BATTERY_FULL_CHARGED_CAPACITY_WMI_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x40b40565_96f7_4435_8694_97e0e4395905);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( BATTERY_FULL_CHARGED_CAPACITY_WMI_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x40b40565_96f7_4435_8694_97e0e4395905) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_System_Power'*"]
 pub struct BATTERY_INFORMATION {
@@ -372,6 +376,8 @@ impl ::core::default::Default for BATTERY_REPORTING_SCALE {
     }
 }
 pub const BATTERY_RUNTIME_WMI_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x535a3767_1ac2_49bc_a077_3f7a02e40aec);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( BATTERY_RUNTIME_WMI_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x535a3767_1ac2_49bc_a077_3f7a02e40aec) , } }
 #[doc = "*Required features: 'Win32_System_Power'*"]
 pub const BATTERY_SEALED: u32 = 268435456u32;
 #[doc = "*Required features: 'Win32_System_Power'*"]
@@ -429,6 +435,8 @@ pub const BatteryChargerId: BATTERY_SET_INFORMATION_LEVEL = 4i32;
 #[doc = "*Required features: 'Win32_System_Power'*"]
 pub const BatteryChargerStatus: BATTERY_SET_INFORMATION_LEVEL = 5i32;
 pub const BATTERY_STATIC_DATA_WMI_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x05e1e463_e4e2_4ea9_80cb_9bd4b3ca0655);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( BATTERY_STATIC_DATA_WMI_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x05e1e463_e4e2_4ea9_80cb_9bd4b3ca0655) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_System_Power'*"]
 pub struct BATTERY_STATUS {
@@ -463,13 +471,21 @@ impl ::core::default::Default for BATTERY_STATUS {
     }
 }
 pub const BATTERY_STATUS_CHANGE_WMI_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcddfa0c3_7c5b_4e43_a034_059fa5b84364);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( BATTERY_STATUS_CHANGE_WMI_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xcddfa0c3_7c5b_4e43_a034_059fa5b84364) , } }
 pub const BATTERY_STATUS_WMI_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfc4670d1_ebbf_416e_87ce_374a4ebc111a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( BATTERY_STATUS_WMI_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xfc4670d1_ebbf_416e_87ce_374a4ebc111a) , } }
 #[doc = "*Required features: 'Win32_System_Power'*"]
 pub const BATTERY_SYSTEM_BATTERY: u32 = 2147483648u32;
 pub const BATTERY_TAG_CHANGE_WMI_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5e1f6e19_8786_4d23_94fc_9e746bd5d888);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( BATTERY_TAG_CHANGE_WMI_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x5e1f6e19_8786_4d23_94fc_9e746bd5d888) , } }
 #[doc = "*Required features: 'Win32_System_Power'*"]
 pub const BATTERY_TAG_INVALID: u32 = 0u32;
 pub const BATTERY_TEMPERATURE_WMI_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1a52a14d_adce_4a44_9a3e_c8d8f15ff2c2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( BATTERY_TEMPERATURE_WMI_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x1a52a14d_adce_4a44_9a3e_c8d8f15ff2c2) , } }
 #[doc = "*Required features: 'Win32_System_Power'*"]
 pub const BATTERY_UNKNOWN_CAPACITY: u32 = 4294967295u32;
 #[doc = "*Required features: 'Win32_System_Power'*"]
@@ -1170,19 +1186,47 @@ impl ::core::default::Default for GLOBAL_USER_POWER_POLICY {
     }
 }
 pub const GUID_CLASS_INPUT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d1e55b2_f16f_11cf_88cb_001111000030);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_CLASS_INPUT ) , guid : :: windows :: core :: GUID::from_u128(0x4d1e55b2_f16f_11cf_88cb_001111000030) , } }
 pub const GUID_DEVICE_ACPI_TIME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x97f99bf6_4497_4f18_bb22_4b9fb2fbef9c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVICE_ACPI_TIME ) , guid : :: windows :: core :: GUID::from_u128(0x97f99bf6_4497_4f18_bb22_4b9fb2fbef9c) , } }
 pub const GUID_DEVICE_APPLICATIONLAUNCH_BUTTON: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x629758ee_986e_4d9e_8e47_de27f8ab054d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVICE_APPLICATIONLAUNCH_BUTTON ) , guid : :: windows :: core :: GUID::from_u128(0x629758ee_986e_4d9e_8e47_de27f8ab054d) , } }
 pub const GUID_DEVICE_BATTERY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x72631e54_78a4_11d0_bcf7_00aa00b7b32a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVICE_BATTERY ) , guid : :: windows :: core :: GUID::from_u128(0x72631e54_78a4_11d0_bcf7_00aa00b7b32a) , } }
 pub const GUID_DEVICE_ENERGY_METER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x45bd8344_7ed6_49cf_a440_c276c933b053);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVICE_ENERGY_METER ) , guid : :: windows :: core :: GUID::from_u128(0x45bd8344_7ed6_49cf_a440_c276c933b053) , } }
 pub const GUID_DEVICE_FAN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x05ecd13d_81da_4a2a_8a4c_524f23dd4dc9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVICE_FAN ) , guid : :: windows :: core :: GUID::from_u128(0x05ecd13d_81da_4a2a_8a4c_524f23dd4dc9) , } }
 pub const GUID_DEVICE_LID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4afa3d52_74a7_11d0_be5e_00a0c9062857);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVICE_LID ) , guid : :: windows :: core :: GUID::from_u128(0x4afa3d52_74a7_11d0_be5e_00a0c9062857) , } }
 pub const GUID_DEVICE_MEMORY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3fd0f03d_92e0_45fb_b75c_5ed8ffb01021);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVICE_MEMORY ) , guid : :: windows :: core :: GUID::from_u128(0x3fd0f03d_92e0_45fb_b75c_5ed8ffb01021) , } }
 pub const GUID_DEVICE_MESSAGE_INDICATOR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcd48a365_fa94_4ce2_a232_a1b764e5d8b4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVICE_MESSAGE_INDICATOR ) , guid : :: windows :: core :: GUID::from_u128(0xcd48a365_fa94_4ce2_a232_a1b764e5d8b4) , } }
 pub const GUID_DEVICE_PROCESSOR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x97fadb10_4e33_40ae_359c_8bef029dbdd0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVICE_PROCESSOR ) , guid : :: windows :: core :: GUID::from_u128(0x97fadb10_4e33_40ae_359c_8bef029dbdd0) , } }
 pub const GUID_DEVICE_SYS_BUTTON: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4afa3d53_74a7_11d0_be5e_00a0c9062857);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVICE_SYS_BUTTON ) , guid : :: windows :: core :: GUID::from_u128(0x4afa3d53_74a7_11d0_be5e_00a0c9062857) , } }
 pub const GUID_DEVICE_THERMAL_ZONE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4afa3d51_74a7_11d0_be5e_00a0c9062857);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVICE_THERMAL_ZONE ) , guid : :: windows :: core :: GUID::from_u128(0x4afa3d51_74a7_11d0_be5e_00a0c9062857) , } }
 pub const GUID_DEVINTERFACE_THERMAL_COOLING: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdbe4373d_3c81_40cb_ace4_e0e5d05f0c9f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_THERMAL_COOLING ) , guid : :: windows :: core :: GUID::from_u128(0xdbe4373d_3c81_40cb_ace4_e0e5d05f0c9f) , } }
 pub const GUID_DEVINTERFACE_THERMAL_MANAGER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x927ec093_69a4_4bc0_bd02_711664714463);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_THERMAL_MANAGER ) , guid : :: windows :: core :: GUID::from_u128(0x927ec093_69a4_4bc0_bd02_711664714463) , } }
 #[doc = "*Required features: 'Win32_System_Power', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
@@ -1975,6 +2019,8 @@ pub const DEVICE_NOTIFY_WINDOW_HANDLE: POWER_SETTING_REGISTER_NOTIFICATION_FLAGS
 #[doc = "*Required features: 'Win32_System_Power', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PROCESSOR_NUMBER_PKEY: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x5724c81d_d5af_4c1f_a103_a06e28f204c6), pid: 1u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROCESSOR_NUMBER_PKEY ) , guid : :: windows :: core :: GUID::from_u128(0x5724c81d_d5af_4c1f_a103_a06e28f204c6) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_System_Power'*"]
 pub struct PROCESSOR_OBJECT_INFO {

--- a/crates/libs/windows/src/Windows/Win32/System/RemoteDesktop/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/RemoteDesktop/mod.rs
@@ -462,7 +462,11 @@ pub const CONNECTION_REQUEST_QUERY_PL_COMPLETED: CONNECTION_CHANGE_NOTIFICATION 
 #[doc = "*Required features: 'Win32_System_RemoteDesktop'*"]
 pub const CONNECTION_REQUEST_ORCH_COMPLETED: CONNECTION_CHANGE_NOTIFICATION = 8i32;
 pub const CONNECTION_PROPERTY_CURSOR_BLINK_DISABLED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4b150580_fea4_4d3c_9de4_7433a66618f7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CONNECTION_PROPERTY_CURSOR_BLINK_DISABLED ) , guid : :: windows :: core :: GUID::from_u128(0x4b150580_fea4_4d3c_9de4_7433a66618f7) , } }
 pub const CONNECTION_PROPERTY_IDLE_TIME_WARNING: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x693f7ff5_0c4e_4d17_b8e0_1f70325e5d58);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CONNECTION_PROPERTY_IDLE_TIME_WARNING ) , guid : :: windows :: core :: GUID::from_u128(0x693f7ff5_0c4e_4d17_b8e0_1f70325e5d58) , } }
 #[doc = "*Required features: 'Win32_System_RemoteDesktop'*"]
 pub const DISPID_AX_ADMINMESSAGERECEIVED: u32 = 760u32;
 #[doc = "*Required features: 'Win32_System_RemoteDesktop'*"]
@@ -9987,9 +9991,17 @@ pub const PRODUCTINFO_COMPANYNAME_LENGTH: u32 = 256u32;
 #[doc = "*Required features: 'Win32_System_RemoteDesktop'*"]
 pub const PRODUCTINFO_PRODUCTID_LENGTH: u32 = 4u32;
 pub const PROPERTY_DYNAMIC_TIME_ZONE_INFORMATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cdfd28e_d0b9_4c1f_a5eb_6d1f6c6535b9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROPERTY_DYNAMIC_TIME_ZONE_INFORMATION ) , guid : :: windows :: core :: GUID::from_u128(0x0cdfd28e_d0b9_4c1f_a5eb_6d1f6c6535b9) , } }
 pub const PROPERTY_TYPE_ENABLE_UNIVERSAL_APPS_FOR_CUSTOM_SHELL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xed2c3fda_338d_4d3f_81a3_e767310d908e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROPERTY_TYPE_ENABLE_UNIVERSAL_APPS_FOR_CUSTOM_SHELL ) , guid : :: windows :: core :: GUID::from_u128(0xed2c3fda_338d_4d3f_81a3_e767310d908e) , } }
 pub const PROPERTY_TYPE_GET_FAST_RECONNECT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6212d757_0043_4862_99c3_9f3059ac2a3b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROPERTY_TYPE_GET_FAST_RECONNECT ) , guid : :: windows :: core :: GUID::from_u128(0x6212d757_0043_4862_99c3_9f3059ac2a3b) , } }
 pub const PROPERTY_TYPE_GET_FAST_RECONNECT_USER_SID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x197c427a_0135_4b6d_9c5e_e6579a0ab625);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROPERTY_TYPE_GET_FAST_RECONNECT_USER_SID ) , guid : :: windows :: core :: GUID::from_u128(0x197c427a_0135_4b6d_9c5e_e6579a0ab625) , } }
 #[doc = "*Required features: 'Win32_System_RemoteDesktop'*"]
 pub type PVIRTUALCHANNELCLOSE = ::core::option::Option<unsafe extern "system" fn(openhandle: u32) -> u32>;
 #[doc = "*Required features: 'Win32_System_RemoteDesktop', 'Win32_Foundation'*"]
@@ -10045,6 +10057,8 @@ pub unsafe fn ProcessIdToSessionId(dwprocessid: u32, psessionid: *mut u32) -> su
     unimplemented!("Unsupported target OS");
 }
 pub const RDCLIENT_BITMAP_RENDER_SERVICE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe4cc08cb_942e_4b19_8504_bd5a89a747f5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( RDCLIENT_BITMAP_RENDER_SERVICE ) , guid : :: windows :: core :: GUID::from_u128(0xe4cc08cb_942e_4b19_8504_bd5a89a747f5) , } }
 #[doc = "*Required features: 'Win32_System_RemoteDesktop'*"]
 pub type RDV_TASK_STATUS = i32;
 #[doc = "*Required features: 'Win32_System_RemoteDesktop'*"]
@@ -11122,6 +11136,8 @@ pub const WRDS_PERF_ENABLE_FONT_SMOOTHING: u32 = 128u32;
 #[doc = "*Required features: 'Win32_System_RemoteDesktop'*"]
 pub const WRDS_PROTOCOL_NAME_LENGTH: u32 = 8u32;
 pub const WRDS_SERVICE_ID_GRAPHICS_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd2993f4d_02cf_4280_8c48_1624b44f8706);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WRDS_SERVICE_ID_GRAPHICS_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xd2993f4d_02cf_4280_8c48_1624b44f8706) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_System_RemoteDesktop', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -14578,9 +14594,17 @@ pub const WTS_PROTOCOL_TYPE_ICA: u32 = 1u32;
 #[doc = "*Required features: 'Win32_System_RemoteDesktop'*"]
 pub const WTS_PROTOCOL_TYPE_RDP: u32 = 2u32;
 pub const WTS_QUERY_ALLOWED_INITIAL_APP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc77d1b30_5be1_4c6b_a0e1_bd6d2e5c9fcc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WTS_QUERY_ALLOWED_INITIAL_APP ) , guid : :: windows :: core :: GUID::from_u128(0xc77d1b30_5be1_4c6b_a0e1_bd6d2e5c9fcc) , } }
 pub const WTS_QUERY_AUDIOENUM_DLL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9bf4fa97_c883_4c2a_80ab_5a39c9af00db);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WTS_QUERY_AUDIOENUM_DLL ) , guid : :: windows :: core :: GUID::from_u128(0x9bf4fa97_c883_4c2a_80ab_5a39c9af00db) , } }
 pub const WTS_QUERY_LOGON_SCREEN_SIZE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8b8e0fe7_0804_4a0e_b279_8660b1df0049);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WTS_QUERY_LOGON_SCREEN_SIZE ) , guid : :: windows :: core :: GUID::from_u128(0x8b8e0fe7_0804_4a0e_b279_8660b1df0049) , } }
 pub const WTS_QUERY_MF_FORMAT_SUPPORT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x41869ad0_6332_4dc8_95d5_db749e2f1d94);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( WTS_QUERY_MF_FORMAT_SUPPORT ) , guid : :: windows :: core :: GUID::from_u128(0x41869ad0_6332_4dc8_95d5_db749e2f1d94) , } }
 #[doc = "*Required features: 'Win32_System_RemoteDesktop'*"]
 pub type WTS_RCM_DRAIN_STATE = i32;
 #[doc = "*Required features: 'Win32_System_RemoteDesktop'*"]

--- a/crates/libs/windows/src/Windows/Win32/System/Search/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Search/mod.rs
@@ -359,12 +359,26 @@ pub const CI_S_NEW_AUXMETADATA: ::windows::core::HRESULT = ::windows::core::HRES
 #[doc = "*Required features: 'Win32_System_Search'*"]
 pub const CI_S_RETRY_DOCUMENT: ::windows::core::HRESULT = ::windows::core::HRESULT(268332i32);
 pub const CLSID_DataShapeProvider: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3449a1c8_c56c_11d0_ad72_00c04fc29863);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_DataShapeProvider ) , guid : :: windows :: core :: GUID::from_u128(0x3449a1c8_c56c_11d0_ad72_00c04fc29863) , } }
 pub const CLSID_MSDASQL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc8b522cb_5cf3_11ce_ade5_00aa0044773d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_MSDASQL ) , guid : :: windows :: core :: GUID::from_u128(0xc8b522cb_5cf3_11ce_ade5_00aa0044773d) , } }
 pub const CLSID_MSDASQL_ENUMERATOR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc8b522cd_5cf3_11ce_ade5_00aa0044773d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_MSDASQL_ENUMERATOR ) , guid : :: windows :: core :: GUID::from_u128(0xc8b522cd_5cf3_11ce_ade5_00aa0044773d) , } }
 pub const CLSID_MSPersist: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7c07e0d0_4418_11d2_9212_00c04fbbbfb3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_MSPersist ) , guid : :: windows :: core :: GUID::from_u128(0x7c07e0d0_4418_11d2_9212_00c04fbbbfb3) , } }
 pub const CLSID_SQLOLEDB: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0c7ff16c_38e3_11d0_97ab_00c04fc2ad98);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_SQLOLEDB ) , guid : :: windows :: core :: GUID::from_u128(0x0c7ff16c_38e3_11d0_97ab_00c04fc2ad98) , } }
 pub const CLSID_SQLOLEDB_ENUMERATOR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdfa22b8e_e68d_11d0_97e4_00c04fc2ad98);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_SQLOLEDB_ENUMERATOR ) , guid : :: windows :: core :: GUID::from_u128(0xdfa22b8e_e68d_11d0_97e4_00c04fc2ad98) , } }
 pub const CLSID_SQLOLEDB_ERROR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc0932c62_38e5_11d0_97ab_00c04fc2ad98);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_SQLOLEDB_ERROR ) , guid : :: windows :: core :: GUID::from_u128(0xc0932c62_38e5_11d0_97ab_00c04fc2ad98) , } }
 #[doc = "*Required features: 'Win32_System_Search'*"]
 pub type CLUSION_REASON = i32;
 #[doc = "*Required features: 'Win32_System_Search'*"]
@@ -1873,7 +1887,11 @@ impl ::core::default::Default for DBFAILUREINFO {
     }
 }
 pub const DBGUID_MSSQLXML: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5d531cb2_e6ed_11d2_b252_00c04f681b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DBGUID_MSSQLXML ) , guid : :: windows :: core :: GUID::from_u128(0x5d531cb2_e6ed_11d2_b252_00c04f681b71) , } }
 pub const DBGUID_XPATH: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xec2a4293_e898_11d2_b1b7_00c04f680c56);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DBGUID_XPATH ) , guid : :: windows :: core :: GUID::from_u128(0xec2a4293_e898_11d2_b1b7_00c04f680c56) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_System_Search'*"]
 #[cfg(any(target_arch = "aarch64", target_arch = "x86_64"))]
@@ -3647,22 +3665,56 @@ impl ::core::default::Default for DBPROPSET {
     }
 }
 pub const DBPROPSET_MSDAORA8_ROWSET: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7f06a375_dd6a_43db_b4e0_1fc121e5e62b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DBPROPSET_MSDAORA8_ROWSET ) , guid : :: windows :: core :: GUID::from_u128(0x7f06a375_dd6a_43db_b4e0_1fc121e5e62b) , } }
 pub const DBPROPSET_MSDAORA_ROWSET: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe8cc4cbd_fdff_11d0_b865_00a0c9081c1d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DBPROPSET_MSDAORA_ROWSET ) , guid : :: windows :: core :: GUID::from_u128(0xe8cc4cbd_fdff_11d0_b865_00a0c9081c1d) , } }
 pub const DBPROPSET_MSDSDBINIT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x55cb91a8_5c7a_11d1_adad_00c04fc29863);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DBPROPSET_MSDSDBINIT ) , guid : :: windows :: core :: GUID::from_u128(0x55cb91a8_5c7a_11d1_adad_00c04fc29863) , } }
 pub const DBPROPSET_MSDSSESSION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xedf17536_afbf_11d1_8847_0000f879f98c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DBPROPSET_MSDSSESSION ) , guid : :: windows :: core :: GUID::from_u128(0xedf17536_afbf_11d1_8847_0000f879f98c) , } }
 pub const DBPROPSET_PERSIST: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d7839a0_5b8e_11d1_a6b3_00a0c9138c66);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DBPROPSET_PERSIST ) , guid : :: windows :: core :: GUID::from_u128(0x4d7839a0_5b8e_11d1_a6b3_00a0c9138c66) , } }
 pub const DBPROPSET_PROVIDERCONNATTR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x497c60e4_7123_11cf_b171_00aa0057599e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DBPROPSET_PROVIDERCONNATTR ) , guid : :: windows :: core :: GUID::from_u128(0x497c60e4_7123_11cf_b171_00aa0057599e) , } }
 pub const DBPROPSET_PROVIDERDATASOURCEINFO: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x497c60e0_7123_11cf_b171_00aa0057599e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DBPROPSET_PROVIDERDATASOURCEINFO ) , guid : :: windows :: core :: GUID::from_u128(0x497c60e0_7123_11cf_b171_00aa0057599e) , } }
 pub const DBPROPSET_PROVIDERDBINIT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x497c60e2_7123_11cf_b171_00aa0057599e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DBPROPSET_PROVIDERDBINIT ) , guid : :: windows :: core :: GUID::from_u128(0x497c60e2_7123_11cf_b171_00aa0057599e) , } }
 pub const DBPROPSET_PROVIDERROWSET: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x497c60e1_7123_11cf_b171_00aa0057599e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DBPROPSET_PROVIDERROWSET ) , guid : :: windows :: core :: GUID::from_u128(0x497c60e1_7123_11cf_b171_00aa0057599e) , } }
 pub const DBPROPSET_PROVIDERSTMTATTR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x497c60e3_7123_11cf_b171_00aa0057599e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DBPROPSET_PROVIDERSTMTATTR ) , guid : :: windows :: core :: GUID::from_u128(0x497c60e3_7123_11cf_b171_00aa0057599e) , } }
 pub const DBPROPSET_SQLSERVERCOLUMN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3b63fb5e_3fbb_11d3_9f29_00c04f8ee9dc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DBPROPSET_SQLSERVERCOLUMN ) , guid : :: windows :: core :: GUID::from_u128(0x3b63fb5e_3fbb_11d3_9f29_00c04f8ee9dc) , } }
 pub const DBPROPSET_SQLSERVERDATASOURCE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x28efaee4_2d2c_11d1_9807_00c04fc2ad98);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DBPROPSET_SQLSERVERDATASOURCE ) , guid : :: windows :: core :: GUID::from_u128(0x28efaee4_2d2c_11d1_9807_00c04fc2ad98) , } }
 pub const DBPROPSET_SQLSERVERDATASOURCEINFO: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdf10cb94_35f6_11d2_9c54_00c04f7971d3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DBPROPSET_SQLSERVERDATASOURCEINFO ) , guid : :: windows :: core :: GUID::from_u128(0xdf10cb94_35f6_11d2_9c54_00c04f7971d3) , } }
 pub const DBPROPSET_SQLSERVERDBINIT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5cf4ca10_ef21_11d0_97e7_00c04fc2ad98);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DBPROPSET_SQLSERVERDBINIT ) , guid : :: windows :: core :: GUID::from_u128(0x5cf4ca10_ef21_11d0_97e7_00c04fc2ad98) , } }
 pub const DBPROPSET_SQLSERVERROWSET: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5cf4ca11_ef21_11d0_97e7_00c04fc2ad98);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DBPROPSET_SQLSERVERROWSET ) , guid : :: windows :: core :: GUID::from_u128(0x5cf4ca11_ef21_11d0_97e7_00c04fc2ad98) , } }
 pub const DBPROPSET_SQLSERVERSESSION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x28efaee5_2d2c_11d1_9807_00c04fc2ad98);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DBPROPSET_SQLSERVERSESSION ) , guid : :: windows :: core :: GUID::from_u128(0x28efaee5_2d2c_11d1_9807_00c04fc2ad98) , } }
 pub const DBPROPSET_SQLSERVERSTREAM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9f79c073_8a6d_4bca_a8a8_c9b79a9b962d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DBPROPSET_SQLSERVERSTREAM ) , guid : :: windows :: core :: GUID::from_u128(0x9f79c073_8a6d_4bca_a8a8_c9b79a9b962d) , } }
 #[doc = "*Required features: 'Win32_System_Search'*"]
 pub type DBPROPSTATUSENUM = i32;
 #[doc = "*Required features: 'Win32_System_Search'*"]
@@ -4230,6 +4282,8 @@ pub type DBROWSTATUSENUM20 = i32;
 #[doc = "*Required features: 'Win32_System_Search'*"]
 pub const DBROWSTATUS_S_NOCHANGE: DBROWSTATUSENUM20 = 20i32;
 pub const DBSCHEMA_LINKEDSERVERS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9093caf4_2eac_11d1_9809_00c04fc2ad98);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DBSCHEMA_LINKEDSERVERS ) , guid : :: windows :: core :: GUID::from_u128(0x9093caf4_2eac_11d1_9809_00c04fc2ad98) , } }
 #[doc = "*Required features: 'Win32_System_Search'*"]
 pub type DBSEEKENUM = i32;
 #[doc = "*Required features: 'Win32_System_Search'*"]

--- a/crates/libs/windows/src/Windows/Win32/System/Services/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Services/mod.rs
@@ -1,5 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 pub const CUSTOM_SYSTEM_STATE_CHANGE_EVENT_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2d7a2816_0c5e_45fc_9ce7_570e5ecde9c9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CUSTOM_SYSTEM_STATE_CHANGE_EVENT_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x2d7a2816_0c5e_45fc_9ce7_570e5ecde9c9) , } }
 #[doc = "*Required features: 'Win32_System_Services', 'Win32_Foundation', 'Win32_Security'*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 #[inline]
@@ -231,7 +233,11 @@ pub unsafe fn CreateServiceW<'a, Param0: ::windows::core::IntoParam<'a, super::s
     unimplemented!("Unsupported target OS");
 }
 pub const DOMAIN_JOIN_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1ce20aba_9851_4421_9430_1ddeb766e809);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DOMAIN_JOIN_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x1ce20aba_9851_4421_9430_1ddeb766e809) , } }
 pub const DOMAIN_LEAVE_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xddaf516e_58c2_4866_9574_c3b615d42ea1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DOMAIN_LEAVE_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xddaf516e_58c2_4866_9574_c3b615d42ea1) , } }
 #[doc = "*Required features: 'Win32_System_Services', 'Win32_Foundation', 'Win32_Security'*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 #[inline]
@@ -532,7 +538,11 @@ pub unsafe fn EnumServicesStatusW<'a, Param0: ::windows::core::IntoParam<'a, sup
     unimplemented!("Unsupported target OS");
 }
 pub const FIREWALL_PORT_CLOSE_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa144ed38_8e12_4de4_9d96_e64740b1a524);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FIREWALL_PORT_CLOSE_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xa144ed38_8e12_4de4_9d96_e64740b1a524) , } }
 pub const FIREWALL_PORT_OPEN_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb7569e07_8421_4ee0_ad10_86915afdad09);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FIREWALL_PORT_OPEN_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xb7569e07_8421_4ee0_ad10_86915afdad09) , } }
 #[doc = "*Required features: 'Win32_System_Services', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
@@ -683,9 +693,17 @@ pub unsafe fn LockServiceDatabase<'a, Param0: ::windows::core::IntoParam<'a, sup
     unimplemented!("Unsupported target OS");
 }
 pub const MACHINE_POLICY_PRESENT_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x659fcae6_5bdb_4da9_b1ff_ca2a178d46e0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( MACHINE_POLICY_PRESENT_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x659fcae6_5bdb_4da9_b1ff_ca2a178d46e0) , } }
 pub const NAMED_PIPE_EVENT_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1f81d131_3fac_4537_9e0c_7e7b0c2f4b55);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( NAMED_PIPE_EVENT_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x1f81d131_3fac_4537_9e0c_7e7b0c2f4b55) , } }
 pub const NETWORK_MANAGER_FIRST_IP_ADDRESS_ARRIVAL_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4f27f2de_14e2_430b_a549_7cd48cbc8245);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( NETWORK_MANAGER_FIRST_IP_ADDRESS_ARRIVAL_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x4f27f2de_14e2_430b_a549_7cd48cbc8245) , } }
 pub const NETWORK_MANAGER_LAST_IP_ADDRESS_REMOVAL_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcc4ba62a_162e_4648_847a_b6bdf993e335);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( NETWORK_MANAGER_LAST_IP_ADDRESS_REMOVAL_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xcc4ba62a_162e_4648_847a_b6bdf993e335) , } }
 #[doc = "*Required features: 'Win32_System_Services', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
@@ -1118,6 +1136,8 @@ pub unsafe fn QueryServiceStatusEx<'a, Param0: ::windows::core::IntoParam<'a, su
     unimplemented!("Unsupported target OS");
 }
 pub const RPC_INTERFACE_EVENT_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbc90d167_9470_4139_a9ba_be0bbbf5b74d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( RPC_INTERFACE_EVENT_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xbc90d167_9470_4139_a9ba_be0bbbf5b74d) , } }
 #[doc = "*Required features: 'Win32_System_Services', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
@@ -2783,6 +2803,8 @@ pub unsafe fn StartServiceW<'a, Param0: ::windows::core::IntoParam<'a, super::su
     unimplemented!("Unsupported target OS");
 }
 pub const USER_POLICY_PRESENT_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x54fb46c8_f089_464c_b1fd_59d1b62c3b50);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( USER_POLICY_PRESENT_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x54fb46c8_f089_464c_b1fd_59d1b62c3b50) , } }
 #[doc = "*Required features: 'Win32_System_Services', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]

--- a/crates/libs/windows/src/Windows/Win32/System/SideShow/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SideShow/mod.rs
@@ -116,6 +116,8 @@ impl ::core::default::Default for EVENT_DATA_HEADER {
     }
 }
 pub const GUID_DEVINTERFACE_SIDESHOW: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x152e5811_feb9_4b00_90f4_d32947ae1681);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_SIDESHOW ) , guid : :: windows :: core :: GUID::from_u128(0x152e5811_feb9_4b00_90f4_d32947ae1681) , } }
 #[doc = "*Required features: 'Win32_System_SideShow'*"]
 #[repr(transparent)]
 pub struct ISideShowBulkCapabilities(::windows::core::IUnknown);
@@ -1152,46 +1154,76 @@ impl ::core::default::Default for SCF_NAVIGATION_EVENT {
     }
 }
 pub const SIDESHOW_APPLICATION_EVENT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4cb572fa_1d3b_49b3_a17a_2e6bff052854);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SIDESHOW_APPLICATION_EVENT ) , guid : :: windows :: core :: GUID::from_u128(0x4cb572fa_1d3b_49b3_a17a_2e6bff052854) , } }
 #[doc = "*Required features: 'Win32_System_SideShow', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SIDESHOW_CAPABILITY_CLIENT_AREA_HEIGHT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8abc88a8_857b_4ad7_a35a_b5942f492b99), pid: 16u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SIDESHOW_CAPABILITY_CLIENT_AREA_HEIGHT ) , guid : :: windows :: core :: GUID::from_u128(0x8abc88a8_857b_4ad7_a35a_b5942f492b99) , } }
 #[doc = "*Required features: 'Win32_System_SideShow', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SIDESHOW_CAPABILITY_CLIENT_AREA_WIDTH: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8abc88a8_857b_4ad7_a35a_b5942f492b99), pid: 15u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SIDESHOW_CAPABILITY_CLIENT_AREA_WIDTH ) , guid : :: windows :: core :: GUID::from_u128(0x8abc88a8_857b_4ad7_a35a_b5942f492b99) , } }
 #[doc = "*Required features: 'Win32_System_SideShow', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SIDESHOW_CAPABILITY_COLOR_DEPTH: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8abc88a8_857b_4ad7_a35a_b5942f492b99), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SIDESHOW_CAPABILITY_COLOR_DEPTH ) , guid : :: windows :: core :: GUID::from_u128(0x8abc88a8_857b_4ad7_a35a_b5942f492b99) , } }
 #[doc = "*Required features: 'Win32_System_SideShow', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SIDESHOW_CAPABILITY_COLOR_TYPE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8abc88a8_857b_4ad7_a35a_b5942f492b99), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SIDESHOW_CAPABILITY_COLOR_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x8abc88a8_857b_4ad7_a35a_b5942f492b99) , } }
 #[doc = "*Required features: 'Win32_System_SideShow', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SIDESHOW_CAPABILITY_CURRENT_LANGUAGE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8abc88a8_857b_4ad7_a35a_b5942f492b99), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SIDESHOW_CAPABILITY_CURRENT_LANGUAGE ) , guid : :: windows :: core :: GUID::from_u128(0x8abc88a8_857b_4ad7_a35a_b5942f492b99) , } }
 #[doc = "*Required features: 'Win32_System_SideShow', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SIDESHOW_CAPABILITY_DATA_CACHE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8abc88a8_857b_4ad7_a35a_b5942f492b99), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SIDESHOW_CAPABILITY_DATA_CACHE ) , guid : :: windows :: core :: GUID::from_u128(0x8abc88a8_857b_4ad7_a35a_b5942f492b99) , } }
 #[doc = "*Required features: 'Win32_System_SideShow', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SIDESHOW_CAPABILITY_DEVICE_ID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8abc88a8_857b_4ad7_a35a_b5942f492b99), pid: 1u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SIDESHOW_CAPABILITY_DEVICE_ID ) , guid : :: windows :: core :: GUID::from_u128(0x8abc88a8_857b_4ad7_a35a_b5942f492b99) , } }
 pub const SIDESHOW_CAPABILITY_DEVICE_PROPERTIES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8abc88a8_857b_4ad7_a35a_b5942f492b99);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SIDESHOW_CAPABILITY_DEVICE_PROPERTIES ) , guid : :: windows :: core :: GUID::from_u128(0x8abc88a8_857b_4ad7_a35a_b5942f492b99) , } }
 #[doc = "*Required features: 'Win32_System_SideShow', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SIDESHOW_CAPABILITY_SCREEN_HEIGHT: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8abc88a8_857b_4ad7_a35a_b5942f492b99), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SIDESHOW_CAPABILITY_SCREEN_HEIGHT ) , guid : :: windows :: core :: GUID::from_u128(0x8abc88a8_857b_4ad7_a35a_b5942f492b99) , } }
 #[doc = "*Required features: 'Win32_System_SideShow', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SIDESHOW_CAPABILITY_SCREEN_TYPE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8abc88a8_857b_4ad7_a35a_b5942f492b99), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SIDESHOW_CAPABILITY_SCREEN_TYPE ) , guid : :: windows :: core :: GUID::from_u128(0x8abc88a8_857b_4ad7_a35a_b5942f492b99) , } }
 #[doc = "*Required features: 'Win32_System_SideShow', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SIDESHOW_CAPABILITY_SCREEN_WIDTH: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8abc88a8_857b_4ad7_a35a_b5942f492b99), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SIDESHOW_CAPABILITY_SCREEN_WIDTH ) , guid : :: windows :: core :: GUID::from_u128(0x8abc88a8_857b_4ad7_a35a_b5942f492b99) , } }
 #[doc = "*Required features: 'Win32_System_SideShow', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SIDESHOW_CAPABILITY_SUPPORTED_IMAGE_FORMATS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8abc88a8_857b_4ad7_a35a_b5942f492b99), pid: 14u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SIDESHOW_CAPABILITY_SUPPORTED_IMAGE_FORMATS ) , guid : :: windows :: core :: GUID::from_u128(0x8abc88a8_857b_4ad7_a35a_b5942f492b99) , } }
 #[doc = "*Required features: 'Win32_System_SideShow', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SIDESHOW_CAPABILITY_SUPPORTED_LANGUAGES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8abc88a8_857b_4ad7_a35a_b5942f492b99), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SIDESHOW_CAPABILITY_SUPPORTED_LANGUAGES ) , guid : :: windows :: core :: GUID::from_u128(0x8abc88a8_857b_4ad7_a35a_b5942f492b99) , } }
 #[doc = "*Required features: 'Win32_System_SideShow', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const SIDESHOW_CAPABILITY_SUPPORTED_THEMES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x8abc88a8_857b_4ad7_a35a_b5942f492b99), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SIDESHOW_CAPABILITY_SUPPORTED_THEMES ) , guid : :: windows :: core :: GUID::from_u128(0x8abc88a8_857b_4ad7_a35a_b5942f492b99) , } }
 #[doc = "*Required features: 'Win32_System_SideShow'*"]
 pub type SIDESHOW_COLOR_TYPE = i32;
 #[doc = "*Required features: 'Win32_System_SideShow'*"]
@@ -1201,13 +1233,21 @@ pub const SIDESHOW_COLOR_TYPE_GREYSCALE: SIDESHOW_COLOR_TYPE = 1i32;
 #[doc = "*Required features: 'Win32_System_SideShow'*"]
 pub const SIDESHOW_COLOR_TYPE_BLACK_AND_WHITE: SIDESHOW_COLOR_TYPE = 2i32;
 pub const SIDESHOW_CONTENT_MISSING_EVENT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5007fba8_d313_439f_bea2_a50201d3e9a8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SIDESHOW_CONTENT_MISSING_EVENT ) , guid : :: windows :: core :: GUID::from_u128(0x5007fba8_d313_439f_bea2_a50201d3e9a8) , } }
 pub const SIDESHOW_ENDPOINT_ICAL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4dff36b5_9dde_4f76_9a2a_96435047063d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SIDESHOW_ENDPOINT_ICAL ) , guid : :: windows :: core :: GUID::from_u128(0x4dff36b5_9dde_4f76_9a2a_96435047063d) , } }
 pub const SIDESHOW_ENDPOINT_SIMPLE_CONTENT_FORMAT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa9a5353f_2d4b_47ce_93ee_759f3a7dda4f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SIDESHOW_ENDPOINT_SIMPLE_CONTENT_FORMAT ) , guid : :: windows :: core :: GUID::from_u128(0xa9a5353f_2d4b_47ce_93ee_759f3a7dda4f) , } }
 #[doc = "*Required features: 'Win32_System_SideShow'*"]
 pub const SIDESHOW_EVENTID_APPLICATION_ENTER: u32 = 4294901760u32;
 #[doc = "*Required features: 'Win32_System_SideShow'*"]
 pub const SIDESHOW_EVENTID_APPLICATION_EXIT: u32 = 4294901761u32;
 pub const SIDESHOW_NEW_EVENT_DATA_AVAILABLE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x57813854_2fc1_411c_a59f_f24927608804);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SIDESHOW_NEW_EVENT_DATA_AVAILABLE ) , guid : :: windows :: core :: GUID::from_u128(0x57813854_2fc1_411c_a59f_f24927608804) , } }
 #[doc = "*Required features: 'Win32_System_SideShow'*"]
 pub type SIDESHOW_SCREEN_TYPE = i32;
 #[doc = "*Required features: 'Win32_System_SideShow'*"]
@@ -1215,6 +1255,8 @@ pub const SIDESHOW_SCREEN_TYPE_BITMAP: SIDESHOW_SCREEN_TYPE = 0i32;
 #[doc = "*Required features: 'Win32_System_SideShow'*"]
 pub const SIDESHOW_SCREEN_TYPE_TEXT: SIDESHOW_SCREEN_TYPE = 1i32;
 pub const SIDESHOW_USER_CHANGE_REQUEST_EVENT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5009673c_3f7d_4c7e_9971_eaa2e91f1575);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SIDESHOW_USER_CHANGE_REQUEST_EVENT ) , guid : :: windows :: core :: GUID::from_u128(0x5009673c_3f7d_4c7e_9971_eaa2e91f1575) , } }
 pub const SideShowKeyCollection: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdfbbdbf8_18de_49b8_83dc_ebc727c62d94);
 pub const SideShowNotification: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0ce3e86f_d5cd_4525_a766_1abab1a752f5);
 pub const SideShowPropVariantCollection: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe640f415_539e_4923_96cd_5f093bc250cd);

--- a/crates/libs/windows/src/Windows/Win32/System/SystemServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SystemServices/mod.rs
@@ -172,6 +172,8 @@ pub const ALERT_SYSTEM_QUERY: ALERT_SYSTEM_SEV = 4u32;
 #[doc = "*Required features: 'Win32_System_SystemServices'*"]
 pub const ALERT_SYSTEM_CRITICAL: ALERT_SYSTEM_SEV = 5u32;
 pub const ALL_POWERSCHEMES_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x68a1e95e_13ea_41e1_8011_0c496ca490b0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ALL_POWERSCHEMES_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x68a1e95e_13ea_41e1_8011_0c496ca490b0) , } }
 #[doc = "*Required features: 'Win32_System_SystemServices'*"]
 pub const ALL_PROCESSOR_GROUPS: u32 = 65535u32;
 #[repr(C)]
@@ -3181,77 +3183,221 @@ pub const GC_PRESSANDTAP: GESTURECONFIG_FLAGS = 1u32;
 #[doc = "*Required features: 'Win32_System_SystemServices'*"]
 pub const GC_ROLLOVER: GESTURECONFIG_FLAGS = 1u32;
 pub const GUID_ACDC_POWER_SOURCE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5d3e9a59_e9d5_4b00_a6bd_ff34ff516548);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ACDC_POWER_SOURCE ) , guid : :: windows :: core :: GUID::from_u128(0x5d3e9a59_e9d5_4b00_a6bd_ff34ff516548) , } }
 pub const GUID_ACTIVE_POWERSCHEME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x31f9f286_5084_42fe_b720_2b0264993763);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ACTIVE_POWERSCHEME ) , guid : :: windows :: core :: GUID::from_u128(0x31f9f286_5084_42fe_b720_2b0264993763) , } }
 pub const GUID_ADAPTIVE_INPUT_CONTROLLER_STATE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0e98fae9_f45a_4de1_a757_6031f197f6ea);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ADAPTIVE_INPUT_CONTROLLER_STATE ) , guid : :: windows :: core :: GUID::from_u128(0x0e98fae9_f45a_4de1_a757_6031f197f6ea) , } }
 pub const GUID_ADAPTIVE_POWER_BEHAVIOR_SUBGROUP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8619b916_e004_4dd8_9b66_dae86f806698);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ADAPTIVE_POWER_BEHAVIOR_SUBGROUP ) , guid : :: windows :: core :: GUID::from_u128(0x8619b916_e004_4dd8_9b66_dae86f806698) , } }
 pub const GUID_ADVANCED_COLOR_QUALITY_BIAS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x684c3e69_a4f7_4014_8754_d45179a56167);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ADVANCED_COLOR_QUALITY_BIAS ) , guid : :: windows :: core :: GUID::from_u128(0x684c3e69_a4f7_4014_8754_d45179a56167) , } }
 pub const GUID_ALLOW_AWAYMODE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x25dfa149_5dd1_4736_b5ab_e8a37b5b8187);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ALLOW_AWAYMODE ) , guid : :: windows :: core :: GUID::from_u128(0x25dfa149_5dd1_4736_b5ab_e8a37b5b8187) , } }
 pub const GUID_ALLOW_DISPLAY_REQUIRED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa9ceb8da_cd46_44fb_a98b_02af69de4623);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ALLOW_DISPLAY_REQUIRED ) , guid : :: windows :: core :: GUID::from_u128(0xa9ceb8da_cd46_44fb_a98b_02af69de4623) , } }
 pub const GUID_ALLOW_RTC_WAKE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbd3b718a_0680_4d9d_8ab2_e1d2b4ac806d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ALLOW_RTC_WAKE ) , guid : :: windows :: core :: GUID::from_u128(0xbd3b718a_0680_4d9d_8ab2_e1d2b4ac806d) , } }
 pub const GUID_ALLOW_STANDBY_STATES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xabfc2519_3608_4c2a_94ea_171b0ed546ab);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ALLOW_STANDBY_STATES ) , guid : :: windows :: core :: GUID::from_u128(0xabfc2519_3608_4c2a_94ea_171b0ed546ab) , } }
 pub const GUID_ALLOW_SYSTEM_REQUIRED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa4b195f5_8225_47d8_8012_9d41369786e2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ALLOW_SYSTEM_REQUIRED ) , guid : :: windows :: core :: GUID::from_u128(0xa4b195f5_8225_47d8_8012_9d41369786e2) , } }
 pub const GUID_APPLAUNCH_BUTTON: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1a689231_7399_4e9a_8f99_b71f999db3fa);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_APPLAUNCH_BUTTON ) , guid : :: windows :: core :: GUID::from_u128(0x1a689231_7399_4e9a_8f99_b71f999db3fa) , } }
 pub const GUID_BACKGROUND_TASK_NOTIFICATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcf23f240_2a54_48d8_b114_de1518ff052e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BACKGROUND_TASK_NOTIFICATION ) , guid : :: windows :: core :: GUID::from_u128(0xcf23f240_2a54_48d8_b114_de1518ff052e) , } }
 pub const GUID_BATTERY_COUNT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7d263f15_fca4_49e5_854b_a9f2bfbd5c24);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BATTERY_COUNT ) , guid : :: windows :: core :: GUID::from_u128(0x7d263f15_fca4_49e5_854b_a9f2bfbd5c24) , } }
 pub const GUID_BATTERY_DISCHARGE_ACTION_0: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x637ea02f_bbcb_4015_8e2c_a1c7b9c0b546);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BATTERY_DISCHARGE_ACTION_0 ) , guid : :: windows :: core :: GUID::from_u128(0x637ea02f_bbcb_4015_8e2c_a1c7b9c0b546) , } }
 pub const GUID_BATTERY_DISCHARGE_ACTION_1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd8742dcb_3e6a_4b3c_b3fe_374623cdcf06);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BATTERY_DISCHARGE_ACTION_1 ) , guid : :: windows :: core :: GUID::from_u128(0xd8742dcb_3e6a_4b3c_b3fe_374623cdcf06) , } }
 pub const GUID_BATTERY_DISCHARGE_ACTION_2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x421cba38_1a8e_4881_ac89_e33a8b04ece4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BATTERY_DISCHARGE_ACTION_2 ) , guid : :: windows :: core :: GUID::from_u128(0x421cba38_1a8e_4881_ac89_e33a8b04ece4) , } }
 pub const GUID_BATTERY_DISCHARGE_ACTION_3: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x80472613_9780_455e_b308_72d3003cf2f8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BATTERY_DISCHARGE_ACTION_3 ) , guid : :: windows :: core :: GUID::from_u128(0x80472613_9780_455e_b308_72d3003cf2f8) , } }
 pub const GUID_BATTERY_DISCHARGE_FLAGS_0: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5dbb7c9f_38e9_40d2_9749_4f8a0e9f640f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BATTERY_DISCHARGE_FLAGS_0 ) , guid : :: windows :: core :: GUID::from_u128(0x5dbb7c9f_38e9_40d2_9749_4f8a0e9f640f) , } }
 pub const GUID_BATTERY_DISCHARGE_FLAGS_1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbcded951_187b_4d05_bccc_f7e51960c258);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BATTERY_DISCHARGE_FLAGS_1 ) , guid : :: windows :: core :: GUID::from_u128(0xbcded951_187b_4d05_bccc_f7e51960c258) , } }
 pub const GUID_BATTERY_DISCHARGE_FLAGS_2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7fd2f0c4_feb7_4da3_8117_e3fbedc46582);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BATTERY_DISCHARGE_FLAGS_2 ) , guid : :: windows :: core :: GUID::from_u128(0x7fd2f0c4_feb7_4da3_8117_e3fbedc46582) , } }
 pub const GUID_BATTERY_DISCHARGE_FLAGS_3: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x73613ccf_dbfa_4279_8356_4935f6bf62f3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BATTERY_DISCHARGE_FLAGS_3 ) , guid : :: windows :: core :: GUID::from_u128(0x73613ccf_dbfa_4279_8356_4935f6bf62f3) , } }
 pub const GUID_BATTERY_DISCHARGE_LEVEL_0: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9a66d8d7_4ff7_4ef9_b5a2_5a326ca2a469);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BATTERY_DISCHARGE_LEVEL_0 ) , guid : :: windows :: core :: GUID::from_u128(0x9a66d8d7_4ff7_4ef9_b5a2_5a326ca2a469) , } }
 pub const GUID_BATTERY_DISCHARGE_LEVEL_1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8183ba9a_e910_48da_8769_14ae6dc1170a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BATTERY_DISCHARGE_LEVEL_1 ) , guid : :: windows :: core :: GUID::from_u128(0x8183ba9a_e910_48da_8769_14ae6dc1170a) , } }
 pub const GUID_BATTERY_DISCHARGE_LEVEL_2: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x07a07ca2_adaf_40d7_b077_533aaded1bfa);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BATTERY_DISCHARGE_LEVEL_2 ) , guid : :: windows :: core :: GUID::from_u128(0x07a07ca2_adaf_40d7_b077_533aaded1bfa) , } }
 pub const GUID_BATTERY_DISCHARGE_LEVEL_3: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x58afd5a6_c2dd_47d2_9fbf_ef70cc5c5965);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BATTERY_DISCHARGE_LEVEL_3 ) , guid : :: windows :: core :: GUID::from_u128(0x58afd5a6_c2dd_47d2_9fbf_ef70cc5c5965) , } }
 pub const GUID_BATTERY_PERCENTAGE_REMAINING: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa7ad8041_b45a_4cae_87a3_eecbb468a9e1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BATTERY_PERCENTAGE_REMAINING ) , guid : :: windows :: core :: GUID::from_u128(0xa7ad8041_b45a_4cae_87a3_eecbb468a9e1) , } }
 pub const GUID_BATTERY_SUBGROUP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe73a048d_bf27_4f12_9731_8b2076e8891f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_BATTERY_SUBGROUP ) , guid : :: windows :: core :: GUID::from_u128(0xe73a048d_bf27_4f12_9731_8b2076e8891f) , } }
 pub const GUID_CONNECTIVITY_IN_STANDBY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf15576e8_98b7_4186_b944_eafa664402d9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_CONNECTIVITY_IN_STANDBY ) , guid : :: windows :: core :: GUID::from_u128(0xf15576e8_98b7_4186_b944_eafa664402d9) , } }
 pub const GUID_CONSOLE_DISPLAY_STATE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fe69556_704a_47a0_8f24_c28d936fda47);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_CONSOLE_DISPLAY_STATE ) , guid : :: windows :: core :: GUID::from_u128(0x6fe69556_704a_47a0_8f24_c28d936fda47) , } }
 pub const GUID_CRITICAL_POWER_TRANSITION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb7a27025_e569_46c2_a504_2b96cad225a1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_CRITICAL_POWER_TRANSITION ) , guid : :: windows :: core :: GUID::from_u128(0xb7a27025_e569_46c2_a504_2b96cad225a1) , } }
 pub const GUID_DEEP_SLEEP_ENABLED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd502f7ee_1dc7_4efd_a55d_f04b6f5c0545);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEEP_SLEEP_ENABLED ) , guid : :: windows :: core :: GUID::from_u128(0xd502f7ee_1dc7_4efd_a55d_f04b6f5c0545) , } }
 pub const GUID_DEEP_SLEEP_PLATFORM_STATE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd23f2fb8_9536_4038_9c94_1ce02e5c2152);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEEP_SLEEP_PLATFORM_STATE ) , guid : :: windows :: core :: GUID::from_u128(0xd23f2fb8_9536_4038_9c94_1ce02e5c2152) , } }
 pub const GUID_DEVICE_EVENT_RBC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd0744792_a98e_11d2_917a_00a0c9068ff3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVICE_EVENT_RBC ) , guid : :: windows :: core :: GUID::from_u128(0xd0744792_a98e_11d2_917a_00a0c9068ff3) , } }
 pub const GUID_DEVICE_IDLE_POLICY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4faab71a_92e5_4726_b531_224559672d19);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVICE_IDLE_POLICY ) , guid : :: windows :: core :: GUID::from_u128(0x4faab71a_92e5_4726_b531_224559672d19) , } }
 pub const GUID_DEVICE_POWER_POLICY_VIDEO_BRIGHTNESS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaded5e82_b909_4619_9949_f5d71dac0bcb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVICE_POWER_POLICY_VIDEO_BRIGHTNESS ) , guid : :: windows :: core :: GUID::from_u128(0xaded5e82_b909_4619_9949_f5d71dac0bcb) , } }
 pub const GUID_DEVICE_POWER_POLICY_VIDEO_DIM_BRIGHTNESS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf1fbfde2_a960_4165_9f88_50667911ce96);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVICE_POWER_POLICY_VIDEO_DIM_BRIGHTNESS ) , guid : :: windows :: core :: GUID::from_u128(0xf1fbfde2_a960_4165_9f88_50667911ce96) , } }
 pub const GUID_DEVINTERFACE_DMP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x25b4e268_2a05_496e_803b_266837fbda4b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_DMP ) , guid : :: windows :: core :: GUID::from_u128(0x25b4e268_2a05_496e_803b_266837fbda4b) , } }
 pub const GUID_DEVINTERFACE_DMR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd0875fb4_2196_4c7a_a63d_e416addd60a1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_DMR ) , guid : :: windows :: core :: GUID::from_u128(0xd0875fb4_2196_4c7a_a63d_e416addd60a1) , } }
 pub const GUID_DEVINTERFACE_DMS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc96037ae_a558_4470_b432_115a31b85553);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DEVINTERFACE_DMS ) , guid : :: windows :: core :: GUID::from_u128(0xc96037ae_a558_4470_b432_115a31b85553) , } }
 pub const GUID_DISCONNECTED_STANDBY_MODE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x68afb2d9_ee95_47a8_8f50_4115088073b1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DISCONNECTED_STANDBY_MODE ) , guid : :: windows :: core :: GUID::from_u128(0x68afb2d9_ee95_47a8_8f50_4115088073b1) , } }
 pub const GUID_DISK_ADAPTIVE_POWERDOWN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x396a32e1_499a_40b2_9124_a96afe707667);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DISK_ADAPTIVE_POWERDOWN ) , guid : :: windows :: core :: GUID::from_u128(0x396a32e1_499a_40b2_9124_a96afe707667) , } }
 pub const GUID_DISK_BURST_IGNORE_THRESHOLD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x80e3c60e_bb94_4ad8_bbe0_0d3195efc663);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DISK_BURST_IGNORE_THRESHOLD ) , guid : :: windows :: core :: GUID::from_u128(0x80e3c60e_bb94_4ad8_bbe0_0d3195efc663) , } }
 pub const GUID_DISK_COALESCING_POWERDOWN_TIMEOUT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc36f0eb4_2988_4a70_8eee_0884fc2c2433);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DISK_COALESCING_POWERDOWN_TIMEOUT ) , guid : :: windows :: core :: GUID::from_u128(0xc36f0eb4_2988_4a70_8eee_0884fc2c2433) , } }
 pub const GUID_DISK_IDLE_TIMEOUT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x58e39ba8_b8e6_4ef6_90d0_89ae32b258d6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DISK_IDLE_TIMEOUT ) , guid : :: windows :: core :: GUID::from_u128(0x58e39ba8_b8e6_4ef6_90d0_89ae32b258d6) , } }
 pub const GUID_DISK_MAX_POWER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x51dea550_bb38_4bc4_991b_eacf37be5ec8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DISK_MAX_POWER ) , guid : :: windows :: core :: GUID::from_u128(0x51dea550_bb38_4bc4_991b_eacf37be5ec8) , } }
 pub const GUID_DISK_NVME_NOPPME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfc7372b6_ab2d_43ee_8797_15e9841f2cca);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DISK_NVME_NOPPME ) , guid : :: windows :: core :: GUID::from_u128(0xfc7372b6_ab2d_43ee_8797_15e9841f2cca) , } }
 pub const GUID_DISK_POWERDOWN_TIMEOUT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6738e2c4_e8a5_4a42_b16a_e040e769756e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DISK_POWERDOWN_TIMEOUT ) , guid : :: windows :: core :: GUID::from_u128(0x6738e2c4_e8a5_4a42_b16a_e040e769756e) , } }
 pub const GUID_DISK_SUBGROUP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0012ee47_9041_4b5d_9b77_535fba8b1442);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DISK_SUBGROUP ) , guid : :: windows :: core :: GUID::from_u128(0x0012ee47_9041_4b5d_9b77_535fba8b1442) , } }
 pub const GUID_ENABLE_SWITCH_FORCED_SHUTDOWN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x833a6b62_dfa4_46d1_82f8_e09e34d029d6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ENABLE_SWITCH_FORCED_SHUTDOWN ) , guid : :: windows :: core :: GUID::from_u128(0x833a6b62_dfa4_46d1_82f8_e09e34d029d6) , } }
 pub const GUID_ENERGY_SAVER_BATTERY_THRESHOLD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe69653ca_cf7f_4f05_aa73_cb833fa90ad4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ENERGY_SAVER_BATTERY_THRESHOLD ) , guid : :: windows :: core :: GUID::from_u128(0xe69653ca_cf7f_4f05_aa73_cb833fa90ad4) , } }
 pub const GUID_ENERGY_SAVER_BRIGHTNESS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x13d09884_f74e_474a_a852_b6bde8ad03a8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ENERGY_SAVER_BRIGHTNESS ) , guid : :: windows :: core :: GUID::from_u128(0x13d09884_f74e_474a_a852_b6bde8ad03a8) , } }
 pub const GUID_ENERGY_SAVER_POLICY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5c5bb349_ad29_4ee2_9d0b_2b25270f7a81);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ENERGY_SAVER_POLICY ) , guid : :: windows :: core :: GUID::from_u128(0x5c5bb349_ad29_4ee2_9d0b_2b25270f7a81) , } }
 pub const GUID_ENERGY_SAVER_SUBGROUP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xde830923_a562_41af_a086_e3a2c6bad2da);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_ENERGY_SAVER_SUBGROUP ) , guid : :: windows :: core :: GUID::from_u128(0xde830923_a562_41af_a086_e3a2c6bad2da) , } }
 pub const GUID_EXECUTION_REQUIRED_REQUEST_TIMEOUT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3166bc41_7e98_4e03_b34e_ec0f5f2b218e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_EXECUTION_REQUIRED_REQUEST_TIMEOUT ) , guid : :: windows :: core :: GUID::from_u128(0x3166bc41_7e98_4e03_b34e_ec0f5f2b218e) , } }
 pub const GUID_GLOBAL_USER_PRESENCE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x786e8a1d_b427_4344_9207_09e70bdcbea9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_GLOBAL_USER_PRESENCE ) , guid : :: windows :: core :: GUID::from_u128(0x786e8a1d_b427_4344_9207_09e70bdcbea9) , } }
 pub const GUID_GPU_PREFERENCE_POLICY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdd848b2a_8a5d_4451_9ae2_39cd41658f6c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_GPU_PREFERENCE_POLICY ) , guid : :: windows :: core :: GUID::from_u128(0xdd848b2a_8a5d_4451_9ae2_39cd41658f6c) , } }
 pub const GUID_GRAPHICS_SUBGROUP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5fb4938d_1ee8_4b0f_9a3c_5036b0ab995c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_GRAPHICS_SUBGROUP ) , guid : :: windows :: core :: GUID::from_u128(0x5fb4938d_1ee8_4b0f_9a3c_5036b0ab995c) , } }
 pub const GUID_HIBERNATE_FASTS4_POLICY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x94ac6d29_73ce_41a6_809f_6363ba21b47e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_HIBERNATE_FASTS4_POLICY ) , guid : :: windows :: core :: GUID::from_u128(0x94ac6d29_73ce_41a6_809f_6363ba21b47e) , } }
 pub const GUID_HIBERNATE_TIMEOUT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9d7815a6_7ee4_497e_8888_515a05f02364);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_HIBERNATE_TIMEOUT ) , guid : :: windows :: core :: GUID::from_u128(0x9d7815a6_7ee4_497e_8888_515a05f02364) , } }
 pub const GUID_HUPR_ADAPTIVE_DISPLAY_TIMEOUT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0a7d6ab6_ac83_4ad1_8282_eca5b58308f3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_HUPR_ADAPTIVE_DISPLAY_TIMEOUT ) , guid : :: windows :: core :: GUID::from_u128(0x0a7d6ab6_ac83_4ad1_8282_eca5b58308f3) , } }
 pub const GUID_IDLE_BACKGROUND_TASK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x515c31d8_f734_163d_a0fd_11a08c91e8f1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IDLE_BACKGROUND_TASK ) , guid : :: windows :: core :: GUID::from_u128(0x515c31d8_f734_163d_a0fd_11a08c91e8f1) , } }
 pub const GUID_IDLE_RESILIENCY_PERIOD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc42b79aa_aa3a_484b_a98f_2cf32aa90a28);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IDLE_RESILIENCY_PERIOD ) , guid : :: windows :: core :: GUID::from_u128(0xc42b79aa_aa3a_484b_a98f_2cf32aa90a28) , } }
 pub const GUID_IDLE_RESILIENCY_SUBGROUP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2e601130_5351_4d9d_8e04_252966bad054);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IDLE_RESILIENCY_SUBGROUP ) , guid : :: windows :: core :: GUID::from_u128(0x2e601130_5351_4d9d_8e04_252966bad054) , } }
 pub const GUID_INTSTEER_LOAD_PER_PROC_TRIGGER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x73cde64d_d720_4bb2_a860_c755afe77ef2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_INTSTEER_LOAD_PER_PROC_TRIGGER ) , guid : :: windows :: core :: GUID::from_u128(0x73cde64d_d720_4bb2_a860_c755afe77ef2) , } }
 pub const GUID_INTSTEER_MODE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2bfc24f9_5ea2_4801_8213_3dbae01aa39d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_INTSTEER_MODE ) , guid : :: windows :: core :: GUID::from_u128(0x2bfc24f9_5ea2_4801_8213_3dbae01aa39d) , } }
 pub const GUID_INTSTEER_SUBGROUP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x48672f38_7a9a_4bb2_8bf8_3d85be19de4e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_INTSTEER_SUBGROUP ) , guid : :: windows :: core :: GUID::from_u128(0x48672f38_7a9a_4bb2_8bf8_3d85be19de4e) , } }
 pub const GUID_INTSTEER_TIME_UNPARK_TRIGGER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd6ba4903_386f_4c2c_8adb_5c21b3328d25);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_INTSTEER_TIME_UNPARK_TRIGGER ) , guid : :: windows :: core :: GUID::from_u128(0xd6ba4903_386f_4c2c_8adb_5c21b3328d25) , } }
 pub const GUID_IO_CDROM_EXCLUSIVE_LOCK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbc56c139_7a10_47ee_a294_4c6a38f0149a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_CDROM_EXCLUSIVE_LOCK ) , guid : :: windows :: core :: GUID::from_u128(0xbc56c139_7a10_47ee_a294_4c6a38f0149a) , } }
 pub const GUID_IO_CDROM_EXCLUSIVE_UNLOCK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa3b6d27d_5e35_4885_81e5_ee18c00ed779);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_CDROM_EXCLUSIVE_UNLOCK ) , guid : :: windows :: core :: GUID::from_u128(0xa3b6d27d_5e35_4885_81e5_ee18c00ed779) , } }
 pub const GUID_IO_DEVICE_BECOMING_READY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd07433f0_a98e_11d2_917a_00a0c9068ff3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_DEVICE_BECOMING_READY ) , guid : :: windows :: core :: GUID::from_u128(0xd07433f0_a98e_11d2_917a_00a0c9068ff3) , } }
 pub const GUID_IO_DEVICE_EXTERNAL_REQUEST: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd07433d0_a98e_11d2_917a_00a0c9068ff3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_DEVICE_EXTERNAL_REQUEST ) , guid : :: windows :: core :: GUID::from_u128(0xd07433d0_a98e_11d2_917a_00a0c9068ff3) , } }
 pub const GUID_IO_DISK_CLONE_ARRIVAL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6a61885b_7c39_43dd_9b56_b8ac22a549aa);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_DISK_CLONE_ARRIVAL ) , guid : :: windows :: core :: GUID::from_u128(0x6a61885b_7c39_43dd_9b56_b8ac22a549aa) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_System_SystemServices'*"]
 pub struct GUID_IO_DISK_CLONE_ARRIVAL_INFORMATION {
@@ -3283,170 +3429,500 @@ impl ::core::default::Default for GUID_IO_DISK_CLONE_ARRIVAL_INFORMATION {
     }
 }
 pub const GUID_IO_DISK_HEALTH_NOTIFICATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0f1bd644_3916_49c5_b063_991940118fb2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_DISK_HEALTH_NOTIFICATION ) , guid : :: windows :: core :: GUID::from_u128(0x0f1bd644_3916_49c5_b063_991940118fb2) , } }
 pub const GUID_IO_DISK_LAYOUT_CHANGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x11dff54c_8469_41f9_b3de_ef836487c54a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_DISK_LAYOUT_CHANGE ) , guid : :: windows :: core :: GUID::from_u128(0x11dff54c_8469_41f9_b3de_ef836487c54a) , } }
 pub const GUID_IO_DRIVE_REQUIRES_CLEANING: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7207877c_90ed_44e5_a000_81428d4c79bb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_DRIVE_REQUIRES_CLEANING ) , guid : :: windows :: core :: GUID::from_u128(0x7207877c_90ed_44e5_a000_81428d4c79bb) , } }
 pub const GUID_IO_MEDIA_ARRIVAL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd07433c0_a98e_11d2_917a_00a0c9068ff3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_MEDIA_ARRIVAL ) , guid : :: windows :: core :: GUID::from_u128(0xd07433c0_a98e_11d2_917a_00a0c9068ff3) , } }
 pub const GUID_IO_MEDIA_EJECT_REQUEST: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd07433d1_a98e_11d2_917a_00a0c9068ff3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_MEDIA_EJECT_REQUEST ) , guid : :: windows :: core :: GUID::from_u128(0xd07433d1_a98e_11d2_917a_00a0c9068ff3) , } }
 pub const GUID_IO_MEDIA_REMOVAL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd07433c1_a98e_11d2_917a_00a0c9068ff3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_MEDIA_REMOVAL ) , guid : :: windows :: core :: GUID::from_u128(0xd07433c1_a98e_11d2_917a_00a0c9068ff3) , } }
 pub const GUID_IO_TAPE_ERASE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x852d11eb_4bb8_4507_9d9b_417cc2b1b438);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_TAPE_ERASE ) , guid : :: windows :: core :: GUID::from_u128(0x852d11eb_4bb8_4507_9d9b_417cc2b1b438) , } }
 pub const GUID_IO_VOLUME_BACKGROUND_FORMAT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa2e5fc86_d5cd_4038_b2e3_4445065c2377);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_VOLUME_BACKGROUND_FORMAT ) , guid : :: windows :: core :: GUID::from_u128(0xa2e5fc86_d5cd_4038_b2e3_4445065c2377) , } }
 pub const GUID_IO_VOLUME_CHANGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7373654a_812a_11d0_bec7_08002be2092f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_VOLUME_CHANGE ) , guid : :: windows :: core :: GUID::from_u128(0x7373654a_812a_11d0_bec7_08002be2092f) , } }
 pub const GUID_IO_VOLUME_CHANGE_SIZE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3a1625be_ad03_49f1_8ef8_6bbac182d1fd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_VOLUME_CHANGE_SIZE ) , guid : :: windows :: core :: GUID::from_u128(0x3a1625be_ad03_49f1_8ef8_6bbac182d1fd) , } }
 pub const GUID_IO_VOLUME_DEVICE_INTERFACE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x53f5630d_b6bf_11d0_94f2_00a0c91efb8b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_VOLUME_DEVICE_INTERFACE ) , guid : :: windows :: core :: GUID::from_u128(0x53f5630d_b6bf_11d0_94f2_00a0c91efb8b) , } }
 pub const GUID_IO_VOLUME_DISMOUNT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd16a55e8_1059_11d2_8ffd_00a0c9a06d32);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_VOLUME_DISMOUNT ) , guid : :: windows :: core :: GUID::from_u128(0xd16a55e8_1059_11d2_8ffd_00a0c9a06d32) , } }
 pub const GUID_IO_VOLUME_DISMOUNT_FAILED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe3c5b178_105d_11d2_8ffd_00a0c9a06d32);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_VOLUME_DISMOUNT_FAILED ) , guid : :: windows :: core :: GUID::from_u128(0xe3c5b178_105d_11d2_8ffd_00a0c9a06d32) , } }
 pub const GUID_IO_VOLUME_FORCE_CLOSED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x411ad84f_433e_4dc2_a5ae_4a2d1a2de654);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_VOLUME_FORCE_CLOSED ) , guid : :: windows :: core :: GUID::from_u128(0x411ad84f_433e_4dc2_a5ae_4a2d1a2de654) , } }
 pub const GUID_IO_VOLUME_FVE_STATUS_CHANGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x062998b2_ee1f_4b6a_b857_e76cbbe9a6da);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_VOLUME_FVE_STATUS_CHANGE ) , guid : :: windows :: core :: GUID::from_u128(0x062998b2_ee1f_4b6a_b857_e76cbbe9a6da) , } }
 pub const GUID_IO_VOLUME_INFO_MAKE_COMPAT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3ab9a0d2_ef80_45cf_8cdc_cbe02a212906);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_VOLUME_INFO_MAKE_COMPAT ) , guid : :: windows :: core :: GUID::from_u128(0x3ab9a0d2_ef80_45cf_8cdc_cbe02a212906) , } }
 pub const GUID_IO_VOLUME_LOCK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x50708874_c9af_11d1_8fef_00a0c9a06d32);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_VOLUME_LOCK ) , guid : :: windows :: core :: GUID::from_u128(0x50708874_c9af_11d1_8fef_00a0c9a06d32) , } }
 pub const GUID_IO_VOLUME_LOCK_FAILED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xae2eed10_0ba8_11d2_8ffb_00a0c9a06d32);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_VOLUME_LOCK_FAILED ) , guid : :: windows :: core :: GUID::from_u128(0xae2eed10_0ba8_11d2_8ffb_00a0c9a06d32) , } }
 pub const GUID_IO_VOLUME_MOUNT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb5804878_1a96_11d2_8ffd_00a0c9a06d32);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_VOLUME_MOUNT ) , guid : :: windows :: core :: GUID::from_u128(0xb5804878_1a96_11d2_8ffd_00a0c9a06d32) , } }
 pub const GUID_IO_VOLUME_NAME_CHANGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2de97f83_4c06_11d2_a532_00609713055a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_VOLUME_NAME_CHANGE ) , guid : :: windows :: core :: GUID::from_u128(0x2de97f83_4c06_11d2_a532_00609713055a) , } }
 pub const GUID_IO_VOLUME_NEED_CHKDSK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x799a0960_0a0b_4e03_ad88_2fa7c6ce748a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_VOLUME_NEED_CHKDSK ) , guid : :: windows :: core :: GUID::from_u128(0x799a0960_0a0b_4e03_ad88_2fa7c6ce748a) , } }
 pub const GUID_IO_VOLUME_PHYSICAL_CONFIGURATION_CHANGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2de97f84_4c06_11d2_a532_00609713055a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_VOLUME_PHYSICAL_CONFIGURATION_CHANGE ) , guid : :: windows :: core :: GUID::from_u128(0x2de97f84_4c06_11d2_a532_00609713055a) , } }
 pub const GUID_IO_VOLUME_PREPARING_EJECT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc79eb16e_0dac_4e7a_a86c_b25ceeaa88f6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_VOLUME_PREPARING_EJECT ) , guid : :: windows :: core :: GUID::from_u128(0xc79eb16e_0dac_4e7a_a86c_b25ceeaa88f6) , } }
 pub const GUID_IO_VOLUME_UNIQUE_ID_CHANGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaf39da42_6622_41f5_970b_139d092fa3d9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_VOLUME_UNIQUE_ID_CHANGE ) , guid : :: windows :: core :: GUID::from_u128(0xaf39da42_6622_41f5_970b_139d092fa3d9) , } }
 pub const GUID_IO_VOLUME_UNLOCK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9a8c3d68_d0cb_11d1_8fef_00a0c9a06d32);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_VOLUME_UNLOCK ) , guid : :: windows :: core :: GUID::from_u128(0x9a8c3d68_d0cb_11d1_8fef_00a0c9a06d32) , } }
 pub const GUID_IO_VOLUME_WEARING_OUT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x873113ca_1486_4508_82ac_c3b2e5297aaa);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_VOLUME_WEARING_OUT ) , guid : :: windows :: core :: GUID::from_u128(0x873113ca_1486_4508_82ac_c3b2e5297aaa) , } }
 pub const GUID_IO_VOLUME_WORM_NEAR_FULL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf3bfff82_f3de_48d2_af95_457f80b763f2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_IO_VOLUME_WORM_NEAR_FULL ) , guid : :: windows :: core :: GUID::from_u128(0xf3bfff82_f3de_48d2_af95_457f80b763f2) , } }
 pub const GUID_LEGACY_RTC_MITIGATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1a34bdc3_7e6b_442e_a9d0_64b6ef378e84);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_LEGACY_RTC_MITIGATION ) , guid : :: windows :: core :: GUID::from_u128(0x1a34bdc3_7e6b_442e_a9d0_64b6ef378e84) , } }
 pub const GUID_LIDCLOSE_ACTION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5ca83367_6e45_459f_a27b_476b1d01c936);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_LIDCLOSE_ACTION ) , guid : :: windows :: core :: GUID::from_u128(0x5ca83367_6e45_459f_a27b_476b1d01c936) , } }
 pub const GUID_LIDOPEN_POWERSTATE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x99ff10e7_23b1_4c07_a9d1_5c3206d741b4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_LIDOPEN_POWERSTATE ) , guid : :: windows :: core :: GUID::from_u128(0x99ff10e7_23b1_4c07_a9d1_5c3206d741b4) , } }
 pub const GUID_LIDSWITCH_STATE_CHANGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xba3e0f4d_b817_4094_a2d1_d56379e6a0f3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_LIDSWITCH_STATE_CHANGE ) , guid : :: windows :: core :: GUID::from_u128(0xba3e0f4d_b817_4094_a2d1_d56379e6a0f3) , } }
 pub const GUID_LIDSWITCH_STATE_RELIABILITY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xae4c4ff1_d361_43f4_80aa_bbb6eb03de94);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_LIDSWITCH_STATE_RELIABILITY ) , guid : :: windows :: core :: GUID::from_u128(0xae4c4ff1_d361_43f4_80aa_bbb6eb03de94) , } }
 pub const GUID_LOCK_CONSOLE_ON_WAKE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0e796bdb_100d_47d6_a2d5_f7d2daa51f51);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_LOCK_CONSOLE_ON_WAKE ) , guid : :: windows :: core :: GUID::from_u128(0x0e796bdb_100d_47d6_a2d5_f7d2daa51f51) , } }
 pub const GUID_MAX_POWER_SAVINGS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa1841308_3541_4fab_bc81_f71556f20b4a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MAX_POWER_SAVINGS ) , guid : :: windows :: core :: GUID::from_u128(0xa1841308_3541_4fab_bc81_f71556f20b4a) , } }
 pub const GUID_MIN_POWER_SAVINGS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8c5e7fda_e8bf_4a96_9a85_a6e23a8c635c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MIN_POWER_SAVINGS ) , guid : :: windows :: core :: GUID::from_u128(0x8c5e7fda_e8bf_4a96_9a85_a6e23a8c635c) , } }
 pub const GUID_MIXED_REALITY_MODE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1e626b4e_cf04_4f8d_9cc7_c97c5b0f2391);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MIXED_REALITY_MODE ) , guid : :: windows :: core :: GUID::from_u128(0x1e626b4e_cf04_4f8d_9cc7_c97c5b0f2391) , } }
 pub const GUID_MONITOR_POWER_ON: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x02731015_4510_4526_99e6_e5a17ebd1aea);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MONITOR_POWER_ON ) , guid : :: windows :: core :: GUID::from_u128(0x02731015_4510_4526_99e6_e5a17ebd1aea) , } }
 pub const GUID_NON_ADAPTIVE_INPUT_TIMEOUT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5adbbfbc_074e_4da1_ba38_db8b36b2c8f3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_NON_ADAPTIVE_INPUT_TIMEOUT ) , guid : :: windows :: core :: GUID::from_u128(0x5adbbfbc_074e_4da1_ba38_db8b36b2c8f3) , } }
 pub const GUID_PCIEXPRESS_ASPM_POLICY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xee12f906_d277_404b_b6da_e5fa1a576df5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PCIEXPRESS_ASPM_POLICY ) , guid : :: windows :: core :: GUID::from_u128(0xee12f906_d277_404b_b6da_e5fa1a576df5) , } }
 pub const GUID_PCIEXPRESS_SETTINGS_SUBGROUP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x501a4d13_42af_4429_9fd1_a8218c268e20);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PCIEXPRESS_SETTINGS_SUBGROUP ) , guid : :: windows :: core :: GUID::from_u128(0x501a4d13_42af_4429_9fd1_a8218c268e20) , } }
 pub const GUID_POWERBUTTON_ACTION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7648efa3_dd9c_4e3e_b566_50f929386280);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_POWERBUTTON_ACTION ) , guid : :: windows :: core :: GUID::from_u128(0x7648efa3_dd9c_4e3e_b566_50f929386280) , } }
 pub const GUID_POWERSCHEME_PERSONALITY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x245d8541_3943_4422_b025_13a784f679b7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_POWERSCHEME_PERSONALITY ) , guid : :: windows :: core :: GUID::from_u128(0x245d8541_3943_4422_b025_13a784f679b7) , } }
 pub const GUID_POWER_SAVING_STATUS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe00958c0_c213_4ace_ac77_fecced2eeea5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_POWER_SAVING_STATUS ) , guid : :: windows :: core :: GUID::from_u128(0xe00958c0_c213_4ace_ac77_fecced2eeea5) , } }
 pub const GUID_PROCESSOR_ALLOW_THROTTLING: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3b04d4fd_1cc7_4f23_ab1c_d1337819c4bb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_ALLOW_THROTTLING ) , guid : :: windows :: core :: GUID::from_u128(0x3b04d4fd_1cc7_4f23_ab1c_d1337819c4bb) , } }
 pub const GUID_PROCESSOR_CLASS0_FLOOR_PERF: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfddc842b_8364_4edc_94cf_c17f60de1c80);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_CLASS0_FLOOR_PERF ) , guid : :: windows :: core :: GUID::from_u128(0xfddc842b_8364_4edc_94cf_c17f60de1c80) , } }
 pub const GUID_PROCESSOR_CLASS1_INITIAL_PERF: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1facfc65_a930_4bc5_9f38_504ec097bbc0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_CLASS1_INITIAL_PERF ) , guid : :: windows :: core :: GUID::from_u128(0x1facfc65_a930_4bc5_9f38_504ec097bbc0) , } }
 pub const GUID_PROCESSOR_CORE_PARKING_AFFINITY_HISTORY_DECREASE_FACTOR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8f7b45e3_c393_480a_878c_f67ac3d07082);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_CORE_PARKING_AFFINITY_HISTORY_DECREASE_FACTOR ) , guid : :: windows :: core :: GUID::from_u128(0x8f7b45e3_c393_480a_878c_f67ac3d07082) , } }
 pub const GUID_PROCESSOR_CORE_PARKING_AFFINITY_HISTORY_THRESHOLD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5b33697b_e89d_4d38_aa46_9e7dfb7cd2f9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_CORE_PARKING_AFFINITY_HISTORY_THRESHOLD ) , guid : :: windows :: core :: GUID::from_u128(0x5b33697b_e89d_4d38_aa46_9e7dfb7cd2f9) , } }
 pub const GUID_PROCESSOR_CORE_PARKING_AFFINITY_WEIGHTING: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe70867f1_fa2f_4f4e_aea1_4d8a0ba23b20);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_CORE_PARKING_AFFINITY_WEIGHTING ) , guid : :: windows :: core :: GUID::from_u128(0xe70867f1_fa2f_4f4e_aea1_4d8a0ba23b20) , } }
 pub const GUID_PROCESSOR_CORE_PARKING_DECREASE_POLICY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x71021b41_c749_4d21_be74_a00f335d582b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_CORE_PARKING_DECREASE_POLICY ) , guid : :: windows :: core :: GUID::from_u128(0x71021b41_c749_4d21_be74_a00f335d582b) , } }
 pub const GUID_PROCESSOR_CORE_PARKING_DECREASE_THRESHOLD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x68dd2f27_a4ce_4e11_8487_3794e4135dfa);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_CORE_PARKING_DECREASE_THRESHOLD ) , guid : :: windows :: core :: GUID::from_u128(0x68dd2f27_a4ce_4e11_8487_3794e4135dfa) , } }
 pub const GUID_PROCESSOR_CORE_PARKING_DECREASE_TIME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdfd10d17_d5eb_45dd_877a_9a34ddd15c82);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_CORE_PARKING_DECREASE_TIME ) , guid : :: windows :: core :: GUID::from_u128(0xdfd10d17_d5eb_45dd_877a_9a34ddd15c82) , } }
 pub const GUID_PROCESSOR_CORE_PARKING_INCREASE_POLICY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc7be0679_2817_4d69_9d02_519a537ed0c6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_CORE_PARKING_INCREASE_POLICY ) , guid : :: windows :: core :: GUID::from_u128(0xc7be0679_2817_4d69_9d02_519a537ed0c6) , } }
 pub const GUID_PROCESSOR_CORE_PARKING_INCREASE_THRESHOLD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdf142941_20f3_4edf_9a4a_9c83d3d717d1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_CORE_PARKING_INCREASE_THRESHOLD ) , guid : :: windows :: core :: GUID::from_u128(0xdf142941_20f3_4edf_9a4a_9c83d3d717d1) , } }
 pub const GUID_PROCESSOR_CORE_PARKING_INCREASE_TIME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2ddd5a84_5a71_437e_912a_db0b8c788732);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_CORE_PARKING_INCREASE_TIME ) , guid : :: windows :: core :: GUID::from_u128(0x2ddd5a84_5a71_437e_912a_db0b8c788732) , } }
 pub const GUID_PROCESSOR_CORE_PARKING_MAX_CORES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xea062031_0e34_4ff1_9b6d_eb1059334028);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_CORE_PARKING_MAX_CORES ) , guid : :: windows :: core :: GUID::from_u128(0xea062031_0e34_4ff1_9b6d_eb1059334028) , } }
 pub const GUID_PROCESSOR_CORE_PARKING_MAX_CORES_1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xea062031_0e34_4ff1_9b6d_eb1059334029);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_CORE_PARKING_MAX_CORES_1 ) , guid : :: windows :: core :: GUID::from_u128(0xea062031_0e34_4ff1_9b6d_eb1059334029) , } }
 pub const GUID_PROCESSOR_CORE_PARKING_MIN_CORES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cc5b647_c1df_4637_891a_dec35c318583);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_CORE_PARKING_MIN_CORES ) , guid : :: windows :: core :: GUID::from_u128(0x0cc5b647_c1df_4637_891a_dec35c318583) , } }
 pub const GUID_PROCESSOR_CORE_PARKING_MIN_CORES_1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cc5b647_c1df_4637_891a_dec35c318584);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_CORE_PARKING_MIN_CORES_1 ) , guid : :: windows :: core :: GUID::from_u128(0x0cc5b647_c1df_4637_891a_dec35c318584) , } }
 pub const GUID_PROCESSOR_CORE_PARKING_OVER_UTILIZATION_HISTORY_DECREASE_FACTOR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1299023c_bc28_4f0a_81ec_d3295a8d815d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_CORE_PARKING_OVER_UTILIZATION_HISTORY_DECREASE_FACTOR ) , guid : :: windows :: core :: GUID::from_u128(0x1299023c_bc28_4f0a_81ec_d3295a8d815d) , } }
 pub const GUID_PROCESSOR_CORE_PARKING_OVER_UTILIZATION_HISTORY_THRESHOLD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9ac18e92_aa3c_4e27_b307_01ae37307129);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_CORE_PARKING_OVER_UTILIZATION_HISTORY_THRESHOLD ) , guid : :: windows :: core :: GUID::from_u128(0x9ac18e92_aa3c_4e27_b307_01ae37307129) , } }
 pub const GUID_PROCESSOR_CORE_PARKING_OVER_UTILIZATION_THRESHOLD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x943c8cb6_6f93_4227_ad87_e9a3feec08d1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_CORE_PARKING_OVER_UTILIZATION_THRESHOLD ) , guid : :: windows :: core :: GUID::from_u128(0x943c8cb6_6f93_4227_ad87_e9a3feec08d1) , } }
 pub const GUID_PROCESSOR_CORE_PARKING_OVER_UTILIZATION_WEIGHTING: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8809c2d8_b155_42d4_bcda_0d345651b1db);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_CORE_PARKING_OVER_UTILIZATION_WEIGHTING ) , guid : :: windows :: core :: GUID::from_u128(0x8809c2d8_b155_42d4_bcda_0d345651b1db) , } }
 pub const GUID_PROCESSOR_DISTRIBUTE_UTILITY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe0007330_f589_42ed_a401_5ddb10e785d3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_DISTRIBUTE_UTILITY ) , guid : :: windows :: core :: GUID::from_u128(0xe0007330_f589_42ed_a401_5ddb10e785d3) , } }
 pub const GUID_PROCESSOR_DUTY_CYCLING: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4e4450b3_6179_4e91_b8f1_5bb9938f81a1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_DUTY_CYCLING ) , guid : :: windows :: core :: GUID::from_u128(0x4e4450b3_6179_4e91_b8f1_5bb9938f81a1) , } }
 pub const GUID_PROCESSOR_FREQUENCY_LIMIT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x75b0ae3f_bce0_45a7_8c89_c9611c25e100);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_FREQUENCY_LIMIT ) , guid : :: windows :: core :: GUID::from_u128(0x75b0ae3f_bce0_45a7_8c89_c9611c25e100) , } }
 pub const GUID_PROCESSOR_FREQUENCY_LIMIT_1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x75b0ae3f_bce0_45a7_8c89_c9611c25e101);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_FREQUENCY_LIMIT_1 ) , guid : :: windows :: core :: GUID::from_u128(0x75b0ae3f_bce0_45a7_8c89_c9611c25e101) , } }
 pub const GUID_PROCESSOR_HETEROGENEOUS_POLICY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7f2f5cfa_f10c_4823_b5e1_e93ae85f46b5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_HETEROGENEOUS_POLICY ) , guid : :: windows :: core :: GUID::from_u128(0x7f2f5cfa_f10c_4823_b5e1_e93ae85f46b5) , } }
 pub const GUID_PROCESSOR_HETERO_DECREASE_THRESHOLD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf8861c27_95e7_475c_865b_13c0cb3f9d6b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_HETERO_DECREASE_THRESHOLD ) , guid : :: windows :: core :: GUID::from_u128(0xf8861c27_95e7_475c_865b_13c0cb3f9d6b) , } }
 pub const GUID_PROCESSOR_HETERO_DECREASE_TIME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7f2492b6_60b1_45e5_ae55_773f8cd5caec);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_HETERO_DECREASE_TIME ) , guid : :: windows :: core :: GUID::from_u128(0x7f2492b6_60b1_45e5_ae55_773f8cd5caec) , } }
 pub const GUID_PROCESSOR_HETERO_INCREASE_THRESHOLD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb000397d_9b0b_483d_98c9_692a6060cfbf);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_HETERO_INCREASE_THRESHOLD ) , guid : :: windows :: core :: GUID::from_u128(0xb000397d_9b0b_483d_98c9_692a6060cfbf) , } }
 pub const GUID_PROCESSOR_HETERO_INCREASE_TIME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4009efa7_e72d_4cba_9edf_91084ea8cbc3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_HETERO_INCREASE_TIME ) , guid : :: windows :: core :: GUID::from_u128(0x4009efa7_e72d_4cba_9edf_91084ea8cbc3) , } }
 pub const GUID_PROCESSOR_IDLESTATE_POLICY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x68f262a7_f621_4069_b9a5_4874169be23c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_IDLESTATE_POLICY ) , guid : :: windows :: core :: GUID::from_u128(0x68f262a7_f621_4069_b9a5_4874169be23c) , } }
 pub const GUID_PROCESSOR_IDLE_ALLOW_SCALING: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6c2993b0_8f48_481f_bcc6_00dd2742aa06);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_IDLE_ALLOW_SCALING ) , guid : :: windows :: core :: GUID::from_u128(0x6c2993b0_8f48_481f_bcc6_00dd2742aa06) , } }
 pub const GUID_PROCESSOR_IDLE_DEMOTE_THRESHOLD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4b92d758_5a24_4851_a470_815d78aee119);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_IDLE_DEMOTE_THRESHOLD ) , guid : :: windows :: core :: GUID::from_u128(0x4b92d758_5a24_4851_a470_815d78aee119) , } }
 pub const GUID_PROCESSOR_IDLE_DISABLE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5d76a2ca_e8c0_402f_a133_2158492d58ad);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_IDLE_DISABLE ) , guid : :: windows :: core :: GUID::from_u128(0x5d76a2ca_e8c0_402f_a133_2158492d58ad) , } }
 pub const GUID_PROCESSOR_IDLE_PROMOTE_THRESHOLD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7b224883_b3cc_4d79_819f_8374152cbe7c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_IDLE_PROMOTE_THRESHOLD ) , guid : :: windows :: core :: GUID::from_u128(0x7b224883_b3cc_4d79_819f_8374152cbe7c) , } }
 pub const GUID_PROCESSOR_IDLE_STATE_MAXIMUM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9943e905_9a30_4ec1_9b99_44dd3b76f7a2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_IDLE_STATE_MAXIMUM ) , guid : :: windows :: core :: GUID::from_u128(0x9943e905_9a30_4ec1_9b99_44dd3b76f7a2) , } }
 pub const GUID_PROCESSOR_IDLE_TIME_CHECK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc4581c31_89ab_4597_8e2b_9c9cab440e6b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_IDLE_TIME_CHECK ) , guid : :: windows :: core :: GUID::from_u128(0xc4581c31_89ab_4597_8e2b_9c9cab440e6b) , } }
 pub const GUID_PROCESSOR_LATENCY_HINT_MIN_UNPARK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x616cdaa5_695e_4545_97ad_97dc2d1bdd88);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_LATENCY_HINT_MIN_UNPARK ) , guid : :: windows :: core :: GUID::from_u128(0x616cdaa5_695e_4545_97ad_97dc2d1bdd88) , } }
 pub const GUID_PROCESSOR_LATENCY_HINT_MIN_UNPARK_1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x616cdaa5_695e_4545_97ad_97dc2d1bdd89);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_LATENCY_HINT_MIN_UNPARK_1 ) , guid : :: windows :: core :: GUID::from_u128(0x616cdaa5_695e_4545_97ad_97dc2d1bdd89) , } }
 pub const GUID_PROCESSOR_PARKING_CONCURRENCY_THRESHOLD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2430ab6f_a520_44a2_9601_f7f23b5134b1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PARKING_CONCURRENCY_THRESHOLD ) , guid : :: windows :: core :: GUID::from_u128(0x2430ab6f_a520_44a2_9601_f7f23b5134b1) , } }
 pub const GUID_PROCESSOR_PARKING_CORE_OVERRIDE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa55612aa_f624_42c6_a443_7397d064c04f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PARKING_CORE_OVERRIDE ) , guid : :: windows :: core :: GUID::from_u128(0xa55612aa_f624_42c6_a443_7397d064c04f) , } }
 pub const GUID_PROCESSOR_PARKING_DISTRIBUTION_THRESHOLD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4bdaf4e9_d103_46d7_a5f0_6280121616ef);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PARKING_DISTRIBUTION_THRESHOLD ) , guid : :: windows :: core :: GUID::from_u128(0x4bdaf4e9_d103_46d7_a5f0_6280121616ef) , } }
 pub const GUID_PROCESSOR_PARKING_HEADROOM_THRESHOLD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf735a673_2066_4f80_a0c5_ddee0cf1bf5d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PARKING_HEADROOM_THRESHOLD ) , guid : :: windows :: core :: GUID::from_u128(0xf735a673_2066_4f80_a0c5_ddee0cf1bf5d) , } }
 pub const GUID_PROCESSOR_PARKING_PERF_STATE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x447235c7_6a8d_4cc0_8e24_9eaf70b96e2b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PARKING_PERF_STATE ) , guid : :: windows :: core :: GUID::from_u128(0x447235c7_6a8d_4cc0_8e24_9eaf70b96e2b) , } }
 pub const GUID_PROCESSOR_PARKING_PERF_STATE_1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x447235c7_6a8d_4cc0_8e24_9eaf70b96e2c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PARKING_PERF_STATE_1 ) , guid : :: windows :: core :: GUID::from_u128(0x447235c7_6a8d_4cc0_8e24_9eaf70b96e2c) , } }
 pub const GUID_PROCESSOR_PERFSTATE_POLICY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbbdc3814_18e9_4463_8a55_d197327c45c0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PERFSTATE_POLICY ) , guid : :: windows :: core :: GUID::from_u128(0xbbdc3814_18e9_4463_8a55_d197327c45c0) , } }
 pub const GUID_PROCESSOR_PERF_AUTONOMOUS_ACTIVITY_WINDOW: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcfeda3d0_7697_4566_a922_a9086cd49dfa);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PERF_AUTONOMOUS_ACTIVITY_WINDOW ) , guid : :: windows :: core :: GUID::from_u128(0xcfeda3d0_7697_4566_a922_a9086cd49dfa) , } }
 pub const GUID_PROCESSOR_PERF_AUTONOMOUS_MODE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8baa4a8a_14c6_4451_8e8b_14bdbd197537);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PERF_AUTONOMOUS_MODE ) , guid : :: windows :: core :: GUID::from_u128(0x8baa4a8a_14c6_4451_8e8b_14bdbd197537) , } }
 pub const GUID_PROCESSOR_PERF_BOOST_MODE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbe337238_0d82_4146_a960_4f3749d470c7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PERF_BOOST_MODE ) , guid : :: windows :: core :: GUID::from_u128(0xbe337238_0d82_4146_a960_4f3749d470c7) , } }
 pub const GUID_PROCESSOR_PERF_BOOST_POLICY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x45bcc044_d885_43e2_8605_ee0ec6e96b59);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PERF_BOOST_POLICY ) , guid : :: windows :: core :: GUID::from_u128(0x45bcc044_d885_43e2_8605_ee0ec6e96b59) , } }
 pub const GUID_PROCESSOR_PERF_CORE_PARKING_HISTORY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x77d7f282_8f1a_42cd_8537_45450a839be8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PERF_CORE_PARKING_HISTORY ) , guid : :: windows :: core :: GUID::from_u128(0x77d7f282_8f1a_42cd_8537_45450a839be8) , } }
 pub const GUID_PROCESSOR_PERF_DECREASE_HISTORY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0300f6f8_abd6_45a9_b74f_4908691a40b5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PERF_DECREASE_HISTORY ) , guid : :: windows :: core :: GUID::from_u128(0x0300f6f8_abd6_45a9_b74f_4908691a40b5) , } }
 pub const GUID_PROCESSOR_PERF_DECREASE_POLICY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x40fbefc7_2e9d_4d25_a185_0cfd8574bac6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PERF_DECREASE_POLICY ) , guid : :: windows :: core :: GUID::from_u128(0x40fbefc7_2e9d_4d25_a185_0cfd8574bac6) , } }
 pub const GUID_PROCESSOR_PERF_DECREASE_POLICY_1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x40fbefc7_2e9d_4d25_a185_0cfd8574bac7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PERF_DECREASE_POLICY_1 ) , guid : :: windows :: core :: GUID::from_u128(0x40fbefc7_2e9d_4d25_a185_0cfd8574bac7) , } }
 pub const GUID_PROCESSOR_PERF_DECREASE_THRESHOLD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x12a0ab44_fe28_4fa9_b3bd_4b64f44960a6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PERF_DECREASE_THRESHOLD ) , guid : :: windows :: core :: GUID::from_u128(0x12a0ab44_fe28_4fa9_b3bd_4b64f44960a6) , } }
 pub const GUID_PROCESSOR_PERF_DECREASE_THRESHOLD_1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x12a0ab44_fe28_4fa9_b3bd_4b64f44960a7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PERF_DECREASE_THRESHOLD_1 ) , guid : :: windows :: core :: GUID::from_u128(0x12a0ab44_fe28_4fa9_b3bd_4b64f44960a7) , } }
 pub const GUID_PROCESSOR_PERF_DECREASE_TIME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd8edeb9b_95cf_4f95_a73c_b061973693c8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PERF_DECREASE_TIME ) , guid : :: windows :: core :: GUID::from_u128(0xd8edeb9b_95cf_4f95_a73c_b061973693c8) , } }
 pub const GUID_PROCESSOR_PERF_DECREASE_TIME_1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd8edeb9b_95cf_4f95_a73c_b061973693c9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PERF_DECREASE_TIME_1 ) , guid : :: windows :: core :: GUID::from_u128(0xd8edeb9b_95cf_4f95_a73c_b061973693c9) , } }
 pub const GUID_PROCESSOR_PERF_ENERGY_PERFORMANCE_PREFERENCE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x36687f9e_e3a5_4dbf_b1dc_15eb381c6863);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PERF_ENERGY_PERFORMANCE_PREFERENCE ) , guid : :: windows :: core :: GUID::from_u128(0x36687f9e_e3a5_4dbf_b1dc_15eb381c6863) , } }
 pub const GUID_PROCESSOR_PERF_ENERGY_PERFORMANCE_PREFERENCE_1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x36687f9e_e3a5_4dbf_b1dc_15eb381c6864);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PERF_ENERGY_PERFORMANCE_PREFERENCE_1 ) , guid : :: windows :: core :: GUID::from_u128(0x36687f9e_e3a5_4dbf_b1dc_15eb381c6864) , } }
 pub const GUID_PROCESSOR_PERF_HISTORY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7d24baa7_0b84_480f_840c_1b0743c00f5f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PERF_HISTORY ) , guid : :: windows :: core :: GUID::from_u128(0x7d24baa7_0b84_480f_840c_1b0743c00f5f) , } }
 pub const GUID_PROCESSOR_PERF_HISTORY_1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7d24baa7_0b84_480f_840c_1b0743c00f60);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PERF_HISTORY_1 ) , guid : :: windows :: core :: GUID::from_u128(0x7d24baa7_0b84_480f_840c_1b0743c00f60) , } }
 pub const GUID_PROCESSOR_PERF_INCREASE_HISTORY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x99b3ef01_752f_46a1_80fb_7730011f2354);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PERF_INCREASE_HISTORY ) , guid : :: windows :: core :: GUID::from_u128(0x99b3ef01_752f_46a1_80fb_7730011f2354) , } }
 pub const GUID_PROCESSOR_PERF_INCREASE_POLICY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x465e1f50_b610_473a_ab58_00d1077dc418);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PERF_INCREASE_POLICY ) , guid : :: windows :: core :: GUID::from_u128(0x465e1f50_b610_473a_ab58_00d1077dc418) , } }
 pub const GUID_PROCESSOR_PERF_INCREASE_POLICY_1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x465e1f50_b610_473a_ab58_00d1077dc419);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PERF_INCREASE_POLICY_1 ) , guid : :: windows :: core :: GUID::from_u128(0x465e1f50_b610_473a_ab58_00d1077dc419) , } }
 pub const GUID_PROCESSOR_PERF_INCREASE_THRESHOLD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x06cadf0e_64ed_448a_8927_ce7bf90eb35d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PERF_INCREASE_THRESHOLD ) , guid : :: windows :: core :: GUID::from_u128(0x06cadf0e_64ed_448a_8927_ce7bf90eb35d) , } }
 pub const GUID_PROCESSOR_PERF_INCREASE_THRESHOLD_1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x06cadf0e_64ed_448a_8927_ce7bf90eb35e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PERF_INCREASE_THRESHOLD_1 ) , guid : :: windows :: core :: GUID::from_u128(0x06cadf0e_64ed_448a_8927_ce7bf90eb35e) , } }
 pub const GUID_PROCESSOR_PERF_INCREASE_TIME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x984cf492_3bed_4488_a8f9_4286c97bf5aa);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PERF_INCREASE_TIME ) , guid : :: windows :: core :: GUID::from_u128(0x984cf492_3bed_4488_a8f9_4286c97bf5aa) , } }
 pub const GUID_PROCESSOR_PERF_INCREASE_TIME_1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x984cf492_3bed_4488_a8f9_4286c97bf5ab);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PERF_INCREASE_TIME_1 ) , guid : :: windows :: core :: GUID::from_u128(0x984cf492_3bed_4488_a8f9_4286c97bf5ab) , } }
 pub const GUID_PROCESSOR_PERF_LATENCY_HINT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0822df31_9c83_441c_a079_0de4cf009c7b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PERF_LATENCY_HINT ) , guid : :: windows :: core :: GUID::from_u128(0x0822df31_9c83_441c_a079_0de4cf009c7b) , } }
 pub const GUID_PROCESSOR_PERF_LATENCY_HINT_PERF: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x619b7505_003b_4e82_b7a6_4dd29c300971);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PERF_LATENCY_HINT_PERF ) , guid : :: windows :: core :: GUID::from_u128(0x619b7505_003b_4e82_b7a6_4dd29c300971) , } }
 pub const GUID_PROCESSOR_PERF_LATENCY_HINT_PERF_1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x619b7505_003b_4e82_b7a6_4dd29c300972);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PERF_LATENCY_HINT_PERF_1 ) , guid : :: windows :: core :: GUID::from_u128(0x619b7505_003b_4e82_b7a6_4dd29c300972) , } }
 pub const GUID_PROCESSOR_PERF_TIME_CHECK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d2b0152_7d5c_498b_88e2_34345392a2c5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_PERF_TIME_CHECK ) , guid : :: windows :: core :: GUID::from_u128(0x4d2b0152_7d5c_498b_88e2_34345392a2c5) , } }
 pub const GUID_PROCESSOR_RESPONSIVENESS_DISABLE_THRESHOLD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x38b8383d_cce0_4c79_9e3e_56a4f17cc480);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_RESPONSIVENESS_DISABLE_THRESHOLD ) , guid : :: windows :: core :: GUID::from_u128(0x38b8383d_cce0_4c79_9e3e_56a4f17cc480) , } }
 pub const GUID_PROCESSOR_RESPONSIVENESS_DISABLE_THRESHOLD_1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x38b8383d_cce0_4c79_9e3e_56a4f17cc481);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_RESPONSIVENESS_DISABLE_THRESHOLD_1 ) , guid : :: windows :: core :: GUID::from_u128(0x38b8383d_cce0_4c79_9e3e_56a4f17cc481) , } }
 pub const GUID_PROCESSOR_RESPONSIVENESS_DISABLE_TIME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf565999f_3fb0_411a_a226_3f0198dec130);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_RESPONSIVENESS_DISABLE_TIME ) , guid : :: windows :: core :: GUID::from_u128(0xf565999f_3fb0_411a_a226_3f0198dec130) , } }
 pub const GUID_PROCESSOR_RESPONSIVENESS_DISABLE_TIME_1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf565999f_3fb0_411a_a226_3f0198dec131);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_RESPONSIVENESS_DISABLE_TIME_1 ) , guid : :: windows :: core :: GUID::from_u128(0xf565999f_3fb0_411a_a226_3f0198dec131) , } }
 pub const GUID_PROCESSOR_RESPONSIVENESS_ENABLE_THRESHOLD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3d44e256_7222_4415_a9ed_9c45fa3dd830);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_RESPONSIVENESS_ENABLE_THRESHOLD ) , guid : :: windows :: core :: GUID::from_u128(0x3d44e256_7222_4415_a9ed_9c45fa3dd830) , } }
 pub const GUID_PROCESSOR_RESPONSIVENESS_ENABLE_THRESHOLD_1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3d44e256_7222_4415_a9ed_9c45fa3dd831);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_RESPONSIVENESS_ENABLE_THRESHOLD_1 ) , guid : :: windows :: core :: GUID::from_u128(0x3d44e256_7222_4415_a9ed_9c45fa3dd831) , } }
 pub const GUID_PROCESSOR_RESPONSIVENESS_ENABLE_TIME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3d915188_7830_49ae_a79a_0fb0a1e5a200);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_RESPONSIVENESS_ENABLE_TIME ) , guid : :: windows :: core :: GUID::from_u128(0x3d915188_7830_49ae_a79a_0fb0a1e5a200) , } }
 pub const GUID_PROCESSOR_RESPONSIVENESS_ENABLE_TIME_1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3d915188_7830_49ae_a79a_0fb0a1e5a201);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_RESPONSIVENESS_ENABLE_TIME_1 ) , guid : :: windows :: core :: GUID::from_u128(0x3d915188_7830_49ae_a79a_0fb0a1e5a201) , } }
 pub const GUID_PROCESSOR_RESPONSIVENESS_EPP_CEILING: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4427c73b_9756_4a5c_b84b_c7bda79c7320);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_RESPONSIVENESS_EPP_CEILING ) , guid : :: windows :: core :: GUID::from_u128(0x4427c73b_9756_4a5c_b84b_c7bda79c7320) , } }
 pub const GUID_PROCESSOR_RESPONSIVENESS_EPP_CEILING_1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4427c73b_9756_4a5c_b84b_c7bda79c7321);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_RESPONSIVENESS_EPP_CEILING_1 ) , guid : :: windows :: core :: GUID::from_u128(0x4427c73b_9756_4a5c_b84b_c7bda79c7321) , } }
 pub const GUID_PROCESSOR_RESPONSIVENESS_PERF_FLOOR: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xce8e92ee_6a86_4572_bfe0_20c21d03cd40);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_RESPONSIVENESS_PERF_FLOOR ) , guid : :: windows :: core :: GUID::from_u128(0xce8e92ee_6a86_4572_bfe0_20c21d03cd40) , } }
 pub const GUID_PROCESSOR_RESPONSIVENESS_PERF_FLOOR_1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xce8e92ee_6a86_4572_bfe0_20c21d03cd41);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_RESPONSIVENESS_PERF_FLOOR_1 ) , guid : :: windows :: core :: GUID::from_u128(0xce8e92ee_6a86_4572_bfe0_20c21d03cd41) , } }
 pub const GUID_PROCESSOR_SETTINGS_SUBGROUP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x54533251_82be_4824_96c1_47b60b740d00);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_SETTINGS_SUBGROUP ) , guid : :: windows :: core :: GUID::from_u128(0x54533251_82be_4824_96c1_47b60b740d00) , } }
 pub const GUID_PROCESSOR_SHORT_THREAD_RUNTIME_THRESHOLD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd92998c2_6a48_49ca_85d4_8cceec294570);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_SHORT_THREAD_RUNTIME_THRESHOLD ) , guid : :: windows :: core :: GUID::from_u128(0xd92998c2_6a48_49ca_85d4_8cceec294570) , } }
 pub const GUID_PROCESSOR_SHORT_THREAD_SCHEDULING_POLICY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbae08b81_2d5e_4688_ad6a_13243356654b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_SHORT_THREAD_SCHEDULING_POLICY ) , guid : :: windows :: core :: GUID::from_u128(0xbae08b81_2d5e_4688_ad6a_13243356654b) , } }
 pub const GUID_PROCESSOR_SOFT_PARKING_LATENCY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x97cfac41_2217_47eb_992d_618b1977c907);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_SOFT_PARKING_LATENCY ) , guid : :: windows :: core :: GUID::from_u128(0x97cfac41_2217_47eb_992d_618b1977c907) , } }
 pub const GUID_PROCESSOR_THREAD_SCHEDULING_POLICY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x93b8b6dc_0698_4d1c_9ee4_0644e900c85d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_THREAD_SCHEDULING_POLICY ) , guid : :: windows :: core :: GUID::from_u128(0x93b8b6dc_0698_4d1c_9ee4_0644e900c85d) , } }
 pub const GUID_PROCESSOR_THROTTLE_MAXIMUM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbc5038f7_23e0_4960_96da_33abaf5935ec);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_THROTTLE_MAXIMUM ) , guid : :: windows :: core :: GUID::from_u128(0xbc5038f7_23e0_4960_96da_33abaf5935ec) , } }
 pub const GUID_PROCESSOR_THROTTLE_MAXIMUM_1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbc5038f7_23e0_4960_96da_33abaf5935ed);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_THROTTLE_MAXIMUM_1 ) , guid : :: windows :: core :: GUID::from_u128(0xbc5038f7_23e0_4960_96da_33abaf5935ed) , } }
 pub const GUID_PROCESSOR_THROTTLE_MINIMUM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x893dee8e_2bef_41e0_89c6_b55d0929964c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_THROTTLE_MINIMUM ) , guid : :: windows :: core :: GUID::from_u128(0x893dee8e_2bef_41e0_89c6_b55d0929964c) , } }
 pub const GUID_PROCESSOR_THROTTLE_MINIMUM_1: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x893dee8e_2bef_41e0_89c6_b55d0929964d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_THROTTLE_MINIMUM_1 ) , guid : :: windows :: core :: GUID::from_u128(0x893dee8e_2bef_41e0_89c6_b55d0929964d) , } }
 pub const GUID_PROCESSOR_THROTTLE_POLICY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x57027304_4af6_4104_9260_e3d95248fc36);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROCESSOR_THROTTLE_POLICY ) , guid : :: windows :: core :: GUID::from_u128(0x57027304_4af6_4104_9260_e3d95248fc36) , } }
 pub const GUID_SESSION_DISPLAY_STATUS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2b84c20e_ad23_4ddf_93db_05ffbd7efca5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SESSION_DISPLAY_STATUS ) , guid : :: windows :: core :: GUID::from_u128(0x2b84c20e_ad23_4ddf_93db_05ffbd7efca5) , } }
 pub const GUID_SESSION_USER_PRESENCE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3c0f4548_c03f_4c4d_b9f2_237ede686376);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SESSION_USER_PRESENCE ) , guid : :: windows :: core :: GUID::from_u128(0x3c0f4548_c03f_4c4d_b9f2_237ede686376) , } }
 pub const GUID_SLEEPBUTTON_ACTION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x96996bc0_ad50_47ec_923b_6f41874dd9eb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SLEEPBUTTON_ACTION ) , guid : :: windows :: core :: GUID::from_u128(0x96996bc0_ad50_47ec_923b_6f41874dd9eb) , } }
 pub const GUID_SLEEP_IDLE_THRESHOLD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x81cd32e0_7833_44f3_8737_7081f38d1f70);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SLEEP_IDLE_THRESHOLD ) , guid : :: windows :: core :: GUID::from_u128(0x81cd32e0_7833_44f3_8737_7081f38d1f70) , } }
 pub const GUID_SLEEP_SUBGROUP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x238c9fa8_0aad_41ed_83f4_97be242c8f20);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SLEEP_SUBGROUP ) , guid : :: windows :: core :: GUID::from_u128(0x238c9fa8_0aad_41ed_83f4_97be242c8f20) , } }
 pub const GUID_SPR_ACTIVE_SESSION_CHANGE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0e24ce38_c393_4742_bdb1_744f4b9ee08e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SPR_ACTIVE_SESSION_CHANGE ) , guid : :: windows :: core :: GUID::from_u128(0x0e24ce38_c393_4742_bdb1_744f4b9ee08e) , } }
 pub const GUID_STANDBY_BUDGET_GRACE_PERIOD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x60c07fe1_0556_45cf_9903_d56e32210242);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_STANDBY_BUDGET_GRACE_PERIOD ) , guid : :: windows :: core :: GUID::from_u128(0x60c07fe1_0556_45cf_9903_d56e32210242) , } }
 pub const GUID_STANDBY_BUDGET_PERCENT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9fe527be_1b70_48da_930d_7bcf17b44990);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_STANDBY_BUDGET_PERCENT ) , guid : :: windows :: core :: GUID::from_u128(0x9fe527be_1b70_48da_930d_7bcf17b44990) , } }
 pub const GUID_STANDBY_RESERVE_GRACE_PERIOD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc763ee92_71e8_4127_84eb_f6ed043a3e3d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_STANDBY_RESERVE_GRACE_PERIOD ) , guid : :: windows :: core :: GUID::from_u128(0xc763ee92_71e8_4127_84eb_f6ed043a3e3d) , } }
 pub const GUID_STANDBY_RESERVE_TIME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x468fe7e5_1158_46ec_88bc_5b96c9e44fd0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_STANDBY_RESERVE_TIME ) , guid : :: windows :: core :: GUID::from_u128(0x468fe7e5_1158_46ec_88bc_5b96c9e44fd0) , } }
 pub const GUID_STANDBY_RESET_PERCENT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x49cb11a5_56e2_4afb_9d38_3df47872e21b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_STANDBY_RESET_PERCENT ) , guid : :: windows :: core :: GUID::from_u128(0x49cb11a5_56e2_4afb_9d38_3df47872e21b) , } }
 pub const GUID_STANDBY_TIMEOUT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x29f6c1db_86da_48c5_9fdb_f2b67b1f44da);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_STANDBY_TIMEOUT ) , guid : :: windows :: core :: GUID::from_u128(0x29f6c1db_86da_48c5_9fdb_f2b67b1f44da) , } }
 pub const GUID_SYSTEM_AWAYMODE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x98a7f580_01f7_48aa_9c0f_44352c29e5c0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SYSTEM_AWAYMODE ) , guid : :: windows :: core :: GUID::from_u128(0x98a7f580_01f7_48aa_9c0f_44352c29e5c0) , } }
 pub const GUID_SYSTEM_BUTTON_SUBGROUP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4f971e89_eebd_4455_a8de_9e59040e7347);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SYSTEM_BUTTON_SUBGROUP ) , guid : :: windows :: core :: GUID::from_u128(0x4f971e89_eebd_4455_a8de_9e59040e7347) , } }
 pub const GUID_SYSTEM_COOLING_POLICY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x94d3a615_a899_4ac5_ae2b_e4d8f634367f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SYSTEM_COOLING_POLICY ) , guid : :: windows :: core :: GUID::from_u128(0x94d3a615_a899_4ac5_ae2b_e4d8f634367f) , } }
 pub const GUID_TYPICAL_POWER_SAVINGS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x381b4222_f694_41f0_9685_ff5bb260df2e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TYPICAL_POWER_SAVINGS ) , guid : :: windows :: core :: GUID::from_u128(0x381b4222_f694_41f0_9685_ff5bb260df2e) , } }
 pub const GUID_UNATTEND_SLEEP_TIMEOUT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7bc4a2f9_d8fc_4469_b07b_33eb785aaca0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_UNATTEND_SLEEP_TIMEOUT ) , guid : :: windows :: core :: GUID::from_u128(0x7bc4a2f9_d8fc_4469_b07b_33eb785aaca0) , } }
 pub const GUID_USERINTERFACEBUTTON_ACTION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa7066653_8d6c_40a8_910e_a1f54b84c7e5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_USERINTERFACEBUTTON_ACTION ) , guid : :: windows :: core :: GUID::from_u128(0xa7066653_8d6c_40a8_910e_a1f54b84c7e5) , } }
 pub const GUID_USER_PRESENCE_PREDICTION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x82011705_fb95_4d46_8d35_4042b1d20def);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_USER_PRESENCE_PREDICTION ) , guid : :: windows :: core :: GUID::from_u128(0x82011705_fb95_4d46_8d35_4042b1d20def) , } }
 pub const GUID_VIDEO_ADAPTIVE_DISPLAY_BRIGHTNESS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfbd9aa66_9553_4097_ba44_ed6e9d65eab8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_VIDEO_ADAPTIVE_DISPLAY_BRIGHTNESS ) , guid : :: windows :: core :: GUID::from_u128(0xfbd9aa66_9553_4097_ba44_ed6e9d65eab8) , } }
 pub const GUID_VIDEO_ADAPTIVE_PERCENT_INCREASE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xeed904df_b142_4183_b10b_5a1197a37864);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_VIDEO_ADAPTIVE_PERCENT_INCREASE ) , guid : :: windows :: core :: GUID::from_u128(0xeed904df_b142_4183_b10b_5a1197a37864) , } }
 pub const GUID_VIDEO_ADAPTIVE_POWERDOWN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x90959d22_d6a1_49b9_af93_bce885ad335b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_VIDEO_ADAPTIVE_POWERDOWN ) , guid : :: windows :: core :: GUID::from_u128(0x90959d22_d6a1_49b9_af93_bce885ad335b) , } }
 pub const GUID_VIDEO_ANNOYANCE_TIMEOUT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x82dbcf2d_cd67_40c5_bfdc_9f1a5ccd4663);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_VIDEO_ANNOYANCE_TIMEOUT ) , guid : :: windows :: core :: GUID::from_u128(0x82dbcf2d_cd67_40c5_bfdc_9f1a5ccd4663) , } }
 pub const GUID_VIDEO_CONSOLE_LOCK_TIMEOUT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8ec4b3a5_6868_48c2_be75_4f3044be88a7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_VIDEO_CONSOLE_LOCK_TIMEOUT ) , guid : :: windows :: core :: GUID::from_u128(0x8ec4b3a5_6868_48c2_be75_4f3044be88a7) , } }
 pub const GUID_VIDEO_CURRENT_MONITOR_BRIGHTNESS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8ffee2c6_2d01_46be_adb9_398addc5b4ff);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_VIDEO_CURRENT_MONITOR_BRIGHTNESS ) , guid : :: windows :: core :: GUID::from_u128(0x8ffee2c6_2d01_46be_adb9_398addc5b4ff) , } }
 pub const GUID_VIDEO_DIM_TIMEOUT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x17aaa29b_8b43_4b94_aafe_35f64daaf1ee);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_VIDEO_DIM_TIMEOUT ) , guid : :: windows :: core :: GUID::from_u128(0x17aaa29b_8b43_4b94_aafe_35f64daaf1ee) , } }
 pub const GUID_VIDEO_POWERDOWN_TIMEOUT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3c0bc021_c8a8_4e07_a973_6b14cbcb2b7e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_VIDEO_POWERDOWN_TIMEOUT ) , guid : :: windows :: core :: GUID::from_u128(0x3c0bc021_c8a8_4e07_a973_6b14cbcb2b7e) , } }
 pub const GUID_VIDEO_SUBGROUP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7516b95f_f776_4464_8c53_06167f40cc99);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_VIDEO_SUBGROUP ) , guid : :: windows :: core :: GUID::from_u128(0x7516b95f_f776_4464_8c53_06167f40cc99) , } }
 #[doc = "*Required features: 'Win32_System_SystemServices'*"]
 pub const HEAP_OPTIMIZE_RESOURCES_CURRENT_VERSION: u32 = 1u32;
 #[repr(C)]
@@ -8482,6 +8958,8 @@ impl ::core::default::Default for NOTIFY_USER_POWER_SETTING {
     }
 }
 pub const NO_SUBGROUP_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfea3413e_7e05_4911_9a71_700331f1c294);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( NO_SUBGROUP_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xfea3413e_7e05_4911_9a71_700331f1c294) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_System_SystemServices'*"]
 pub struct NT_TIB32 {
@@ -9326,7 +9804,11 @@ pub const PPM_FIRMWARE_TSS: u32 = 2048u32;
 #[doc = "*Required features: 'Win32_System_SystemServices'*"]
 pub const PPM_FIRMWARE_XPSS: u32 = 128u32;
 pub const PPM_IDLESTATES_DATA_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xba138e10_e250_4ad7_8616_cf1a7ad410e7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PPM_IDLESTATES_DATA_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xba138e10_e250_4ad7_8616_cf1a7ad410e7) , } }
 pub const PPM_IDLESTATE_CHANGE_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4838fe4f_f71c_4e51_9ecc_8430a7ac4c6c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PPM_IDLESTATE_CHANGE_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x4838fe4f_f71c_4e51_9ecc_8430a7ac4c6c) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_System_SystemServices'*"]
 pub struct PPM_IDLESTATE_EVENT {
@@ -9429,7 +9911,11 @@ impl ::core::default::Default for PPM_IDLE_ACCOUNTING_EX {
     }
 }
 pub const PPM_IDLE_ACCOUNTING_EX_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd67abd39_81f8_4a5e_8152_72e31ec912ee);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PPM_IDLE_ACCOUNTING_EX_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xd67abd39_81f8_4a5e_8152_72e31ec912ee) , } }
 pub const PPM_IDLE_ACCOUNTING_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe2a26f78_ae07_4ee0_a30f_ce54f55a94cd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PPM_IDLE_ACCOUNTING_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xe2a26f78_ae07_4ee0_a30f_ce54f55a94cd) , } }
 #[doc = "*Required features: 'Win32_System_SystemServices'*"]
 pub const PPM_IDLE_IMPLEMENTATION_CSTATES: u32 = 1u32;
 #[doc = "*Required features: 'Win32_System_SystemServices'*"]
@@ -9545,6 +10031,8 @@ impl ::core::default::Default for PPM_IDLE_STATE_BUCKET_EX {
     }
 }
 pub const PPM_PERFMON_PERFSTATE_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7fd18652_0cfe_40d2_b0a1_0b066a87759e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PPM_PERFMON_PERFSTATE_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x7fd18652_0cfe_40d2_b0a1_0b066a87759e) , } }
 #[doc = "*Required features: 'Win32_System_SystemServices'*"]
 pub const PPM_PERFORMANCE_IMPLEMENTATION_CPPC: u32 = 3u32;
 #[doc = "*Required features: 'Win32_System_SystemServices'*"]
@@ -9556,8 +10044,14 @@ pub const PPM_PERFORMANCE_IMPLEMENTATION_PEP: u32 = 4u32;
 #[doc = "*Required features: 'Win32_System_SystemServices'*"]
 pub const PPM_PERFORMANCE_IMPLEMENTATION_PSTATES: u32 = 1u32;
 pub const PPM_PERFSTATES_DATA_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5708cc20_7d40_4bf4_b4aa_2b01338d0126);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PPM_PERFSTATES_DATA_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x5708cc20_7d40_4bf4_b4aa_2b01338d0126) , } }
 pub const PPM_PERFSTATE_CHANGE_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa5b32ddd_7f39_4abc_b892_900e43b59ebb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PPM_PERFSTATE_CHANGE_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xa5b32ddd_7f39_4abc_b892_900e43b59ebb) , } }
 pub const PPM_PERFSTATE_DOMAIN_CHANGE_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x995e6b7f_d653_497a_b978_36a30c29bf01);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PPM_PERFSTATE_DOMAIN_CHANGE_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x995e6b7f_d653_497a_b978_36a30c29bf01) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_System_SystemServices'*"]
 pub struct PPM_PERFSTATE_DOMAIN_EVENT {
@@ -9657,7 +10151,11 @@ impl ::core::default::Default for PPM_THERMALCHANGE_EVENT {
     }
 }
 pub const PPM_THERMALCONSTRAINT_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa852c2c8_1a4c_423b_8c2c_f30d82931a88);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PPM_THERMALCONSTRAINT_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xa852c2c8_1a4c_423b_8c2c_f30d82931a88) , } }
 pub const PPM_THERMAL_POLICY_CHANGE_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x48f377b8_6880_4c7b_8bdc_380176c6654d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PPM_THERMAL_POLICY_CHANGE_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x48f377b8_6880_4c7b_8bdc_380176c6654d) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_System_SystemServices'*"]
 pub struct PPM_THERMAL_POLICY_EVENT {

--- a/crates/libs/windows/src/Windows/Win32/System/TaskScheduler/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/TaskScheduler/mod.rs
@@ -1,6 +1,10 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 pub const CLSID_CTask: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x148bd520_a2ab_11ce_b11f_00aa00530503);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_CTask ) , guid : :: windows :: core :: GUID::from_u128(0x148bd520_a2ab_11ce_b11f_00aa00530503) , } }
 pub const CLSID_CTaskScheduler: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x148bd52a_a2ab_11ce_b11f_00aa00530503);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_CTaskScheduler ) , guid : :: windows :: core :: GUID::from_u128(0x148bd52a_a2ab_11ce_b11f_00aa00530503) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_System_TaskScheduler'*"]
 pub struct DAILY {

--- a/crates/libs/windows/src/Windows/Win32/System/UpdateAgent/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/UpdateAgent/mod.rs
@@ -15232,6 +15232,8 @@ pub const irbAlwaysRequiresReboot: InstallationRebootBehavior = 1i32;
 #[doc = "*Required features: 'Win32_System_UpdateAgent'*"]
 pub const irbCanRequestReboot: InstallationRebootBehavior = 2i32;
 pub const LIBID_WUApiLib: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb596cc9f_56e5_419e_a622_e01bb457431e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( LIBID_WUApiLib ) , guid : :: windows :: core :: GUID::from_u128(0xb596cc9f_56e5_419e_a622_e01bb457431e) , } }
 #[doc = "*Required features: 'Win32_System_UpdateAgent'*"]
 pub type OperationResultCode = i32;
 #[doc = "*Required features: 'Win32_System_UpdateAgent'*"]

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Imaging/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Graphics/Imaging/mod.rs
@@ -1,5 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 pub const CLSID_SoftwareBitmapNativeFactory: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x84e65691_8602_4a84_be46_708be9cd4b74);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_SoftwareBitmapNativeFactory ) , guid : :: windows :: core :: GUID::from_u128(0x84e65691_8602_4a84_be46_708be9cd4b74) , } }
 #[doc = "*Required features: 'Win32_System_WinRT_Graphics_Imaging'*"]
 #[repr(transparent)]
 pub struct ISoftwareBitmapNative(::windows::core::IUnknown);

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Media/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Media/mod.rs
@@ -1,6 +1,10 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 pub const CLSID_AudioFrameNativeFactory: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x16a0a3b9_9f65_4102_9367_2cda3a4f372a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_AudioFrameNativeFactory ) , guid : :: windows :: core :: GUID::from_u128(0x16a0a3b9_9f65_4102_9367_2cda3a4f372a) , } }
 pub const CLSID_VideoFrameNativeFactory: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd194386a_04e3_4814_8100_b2b0ae6d78c7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_VideoFrameNativeFactory ) , guid : :: windows :: core :: GUID::from_u128(0xd194386a_04e3_4814_8100_b2b0ae6d78c7) , } }
 #[doc = "*Required features: 'Win32_System_WinRT_Media'*"]
 #[repr(transparent)]
 pub struct IAudioFrameNative(::windows::core::IUnknown);

--- a/crates/libs/windows/src/Windows/Win32/System/WindowsProgramming/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WindowsProgramming/mod.rs
@@ -420,6 +420,8 @@ impl ::core::default::Default for CABINFOW {
     }
 }
 pub const CATID_DeleteBrowsingHistory: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x31caf6e4_d6aa_4090_a050_a5ac8972e9ef);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_DeleteBrowsingHistory ) , guid : :: windows :: core :: GUID::from_u128(0x31caf6e4_d6aa_4090_a050_a5ac8972e9ef) , } }
 #[doc = "*Required features: 'Win32_System_WindowsProgramming'*"]
 pub const CBR_110: u32 = 110u32;
 #[doc = "*Required features: 'Win32_System_WindowsProgramming'*"]

--- a/crates/libs/windows/src/Windows/Win32/System/WindowsSync/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WindowsSync/mod.rs
@@ -7145,69 +7145,113 @@ pub const KCCR_COOKIE_KNOWLEDGE_NOT_COMPARABLE: KNOWLEDGE_COOKIE_COMPARISON_RESU
 #[doc = "*Required features: 'Win32_System_WindowsSync', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_CONFIGUI_CAPABILITIES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x554b24ea_e8e3_45ba_9352_dfb561e171e4), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_CONFIGUI_CAPABILITIES ) , guid : :: windows :: core :: GUID::from_u128(0x554b24ea_e8e3_45ba_9352_dfb561e171e4) , } }
 #[doc = "*Required features: 'Win32_System_WindowsSync', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_CONFIGUI_CLSID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x554b24ea_e8e3_45ba_9352_dfb561e171e4), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_CONFIGUI_CLSID ) , guid : :: windows :: core :: GUID::from_u128(0x554b24ea_e8e3_45ba_9352_dfb561e171e4) , } }
 #[doc = "*Required features: 'Win32_System_WindowsSync', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_CONFIGUI_CONTENTTYPE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x554b24ea_e8e3_45ba_9352_dfb561e171e4), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_CONFIGUI_CONTENTTYPE ) , guid : :: windows :: core :: GUID::from_u128(0x554b24ea_e8e3_45ba_9352_dfb561e171e4) , } }
 #[doc = "*Required features: 'Win32_System_WindowsSync', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_CONFIGUI_DESCRIPTION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x554b24ea_e8e3_45ba_9352_dfb561e171e4), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_CONFIGUI_DESCRIPTION ) , guid : :: windows :: core :: GUID::from_u128(0x554b24ea_e8e3_45ba_9352_dfb561e171e4) , } }
 #[doc = "*Required features: 'Win32_System_WindowsSync', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_CONFIGUI_ICON: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x554b24ea_e8e3_45ba_9352_dfb561e171e4), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_CONFIGUI_ICON ) , guid : :: windows :: core :: GUID::from_u128(0x554b24ea_e8e3_45ba_9352_dfb561e171e4) , } }
 #[doc = "*Required features: 'Win32_System_WindowsSync', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_CONFIGUI_INSTANCEID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x554b24ea_e8e3_45ba_9352_dfb561e171e4), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_CONFIGUI_INSTANCEID ) , guid : :: windows :: core :: GUID::from_u128(0x554b24ea_e8e3_45ba_9352_dfb561e171e4) , } }
 #[doc = "*Required features: 'Win32_System_WindowsSync', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_CONFIGUI_IS_GLOBAL: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x554b24ea_e8e3_45ba_9352_dfb561e171e4), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_CONFIGUI_IS_GLOBAL ) , guid : :: windows :: core :: GUID::from_u128(0x554b24ea_e8e3_45ba_9352_dfb561e171e4) , } }
 #[doc = "*Required features: 'Win32_System_WindowsSync', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_CONFIGUI_MENUITEM: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x554b24ea_e8e3_45ba_9352_dfb561e171e4), pid: 13u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_CONFIGUI_MENUITEM ) , guid : :: windows :: core :: GUID::from_u128(0x554b24ea_e8e3_45ba_9352_dfb561e171e4) , } }
 #[doc = "*Required features: 'Win32_System_WindowsSync', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_CONFIGUI_MENUITEM_NOUI: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x554b24ea_e8e3_45ba_9352_dfb561e171e4), pid: 12u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_CONFIGUI_MENUITEM_NOUI ) , guid : :: windows :: core :: GUID::from_u128(0x554b24ea_e8e3_45ba_9352_dfb561e171e4) , } }
 #[doc = "*Required features: 'Win32_System_WindowsSync', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_CONFIGUI_NAME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x554b24ea_e8e3_45ba_9352_dfb561e171e4), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_CONFIGUI_NAME ) , guid : :: windows :: core :: GUID::from_u128(0x554b24ea_e8e3_45ba_9352_dfb561e171e4) , } }
 #[doc = "*Required features: 'Win32_System_WindowsSync', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_CONFIGUI_SUPPORTED_ARCHITECTURE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x554b24ea_e8e3_45ba_9352_dfb561e171e4), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_CONFIGUI_SUPPORTED_ARCHITECTURE ) , guid : :: windows :: core :: GUID::from_u128(0x554b24ea_e8e3_45ba_9352_dfb561e171e4) , } }
 #[doc = "*Required features: 'Win32_System_WindowsSync', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_CONFIGUI_TOOLTIPS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x554b24ea_e8e3_45ba_9352_dfb561e171e4), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_CONFIGUI_TOOLTIPS ) , guid : :: windows :: core :: GUID::from_u128(0x554b24ea_e8e3_45ba_9352_dfb561e171e4) , } }
 #[doc = "*Required features: 'Win32_System_WindowsSync', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PROVIDER_CAPABILITIES: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x84179e61_60f6_4c1c_88ed_f1c531b32bda), pid: 6u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PROVIDER_CAPABILITIES ) , guid : :: windows :: core :: GUID::from_u128(0x84179e61_60f6_4c1c_88ed_f1c531b32bda) , } }
 #[doc = "*Required features: 'Win32_System_WindowsSync', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PROVIDER_CLSID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x84179e61_60f6_4c1c_88ed_f1c531b32bda), pid: 3u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PROVIDER_CLSID ) , guid : :: windows :: core :: GUID::from_u128(0x84179e61_60f6_4c1c_88ed_f1c531b32bda) , } }
 #[doc = "*Required features: 'Win32_System_WindowsSync', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PROVIDER_CONFIGUI: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x84179e61_60f6_4c1c_88ed_f1c531b32bda), pid: 4u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PROVIDER_CONFIGUI ) , guid : :: windows :: core :: GUID::from_u128(0x84179e61_60f6_4c1c_88ed_f1c531b32bda) , } }
 #[doc = "*Required features: 'Win32_System_WindowsSync', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PROVIDER_CONTENTTYPE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x84179e61_60f6_4c1c_88ed_f1c531b32bda), pid: 5u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PROVIDER_CONTENTTYPE ) , guid : :: windows :: core :: GUID::from_u128(0x84179e61_60f6_4c1c_88ed_f1c531b32bda) , } }
 #[doc = "*Required features: 'Win32_System_WindowsSync', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PROVIDER_DESCRIPTION: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x84179e61_60f6_4c1c_88ed_f1c531b32bda), pid: 9u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PROVIDER_DESCRIPTION ) , guid : :: windows :: core :: GUID::from_u128(0x84179e61_60f6_4c1c_88ed_f1c531b32bda) , } }
 #[doc = "*Required features: 'Win32_System_WindowsSync', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PROVIDER_ICON: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x84179e61_60f6_4c1c_88ed_f1c531b32bda), pid: 11u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PROVIDER_ICON ) , guid : :: windows :: core :: GUID::from_u128(0x84179e61_60f6_4c1c_88ed_f1c531b32bda) , } }
 #[doc = "*Required features: 'Win32_System_WindowsSync', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PROVIDER_INSTANCEID: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x84179e61_60f6_4c1c_88ed_f1c531b32bda), pid: 2u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PROVIDER_INSTANCEID ) , guid : :: windows :: core :: GUID::from_u128(0x84179e61_60f6_4c1c_88ed_f1c531b32bda) , } }
 #[doc = "*Required features: 'Win32_System_WindowsSync', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PROVIDER_NAME: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x84179e61_60f6_4c1c_88ed_f1c531b32bda), pid: 8u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PROVIDER_NAME ) , guid : :: windows :: core :: GUID::from_u128(0x84179e61_60f6_4c1c_88ed_f1c531b32bda) , } }
 #[doc = "*Required features: 'Win32_System_WindowsSync', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PROVIDER_SUPPORTED_ARCHITECTURE: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x84179e61_60f6_4c1c_88ed_f1c531b32bda), pid: 7u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PROVIDER_SUPPORTED_ARCHITECTURE ) , guid : :: windows :: core :: GUID::from_u128(0x84179e61_60f6_4c1c_88ed_f1c531b32bda) , } }
 #[doc = "*Required features: 'Win32_System_WindowsSync', 'Win32_UI_Shell_PropertiesSystem'*"]
 #[cfg(feature = "Win32_UI_Shell_PropertiesSystem")]
 pub const PKEY_PROVIDER_TOOLTIPS: super::super::UI::Shell::PropertiesSystem::PROPERTYKEY = super::super::UI::Shell::PropertiesSystem::PROPERTYKEY { fmtid: ::windows::core::GUID::from_u128(0x84179e61_60f6_4c1c_88ed_f1c531b32bda), pid: 10u32 };
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PKEY_PROVIDER_TOOLTIPS ) , guid : :: windows :: core :: GUID::from_u128(0x84179e61_60f6_4c1c_88ed_f1c531b32bda) , } }
 #[doc = "*Required features: 'Win32_System_WindowsSync'*"]
 pub const SYNC_CHANGE_FLAG_DELETED: u32 = 1u32;
 #[doc = "*Required features: 'Win32_System_WindowsSync'*"]

--- a/crates/libs/windows/src/Windows/Win32/UI/Accessibility/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Accessibility/mod.rs
@@ -74,7 +74,11 @@ pub unsafe fn AccSetRunningUtilityState<'a, Param0: ::windows::core::IntoParam<'
     unimplemented!("Unsupported target OS");
 }
 pub const AcceleratorKey_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x514865df_2557_4cb9_aeed_6ced084ce52c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( AcceleratorKey_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x514865df_2557_4cb9_aeed_6ced084ce52c) , } }
 pub const AccessKey_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x06827b12_a7f9_4a15_917c_ffa5ad3eb0a7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( AccessKey_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x06827b12_a7f9_4a15_917c_ffa5ad3eb0a7) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility', 'Win32_Foundation', 'Win32_System_Com', 'Win32_System_Ole'*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 #[inline]
@@ -144,6 +148,8 @@ pub const ActiveEnd_Start: ActiveEnd = 1i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const ActiveEnd_End: ActiveEnd = 2i32;
 pub const ActiveTextPositionChanged_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa5c09e9c_c77d_4f25_b491_e5bb7017cbd4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ActiveTextPositionChanged_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xa5c09e9c_c77d_4f25_b491_e5bb7017cbd4) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub type AnimationStyle = i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -169,6 +175,8 @@ pub const ANNO_THIS: AnnoScope = 0i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const ANNO_CONTAINER: AnnoScope = 1i32;
 pub const AnnotationObjects_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x310910c8_7c6e_4f20_becd_4aaf6d191156);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( AnnotationObjects_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x310910c8_7c6e_4f20_becd_4aaf6d191156) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const AnnotationType_AdvancedProofingIssue: i32 = 60020i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -220,40 +228,110 @@ pub const AnnotationType_Unknown: i32 = 60000i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const AnnotationType_UnsyncedChange: i32 = 60015i32;
 pub const AnnotationTypes_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x64b71f76_53c4_4696_a219_20e940c9a176);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( AnnotationTypes_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x64b71f76_53c4_4696_a219_20e940c9a176) , } }
 pub const Annotation_AdvancedProofingIssue_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdac7b72c_c0f2_4b84_b90d_5fafc0f0ef1c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_AdvancedProofingIssue_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xdac7b72c_c0f2_4b84_b90d_5fafc0f0ef1c) , } }
 pub const Annotation_AnnotationTypeId_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x20ae484f_69ef_4c48_8f5b_c4938b206ac7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_AnnotationTypeId_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x20ae484f_69ef_4c48_8f5b_c4938b206ac7) , } }
 pub const Annotation_AnnotationTypeName_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9b818892_5ac9_4af9_aa96_f58a77b058e3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_AnnotationTypeName_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x9b818892_5ac9_4af9_aa96_f58a77b058e3) , } }
 pub const Annotation_Author_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf161d3a7_f81b_4128_b17f_71f690914520);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_Author_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xf161d3a7_f81b_4128_b17f_71f690914520) , } }
 pub const Annotation_Author_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7a528462_9c5c_4a03_a974_8b307a9937f2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_Author_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x7a528462_9c5c_4a03_a974_8b307a9937f2) , } }
 pub const Annotation_CircularReferenceError_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x25bd9cf4_1745_4659_ba67_727f0318c616);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_CircularReferenceError_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x25bd9cf4_1745_4659_ba67_727f0318c616) , } }
 pub const Annotation_Comment_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfd2fda30_26b3_4c06_8bc7_98f1532e46fd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_Comment_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xfd2fda30_26b3_4c06_8bc7_98f1532e46fd) , } }
 pub const Annotation_ConflictingChange_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x98af8802_517c_459f_af13_016d3fab877e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_ConflictingChange_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x98af8802_517c_459f_af13_016d3fab877e) , } }
 pub const Annotation_Custom_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9ec82750_3931_4952_85bc_1dbff78a43e3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_Custom_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x9ec82750_3931_4952_85bc_1dbff78a43e3) , } }
 pub const Annotation_DataValidationError_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc8649fa8_9775_437e_ad46_e709d93c2343);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_DataValidationError_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xc8649fa8_9775_437e_ad46_e709d93c2343) , } }
 pub const Annotation_DateTime_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x99b5ca5d_1acf_414b_a4d0_6b350b047578);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_DateTime_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x99b5ca5d_1acf_414b_a4d0_6b350b047578) , } }
 pub const Annotation_DeletionChange_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbe3d5b05_951d_42e7_901d_adc8c2cf34d0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_DeletionChange_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xbe3d5b05_951d_42e7_901d_adc8c2cf34d0) , } }
 pub const Annotation_EditingLockedChange_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc31f3e1c_7423_4dac_8348_41f099ff6f64);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_EditingLockedChange_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xc31f3e1c_7423_4dac_8348_41f099ff6f64) , } }
 pub const Annotation_Endnote_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7565725c_2d99_4839_960d_33d3b866aba5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_Endnote_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x7565725c_2d99_4839_960d_33d3b866aba5) , } }
 pub const Annotation_ExternalChange_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x75a05b31_5f11_42fd_887d_dfa010db2392);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_ExternalChange_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x75a05b31_5f11_42fd_887d_dfa010db2392) , } }
 pub const Annotation_Footer_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcceab046_1833_47aa_8080_701ed0b0c832);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_Footer_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xcceab046_1833_47aa_8080_701ed0b0c832) , } }
 pub const Annotation_Footnote_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3de10e21_4125_42db_8620_be8083080624);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_Footnote_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x3de10e21_4125_42db_8620_be8083080624) , } }
 pub const Annotation_FormatChange_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xeb247345_d4f1_41ce_8e52_f79b69635e48);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_FormatChange_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xeb247345_d4f1_41ce_8e52_f79b69635e48) , } }
 pub const Annotation_FormulaError_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x95611982_0cab_46d5_a2f0_e30d1905f8bf);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_FormulaError_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x95611982_0cab_46d5_a2f0_e30d1905f8bf) , } }
 pub const Annotation_GrammarError_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x757a048d_4518_41c6_854c_dc009b7cfb53);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_GrammarError_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x757a048d_4518_41c6_854c_dc009b7cfb53) , } }
 pub const Annotation_Header_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x867b409b_b216_4472_a219_525e310681f8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_Header_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x867b409b_b216_4472_a219_525e310681f8) , } }
 pub const Annotation_Highlighted_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x757c884e_8083_4081_8b9c_e87f5072f0e4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_Highlighted_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x757c884e_8083_4081_8b9c_e87f5072f0e4) , } }
 pub const Annotation_InsertionChange_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0dbeb3a6_df15_4164_a3c0_e21a8ce931c4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_InsertionChange_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x0dbeb3a6_df15_4164_a3c0_e21a8ce931c4) , } }
 pub const Annotation_Mathematics_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xeaab634b_26d0_40c1_8073_57ca1c633c9b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_Mathematics_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xeaab634b_26d0_40c1_8073_57ca1c633c9b) , } }
 pub const Annotation_MoveChange_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9da587eb_23e5_4490_b385_1a22ddc8b187);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_MoveChange_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x9da587eb_23e5_4490_b385_1a22ddc8b187) , } }
 pub const Annotation_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf6c72ad7_356c_4850_9291_316f608a8c84);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xf6c72ad7_356c_4850_9291_316f608a8c84) , } }
 pub const Annotation_Sensitive_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x37f4c04f_0f12_4464_929c_828fd15292e3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_Sensitive_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x37f4c04f_0f12_4464_929c_828fd15292e3) , } }
 pub const Annotation_SpellingError_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xae85567e_9ece_423f_81b7_96c43d53e50e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_SpellingError_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xae85567e_9ece_423f_81b7_96c43d53e50e) , } }
 pub const Annotation_Target_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb71b302d_2104_44ad_9c5c_092b4907d70f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_Target_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xb71b302d_2104_44ad_9c5c_092b4907d70f) , } }
 pub const Annotation_TrackChanges_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x21e6e888_dc14_4016_ac27_190553c8c470);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_TrackChanges_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x21e6e888_dc14_4016_ac27_190553c8c470) , } }
 pub const Annotation_UnsyncedChange_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1851116a_0e47_4b30_8cb5_d7dae4fbcd1b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Annotation_UnsyncedChange_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x1851116a_0e47_4b30_8cb5_d7dae4fbcd1b) , } }
 pub const AppBar_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6114908d_cc02_4d37_875b_b530c7139554);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( AppBar_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x6114908d_cc02_4d37_875b_b530c7139554) , } }
 pub const AriaProperties_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4213678c_e025_4922_beb5_e43ba08e6221);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( AriaProperties_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x4213678c_e025_4922_beb5_e43ba08e6221) , } }
 pub const AriaRole_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdd207b95_be4a_4e0d_b727_63ace94b6916);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( AriaRole_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xdd207b95_be4a_4e0d_b727_63ace94b6916) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub type AsyncContentLoadedState = i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -263,6 +341,8 @@ pub const AsyncContentLoadedState_Progress: AsyncContentLoadedState = 1i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const AsyncContentLoadedState_Completed: AsyncContentLoadedState = 2i32;
 pub const AsyncContentLoaded_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5fdee11c_d2fa_4fb9_904e_5cbee894d5ef);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( AsyncContentLoaded_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x5fdee11c_d2fa_4fb9_904e_5cbee894d5ef) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub type AutomationElementMode = i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -270,7 +350,11 @@ pub const AutomationElementMode_None: AutomationElementMode = 0i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const AutomationElementMode_Full: AutomationElementMode = 1i32;
 pub const AutomationFocusChanged_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb68a1f17_f60d_41a7_a3cc_b05292155fe0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( AutomationFocusChanged_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xb68a1f17_f60d_41a7_a3cc_b05292155fe0) , } }
 pub const AutomationId_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc82c0500_b60e_4310_a267_303c531f8ee5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( AutomationId_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xc82c0500_b60e_4310_a267_303c531f8ee5) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub type AutomationIdentifierType = i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -292,7 +376,11 @@ pub const AutomationIdentifierType_Changes: AutomationIdentifierType = 7i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const AutomationIdentifierType_Style: AutomationIdentifierType = 8i32;
 pub const AutomationPropertyChanged_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2527fba1_8d7a_4630_a4cc_e66315942f52);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( AutomationPropertyChanged_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x2527fba1_8d7a_4630_a4cc_e66315942f52) , } }
 pub const BoundingRectangle_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7bbfe8b2_3bfc_48dd_b729_c794b846e9a1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( BoundingRectangle_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x7bbfe8b2_3bfc_48dd_b729_c794b846e9a1) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub type BulletStyle = i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -310,12 +398,18 @@ pub const BulletStyle_DashBullet: BulletStyle = 5i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const BulletStyle_Other: BulletStyle = -1i32;
 pub const Button_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5a78e369_c6a1_4f33_a9d7_79f20d0c788e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Button_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x5a78e369_c6a1_4f33_a9d7_79f20d0c788e) , } }
 pub const CAccPropServices: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb5f8350b_0548_48b1_a6ee_88bd00b4a5e7);
 pub const CLSID_AccPropServices: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb5f8350b_0548_48b1_a6ee_88bd00b4a5e7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_AccPropServices ) , guid : :: windows :: core :: GUID::from_u128(0xb5f8350b_0548_48b1_a6ee_88bd00b4a5e7) , } }
 pub const CUIAutomation: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xff48dba4_60ef_4201_aa87_54103eef594e);
 pub const CUIAutomation8: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe22ad333_b25f_460c_83d0_0581107395c9);
 pub const CUIAutomationRegistrar: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6e29fabf_9977_42d1_8d0e_ca7e61ad87e6);
 pub const Calendar_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8913eb88_00e5_46bc_8e4e_14a786e165a1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Calendar_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x8913eb88_00e5_46bc_8e4e_14a786e165a1) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub type CapStyle = i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -349,11 +443,23 @@ pub const CaretPosition_EndOfLine: CaretPosition = 1i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const CaretPosition_BeginningOfLine: CaretPosition = 2i32;
 pub const CenterPoint_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0cb00c08_540c_4edb_9445_26359ea69785);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CenterPoint_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x0cb00c08_540c_4edb_9445_26359ea69785) , } }
 pub const Changes_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7df26714_614f_4e05_9488_716c5ba19436);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Changes_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x7df26714_614f_4e05_9488_716c5ba19436) , } }
 pub const Changes_Summary_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x313d65a6_e60f_4d62_9861_55afd728d207);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Changes_Summary_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x313d65a6_e60f_4d62_9861_55afd728d207) , } }
 pub const CheckBox_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfb50f922_a3db_49c0_8bc3_06dad55778e2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CheckBox_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xfb50f922_a3db_49c0_8bc3_06dad55778e2) , } }
 pub const ClassName_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x157b7215_894f_4b65_84e2_aac0da08b16b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ClassName_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x157b7215_894f_4b65_84e2_aac0da08b16b) , } }
 pub const ClickablePoint_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0196903b_b203_4818_a9f3_f08e675f2341);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ClickablePoint_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x0196903b_b203_4818_a9f3_f08e675f2341) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub type CoalesceEventsOptions = i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -361,6 +467,8 @@ pub const CoalesceEventsOptions_Disabled: CoalesceEventsOptions = 0i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const CoalesceEventsOptions_Enabled: CoalesceEventsOptions = 1i32;
 pub const ComboBox_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x54cb426c_2f33_4fff_aaa1_aef60dac5deb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ComboBox_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x54cb426c_2f33_4fff_aaa1_aef60dac5deb) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub type ConditionType = i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -382,7 +490,11 @@ pub const ConnectionRecoveryBehaviorOptions_Disabled: ConnectionRecoveryBehavior
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const ConnectionRecoveryBehaviorOptions_Enabled: ConnectionRecoveryBehaviorOptions = 1i32;
 pub const ControlType_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xca774fea_28ac_4bc2_94ca_acec6d6c10a3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ControlType_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xca774fea_28ac_4bc2_94ca_acec6d6c10a3) , } }
 pub const ControllerFor_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x51124c8a_a5d2_4f13_9be6_7fa8ba9d3a90);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ControllerFor_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x51124c8a_a5d2_4f13_9be6_7fa8ba9d3a90) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
@@ -429,8 +541,14 @@ pub unsafe fn CreateStdAccessibleProxyW<'a, Param0: ::windows::core::IntoParam<'
     unimplemented!("Unsupported target OS");
 }
 pub const Culture_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe2d74f27_3d79_4dc2_b88b_3044963a8afb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Culture_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xe2d74f27_3d79_4dc2_b88b_3044963a8afb) , } }
 pub const CustomNavigation_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xafea938a_621e_4054_bb2c_2f46114dac3f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CustomNavigation_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xafea938a_621e_4054_bb2c_2f46114dac3f) , } }
 pub const Custom_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf29ea0c3_adb7_430a_ba90_e52c7313e6ed);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Custom_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xf29ea0c3_adb7_430a_ba90_e52c7313e6ed) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const DISPID_ACC_CHILD: i32 = -5002i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -470,8 +588,14 @@ pub const DISPID_ACC_STATE: i32 = -5007i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const DISPID_ACC_VALUE: i32 = -5004i32;
 pub const DataGrid_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x84b783af_d103_4b0a_8415_e73942410f4b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DataGrid_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x84b783af_d103_4b0a_8415_e73942410f4b) , } }
 pub const DataItem_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa0177842_d94f_42a5_814b_6068addc8da5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DataItem_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xa0177842_d94f_42a5_814b_6068addc8da5) , } }
 pub const DescribedBy_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7c5865b8_9992_40fd_8db0_6bf1d317f998);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DescribedBy_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x7c5865b8_9992_40fd_8db0_6bf1d317f998) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 #[inline]
 pub unsafe fn DockPattern_SetDockPosition<'a, Param0: ::windows::core::IntoParam<'a, HUIAPATTERNOBJECT>>(hobj: Param0, dockposition: DockPosition) -> ::windows::core::Result<()> {
@@ -501,23 +625,59 @@ pub const DockPosition_Fill: DockPosition = 4i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const DockPosition_None: DockPosition = 5i32;
 pub const Dock_DockPosition_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6d67f02e_c0b0_4b10_b5b9_18d6ecf98760);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Dock_DockPosition_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x6d67f02e_c0b0_4b10_b5b9_18d6ecf98760) , } }
 pub const Dock_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9cbaa846_83c8_428d_827f_7e6063fe0620);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Dock_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x9cbaa846_83c8_428d_827f_7e6063fe0620) , } }
 pub const Document_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3cd6bb6f_6f08_4562_b229_e4e2fc7a9eb4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Document_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x3cd6bb6f_6f08_4562_b229_e4e2fc7a9eb4) , } }
 pub const Drag_DragCancel_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc3ede6fa_3451_4e0f_9e71_df9c280a4657);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Drag_DragCancel_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xc3ede6fa_3451_4e0f_9e71_df9c280a4657) , } }
 pub const Drag_DragComplete_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x38e96188_ef1f_463e_91ca_3a7792c29caf);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Drag_DragComplete_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x38e96188_ef1f_463e_91ca_3a7792c29caf) , } }
 pub const Drag_DragStart_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x883a480b_3aa9_429d_95e4_d9c8d011f0dd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Drag_DragStart_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x883a480b_3aa9_429d_95e4_d9c8d011f0dd) , } }
 pub const Drag_DropEffect_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x646f2779_48d3_4b23_8902_4bf100005df3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Drag_DropEffect_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x646f2779_48d3_4b23_8902_4bf100005df3) , } }
 pub const Drag_DropEffects_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf5d61156_7ce6_49be_a836_9269dcec920f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Drag_DropEffects_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xf5d61156_7ce6_49be_a836_9269dcec920f) , } }
 pub const Drag_GrabbedItems_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x77c1562c_7b86_4b21_9ed7_3cefda6f4c43);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Drag_GrabbedItems_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x77c1562c_7b86_4b21_9ed7_3cefda6f4c43) , } }
 pub const Drag_IsGrabbed_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x45f206f3_75cc_4cca_a9b9_fcdfb982d8a2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Drag_IsGrabbed_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x45f206f3_75cc_4cca_a9b9_fcdfb982d8a2) , } }
 pub const Drag_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc0bee21f_ccb3_4fed_995b_114f6e3d2728);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Drag_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xc0bee21f_ccb3_4fed_995b_114f6e3d2728) , } }
 pub const DropTarget_DragEnter_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaad9319b_032c_4a88_961d_1cf579581e34);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DropTarget_DragEnter_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xaad9319b_032c_4a88_961d_1cf579581e34) , } }
 pub const DropTarget_DragLeave_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0f82eb15_24a2_4988_9217_de162aee272b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DropTarget_DragLeave_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x0f82eb15_24a2_4988_9217_de162aee272b) , } }
 pub const DropTarget_DropTargetEffect_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8bb75975_a0ca_4981_b818_87fc66e9509d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DropTarget_DropTargetEffect_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x8bb75975_a0ca_4981_b818_87fc66e9509d) , } }
 pub const DropTarget_DropTargetEffects_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbc1dd4ed_cb89_45f1_a592_e03b08ae790f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DropTarget_DropTargetEffects_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xbc1dd4ed_cb89_45f1_a592_e03b08ae790f) , } }
 pub const DropTarget_Dropped_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x622cead8_1edb_4a3d_abbc_be2211ff68b5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DropTarget_Dropped_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x622cead8_1edb_4a3d_abbc_be2211ff68b5) , } }
 pub const DropTarget_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0bcbec56_bd34_4b7b_9fd5_2659905ea3dc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( DropTarget_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x0bcbec56_bd34_4b7b_9fd5_2659905ea3dc) , } }
 pub const Edit_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6504a5c8_2c86_4f87_ae7b_1abddc810cf9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Edit_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x6504a5c8_2c86_4f87_ae7b_1abddc810cf9) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub type EventArgsType = i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -579,7 +739,11 @@ pub const ExpandCollapseState_PartiallyExpanded: ExpandCollapseState = 2i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const ExpandCollapseState_LeafNode: ExpandCollapseState = 3i32;
 pub const ExpandCollapse_ExpandCollapseState_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x275a4c48_85a7_4f69_aba0_af157610002b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ExpandCollapse_ExpandCollapseState_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x275a4c48_85a7_4f69_aba0_af157610002b) , } }
 pub const ExpandCollapse_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xae05efa2_f9d1_428a_834c_53a5c52f9b8b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ExpandCollapse_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xae05efa2_f9d1_428a_834c_53a5c52f9b8b) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_UI_Accessibility', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -653,6 +817,8 @@ impl ::core::default::Default for FILTERKEYS {
     }
 }
 pub const FillColor_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6e0ec4d0_e2a8_4a56_9de7_953389933b39);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FillColor_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x6e0ec4d0_e2a8_4a56_9de7_953389933b39) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub type FillType = i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -666,6 +832,8 @@ pub const FillType_Picture: FillType = 3i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const FillType_Pattern: FillType = 4i32;
 pub const FillType_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc6fc74e4_8cb9_429c_a9e1_9bc4ac372b62);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FillType_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xc6fc74e4_8cb9_429c_a9e1_9bc4ac372b62) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub type FlowDirections = i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -677,9 +845,17 @@ pub const FlowDirections_BottomToTop: FlowDirections = 2i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const FlowDirections_Vertical: FlowDirections = 4i32;
 pub const FlowsFrom_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x05c6844f_19de_48f8_95fa_880d5b0fd615);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FlowsFrom_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x05c6844f_19de_48f8_95fa_880d5b0fd615) , } }
 pub const FlowsTo_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe4f33d20_559a_47fb_a830_f9cb4ff1a70a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FlowsTo_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xe4f33d20_559a_47fb_a830_f9cb4ff1a70a) , } }
 pub const FrameworkId_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdbfd9900_7e1a_4f58_b61b_7063120f773b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FrameworkId_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xdbfd9900_7e1a_4f58_b61b_7063120f773b) , } }
 pub const FullDescription_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0d4450ff_6aef_4f33_95dd_7befa72a4391);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( FullDescription_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x0d4450ff_6aef_4f33_95dd_7befa72a4391) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 #[inline]
 pub unsafe fn GetOleaccVersionInfo(pver: *mut u32, pbuild: *mut u32) {
@@ -755,11 +931,23 @@ pub unsafe fn GetStateTextW(lstatebit: u32, lpszstate: super::super::Foundation:
     unimplemented!("Unsupported target OS");
 }
 pub const GridItem_ColumnSpan_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x583ea3f5_86d0_4b08_a6ec_2c5463ffc109);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GridItem_ColumnSpan_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x583ea3f5_86d0_4b08_a6ec_2c5463ffc109) , } }
 pub const GridItem_Column_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc774c15c_62c0_4519_8bdc_47be573c8ad5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GridItem_Column_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xc774c15c_62c0_4519_8bdc_47be573c8ad5) , } }
 pub const GridItem_Parent_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9d912252_b97f_4ecc_8510_ea0e33427c72);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GridItem_Parent_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x9d912252_b97f_4ecc_8510_ea0e33427c72) , } }
 pub const GridItem_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf2d5c877_a462_4957_a2a5_2c96b303bc63);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GridItem_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xf2d5c877_a462_4957_a2a5_2c96b303bc63) , } }
 pub const GridItem_RowSpan_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4582291c_466b_4e93_8e83_3d1715ec0c5e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GridItem_RowSpan_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x4582291c_466b_4e93_8e83_3d1715ec0c5e) , } }
 pub const GridItem_Row_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6223972a_c945_4563_9329_fdc974af2553);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GridItem_Row_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x6223972a_c945_4563_9329_fdc974af2553) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 #[inline]
 pub unsafe fn GridPattern_GetItem<'a, Param0: ::windows::core::IntoParam<'a, HUIAPATTERNOBJECT>>(hobj: Param0, row: i32, column: i32, presult: *mut HUIANODE) -> ::windows::core::Result<()> {
@@ -775,9 +963,17 @@ pub unsafe fn GridPattern_GetItem<'a, Param0: ::windows::core::IntoParam<'a, HUI
     unimplemented!("Unsupported target OS");
 }
 pub const Grid_ColumnCount_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfe96f375_44aa_4536_ac7a_2a75d71a3efc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Grid_ColumnCount_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xfe96f375_44aa_4536_ac7a_2a75d71a3efc) , } }
 pub const Grid_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x260a2ccb_93a8_4e44_a4c1_3df397f2b02b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Grid_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x260a2ccb_93a8_4e44_a4c1_3df397f2b02b) , } }
 pub const Grid_RowCount_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2a9505bf_c2eb_4fb6_b356_8245ae53703e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Grid_RowCount_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x2a9505bf_c2eb_4fb6_b356_8245ae53703e) , } }
 pub const Group_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xad50aa1c_e8c8_4774_ae1b_dd86df0b3bdc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Group_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xad50aa1c_e8c8_4774_ae1b_dd86df0b3bdc) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_UI_Accessibility', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -882,8 +1078,14 @@ pub type HUIAPATTERNOBJECT = isize;
 pub type HUIATEXTRANGE = isize;
 pub type HWINEVENTHOOK = isize;
 pub const HasKeyboardFocus_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcf8afd39_3f46_4800_9656_b2bf12529905);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( HasKeyboardFocus_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xcf8afd39_3f46_4800_9656_b2bf12529905) , } }
 pub const HeaderItem_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe6bc12cb_7c8e_49cf_b168_4a93a32bebb0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( HeaderItem_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xe6bc12cb_7c8e_49cf_b168_4a93a32bebb0) , } }
 pub const Header_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5b90cbce_78fb_4614_82b6_554d74718e67);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Header_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x5b90cbce_78fb_4614_82b6_554d74718e67) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const HeadingLevel1: i32 = 80051i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -905,7 +1107,11 @@ pub const HeadingLevel9: i32 = 80059i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const HeadingLevel_None: i32 = 80050i32;
 pub const HeadingLevel_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x29084272_aaaf_4a30_8796_3c12f62b6bbb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( HeadingLevel_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x29084272_aaaf_4a30_8796_3c12f62b6bbb) , } }
 pub const HelpText_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x08555685_0977_45c7_a7a6_abaf5684121a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( HelpText_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x08555685_0977_45c7_a7a6_abaf5684121a) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub type HorizontalTextAlignment = i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -917,7 +1123,11 @@ pub const HorizontalTextAlignment_Right: HorizontalTextAlignment = 2i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const HorizontalTextAlignment_Justified: HorizontalTextAlignment = 3i32;
 pub const HostedFragmentRootsInvalidated_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe6bdb03e_0921_4ec5_8dcf_eae877b0426b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( HostedFragmentRootsInvalidated_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xe6bdb03e_0921_4ec5_8dcf_eae877b0426b) , } }
 pub const Hyperlink_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8a56022c_b00d_4d15_8ff0_5b6b266e5e02);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Hyperlink_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x8a56022c_b00d_4d15_8ff0_5b6b266e5e02) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 #[repr(transparent)]
 pub struct IAccIdentity(::windows::core::IUnknown);
@@ -2298,7 +2508,11 @@ pub struct IGridProviderVtbl(
     pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void, pretval: *mut i32) -> ::windows::core::HRESULT,
 );
 pub const IIS_ControlAccessible: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x38c682a6_9731_43f2_9fae_e901e641b101);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IIS_ControlAccessible ) , guid : :: windows :: core :: GUID::from_u128(0x38c682a6_9731_43f2_9fae_e901e641b101) , } }
 pub const IIS_IsOleaccProxy: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x902697fa_80e4_4560_802a_a13f22a64709);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IIS_IsOleaccProxy ) , guid : :: windows :: core :: GUID::from_u128(0x902697fa_80e4_4560_802a_a13f22a64709) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 #[repr(transparent)]
 pub struct IInvokeProvider(::windows::core::IUnknown);
@@ -22768,9 +22982,17 @@ pub struct IWindowProviderVtbl(
     #[cfg(not(feature = "Win32_Foundation"))] usize,
 );
 pub const Image_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2d3736e4_6b16_4c57_a962_f93260a75243);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Image_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x2d3736e4_6b16_4c57_a962_f93260a75243) , } }
 pub const InputDiscarded_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7f36c367_7b18_417c_97e3_9d58ddc944ab);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( InputDiscarded_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x7f36c367_7b18_417c_97e3_9d58ddc944ab) , } }
 pub const InputReachedOtherElement_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xed201d8a_4e6c_415e_a874_2460c9b66ba8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( InputReachedOtherElement_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xed201d8a_4e6c_415e_a874_2460c9b66ba8) , } }
 pub const InputReachedTarget_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x93ed549a_0549_40f0_bedb_28e44f7de2a3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( InputReachedTarget_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x93ed549a_0549_40f0_bedb_28e44f7de2a3) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 #[inline]
 pub unsafe fn InvokePattern_Invoke<'a, Param0: ::windows::core::IntoParam<'a, HUIAPATTERNOBJECT>>(hobj: Param0) -> ::windows::core::Result<()> {
@@ -22786,52 +23008,146 @@ pub unsafe fn InvokePattern_Invoke<'a, Param0: ::windows::core::IntoParam<'a, HU
     unimplemented!("Unsupported target OS");
 }
 pub const Invoke_Invoked_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdfd699f0_c915_49dd_b422_dde785c3d24b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Invoke_Invoked_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xdfd699f0_c915_49dd_b422_dde785c3d24b) , } }
 pub const Invoke_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd976c2fc_66ea_4a6e_b28f_c24c7546ad37);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Invoke_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xd976c2fc_66ea_4a6e_b28f_c24c7546ad37) , } }
 pub const IsAnnotationPatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0b5b3238_6d5c_41b6_bcc4_5e807f6551c4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsAnnotationPatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x0b5b3238_6d5c_41b6_bcc4_5e807f6551c4) , } }
 pub const IsContentElement_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4bda64a8_f5d8_480b_8155_ef2e89adb672);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsContentElement_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x4bda64a8_f5d8_480b_8155_ef2e89adb672) , } }
 pub const IsControlElement_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x95f35085_abcc_4afd_a5f4_dbb46c230fdb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsControlElement_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x95f35085_abcc_4afd_a5f4_dbb46c230fdb) , } }
 pub const IsCustomNavigationPatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8f8e80d4_2351_48e0_874a_54aa7313889a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsCustomNavigationPatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x8f8e80d4_2351_48e0_874a_54aa7313889a) , } }
 pub const IsDataValidForForm_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x445ac684_c3fc_4dd9_acf8_845a579296ba);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsDataValidForForm_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x445ac684_c3fc_4dd9_acf8_845a579296ba) , } }
 pub const IsDialog_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9d0dfb9b_8436_4501_bbbb_e534a4fb3b3f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsDialog_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x9d0dfb9b_8436_4501_bbbb_e534a4fb3b3f) , } }
 pub const IsDockPatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2600a4c4_2ff8_4c96_ae31_8fe619a13c6c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsDockPatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x2600a4c4_2ff8_4c96_ae31_8fe619a13c6c) , } }
 pub const IsDragPatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe997a7b7_1d39_4ca7_be0f_277fcf5605cc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsDragPatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xe997a7b7_1d39_4ca7_be0f_277fcf5605cc) , } }
 pub const IsDropTargetPatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0686b62e_8e19_4aaf_873d_384f6d3b92be);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsDropTargetPatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x0686b62e_8e19_4aaf_873d_384f6d3b92be) , } }
 pub const IsEnabled_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2109427f_da60_4fed_bf1b_264bdce6eb3a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsEnabled_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x2109427f_da60_4fed_bf1b_264bdce6eb3a) , } }
 pub const IsExpandCollapsePatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x929d3806_5287_4725_aa16_222afc63d595);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsExpandCollapsePatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x929d3806_5287_4725_aa16_222afc63d595) , } }
 pub const IsGridItemPatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5a43e524_f9a2_4b12_84c8_b48a3efedd34);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsGridItemPatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x5a43e524_f9a2_4b12_84c8_b48a3efedd34) , } }
 pub const IsGridPatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5622c26c_f0ef_4f3b_97cb_714c0868588b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsGridPatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x5622c26c_f0ef_4f3b_97cb_714c0868588b) , } }
 pub const IsInvokePatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4e725738_8364_4679_aa6c_f3f41931f750);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsInvokePatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x4e725738_8364_4679_aa6c_f3f41931f750) , } }
 pub const IsItemContainerPatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x624b5ca7_fe40_4957_a019_20c4cf11920f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsItemContainerPatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x624b5ca7_fe40_4957_a019_20c4cf11920f) , } }
 pub const IsKeyboardFocusable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf7b8552a_0859_4b37_b9cb_51e72092f29f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsKeyboardFocusable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xf7b8552a_0859_4b37_b9cb_51e72092f29f) , } }
 pub const IsLegacyIAccessiblePatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd8ebd0c7_929a_4ee7_8d3a_d3d94413027b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsLegacyIAccessiblePatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xd8ebd0c7_929a_4ee7_8d3a_d3d94413027b) , } }
 pub const IsMultipleViewPatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xff0a31eb_8e25_469d_8d6e_e771a27c1b90);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsMultipleViewPatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xff0a31eb_8e25_469d_8d6e_e771a27c1b90) , } }
 pub const IsObjectModelPatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6b21d89b_2841_412f_8ef2_15ca952318ba);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsObjectModelPatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x6b21d89b_2841_412f_8ef2_15ca952318ba) , } }
 pub const IsOffscreen_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x03c3d160_db79_42db_a2ef_1c231eede507);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsOffscreen_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x03c3d160_db79_42db_a2ef_1c231eede507) , } }
 pub const IsPassword_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe8482eb1_687c_497b_bebc_03be53ec1454);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsPassword_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xe8482eb1_687c_497b_bebc_03be53ec1454) , } }
 pub const IsPeripheral_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xda758276_7ed5_49d4_8e68_ecc9a2d300dd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsPeripheral_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xda758276_7ed5_49d4_8e68_ecc9a2d300dd) , } }
 pub const IsRangeValuePatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfda4244a_eb4d_43ff_b5ad_ed36d373ec4c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsRangeValuePatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xfda4244a_eb4d_43ff_b5ad_ed36d373ec4c) , } }
 pub const IsRequiredForForm_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4f5f43cf_59fb_4bde_a270_602e5e1141e9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsRequiredForForm_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x4f5f43cf_59fb_4bde_a270_602e5e1141e9) , } }
 pub const IsScrollItemPatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1cad1a05_0927_4b76_97e1_0fcdb209b98a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsScrollItemPatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x1cad1a05_0927_4b76_97e1_0fcdb209b98a) , } }
 pub const IsScrollPatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3ebb7b4a_828a_4b57_9d22_2fea1632ed0d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsScrollPatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x3ebb7b4a_828a_4b57_9d22_2fea1632ed0d) , } }
 pub const IsSelectionItemPatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8becd62d_0bc3_4109_bee2_8e6715290e68);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsSelectionItemPatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x8becd62d_0bc3_4109_bee2_8e6715290e68) , } }
 pub const IsSelectionPattern2Available_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x490806fb_6e89_4a47_8319_d266e511f021);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsSelectionPattern2Available_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x490806fb_6e89_4a47_8319_d266e511f021) , } }
 pub const IsSelectionPatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf588acbe_c769_4838_9a60_2686dc1188c4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsSelectionPatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xf588acbe_c769_4838_9a60_2686dc1188c4) , } }
 pub const IsSpreadsheetItemPatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9fe79b2a_2f94_43fd_996b_549e316f4acd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsSpreadsheetItemPatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x9fe79b2a_2f94_43fd_996b_549e316f4acd) , } }
 pub const IsSpreadsheetPatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6ff43732_e4b4_4555_97bc_ecdbbc4d1888);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsSpreadsheetPatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x6ff43732_e4b4_4555_97bc_ecdbbc4d1888) , } }
 pub const IsStructuredMarkupPatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb0d4c196_2c0b_489c_b165_a405928c6f3d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsStructuredMarkupPatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xb0d4c196_2c0b_489c_b165_a405928c6f3d) , } }
 pub const IsStylesPatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x27f353d3_459c_4b59_a490_50611dacafb5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsStylesPatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x27f353d3_459c_4b59_a490_50611dacafb5) , } }
 pub const IsSynchronizedInputPatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x75d69cc5_d2bf_4943_876e_b45b62a6cc66);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsSynchronizedInputPatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x75d69cc5_d2bf_4943_876e_b45b62a6cc66) , } }
 pub const IsTableItemPatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xeb36b40d_8ea4_489b_a013_e60d5951fe34);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsTableItemPatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xeb36b40d_8ea4_489b_a013_e60d5951fe34) , } }
 pub const IsTablePatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcb83575f_45c2_4048_9c76_159715a139df);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsTablePatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xcb83575f_45c2_4048_9c76_159715a139df) , } }
 pub const IsTextChildPatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x559e65df_30ff_43b5_b5ed_5b283b80c7e9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsTextChildPatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x559e65df_30ff_43b5_b5ed_5b283b80c7e9) , } }
 pub const IsTextEditPatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7843425c_8b32_484c_9ab5_e3200571ffda);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsTextEditPatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x7843425c_8b32_484c_9ab5_e3200571ffda) , } }
 pub const IsTextPattern2Available_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x41cf921d_e3f1_4b22_9c81_e1c3ed331c22);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsTextPattern2Available_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x41cf921d_e3f1_4b22_9c81_e1c3ed331c22) , } }
 pub const IsTextPatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfbe2d69d_aff6_4a45_82e2_fc92a82f5917);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsTextPatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xfbe2d69d_aff6_4a45_82e2_fc92a82f5917) , } }
 pub const IsTogglePatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x78686d53_fcd0_4b83_9b78_5832ce63bb5b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsTogglePatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x78686d53_fcd0_4b83_9b78_5832ce63bb5b) , } }
 pub const IsTransformPattern2Available_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x25980b4b_be04_4710_ab4a_fda31dbd2895);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsTransformPattern2Available_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x25980b4b_be04_4710_ab4a_fda31dbd2895) , } }
 pub const IsTransformPatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa7f78804_d68b_4077_a5c6_7a5ea1ac31c5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsTransformPatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xa7f78804_d68b_4077_a5c6_7a5ea1ac31c5) , } }
 pub const IsValuePatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0b5020a7_2119_473b_be37_5ceb98bbfb22);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsValuePatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x0b5020a7_2119_473b_be37_5ceb98bbfb22) , } }
 pub const IsVirtualizedItemPatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x302cb151_2ac8_45d6_977b_d2b3a5a53f20);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsVirtualizedItemPatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x302cb151_2ac8_45d6_977b_d2b3a5a53f20) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
@@ -22848,6 +23164,8 @@ pub unsafe fn IsWinEventHookInstalled(event: u32) -> super::super::Foundation::B
     unimplemented!("Unsupported target OS");
 }
 pub const IsWindowPatternAvailable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe7a57bb1_5888_4155_98dc_b422fd57f2bc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( IsWindowPatternAvailable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xe7a57bb1_5888_4155_98dc_b422fd57f2bc) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility', 'Win32_Foundation', 'Win32_System_Com', 'Win32_System_Ole'*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 #[inline]
@@ -22864,9 +23182,17 @@ pub unsafe fn ItemContainerPattern_FindItemByProperty<'a, Param0: ::windows::cor
     unimplemented!("Unsupported target OS");
 }
 pub const ItemContainer_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3d13da0f_8b9a_4a99_85fa_c5c9a69f1ed4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ItemContainer_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x3d13da0f_8b9a_4a99_85fa_c5c9a69f1ed4) , } }
 pub const ItemStatus_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x51de0321_3973_43e7_8913_0b08e813c37f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ItemStatus_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x51de0321_3973_43e7_8913_0b08e813c37f) , } }
 pub const ItemType_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcdda434d_6222_413b_a68a_325dd1d40f39);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ItemType_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xcdda434d_6222_413b_a68a_325dd1d40f39) , } }
 pub const LIBID_Accessibility: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1ea4dbf0_3c3b_11cf_810c_00aa00389b71);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( LIBID_Accessibility ) , guid : :: windows :: core :: GUID::from_u128(0x1ea4dbf0_3c3b_11cf_810c_00aa00389b71) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility', 'Win32_Foundation', 'Win32_System_Com', 'Win32_System_Ole'*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
 pub type LPFNACCESSIBLECHILDREN = ::core::option::Option<unsafe extern "system" fn(pacccontainer: ::core::option::Option<IAccessible>, ichildstart: i32, cchildren: i32, rgvarchildren: *mut super::super::System::Com::VARIANT, pcobtained: *mut i32) -> ::windows::core::HRESULT>;
@@ -22886,8 +23212,14 @@ pub type LPFNLRESULTFROMOBJECT = ::core::option::Option<unsafe extern "system" f
 #[cfg(feature = "Win32_Foundation")]
 pub type LPFNOBJECTFROMLRESULT = ::core::option::Option<unsafe extern "system" fn(lresult: super::super::Foundation::LRESULT, riid: *const ::windows::core::GUID, wparam: super::super::Foundation::WPARAM, ppvobject: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT>;
 pub const LabeledBy_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe5b8924b_fc8a_4a35_8031_cf78ac43e55e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( LabeledBy_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xe5b8924b_fc8a_4a35_8031_cf78ac43e55e) , } }
 pub const LandmarkType_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x454045f2_6f61_49f7_a4f8_b5f0cf82da1e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( LandmarkType_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x454045f2_6f61_49f7_a4f8_b5f0cf82da1e) , } }
 pub const LayoutInvalidated_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xed7d6544_a6bd_4595_9bae_3d28946cc715);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( LayoutInvalidated_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xed7d6544_a6bd_4595_9bae_3d28946cc715) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 #[inline]
 pub unsafe fn LegacyIAccessiblePattern_DoDefaultAction<'a, Param0: ::windows::core::IntoParam<'a, HUIAPATTERNOBJECT>>(hobj: Param0) -> ::windows::core::Result<()> {
@@ -22947,20 +23279,50 @@ pub unsafe fn LegacyIAccessiblePattern_SetValue<'a, Param0: ::windows::core::Int
     unimplemented!("Unsupported target OS");
 }
 pub const LegacyIAccessible_ChildId_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9a191b5d_9ef2_4787_a459_dcde885dd4e8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( LegacyIAccessible_ChildId_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x9a191b5d_9ef2_4787_a459_dcde885dd4e8) , } }
 pub const LegacyIAccessible_DefaultAction_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3b331729_eaad_4502_b85f_92615622913c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( LegacyIAccessible_DefaultAction_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x3b331729_eaad_4502_b85f_92615622913c) , } }
 pub const LegacyIAccessible_Description_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x46448418_7d70_4ea9_9d27_b7e775cf2ad7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( LegacyIAccessible_Description_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x46448418_7d70_4ea9_9d27_b7e775cf2ad7) , } }
 pub const LegacyIAccessible_Help_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x94402352_161c_4b77_a98d_a872cc33947a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( LegacyIAccessible_Help_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x94402352_161c_4b77_a98d_a872cc33947a) , } }
 pub const LegacyIAccessible_KeyboardShortcut_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8f6909ac_00b8_4259_a41c_966266d43a8a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( LegacyIAccessible_KeyboardShortcut_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x8f6909ac_00b8_4259_a41c_966266d43a8a) , } }
 pub const LegacyIAccessible_Name_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcaeb063d_40ae_4869_aa5a_1b8e5d666739);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( LegacyIAccessible_Name_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xcaeb063d_40ae_4869_aa5a_1b8e5d666739) , } }
 pub const LegacyIAccessible_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x54cc0a9f_3395_48af_ba8d_73f85690f3e0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( LegacyIAccessible_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x54cc0a9f_3395_48af_ba8d_73f85690f3e0) , } }
 pub const LegacyIAccessible_Role_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6856e59f_cbaf_4e31_93e8_bcbf6f7e491c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( LegacyIAccessible_Role_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x6856e59f_cbaf_4e31_93e8_bcbf6f7e491c) , } }
 pub const LegacyIAccessible_Selection_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8aa8b1e0_0891_40cc_8b06_90d7d4166219);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( LegacyIAccessible_Selection_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x8aa8b1e0_0891_40cc_8b06_90d7d4166219) , } }
 pub const LegacyIAccessible_State_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdf985854_2281_4340_ab9c_c60e2c5803f6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( LegacyIAccessible_State_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xdf985854_2281_4340_ab9c_c60e2c5803f6) , } }
 pub const LegacyIAccessible_Value_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb5c5b0b6_8217_4a77_97a5_190a85ed0156);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( LegacyIAccessible_Value_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xb5c5b0b6_8217_4a77_97a5_190a85ed0156) , } }
 pub const Level_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x242ac529_cd36_400f_aad9_7876ef3af627);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Level_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x242ac529_cd36_400f_aad9_7876ef3af627) , } }
 pub const ListItem_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7b3717f2_44d1_4a58_98a8_f12a9b8f78e2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ListItem_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x7b3717f2_44d1_4a58_98a8_f12a9b8f78e2) , } }
 pub const List_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9b149ee1_7cca_4cfc_9af1_cac7bddd3031);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( List_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x9b149ee1_7cca_4cfc_9af1_cac7bddd3031) , } }
 pub const LiveRegionChanged_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x102d5e90_e6a9_41b6_b1c5_a9b1929d9510);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( LiveRegionChanged_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x102d5e90_e6a9_41b6_b1c5_a9b1929d9510) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub type LiveSetting = i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -22970,8 +23332,14 @@ pub const Polite: LiveSetting = 1i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const Assertive: LiveSetting = 2i32;
 pub const LiveSetting_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc12bcd8e_2a8e_4950_8ae7_3625111d58eb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( LiveSetting_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xc12bcd8e_2a8e_4950_8ae7_3625111d58eb) , } }
 pub const LocalizedControlType_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8763404f_a1bd_452a_89c4_3f01d3833806);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( LocalizedControlType_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x8763404f_a1bd_452a_89c4_3f01d3833806) , } }
 pub const LocalizedLandmarkType_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7ac81980_eafb_4fb2_bf91_f485bef5e8e1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( LocalizedLandmarkType_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x7ac81980_eafb_4fb2_bf91_f485bef5e8e1) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
@@ -23066,12 +23434,26 @@ impl ::core::default::Default for MSAAMENUINFO {
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const MSAA_MENU_SIG: i32 = -1441927155i32;
 pub const MenuBar_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcc384250_0e7b_4ae8_95ae_a08f261b52ee);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( MenuBar_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xcc384250_0e7b_4ae8_95ae_a08f261b52ee) , } }
 pub const MenuClosed_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3cf1266e_1582_4041_acd7_88a35a965297);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( MenuClosed_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x3cf1266e_1582_4041_acd7_88a35a965297) , } }
 pub const MenuItem_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf45225d3_d0a0_49d8_9834_9a000d2aeddc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( MenuItem_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xf45225d3_d0a0_49d8_9834_9a000d2aeddc) , } }
 pub const MenuModeEnd_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9ecd4c9f_80dd_47b8_8267_5aec06bb2cff);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( MenuModeEnd_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x9ecd4c9f_80dd_47b8_8267_5aec06bb2cff) , } }
 pub const MenuModeStart_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x18d7c631_166a_4ac9_ae3b_ef4b5420e681);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( MenuModeStart_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x18d7c631_166a_4ac9_ae3b_ef4b5420e681) , } }
 pub const MenuOpened_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xebe2e945_66ca_4ed1_9ff8_2ad7df0a1b08);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( MenuOpened_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xebe2e945_66ca_4ed1_9ff8_2ad7df0a1b08) , } }
 pub const Menu_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2e9b1440_0ea8_41fd_b374_c1ea6f503cd1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Menu_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x2e9b1440_0ea8_41fd_b374_c1ea6f503cd1) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
@@ -23102,8 +23484,14 @@ pub unsafe fn MultipleViewPattern_SetCurrentView<'a, Param0: ::windows::core::In
     unimplemented!("Unsupported target OS");
 }
 pub const MultipleView_CurrentView_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7a81a67a_b94f_4875_918b_65c8d2f998e5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( MultipleView_CurrentView_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x7a81a67a_b94f_4875_918b_65c8d2f998e5) , } }
 pub const MultipleView_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x547a6ae4_113f_47c4_850f_db4dfa466b1d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( MultipleView_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x547a6ae4_113f_47c4_850f_db4dfa466b1d) , } }
 pub const MultipleView_SupportedViews_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8d5db9fd_ce3c_4ae7_b788_400a3c645547);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( MultipleView_SupportedViews_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x8d5db9fd_ce3c_4ae7_b788_400a3c645547) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const NAVDIR_DOWN: u32 = 2u32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -23125,6 +23513,8 @@ pub const NAVDIR_RIGHT: u32 = 4u32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const NAVDIR_UP: u32 = 1u32;
 pub const Name_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc3a6921b_4a99_44f1_bca6_61187052c431);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Name_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xc3a6921b_4a99_44f1_bca6_61187052c431) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub type NavigateDirection = i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -23138,6 +23528,8 @@ pub const NavigateDirection_FirstChild: NavigateDirection = 3i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const NavigateDirection_LastChild: NavigateDirection = 4i32;
 pub const NewNativeWindowHandle_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5196b33b_380a_4982_95e1_91f3ef60e024);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( NewNativeWindowHandle_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x5196b33b_380a_4982_95e1_91f3ef60e024) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub type NormalizeState = i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -23171,6 +23563,8 @@ pub const NotificationProcessing_MostRecent: NotificationProcessing = 3i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const NotificationProcessing_CurrentThenMostRecent: NotificationProcessing = 4i32;
 pub const Notification_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x72c5a2f7_9788_480f_b8eb_4dee00f6186f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Notification_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x72c5a2f7_9788_480f_b8eb_4dee00f6186f) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
@@ -23202,7 +23596,11 @@ pub unsafe fn ObjectFromLresult<'a, Param0: ::windows::core::IntoParam<'a, super
     unimplemented!("Unsupported target OS");
 }
 pub const ObjectModel_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3e04acfe_08fc_47ec_96bc_353fa3b34aa7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ObjectModel_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x3e04acfe_08fc_47ec_96bc_353fa3b34aa7) , } }
 pub const OptimizeForVisualContent_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6a852250_c75a_4e5d_b858_e381b0f78861);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( OptimizeForVisualContent_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x6a852250_c75a_4e5d_b858_e381b0f78861) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub type OrientationType = i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -23212,7 +23610,11 @@ pub const OrientationType_Horizontal: OrientationType = 1i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const OrientationType_Vertical: OrientationType = 2i32;
 pub const Orientation_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa01eee62_3884_4415_887e_678ec21e39ba);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Orientation_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xa01eee62_3884_4415_887e_678ec21e39ba) , } }
 pub const OutlineColor_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc395d6c0_4b55_4762_a073_fd303a634f52);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( OutlineColor_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xc395d6c0_4b55_4762_a073_fd303a634f52) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub type OutlineStyles = i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -23226,35 +23628,95 @@ pub const OutlineStyles_Engraved: OutlineStyles = 4i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const OutlineStyles_Embossed: OutlineStyles = 8i32;
 pub const OutlineThickness_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x13e67cc7_dac2_4888_bdd3_375c62fa9618);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( OutlineThickness_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x13e67cc7_dac2_4888_bdd3_375c62fa9618) , } }
 pub const PROPID_ACC_DEFAULTACTION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x180c072b_c27f_43c7_9922_f63562a4632b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROPID_ACC_DEFAULTACTION ) , guid : :: windows :: core :: GUID::from_u128(0x180c072b_c27f_43c7_9922_f63562a4632b) , } }
 pub const PROPID_ACC_DESCRIPTION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4d48dfe4_bd3f_491f_a648_492d6f20c588);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROPID_ACC_DESCRIPTION ) , guid : :: windows :: core :: GUID::from_u128(0x4d48dfe4_bd3f_491f_a648_492d6f20c588) , } }
 pub const PROPID_ACC_DESCRIPTIONMAP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1ff1435f_8a14_477b_b226_a0abe279975d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROPID_ACC_DESCRIPTIONMAP ) , guid : :: windows :: core :: GUID::from_u128(0x1ff1435f_8a14_477b_b226_a0abe279975d) , } }
 pub const PROPID_ACC_DODEFAULTACTION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1ba09523_2e3b_49a6_a059_59682a3c48fd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROPID_ACC_DODEFAULTACTION ) , guid : :: windows :: core :: GUID::from_u128(0x1ba09523_2e3b_49a6_a059_59682a3c48fd) , } }
 pub const PROPID_ACC_FOCUS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6eb335df_1c29_4127_b12c_dee9fd157f2b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROPID_ACC_FOCUS ) , guid : :: windows :: core :: GUID::from_u128(0x6eb335df_1c29_4127_b12c_dee9fd157f2b) , } }
 pub const PROPID_ACC_HELP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc831e11f_44db_4a99_9768_cb8f978b7231);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROPID_ACC_HELP ) , guid : :: windows :: core :: GUID::from_u128(0xc831e11f_44db_4a99_9768_cb8f978b7231) , } }
 pub const PROPID_ACC_HELPTOPIC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x787d1379_8ede_440b_8aec_11f7bf9030b3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROPID_ACC_HELPTOPIC ) , guid : :: windows :: core :: GUID::from_u128(0x787d1379_8ede_440b_8aec_11f7bf9030b3) , } }
 pub const PROPID_ACC_KEYBOARDSHORTCUT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7d9bceee_7d1e_4979_9382_5180f4172c34);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROPID_ACC_KEYBOARDSHORTCUT ) , guid : :: windows :: core :: GUID::from_u128(0x7d9bceee_7d1e_4979_9382_5180f4172c34) , } }
 pub const PROPID_ACC_NAME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x608d3df8_8128_4aa7_a428_f55e49267291);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROPID_ACC_NAME ) , guid : :: windows :: core :: GUID::from_u128(0x608d3df8_8128_4aa7_a428_f55e49267291) , } }
 pub const PROPID_ACC_NAV_DOWN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x031670ed_3cdf_48d2_9613_138f2dd8a668);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROPID_ACC_NAV_DOWN ) , guid : :: windows :: core :: GUID::from_u128(0x031670ed_3cdf_48d2_9613_138f2dd8a668) , } }
 pub const PROPID_ACC_NAV_FIRSTCHILD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcfd02558_557b_4c67_84f9_2a09fce40749);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROPID_ACC_NAV_FIRSTCHILD ) , guid : :: windows :: core :: GUID::from_u128(0xcfd02558_557b_4c67_84f9_2a09fce40749) , } }
 pub const PROPID_ACC_NAV_LASTCHILD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x302ecaa5_48d5_4f8d_b671_1a8d20a77832);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROPID_ACC_NAV_LASTCHILD ) , guid : :: windows :: core :: GUID::from_u128(0x302ecaa5_48d5_4f8d_b671_1a8d20a77832) , } }
 pub const PROPID_ACC_NAV_LEFT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x228086cb_82f1_4a39_8705_dcdc0fff92f5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROPID_ACC_NAV_LEFT ) , guid : :: windows :: core :: GUID::from_u128(0x228086cb_82f1_4a39_8705_dcdc0fff92f5) , } }
 pub const PROPID_ACC_NAV_NEXT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1cdc5455_8cd9_4c92_a371_3939a2fe3eee);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROPID_ACC_NAV_NEXT ) , guid : :: windows :: core :: GUID::from_u128(0x1cdc5455_8cd9_4c92_a371_3939a2fe3eee) , } }
 pub const PROPID_ACC_NAV_PREV: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x776d3891_c73b_4480_b3f6_076a16a15af6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROPID_ACC_NAV_PREV ) , guid : :: windows :: core :: GUID::from_u128(0x776d3891_c73b_4480_b3f6_076a16a15af6) , } }
 pub const PROPID_ACC_NAV_RIGHT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcd211d9f_e1cb_4fe5_a77c_920b884d095b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROPID_ACC_NAV_RIGHT ) , guid : :: windows :: core :: GUID::from_u128(0xcd211d9f_e1cb_4fe5_a77c_920b884d095b) , } }
 pub const PROPID_ACC_NAV_UP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x016e1a2b_1a4e_4767_8612_3386f66935ec);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROPID_ACC_NAV_UP ) , guid : :: windows :: core :: GUID::from_u128(0x016e1a2b_1a4e_4767_8612_3386f66935ec) , } }
 pub const PROPID_ACC_PARENT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x474c22b6_ffc2_467a_b1b5_e958b4657330);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROPID_ACC_PARENT ) , guid : :: windows :: core :: GUID::from_u128(0x474c22b6_ffc2_467a_b1b5_e958b4657330) , } }
 pub const PROPID_ACC_ROLE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcb905ff2_7bd1_4c05_b3c8_e6c241364d70);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROPID_ACC_ROLE ) , guid : :: windows :: core :: GUID::from_u128(0xcb905ff2_7bd1_4c05_b3c8_e6c241364d70) , } }
 pub const PROPID_ACC_ROLEMAP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf79acda2_140d_4fe6_8914_208476328269);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROPID_ACC_ROLEMAP ) , guid : :: windows :: core :: GUID::from_u128(0xf79acda2_140d_4fe6_8914_208476328269) , } }
 pub const PROPID_ACC_SELECTION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb99d073c_d731_405b_9061_d95e8f842984);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROPID_ACC_SELECTION ) , guid : :: windows :: core :: GUID::from_u128(0xb99d073c_d731_405b_9061_d95e8f842984) , } }
 pub const PROPID_ACC_STATE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa8d4d5b0_0a21_42d0_a5c0_514e984f457b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROPID_ACC_STATE ) , guid : :: windows :: core :: GUID::from_u128(0xa8d4d5b0_0a21_42d0_a5c0_514e984f457b) , } }
 pub const PROPID_ACC_STATEMAP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x43946c5e_0ac0_4042_b525_07bbdbe17fa7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROPID_ACC_STATEMAP ) , guid : :: windows :: core :: GUID::from_u128(0x43946c5e_0ac0_4042_b525_07bbdbe17fa7) , } }
 pub const PROPID_ACC_VALUE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x123fe443_211a_4615_9527_c45a7e93717a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROPID_ACC_VALUE ) , guid : :: windows :: core :: GUID::from_u128(0x123fe443_211a_4615_9527_c45a7e93717a) , } }
 pub const PROPID_ACC_VALUEMAP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xda1c3d79_fc5c_420e_b399_9d1533549e75);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PROPID_ACC_VALUEMAP ) , guid : :: windows :: core :: GUID::from_u128(0xda1c3d79_fc5c_420e_b399_9d1533549e75) , } }
 pub const Pane_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5c2b3f5b_9182_42a3_8dec_8c04c1ee634d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Pane_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x5c2b3f5b_9182_42a3_8dec_8c04c1ee634d) , } }
 pub const PositionInSet_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x33d1dc54_641e_4d76_a6b1_13f341c1f896);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( PositionInSet_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x33d1dc54_641e_4d76_a6b1_13f341c1f896) , } }
 pub const ProcessId_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x40499998_9c31_4245_a403_87320e59eaf6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ProcessId_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x40499998_9c31_4245_a403_87320e59eaf6) , } }
 pub const ProgressBar_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x228c9f86_c36c_47bb_9fb6_a5834bfc53a4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ProgressBar_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x228c9f86_c36c_47bb_9fb6_a5834bfc53a4) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub type PropertyConditionFlags = i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -23264,6 +23726,8 @@ pub const PropertyConditionFlags_IgnoreCase: PropertyConditionFlags = 1i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const PropertyConditionFlags_MatchSubstring: PropertyConditionFlags = 2i32;
 pub const ProviderDescription_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdca5708a_c16b_4cd9_b889_beb16a804904);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ProviderDescription_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xdca5708a_c16b_4cd9_b889_beb16a804904) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub type ProviderOptions = i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -23421,6 +23885,8 @@ pub const ROLE_SYSTEM_WHITESPACE: u32 = 59u32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const ROLE_SYSTEM_WINDOW: u32 = 9u32;
 pub const RadioButton_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3bdb49db_fe2c_4483_b3e1_e57f219440c6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( RadioButton_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x3bdb49db_fe2c_4483_b3e1_e57f219440c6) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 #[inline]
 pub unsafe fn RangeValuePattern_SetValue<'a, Param0: ::windows::core::IntoParam<'a, HUIAPATTERNOBJECT>>(hobj: Param0, val: f64) -> ::windows::core::Result<()> {
@@ -23436,12 +23902,26 @@ pub unsafe fn RangeValuePattern_SetValue<'a, Param0: ::windows::core::IntoParam<
     unimplemented!("Unsupported target OS");
 }
 pub const RangeValue_IsReadOnly_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x25fa1055_debf_4373_a79e_1f1a1908d3c4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( RangeValue_IsReadOnly_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x25fa1055_debf_4373_a79e_1f1a1908d3c4) , } }
 pub const RangeValue_LargeChange_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa1f96325_3a3d_4b44_8e1f_4a46d9844019);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( RangeValue_LargeChange_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xa1f96325_3a3d_4b44_8e1f_4a46d9844019) , } }
 pub const RangeValue_Maximum_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x19319914_f979_4b35_a1a6_d37e05433473);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( RangeValue_Maximum_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x19319914_f979_4b35_a1a6_d37e05433473) , } }
 pub const RangeValue_Minimum_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x78cbd3b2_684d_4860_af93_d1f95cb022fd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( RangeValue_Minimum_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x78cbd3b2_684d_4860_af93_d1f95cb022fd) , } }
 pub const RangeValue_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x18b00d87_b1c9_476a_bfbd_5f0bdb926f63);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( RangeValue_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x18b00d87_b1c9_476a_bfbd_5f0bdb926f63) , } }
 pub const RangeValue_SmallChange_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x81c2c457_3941_4107_9975_139760f7c072);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( RangeValue_SmallChange_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x81c2c457_3941_4107_9975_139760f7c072) , } }
 pub const RangeValue_Value_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x131f5d98_c50c_489d_abe5_ae220898c5f7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( RangeValue_Value_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x131f5d98_c50c_489d_abe5_ae220898c5f7) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility', 'Win32_Foundation', 'Win32_UI_WindowsAndMessaging'*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_UI_WindowsAndMessaging"))]
 #[inline]
@@ -23473,6 +23953,8 @@ pub unsafe fn RegisterPointerInputTargetEx<'a, Param0: ::windows::core::IntoPara
     unimplemented!("Unsupported target OS");
 }
 pub const Rotation_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x767cdc7d_aec0_4110_ad32_30edd403492e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Rotation_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x767cdc7d_aec0_4110_ad32_30edd403492e) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub type RowOrColumnMajor = i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -23482,6 +23964,8 @@ pub const RowOrColumnMajor_ColumnMajor: RowOrColumnMajor = 1i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const RowOrColumnMajor_Indeterminate: RowOrColumnMajor = 2i32;
 pub const RuntimeId_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa39eebfa_7fba_4c89_b4d4_b99e2de7d160);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( RuntimeId_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xa39eebfa_7fba_4c89_b4d4_b99e2de7d160) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const SELFLAG_ADDSELECTION: u32 = 8u32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -23593,7 +24077,11 @@ pub const SERKF_INDICATOR: SERIALKEYS_FLAGS = 4u32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const SERKF_SERIALKEYSON: SERIALKEYS_FLAGS = 1u32;
 pub const SID_ControlElementProvider: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf4791d68_e254_4ba3_9a53_26a5c5497946);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SID_ControlElementProvider ) , guid : :: windows :: core :: GUID::from_u128(0xf4791d68_e254_4ba3_9a53_26a5c5497946) , } }
 pub const SID_IsUIAutomationObject: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb96fdb85_7204_4724_842b_c7059dedb9d0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SID_IsUIAutomationObject ) , guid : :: windows :: core :: GUID::from_u128(0xb96fdb85_7204_4724_842b_c7059dedb9d0) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_UI_Accessibility', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
@@ -23910,6 +24398,8 @@ pub const ScrollAmount_LargeIncrement: ScrollAmount = 3i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const ScrollAmount_SmallIncrement: ScrollAmount = 4i32;
 pub const ScrollBar_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdaf34b36_5065_4946_b22f_92595fc0751a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ScrollBar_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xdaf34b36_5065_4946_b22f_92595fc0751a) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 #[inline]
 pub unsafe fn ScrollItemPattern_ScrollIntoView<'a, Param0: ::windows::core::IntoParam<'a, HUIAPATTERNOBJECT>>(hobj: Param0) -> ::windows::core::Result<()> {
@@ -23925,6 +24415,8 @@ pub unsafe fn ScrollItemPattern_ScrollIntoView<'a, Param0: ::windows::core::Into
     unimplemented!("Unsupported target OS");
 }
 pub const ScrollItem_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4591d005_a803_4d5c_b4d5_8d2800f906a7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ScrollItem_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x4591d005_a803_4d5c_b4d5_8d2800f906a7) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 #[inline]
 pub unsafe fn ScrollPattern_Scroll<'a, Param0: ::windows::core::IntoParam<'a, HUIAPATTERNOBJECT>>(hobj: Param0, horizontalamount: ScrollAmount, verticalamount: ScrollAmount) -> ::windows::core::Result<()> {
@@ -23954,16 +24446,38 @@ pub unsafe fn ScrollPattern_SetScrollPercent<'a, Param0: ::windows::core::IntoPa
     unimplemented!("Unsupported target OS");
 }
 pub const Scroll_HorizontalScrollPercent_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc7c13c0e_eb21_47ff_acc4_b5a3350f5191);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Scroll_HorizontalScrollPercent_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xc7c13c0e_eb21_47ff_acc4_b5a3350f5191) , } }
 pub const Scroll_HorizontalViewSize_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x70c2e5d4_fcb0_4713_a9aa_af92ff79e4cd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Scroll_HorizontalViewSize_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x70c2e5d4_fcb0_4713_a9aa_af92ff79e4cd) , } }
 pub const Scroll_HorizontallyScrollable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8b925147_28cd_49ae_bd63_f44118d2e719);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Scroll_HorizontallyScrollable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x8b925147_28cd_49ae_bd63_f44118d2e719) , } }
 pub const Scroll_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x895fa4b4_759d_4c50_8e15_03460672003c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Scroll_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x895fa4b4_759d_4c50_8e15_03460672003c) , } }
 pub const Scroll_VerticalScrollPercent_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6c8d7099_b2a8_4948_bff7_3cf9058bfefb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Scroll_VerticalScrollPercent_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x6c8d7099_b2a8_4948_bff7_3cf9058bfefb) , } }
 pub const Scroll_VerticalViewSize_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xde6a2e22_d8c7_40c5_83ba_e5f681d53108);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Scroll_VerticalViewSize_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xde6a2e22_d8c7_40c5_83ba_e5f681d53108) , } }
 pub const Scroll_VerticallyScrollable_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x89164798_0068_4315_b89a_1e7cfbbc3dfc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Scroll_VerticallyScrollable_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x89164798_0068_4315_b89a_1e7cfbbc3dfc) , } }
 pub const Selection2_CurrentSelectedItem_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x34257c26_83b5_41a6_939c_ae841c136236);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Selection2_CurrentSelectedItem_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x34257c26_83b5_41a6_939c_ae841c136236) , } }
 pub const Selection2_FirstSelectedItem_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcc24ea67_369c_4e55_9ff7_38da69540c29);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Selection2_FirstSelectedItem_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xcc24ea67_369c_4e55_9ff7_38da69540c29) , } }
 pub const Selection2_ItemCount_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbb49eb9f_456d_4048_b591_9c2026b84636);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Selection2_ItemCount_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xbb49eb9f_456d_4048_b591_9c2026b84636) , } }
 pub const Selection2_LastSelectedItem_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcf7bda90_2d83_49f8_860c_9ce394cf89b4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Selection2_LastSelectedItem_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xcf7bda90_2d83_49f8_860c_9ce394cf89b4) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 #[inline]
 pub unsafe fn SelectionItemPattern_AddToSelection<'a, Param0: ::windows::core::IntoParam<'a, HUIAPATTERNOBJECT>>(hobj: Param0) -> ::windows::core::Result<()> {
@@ -24007,19 +24521,47 @@ pub unsafe fn SelectionItemPattern_Select<'a, Param0: ::windows::core::IntoParam
     unimplemented!("Unsupported target OS");
 }
 pub const SelectionItem_ElementAddedToSelectionEvent_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3c822dd1_c407_4dba_91dd_79d4aed0aec6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SelectionItem_ElementAddedToSelectionEvent_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x3c822dd1_c407_4dba_91dd_79d4aed0aec6) , } }
 pub const SelectionItem_ElementRemovedFromSelectionEvent_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x097fa8a9_7079_41af_8b9c_0934d8305e5c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SelectionItem_ElementRemovedFromSelectionEvent_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x097fa8a9_7079_41af_8b9c_0934d8305e5c) , } }
 pub const SelectionItem_ElementSelectedEvent_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb9c7dbfb_4ebe_4532_aaf4_008cf647233c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SelectionItem_ElementSelectedEvent_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xb9c7dbfb_4ebe_4532_aaf4_008cf647233c) , } }
 pub const SelectionItem_IsSelected_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf122835f_cd5f_43df_b79d_4b849e9e6020);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SelectionItem_IsSelected_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xf122835f_cd5f_43df_b79d_4b849e9e6020) , } }
 pub const SelectionItem_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9bc64eeb_87c7_4b28_94bb_4d9fa437b6ef);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SelectionItem_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x9bc64eeb_87c7_4b28_94bb_4d9fa437b6ef) , } }
 pub const SelectionItem_SelectionContainer_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa4365b6e_9c1e_4b63_8b53_c2421dd1e8fb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SelectionItem_SelectionContainer_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xa4365b6e_9c1e_4b63_8b53_c2421dd1e8fb) , } }
 pub const Selection_CanSelectMultiple_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x49d73da5_c883_4500_883d_8fcf8daf6cbe);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Selection_CanSelectMultiple_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x49d73da5_c883_4500_883d_8fcf8daf6cbe) , } }
 pub const Selection_InvalidatedEvent_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcac14904_16b4_4b53_8e47_4cb1df267bb7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Selection_InvalidatedEvent_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xcac14904_16b4_4b53_8e47_4cb1df267bb7) , } }
 pub const Selection_IsSelectionRequired_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb1ae4422_63fe_44e7_a5a5_a738c829b19a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Selection_IsSelectionRequired_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xb1ae4422_63fe_44e7_a5a5_a738c829b19a) , } }
 pub const Selection_Pattern2_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfba25cab_ab98_49f7_a7dc_fe539dc15be7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Selection_Pattern2_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xfba25cab_ab98_49f7_a7dc_fe539dc15be7) , } }
 pub const Selection_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x66e3b7e8_d821_4d25_8761_435d2c8b253f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Selection_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x66e3b7e8_d821_4d25_8761_435d2c8b253f) , } }
 pub const Selection_Selection_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaa6dc2a2_0e2b_4d38_96d5_34e470b81853);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Selection_Selection_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xaa6dc2a2_0e2b_4d38_96d5_34e470b81853) , } }
 pub const SemanticZoom_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5fd34a43_061e_42c8_b589_9dccf74bc43a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SemanticZoom_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x5fd34a43_061e_42c8_b589_9dccf74bc43a) , } }
 pub const Separator_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8767eba3_2a63_4ab0_ac8d_aa50e23de978);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Separator_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x8767eba3_2a63_4ab0_ac8d_aa50e23de978) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
@@ -24036,16 +24578,38 @@ pub unsafe fn SetWinEventHook<'a, Param2: ::windows::core::IntoParam<'a, super::
     unimplemented!("Unsupported target OS");
 }
 pub const SizeOfSet_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1600d33c_3b9f_4369_9431_aa293f344cf1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SizeOfSet_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x1600d33c_3b9f_4369_9431_aa293f344cf1) , } }
 pub const Size_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2b5f761d_f885_4404_973f_9b1d98e36d8f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Size_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x2b5f761d_f885_4404_973f_9b1d98e36d8f) , } }
 pub const Slider_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb033c24b_3b35_4cea_b609_763682fa660b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Slider_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xb033c24b_3b35_4cea_b609_763682fa660b) , } }
 pub const Spinner_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x60cc4b38_3cb1_4161_b442_c6b726c17825);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Spinner_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x60cc4b38_3cb1_4161_b442_c6b726c17825) , } }
 pub const SplitButton_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7011f01f_4ace_4901_b461_920a6f1ca650);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SplitButton_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x7011f01f_4ace_4901_b461_920a6f1ca650) , } }
 pub const SpreadsheetItem_AnnotationObjects_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa3194c38_c9bc_4604_9396_ae3f9f457f7b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SpreadsheetItem_AnnotationObjects_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xa3194c38_c9bc_4604_9396_ae3f9f457f7b) , } }
 pub const SpreadsheetItem_AnnotationTypes_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc70c51d0_d602_4b45_afbc_b4712b96d72b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SpreadsheetItem_AnnotationTypes_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xc70c51d0_d602_4b45_afbc_b4712b96d72b) , } }
 pub const SpreadsheetItem_Formula_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe602e47d_1b47_4bea_87cf_3b0b0b5c15b6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SpreadsheetItem_Formula_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xe602e47d_1b47_4bea_87cf_3b0b0b5c15b6) , } }
 pub const SpreadsheetItem_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x32cf83ff_f1a8_4a8c_8658_d47ba74e20ba);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SpreadsheetItem_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x32cf83ff_f1a8_4a8c_8658_d47ba74e20ba) , } }
 pub const Spreadsheet_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6a5b24c9_9d1e_4b85_9e44_c02e3169b10b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Spreadsheet_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x6a5b24c9_9d1e_4b85_9e44_c02e3169b10b) , } }
 pub const StatusBar_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd45e7d1b_5873_475f_95a4_0433e1f1b00a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( StatusBar_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xd45e7d1b_5873_475f_95a4_0433e1f1b00a) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub type StructureChangeType = i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -24061,69 +24625,129 @@ pub const StructureChangeType_ChildrenBulkRemoved: StructureChangeType = 4i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const StructureChangeType_ChildrenReordered: StructureChangeType = 5i32;
 pub const StructureChanged_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x59977961_3edd_4b11_b13b_676b2a2a6ca9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( StructureChanged_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x59977961_3edd_4b11_b13b_676b2a2a6ca9) , } }
 pub const StructuredMarkup_CompositionComplete_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc48a3c17_677a_4047_a68d_fc1257528aef);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( StructuredMarkup_CompositionComplete_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xc48a3c17_677a_4047_a68d_fc1257528aef) , } }
 pub const StructuredMarkup_Deleted_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf9d0a020_e1c1_4ecf_b9aa_52efde7e41e1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( StructuredMarkup_Deleted_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xf9d0a020_e1c1_4ecf_b9aa_52efde7e41e1) , } }
 pub const StructuredMarkup_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xabbd0878_8665_4f5c_94fc_36e7d8bb706b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( StructuredMarkup_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xabbd0878_8665_4f5c_94fc_36e7d8bb706b) , } }
 pub const StructuredMarkup_SelectionChanged_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa7c815f7_ff9f_41c7_a3a7_ab6cbfdb4903);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( StructuredMarkup_SelectionChanged_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xa7c815f7_ff9f_41c7_a3a7_ab6cbfdb4903) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const StyleId_BulletedList: i32 = 70015i32;
 pub const StyleId_BulletedList_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5963ed64_6426_4632_8caf_a32ad402d91a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( StyleId_BulletedList_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x5963ed64_6426_4632_8caf_a32ad402d91a) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const StyleId_Custom: i32 = 70000i32;
 pub const StyleId_Custom_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xef2edd3e_a999_4b7c_a378_09bbd52a3516);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( StyleId_Custom_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xef2edd3e_a999_4b7c_a378_09bbd52a3516) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const StyleId_Emphasis: i32 = 70013i32;
 pub const StyleId_Emphasis_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xca6e7dbe_355e_4820_95a0_925f041d3470);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( StyleId_Emphasis_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xca6e7dbe_355e_4820_95a0_925f041d3470) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const StyleId_Heading1: i32 = 70001i32;
 pub const StyleId_Heading1_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7f7e8f69_6866_4621_930c_9a5d0ca5961c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( StyleId_Heading1_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x7f7e8f69_6866_4621_930c_9a5d0ca5961c) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const StyleId_Heading2: i32 = 70002i32;
 pub const StyleId_Heading2_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbaa9b241_5c69_469d_85ad_474737b52b14);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( StyleId_Heading2_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xbaa9b241_5c69_469d_85ad_474737b52b14) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const StyleId_Heading3: i32 = 70003i32;
 pub const StyleId_Heading3_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbf8be9d2_d8b8_4ec5_8c52_9cfb0d035970);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( StyleId_Heading3_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xbf8be9d2_d8b8_4ec5_8c52_9cfb0d035970) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const StyleId_Heading4: i32 = 70004i32;
 pub const StyleId_Heading4_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8436ffc0_9578_45fc_83a4_ff40053315dd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( StyleId_Heading4_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x8436ffc0_9578_45fc_83a4_ff40053315dd) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const StyleId_Heading5: i32 = 70005i32;
 pub const StyleId_Heading5_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x909f424d_0dbf_406e_97bb_4e773d9798f7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( StyleId_Heading5_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x909f424d_0dbf_406e_97bb_4e773d9798f7) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const StyleId_Heading6: i32 = 70006i32;
 pub const StyleId_Heading6_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x89d23459_5d5b_4824_a420_11d3ed82e40f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( StyleId_Heading6_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x89d23459_5d5b_4824_a420_11d3ed82e40f) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const StyleId_Heading7: i32 = 70007i32;
 pub const StyleId_Heading7_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa3790473_e9ae_422d_b8e3_3b675c6181a4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( StyleId_Heading7_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xa3790473_e9ae_422d_b8e3_3b675c6181a4) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const StyleId_Heading8: i32 = 70008i32;
 pub const StyleId_Heading8_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2bc14145_a40c_4881_84ae_f2235685380c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( StyleId_Heading8_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x2bc14145_a40c_4881_84ae_f2235685380c) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const StyleId_Heading9: i32 = 70009i32;
 pub const StyleId_Heading9_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc70d9133_bb2a_43d3_8ac6_33657884b0f0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( StyleId_Heading9_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xc70d9133_bb2a_43d3_8ac6_33657884b0f0) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const StyleId_Normal: i32 = 70012i32;
 pub const StyleId_Normal_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcd14d429_e45e_4475_a1c5_7f9e6be96eba);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( StyleId_Normal_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xcd14d429_e45e_4475_a1c5_7f9e6be96eba) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const StyleId_NumberedList: i32 = 70016i32;
 pub const StyleId_NumberedList_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1e96dbd5_64c3_43d0_b1ee_b53b06e3eddf);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( StyleId_NumberedList_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x1e96dbd5_64c3_43d0_b1ee_b53b06e3eddf) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const StyleId_Quote: i32 = 70014i32;
 pub const StyleId_Quote_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5d1c21ea_8195_4f6c_87ea_5dabece64c1d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( StyleId_Quote_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x5d1c21ea_8195_4f6c_87ea_5dabece64c1d) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const StyleId_Subtitle: i32 = 70011i32;
 pub const StyleId_Subtitle_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb5d9fc17_5d6f_4420_b439_7cb19ad434e2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( StyleId_Subtitle_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xb5d9fc17_5d6f_4420_b439_7cb19ad434e2) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const StyleId_Title: i32 = 70010i32;
 pub const StyleId_Title_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x15d8201a_ffcf_481f_b0a1_30b63be98f07);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( StyleId_Title_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x15d8201a_ffcf_481f_b0a1_30b63be98f07) , } }
 pub const Styles_ExtendedProperties_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf451cda0_ba0a_4681_b0b0_0dbdb53e58f3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Styles_ExtendedProperties_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xf451cda0_ba0a_4681_b0b0_0dbdb53e58f3) , } }
 pub const Styles_FillColor_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x63eff97a_a1c5_4b1d_84eb_b765f2edd632);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Styles_FillColor_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x63eff97a_a1c5_4b1d_84eb_b765f2edd632) , } }
 pub const Styles_FillPatternColor_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x939a59fe_8fbd_4e75_a271_ac4595195163);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Styles_FillPatternColor_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x939a59fe_8fbd_4e75_a271_ac4595195163) , } }
 pub const Styles_FillPatternStyle_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x81cf651f_482b_4451_a30a_e1545e554fb8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Styles_FillPatternStyle_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x81cf651f_482b_4451_a30a_e1545e554fb8) , } }
 pub const Styles_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1ae62655_da72_4d60_a153_e5aa6988e3bf);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Styles_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x1ae62655_da72_4d60_a153_e5aa6988e3bf) , } }
 pub const Styles_Shape_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc71a23f8_778c_400d_8458_3b543e526984);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Styles_Shape_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xc71a23f8_778c_400d_8458_3b543e526984) , } }
 pub const Styles_StyleId_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xda82852f_3817_4233_82af_02279e72cc77);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Styles_StyleId_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xda82852f_3817_4233_82af_02279e72cc77) , } }
 pub const Styles_StyleName_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1c12b035_05d1_4f55_9e8e_1489f3ff550d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Styles_StyleName_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x1c12b035_05d1_4f55_9e8e_1489f3ff550d) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub type SupportedTextSelection = i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -24175,7 +24799,11 @@ pub const SynchronizedInputType_RightMouseUp: SynchronizedInputType = 16i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const SynchronizedInputType_RightMouseDown: SynchronizedInputType = 32i32;
 pub const SynchronizedInput_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x05c288a6_c47b_488b_b653_33977a551b8b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SynchronizedInput_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x05c288a6_c47b_488b_b653_33977a551b8b) , } }
 pub const SystemAlert_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd271545d_7a3a_47a7_8474_81d29a2451c9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( SystemAlert_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xd271545d_7a3a_47a7_8474_81d29a2451c9) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub struct TOGGLEKEYS {
@@ -24208,16 +24836,38 @@ impl ::core::default::Default for TOGGLEKEYS {
     }
 }
 pub const TabItem_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2c6a634f_921b_4e6e_b26e_08fcb0798f4c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TabItem_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x2c6a634f_921b_4e6e_b26e_08fcb0798f4c) , } }
 pub const Tab_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x38cd1f2d_337a_4bd2_a5e3_adb469e30bd3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Tab_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x38cd1f2d_337a_4bd2_a5e3_adb469e30bd3) , } }
 pub const TableItem_ColumnHeaderItems_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x967a56a3_74b6_431e_8de6_99c411031c58);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TableItem_ColumnHeaderItems_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x967a56a3_74b6_431e_8de6_99c411031c58) , } }
 pub const TableItem_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdf1343bd_1888_4a29_a50c_b92e6de37f6f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TableItem_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xdf1343bd_1888_4a29_a50c_b92e6de37f6f) , } }
 pub const TableItem_RowHeaderItems_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb3f853a0_0574_4cd8_bcd7_ed5923572d97);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TableItem_RowHeaderItems_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xb3f853a0_0574_4cd8_bcd7_ed5923572d97) , } }
 pub const Table_ColumnHeaders_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaff1d72b_968d_42b1_b459_150b299da664);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Table_ColumnHeaders_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xaff1d72b_968d_42b1_b459_150b299da664) , } }
 pub const Table_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x773bfa0e_5bc4_4deb_921b_de7b3206229e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Table_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x773bfa0e_5bc4_4deb_921b_de7b3206229e) , } }
 pub const Table_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc415218e_a028_461e_aa92_8f925cf79351);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Table_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xc415218e_a028_461e_aa92_8f925cf79351) , } }
 pub const Table_RowHeaders_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd9e35b87_6eb8_4562_aac6_a8a9075236a8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Table_RowHeaders_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xd9e35b87_6eb8_4562_aac6_a8a9075236a8) , } }
 pub const Table_RowOrColumnMajor_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x83be75c3_29fe_4a30_85e1_2a6277fd106e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Table_RowOrColumnMajor_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x83be75c3_29fe_4a30_85e1_2a6277fd106e) , } }
 pub const TextChild_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7533cab7_3bfe_41ef_9e85_e2638cbe169e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TextChild_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x7533cab7_3bfe_41ef_9e85_e2638cbe169e) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub type TextDecorationLineStyle = i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -24271,8 +24921,14 @@ pub const TextEditChangeType_CompositionFinalized: TextEditChangeType = 3i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const TextEditChangeType_AutoComplete: TextEditChangeType = 4i32;
 pub const TextEdit_ConversionTargetChanged_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3388c183_ed4f_4c8b_9baa_364d51d8847f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TextEdit_ConversionTargetChanged_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x3388c183_ed4f_4c8b_9baa_364d51d8847f) , } }
 pub const TextEdit_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x69f3ff89_5af9_4c75_9340_f2de292e4591);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TextEdit_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x69f3ff89_5af9_4c75_9340_f2de292e4591) , } }
 pub const TextEdit_TextChanged_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x120b0308_ec22_4eb8_9c98_9867cda1b165);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TextEdit_TextChanged_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x120b0308_ec22_4eb8_9c98_9867cda1b165) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub type TextPatternRangeEndpoint = i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -24642,58 +25298,164 @@ pub const TextUnit_Page: TextUnit = 5i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const TextUnit_Document: TextUnit = 6i32;
 pub const Text_AfterParagraphSpacing_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x588cbb38_e62f_497c_b5d1_ccdf0ee823d8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_AfterParagraphSpacing_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x588cbb38_e62f_497c_b5d1_ccdf0ee823d8) , } }
 pub const Text_AfterSpacing_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x588cbb38_e62f_497c_b5d1_ccdf0ee823d8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_AfterSpacing_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x588cbb38_e62f_497c_b5d1_ccdf0ee823d8) , } }
 pub const Text_AnimationStyle_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x628209f0_7c9a_4d57_be64_1f1836571ff5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_AnimationStyle_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x628209f0_7c9a_4d57_be64_1f1836571ff5) , } }
 pub const Text_AnnotationObjects_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xff41cf68_e7ab_40b9_8c72_72a8ed94017d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_AnnotationObjects_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xff41cf68_e7ab_40b9_8c72_72a8ed94017d) , } }
 pub const Text_AnnotationTypes_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xad2eb431_ee4e_4be1_a7ba_5559155a73ef);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_AnnotationTypes_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xad2eb431_ee4e_4be1_a7ba_5559155a73ef) , } }
 pub const Text_BackgroundColor_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfdc49a07_583d_4f17_ad27_77fc832a3c0b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_BackgroundColor_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xfdc49a07_583d_4f17_ad27_77fc832a3c0b) , } }
 pub const Text_BeforeParagraphSpacing_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbe7b0ab1_c822_4a24_85e9_c8f2650fc79c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_BeforeParagraphSpacing_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xbe7b0ab1_c822_4a24_85e9_c8f2650fc79c) , } }
 pub const Text_BeforeSpacing_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbe7b0ab1_c822_4a24_85e9_c8f2650fc79c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_BeforeSpacing_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xbe7b0ab1_c822_4a24_85e9_c8f2650fc79c) , } }
 pub const Text_BulletStyle_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc1097c90_d5c4_4237_9781_3bec8ba54e48);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_BulletStyle_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xc1097c90_d5c4_4237_9781_3bec8ba54e48) , } }
 pub const Text_CapStyle_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfb059c50_92cc_49a5_ba8f_0aa872bba2f3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_CapStyle_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xfb059c50_92cc_49a5_ba8f_0aa872bba2f3) , } }
 pub const Text_CaretBidiMode_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x929ee7a6_51d3_4715_96dc_b694fa24a168);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_CaretBidiMode_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x929ee7a6_51d3_4715_96dc_b694fa24a168) , } }
 pub const Text_CaretPosition_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb227b131_9889_4752_a91b_733efdc5c5a0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_CaretPosition_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xb227b131_9889_4752_a91b_733efdc5c5a0) , } }
 pub const Text_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xae9772dc_d331_4f09_be20_7e6dfaf07b0a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xae9772dc_d331_4f09_be20_7e6dfaf07b0a) , } }
 pub const Text_Culture_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc2025af9_a42d_4ced_a1fb_c6746315222e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_Culture_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xc2025af9_a42d_4ced_a1fb_c6746315222e) , } }
 pub const Text_FontName_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x64e63ba8_f2e5_476e_a477_1734feaaf726);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_FontName_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x64e63ba8_f2e5_476e_a477_1734feaaf726) , } }
 pub const Text_FontSize_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdc5eeeff_0506_4673_93f2_377e4a8e01f1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_FontSize_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xdc5eeeff_0506_4673_93f2_377e4a8e01f1) , } }
 pub const Text_FontWeight_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6fc02359_b316_4f5f_b401_f1ce55741853);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_FontWeight_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x6fc02359_b316_4f5f_b401_f1ce55741853) , } }
 pub const Text_ForegroundColor_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x72d1c95d_5e60_471a_96b1_6c1b3b77a436);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_ForegroundColor_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x72d1c95d_5e60_471a_96b1_6c1b3b77a436) , } }
 pub const Text_HorizontalTextAlignment_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x04ea6161_fba3_477a_952a_bb326d026a5b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_HorizontalTextAlignment_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x04ea6161_fba3_477a_952a_bb326d026a5b) , } }
 pub const Text_IndentationFirstLine_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x206f9ad5_c1d3_424a_8182_6da9a7f3d632);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_IndentationFirstLine_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x206f9ad5_c1d3_424a_8182_6da9a7f3d632) , } }
 pub const Text_IndentationLeading_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5cf66bac_2d45_4a4b_b6c9_f7221d2815b0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_IndentationLeading_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x5cf66bac_2d45_4a4b_b6c9_f7221d2815b0) , } }
 pub const Text_IndentationTrailing_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x97ff6c0f_1ce4_408a_b67b_94d83eb69bf2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_IndentationTrailing_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x97ff6c0f_1ce4_408a_b67b_94d83eb69bf2) , } }
 pub const Text_IsActive_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf5a4e533_e1b8_436b_935d_b57aa3f558c4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_IsActive_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xf5a4e533_e1b8_436b_935d_b57aa3f558c4) , } }
 pub const Text_IsHidden_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x360182fb_bdd7_47f6_ab69_19e33f8a3344);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_IsHidden_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x360182fb_bdd7_47f6_ab69_19e33f8a3344) , } }
 pub const Text_IsItalic_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfce12a56_1336_4a34_9663_1bab47239320);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_IsItalic_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xfce12a56_1336_4a34_9663_1bab47239320) , } }
 pub const Text_IsReadOnly_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa738156b_ca3e_495e_9514_833c440feb11);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_IsReadOnly_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xa738156b_ca3e_495e_9514_833c440feb11) , } }
 pub const Text_IsSubscript_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf0ead858_8f53_413c_873f_1a7d7f5e0de4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_IsSubscript_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xf0ead858_8f53_413c_873f_1a7d7f5e0de4) , } }
 pub const Text_IsSuperscript_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xda706ee4_b3aa_4645_a41f_cd25157dea76);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_IsSuperscript_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xda706ee4_b3aa_4645_a41f_cd25157dea76) , } }
 pub const Text_LineSpacing_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x63ff70ae_d943_4b47_8ab7_a7a033d3214b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_LineSpacing_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x63ff70ae_d943_4b47_8ab7_a7a033d3214b) , } }
 pub const Text_Link_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb38ef51d_9e8d_4e46_9144_56ebe177329b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_Link_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xb38ef51d_9e8d_4e46_9144_56ebe177329b) , } }
 pub const Text_MarginBottom_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7ee593c4_72b4_4cac_9271_3ed24b0e4d42);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_MarginBottom_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x7ee593c4_72b4_4cac_9271_3ed24b0e4d42) , } }
 pub const Text_MarginLeading_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9e9242d0_5ed0_4900_8e8a_eecc03835afc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_MarginLeading_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x9e9242d0_5ed0_4900_8e8a_eecc03835afc) , } }
 pub const Text_MarginTop_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x683d936f_c9b9_4a9a_b3d9_d20d33311e2a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_MarginTop_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x683d936f_c9b9_4a9a_b3d9_d20d33311e2a) , } }
 pub const Text_MarginTrailing_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xaf522f98_999d_40af_a5b2_0169d0342002);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_MarginTrailing_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xaf522f98_999d_40af_a5b2_0169d0342002) , } }
 pub const Text_OutlineStyles_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5b675b27_db89_46fe_970c_614d523bb97d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_OutlineStyles_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x5b675b27_db89_46fe_970c_614d523bb97d) , } }
 pub const Text_OverlineColor_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x83ab383a_fd43_40da_ab3e_ecf8165cbb6d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_OverlineColor_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x83ab383a_fd43_40da_ab3e_ecf8165cbb6d) , } }
 pub const Text_OverlineStyle_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0a234d66_617e_427f_871d_e1ff1e0c213f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_OverlineStyle_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x0a234d66_617e_427f_871d_e1ff1e0c213f) , } }
 pub const Text_Pattern2_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x498479a2_5b22_448d_b6e4_647490860698);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_Pattern2_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x498479a2_5b22_448d_b6e4_647490860698) , } }
 pub const Text_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8615f05d_7de5_44fd_a679_2ca4b46033a8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x8615f05d_7de5_44fd_a679_2ca4b46033a8) , } }
 pub const Text_SayAsInterpretAs_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb38ad6ac_eee1_4b6e_88cc_014cefa93fcb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_SayAsInterpretAs_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xb38ad6ac_eee1_4b6e_88cc_014cefa93fcb) , } }
 pub const Text_SelectionActiveEnd_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1f668cc3_9bbf_416b_b0a2_f89f86f6612c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_SelectionActiveEnd_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x1f668cc3_9bbf_416b_b0a2_f89f86f6612c) , } }
 pub const Text_StrikethroughColor_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbfe15a18_8c41_4c5a_9a0b_04af0e07f487);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_StrikethroughColor_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xbfe15a18_8c41_4c5a_9a0b_04af0e07f487) , } }
 pub const Text_StrikethroughStyle_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x72913ef1_da00_4f01_899c_ac5a8577a307);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_StrikethroughStyle_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x72913ef1_da00_4f01_899c_ac5a8577a307) , } }
 pub const Text_StyleId_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x14c300de_c32b_449b_ab7c_b0e0789aea5d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_StyleId_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x14c300de_c32b_449b_ab7c_b0e0789aea5d) , } }
 pub const Text_StyleName_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x22c9e091_4d66_45d8_a828_737bab4c98a7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_StyleName_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x22c9e091_4d66_45d8_a828_737bab4c98a7) , } }
 pub const Text_Tabs_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2e68d00b_92fe_42d8_899a_a784aa4454a1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_Tabs_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x2e68d00b_92fe_42d8_899a_a784aa4454a1) , } }
 pub const Text_TextChangedEvent_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4a342082_f483_48c4_ac11_a84b435e2a84);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_TextChangedEvent_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x4a342082_f483_48c4_ac11_a84b435e2a84) , } }
 pub const Text_TextFlowDirections_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8bdf8739_f420_423e_af77_20a5d973a907);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_TextFlowDirections_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x8bdf8739_f420_423e_af77_20a5d973a907) , } }
 pub const Text_TextSelectionChangedEvent_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x918edaa1_71b3_49ae_9741_79beb8d358f3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_TextSelectionChangedEvent_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x918edaa1_71b3_49ae_9741_79beb8d358f3) , } }
 pub const Text_UnderlineColor_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbfa12c73_fde2_4473_bf64_1036d6aa0f45);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_UnderlineColor_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xbfa12c73_fde2_4473_bf64_1036d6aa0f45) , } }
 pub const Text_UnderlineStyle_Attribute_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5f3b21c0_ede4_44bd_9c36_3853038cbfeb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Text_UnderlineStyle_Attribute_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x5f3b21c0_ede4_44bd_9c36_3853038cbfeb) , } }
 pub const Thumb_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x701ca877_e310_4dd6_b644_797e4faea213);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Thumb_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x701ca877_e310_4dd6_b644_797e4faea213) , } }
 pub const TitleBar_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x98aa55bf_3bb0_4b65_836e_2ea30dbc171f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TitleBar_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x98aa55bf_3bb0_4b65_836e_2ea30dbc171f) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 #[inline]
 pub unsafe fn TogglePattern_Toggle<'a, Param0: ::windows::core::IntoParam<'a, HUIAPATTERNOBJECT>>(hobj: Param0) -> ::windows::core::Result<()> {
@@ -24717,16 +25479,38 @@ pub const ToggleState_On: ToggleState = 1i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const ToggleState_Indeterminate: ToggleState = 2i32;
 pub const Toggle_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0b419760_e2f4_43ff_8c5f_9457c82b56e9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Toggle_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x0b419760_e2f4_43ff_8c5f_9457c82b56e9) , } }
 pub const Toggle_ToggleState_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb23cdc52_22c2_4c6c_9ded_f5c422479ede);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Toggle_ToggleState_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xb23cdc52_22c2_4c6c_9ded_f5c422479ede) , } }
 pub const ToolBar_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8f06b751_e182_4e98_8893_2284543a7dce);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ToolBar_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x8f06b751_e182_4e98_8893_2284543a7dce) , } }
 pub const ToolTipClosed_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x276d71ef_24a9_49b6_8e97_da98b401bbcd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ToolTipClosed_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x276d71ef_24a9_49b6_8e97_da98b401bbcd) , } }
 pub const ToolTipOpened_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3f4b97ff_2edc_451d_bca4_95a3188d5b03);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ToolTipOpened_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x3f4b97ff_2edc_451d_bca4_95a3188d5b03) , } }
 pub const ToolTip_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x05ddc6d1_2137_4768_98ea_73f52f7134f3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( ToolTip_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x05ddc6d1_2137_4768_98ea_73f52f7134f3) , } }
 pub const Tranform_Pattern2_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8afcfd07_a369_44de_988b_2f7ff49fb8a8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Tranform_Pattern2_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x8afcfd07_a369_44de_988b_2f7ff49fb8a8) , } }
 pub const Transform2_CanZoom_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf357e890_a756_4359_9ca6_86702bf8f381);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Transform2_CanZoom_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xf357e890_a756_4359_9ca6_86702bf8f381) , } }
 pub const Transform2_ZoomLevel_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xeee29f1a_f4a2_4b5b_ac65_95cf93283387);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Transform2_ZoomLevel_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xeee29f1a_f4a2_4b5b_ac65_95cf93283387) , } }
 pub const Transform2_ZoomMaximum_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x42ab6b77_ceb0_4eca_b82a_6cfa5fa1fc08);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Transform2_ZoomMaximum_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x42ab6b77_ceb0_4eca_b82a_6cfa5fa1fc08) , } }
 pub const Transform2_ZoomMinimum_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x742ccc16_4ad1_4e07_96fe_b122c6e6b22b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Transform2_ZoomMinimum_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x742ccc16_4ad1_4e07_96fe_b122c6e6b22b) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 #[inline]
 pub unsafe fn TransformPattern_Move<'a, Param0: ::windows::core::IntoParam<'a, HUIAPATTERNOBJECT>>(hobj: Param0, x: f64, y: f64) -> ::windows::core::Result<()> {
@@ -24770,10 +25554,20 @@ pub unsafe fn TransformPattern_Rotate<'a, Param0: ::windows::core::IntoParam<'a,
     unimplemented!("Unsupported target OS");
 }
 pub const Transform_CanMove_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1b75824d_208b_4fdf_bccd_f1f4e5741f4f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Transform_CanMove_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x1b75824d_208b_4fdf_bccd_f1f4e5741f4f) , } }
 pub const Transform_CanResize_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbb98dca5_4c1a_41d4_a4f6_ebc128644180);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Transform_CanResize_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xbb98dca5_4c1a_41d4_a4f6_ebc128644180) , } }
 pub const Transform_CanRotate_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x10079b48_3849_476f_ac96_44a95c8440d9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Transform_CanRotate_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x10079b48_3849_476f_ac96_44a95c8440d9) , } }
 pub const Transform_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x24b46fdb_587e_49f1_9c4a_d8e98b664b7b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Transform_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x24b46fdb_587e_49f1_9c4a_d8e98b664b7b) , } }
 pub const TreeItem_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x62c9feb9_8ffc_4878_a3a4_96b030315c18);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TreeItem_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x62c9feb9_8ffc_4878_a3a4_96b030315c18) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub type TreeScope = i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -24799,6 +25593,8 @@ pub const TreeTraversalOptions_PostOrder: TreeTraversalOptions = 1i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const TreeTraversalOptions_LastToFirstOrder: TreeTraversalOptions = 2i32;
 pub const Tree_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7561349c_d241_43f4_9908_b5f091bee611);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Tree_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x7561349c_d241_43f4_9908_b5f091bee611) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const UIA_AcceleratorKeyPropertyId: i32 = 30006i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -27053,8 +27849,14 @@ pub unsafe fn ValuePattern_SetValue<'a, Param0: ::windows::core::IntoParam<'a, H
     unimplemented!("Unsupported target OS");
 }
 pub const Value_IsReadOnly_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xeb090f30_e24c_4799_a705_0d247bc037f8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Value_IsReadOnly_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xeb090f30_e24c_4799_a705_0d247bc037f8) , } }
 pub const Value_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x17faad9e_c877_475b_b933_77332779b637);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Value_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x17faad9e_c877_475b_b933_77332779b637) , } }
 pub const Value_Value_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe95f5e64_269f_4a85_ba99_4092c3ea2986);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Value_Value_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xe95f5e64_269f_4a85_ba99_4092c3ea2986) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 #[inline]
 pub unsafe fn VirtualizedItemPattern_Realize<'a, Param0: ::windows::core::IntoParam<'a, HUIAPATTERNOBJECT>>(hobj: Param0) -> ::windows::core::Result<()> {
@@ -27070,6 +27872,8 @@ pub unsafe fn VirtualizedItemPattern_Realize<'a, Param0: ::windows::core::IntoPa
     unimplemented!("Unsupported target OS");
 }
 pub const VirtualizedItem_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf510173e_2e71_45e9_a6e5_62f6ed8289d5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( VirtualizedItem_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xf510173e_2e71_45e9_a6e5_62f6ed8289d5) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub type VisualEffects = i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
@@ -27085,6 +27889,8 @@ pub const VisualEffects_SoftEdges: VisualEffects = 8i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const VisualEffects_Bevel: VisualEffects = 16i32;
 pub const VisualEffects_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe61a8565_aad9_46d7_9e70_4e8a8420d420);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( VisualEffects_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xe61a8565_aad9_46d7_9e70_4e8a8420d420) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
 pub type WINEVENTPROC = ::core::option::Option<unsafe extern "system" fn(hwineventhook: HWINEVENTHOOK, event: u32, hwnd: super::super::Foundation::HWND, idobject: i32, idchild: i32, ideventthread: u32, dwmseventtime: u32)>;
@@ -27168,15 +27974,35 @@ pub const WindowVisualState_Maximized: WindowVisualState = 1i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub const WindowVisualState_Minimized: WindowVisualState = 2i32;
 pub const Window_CanMaximize_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x64fff53f_635d_41c1_950c_cb5adfbe28e3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Window_CanMaximize_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x64fff53f_635d_41c1_950c_cb5adfbe28e3) , } }
 pub const Window_CanMinimize_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb73b4625_5988_4b97_b4c2_a6fe6e78c8c6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Window_CanMinimize_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xb73b4625_5988_4b97_b4c2_a6fe6e78c8c6) , } }
 pub const Window_Control_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe13a7242_f462_4f4d_aec1_53b28d6c3290);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Window_Control_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xe13a7242_f462_4f4d_aec1_53b28d6c3290) , } }
 pub const Window_IsModal_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xff4e6892_37b9_4fca_8532_ffe674ecfeed);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Window_IsModal_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xff4e6892_37b9_4fca_8532_ffe674ecfeed) , } }
 pub const Window_IsTopmost_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xef7d85d3_0937_4962_9241_b62345f24041);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Window_IsTopmost_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xef7d85d3_0937_4962_9241_b62345f24041) , } }
 pub const Window_Pattern_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x27901735_c760_4994_ad11_5919e606b110);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Window_Pattern_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x27901735_c760_4994_ad11_5919e606b110) , } }
 pub const Window_WindowClosed_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xedf141f8_fa67_4e22_bbf7_944e05735ee2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Window_WindowClosed_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xedf141f8_fa67_4e22_bbf7_944e05735ee2) , } }
 pub const Window_WindowInteractionState_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4fed26a4_0455_4fa2_b21c_c4da2db1ff9c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Window_WindowInteractionState_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x4fed26a4_0455_4fa2_b21c_c4da2db1ff9c) , } }
 pub const Window_WindowOpened_Event_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd3e81d06_de45_4f2f_9633_de9e02fb65af);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Window_WindowOpened_Event_GUID ) , guid : :: windows :: core :: GUID::from_u128(0xd3e81d06_de45_4f2f_9633_de9e02fb65af) , } }
 pub const Window_WindowVisualState_Property_GUID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4ab7905f_e860_453e_a30a_f6431e5daad5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( Window_WindowVisualState_Property_GUID ) , guid : :: windows :: core :: GUID::from_u128(0x4ab7905f_e860_453e_a30a_f6431e5daad5) , } }
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]
 pub type ZoomUnit = i32;
 #[doc = "*Required features: 'Win32_UI_Accessibility'*"]

--- a/crates/libs/windows/src/Windows/Win32/UI/ColorSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/ColorSystem/mod.rs
@@ -159,6 +159,8 @@ impl ::core::default::Default for BlackInformation {
     }
 }
 pub const CATID_WcsPlugin: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa0b402e0_8240_405f_8a16_8a5b4df2f0dd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_WcsPlugin ) , guid : :: windows :: core :: GUID::from_u128(0xa0b402e0_8240_405f_8a16_8a5b4df2f0dd) , } }
 #[doc = "*Required features: 'Win32_UI_ColorSystem', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]

--- a/crates/libs/windows/src/Windows/Win32/UI/Input/Ime/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Input/Ime/mod.rs
@@ -195,12 +195,26 @@ impl ::core::default::Default for CANDIDATELIST {
     }
 }
 pub const CATID_MSIME_IImePadApplet: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7566cad1_4ec9_4478_9fe9_8ed766619edf);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_MSIME_IImePadApplet ) , guid : :: windows :: core :: GUID::from_u128(0x7566cad1_4ec9_4478_9fe9_8ed766619edf) , } }
 pub const CATID_MSIME_IImePadApplet1000: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe081e1d6_2389_43cb_b66f_609f823d9f9c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_MSIME_IImePadApplet1000 ) , guid : :: windows :: core :: GUID::from_u128(0xe081e1d6_2389_43cb_b66f_609f823d9f9c) , } }
 pub const CATID_MSIME_IImePadApplet1200: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa47fb5fc_7d15_4223_a789_b781bf9ae667);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_MSIME_IImePadApplet1200 ) , guid : :: windows :: core :: GUID::from_u128(0xa47fb5fc_7d15_4223_a789_b781bf9ae667) , } }
 pub const CATID_MSIME_IImePadApplet900: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfaae51bf_5e5b_4a1d_8de1_17c1d9e1728d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_MSIME_IImePadApplet900 ) , guid : :: windows :: core :: GUID::from_u128(0xfaae51bf_5e5b_4a1d_8de1_17c1d9e1728d) , } }
 pub const CATID_MSIME_IImePadApplet_VER7: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4a0f8e31_c3ee_11d1_afef_00805f0c8b6d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_MSIME_IImePadApplet_VER7 ) , guid : :: windows :: core :: GUID::from_u128(0x4a0f8e31_c3ee_11d1_afef_00805f0c8b6d) , } }
 pub const CATID_MSIME_IImePadApplet_VER80: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x56f7a792_fef1_11d3_8463_00c04f7a06e5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_MSIME_IImePadApplet_VER80 ) , guid : :: windows :: core :: GUID::from_u128(0x56f7a792_fef1_11d3_8463_00c04f7a06e5) , } }
 pub const CATID_MSIME_IImePadApplet_VER81: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x656520b0_bb88_11d4_84c0_00c04f7a06e5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CATID_MSIME_IImePadApplet_VER81 ) , guid : :: windows :: core :: GUID::from_u128(0x656520b0_bb88_11d4_84c0_00c04f7a06e5) , } }
 pub const CActiveIMM: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4955dd33_b159_11d0_8fcf_00aa006bcc59);
 #[doc = "*Required features: 'Win32_UI_Input_Ime'*"]
 pub const CFS_CANDIDATEPOS: u32 = 64u32;
@@ -221,8 +235,14 @@ pub const CHARINFO_CHARID_MASK: u32 = 65535u32;
 #[doc = "*Required features: 'Win32_UI_Input_Ime'*"]
 pub const CHARINFO_FEID_MASK: u32 = 15728640u32;
 pub const CLSID_ImePlugInDictDictionaryList_CHS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7bf0129b_5bef_4de4_9b0b_5edb66ac2fa6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_ImePlugInDictDictionaryList_CHS ) , guid : :: windows :: core :: GUID::from_u128(0x7bf0129b_5bef_4de4_9b0b_5edb66ac2fa6) , } }
 pub const CLSID_ImePlugInDictDictionaryList_JPN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4fe2776b_b0f9_4396_b5fc_e9d4cf1ec195);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_ImePlugInDictDictionaryList_JPN ) , guid : :: windows :: core :: GUID::from_u128(0x4fe2776b_b0f9_4396_b5fc_e9d4cf1ec195) , } }
 pub const CLSID_VERSION_DEPENDENT_MSIME_JAPANESE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6a91029e_aa49_471b_aee7_7d332785660d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_VERSION_DEPENDENT_MSIME_JAPANESE ) , guid : :: windows :: core :: GUID::from_u128(0x6a91029e_aa49_471b_aee7_7d332785660d) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_UI_Input_Ime', 'Win32_Foundation'*"]
 #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/UI/Ribbon/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Ribbon/mod.rs
@@ -804,6 +804,8 @@ pub struct IUISimplePropertySetVtbl(
     #[cfg(not(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem")))] usize,
 );
 pub const LIBID_UIRibbon: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x942f35c2_e83b_45ef_b085_ac295dd63d5b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( LIBID_UIRibbon ) , guid : :: windows :: core :: GUID::from_u128(0x942f35c2_e83b_45ef_b085_ac295dd63d5b) , } }
 pub const UIRibbonFramework: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x926749fa_2615_4987_8845_c33e65f2b957);
 pub const UIRibbonImageFromBitmapFactory: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0f7434b6_59b6_4250_999e_d168d6ae4293);
 #[doc = "*Required features: 'Win32_UI_Ribbon'*"]

--- a/crates/libs/windows/src/Windows/Win32/UI/TabletPC/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/TabletPC/mod.rs
@@ -1677,28 +1677,74 @@ pub const GESTURE_UP_RIGHT: u32 = 61545u32;
 #[doc = "*Required features: 'Win32_UI_TabletPC'*"]
 pub const GESTURE_UP_RIGHT_LONG: u32 = 61541u32;
 pub const GUID_DYNAMIC_RENDERER_CACHED_DATA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbf531b92_25bf_4a95_89ad_0e476b34b4f5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_DYNAMIC_RENDERER_CACHED_DATA ) , guid : :: windows :: core :: GUID::from_u128(0xbf531b92_25bf_4a95_89ad_0e476b34b4f5) , } }
 pub const GUID_GESTURE_DATA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x41e4ec0f_26aa_455a_9aa5_2cd36cf63fb9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_GESTURE_DATA ) , guid : :: windows :: core :: GUID::from_u128(0x41e4ec0f_26aa_455a_9aa5_2cd36cf63fb9) , } }
 pub const GUID_PACKETPROPERTY_GUID_ALTITUDE_ORIENTATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x82dec5c7_f6ba_4906_894f_66d68dfc456c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PACKETPROPERTY_GUID_ALTITUDE_ORIENTATION ) , guid : :: windows :: core :: GUID::from_u128(0x82dec5c7_f6ba_4906_894f_66d68dfc456c) , } }
 pub const GUID_PACKETPROPERTY_GUID_AZIMUTH_ORIENTATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x029123b4_8828_410b_b250_a0536595e5dc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PACKETPROPERTY_GUID_AZIMUTH_ORIENTATION ) , guid : :: windows :: core :: GUID::from_u128(0x029123b4_8828_410b_b250_a0536595e5dc) , } }
 pub const GUID_PACKETPROPERTY_GUID_BUTTON_PRESSURE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8b7fefc4_96aa_4bfe_ac26_8a5f0be07bf5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PACKETPROPERTY_GUID_BUTTON_PRESSURE ) , guid : :: windows :: core :: GUID::from_u128(0x8b7fefc4_96aa_4bfe_ac26_8a5f0be07bf5) , } }
 pub const GUID_PACKETPROPERTY_GUID_DEVICE_CONTACT_ID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x02585b91_049b_4750_9615_df8948ab3c9c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PACKETPROPERTY_GUID_DEVICE_CONTACT_ID ) , guid : :: windows :: core :: GUID::from_u128(0x02585b91_049b_4750_9615_df8948ab3c9c) , } }
 pub const GUID_PACKETPROPERTY_GUID_FINGERCONTACTCONFIDENCE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe706c804_57f0_4f00_8a0c_853d57789be9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PACKETPROPERTY_GUID_FINGERCONTACTCONFIDENCE ) , guid : :: windows :: core :: GUID::from_u128(0xe706c804_57f0_4f00_8a0c_853d57789be9) , } }
 pub const GUID_PACKETPROPERTY_GUID_HEIGHT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe61858d2_e447_4218_9d3f_18865c203df4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PACKETPROPERTY_GUID_HEIGHT ) , guid : :: windows :: core :: GUID::from_u128(0xe61858d2_e447_4218_9d3f_18865c203df4) , } }
 pub const GUID_PACKETPROPERTY_GUID_NORMAL_PRESSURE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7307502d_f9f4_4e18_b3f2_2ce1b1a3610c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PACKETPROPERTY_GUID_NORMAL_PRESSURE ) , guid : :: windows :: core :: GUID::from_u128(0x7307502d_f9f4_4e18_b3f2_2ce1b1a3610c) , } }
 pub const GUID_PACKETPROPERTY_GUID_PACKET_STATUS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6e0e07bf_afe7_4cf7_87d1_af6446208418);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PACKETPROPERTY_GUID_PACKET_STATUS ) , guid : :: windows :: core :: GUID::from_u128(0x6e0e07bf_afe7_4cf7_87d1_af6446208418) , } }
 pub const GUID_PACKETPROPERTY_GUID_PITCH_ROTATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7f7e57b7_be37_4be1_a356_7a84160e1893);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PACKETPROPERTY_GUID_PITCH_ROTATION ) , guid : :: windows :: core :: GUID::from_u128(0x7f7e57b7_be37_4be1_a356_7a84160e1893) , } }
 pub const GUID_PACKETPROPERTY_GUID_ROLL_ROTATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5d5d5e56_6ba9_4c5b_9fb0_851c91714e56);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PACKETPROPERTY_GUID_ROLL_ROTATION ) , guid : :: windows :: core :: GUID::from_u128(0x5d5d5e56_6ba9_4c5b_9fb0_851c91714e56) , } }
 pub const GUID_PACKETPROPERTY_GUID_SERIAL_NUMBER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x78a81b56_0935_4493_baae_00541a8a16c4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PACKETPROPERTY_GUID_SERIAL_NUMBER ) , guid : :: windows :: core :: GUID::from_u128(0x78a81b56_0935_4493_baae_00541a8a16c4) , } }
 pub const GUID_PACKETPROPERTY_GUID_TANGENT_PRESSURE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6da4488b_5244_41ec_905b_32d89ab80809);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PACKETPROPERTY_GUID_TANGENT_PRESSURE ) , guid : :: windows :: core :: GUID::from_u128(0x6da4488b_5244_41ec_905b_32d89ab80809) , } }
 pub const GUID_PACKETPROPERTY_GUID_TIMER_TICK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x436510c5_fed3_45d1_8b76_71d3ea7a829d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PACKETPROPERTY_GUID_TIMER_TICK ) , guid : :: windows :: core :: GUID::from_u128(0x436510c5_fed3_45d1_8b76_71d3ea7a829d) , } }
 pub const GUID_PACKETPROPERTY_GUID_TWIST_ORIENTATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0d324960_13b2_41e4_ace6_7ae9d43d2d3b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PACKETPROPERTY_GUID_TWIST_ORIENTATION ) , guid : :: windows :: core :: GUID::from_u128(0x0d324960_13b2_41e4_ace6_7ae9d43d2d3b) , } }
 pub const GUID_PACKETPROPERTY_GUID_WIDTH: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbaabe94d_2712_48f5_be9d_8f8b5ea0711a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PACKETPROPERTY_GUID_WIDTH ) , guid : :: windows :: core :: GUID::from_u128(0xbaabe94d_2712_48f5_be9d_8f8b5ea0711a) , } }
 pub const GUID_PACKETPROPERTY_GUID_X: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x598a6a8f_52c0_4ba0_93af_af357411a561);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PACKETPROPERTY_GUID_X ) , guid : :: windows :: core :: GUID::from_u128(0x598a6a8f_52c0_4ba0_93af_af357411a561) , } }
 pub const GUID_PACKETPROPERTY_GUID_X_TILT_ORIENTATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa8d07b3a_8bf0_40b0_95a9_b80a6bb787bf);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PACKETPROPERTY_GUID_X_TILT_ORIENTATION ) , guid : :: windows :: core :: GUID::from_u128(0xa8d07b3a_8bf0_40b0_95a9_b80a6bb787bf) , } }
 pub const GUID_PACKETPROPERTY_GUID_Y: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb53f9f75_04e0_4498_a7ee_c30dbb5a9011);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PACKETPROPERTY_GUID_Y ) , guid : :: windows :: core :: GUID::from_u128(0xb53f9f75_04e0_4498_a7ee_c30dbb5a9011) , } }
 pub const GUID_PACKETPROPERTY_GUID_YAW_ROTATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6a849980_7c3a_45b7_aa82_90a262950e89);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PACKETPROPERTY_GUID_YAW_ROTATION ) , guid : :: windows :: core :: GUID::from_u128(0x6a849980_7c3a_45b7_aa82_90a262950e89) , } }
 pub const GUID_PACKETPROPERTY_GUID_Y_TILT_ORIENTATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0e932389_1d77_43af_ac00_5b950d6d4b2d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PACKETPROPERTY_GUID_Y_TILT_ORIENTATION ) , guid : :: windows :: core :: GUID::from_u128(0x0e932389_1d77_43af_ac00_5b950d6d4b2d) , } }
 pub const GUID_PACKETPROPERTY_GUID_Z: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x735adb30_0ebb_4788_a0e4_0f316490055d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PACKETPROPERTY_GUID_Z ) , guid : :: windows :: core :: GUID::from_u128(0x735adb30_0ebb_4788_a0e4_0f316490055d) , } }
 pub const GestureRecognizer: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xea30c654_c62c_441f_ac00_95f9a196782c);
 #[doc = "*Required features: 'Win32_UI_TabletPC'*"]
 #[inline]

--- a/crates/libs/windows/src/Windows/Win32/UI/TextServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/TextServices/mod.rs
@@ -10,14 +10,32 @@ pub const AccDictionary: ::windows::core::GUID = ::windows::core::GUID::from_u12
 pub const AccServerDocMgr: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6089a37e_eb8a_482d_bd6f_f9f46904d16d);
 pub const AccStore: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5440837f_4bff_4ae5_a1b1_7722ecc6332a);
 pub const CLSID_TF_CategoryMgr: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa4b544a1_438d_4b41_9325_869523e2d6c7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_TF_CategoryMgr ) , guid : :: windows :: core :: GUID::from_u128(0xa4b544a1_438d_4b41_9325_869523e2d6c7) , } }
 pub const CLSID_TF_ClassicLangBar: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3318360c_1afc_4d09_a86b_9f9cb6dceb9c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_TF_ClassicLangBar ) , guid : :: windows :: core :: GUID::from_u128(0x3318360c_1afc_4d09_a86b_9f9cb6dceb9c) , } }
 pub const CLSID_TF_DisplayAttributeMgr: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3ce74de4_53d3_4d74_8b83_431b3828ba53);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_TF_DisplayAttributeMgr ) , guid : :: windows :: core :: GUID::from_u128(0x3ce74de4_53d3_4d74_8b83_431b3828ba53) , } }
 pub const CLSID_TF_InputProcessorProfiles: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x33c53a50_f456_4884_b049_85fd643ecfed);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_TF_InputProcessorProfiles ) , guid : :: windows :: core :: GUID::from_u128(0x33c53a50_f456_4884_b049_85fd643ecfed) , } }
 pub const CLSID_TF_LangBarItemMgr: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb9931692_a2b3_4fab_bf33_9ec6f9fb96ac);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_TF_LangBarItemMgr ) , guid : :: windows :: core :: GUID::from_u128(0xb9931692_a2b3_4fab_bf33_9ec6f9fb96ac) , } }
 pub const CLSID_TF_LangBarMgr: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xebb08c45_6c4a_4fdc_ae53_4eb8c4c7db8e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_TF_LangBarMgr ) , guid : :: windows :: core :: GUID::from_u128(0xebb08c45_6c4a_4fdc_ae53_4eb8c4c7db8e) , } }
 pub const CLSID_TF_ThreadMgr: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x529a9e6b_6587_4f23_ab9e_9c7d683e3c50);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_TF_ThreadMgr ) , guid : :: windows :: core :: GUID::from_u128(0x529a9e6b_6587_4f23_ab9e_9c7d683e3c50) , } }
 pub const CLSID_TF_TransitoryExtensionUIEntry: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xae6be008_07fb_400d_8beb_337a64f7051f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_TF_TransitoryExtensionUIEntry ) , guid : :: windows :: core :: GUID::from_u128(0xae6be008_07fb_400d_8beb_337a64f7051f) , } }
 pub const CLSID_TsfServices: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x39aedc00_6b60_46db_8d31_3642be0e4373);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_TsfServices ) , guid : :: windows :: core :: GUID::from_u128(0x39aedc00_6b60_46db_8d31_3642be0e4373) , } }
 #[doc = "*Required features: 'Win32_UI_TextServices'*"]
 pub const DCM_FLAGS_CTFMON: u32 = 2u32;
 #[doc = "*Required features: 'Win32_UI_TextServices'*"]
@@ -47,76 +65,218 @@ pub const TF_GTP_NONE: GET_TEXT_AND_PROPERTY_UPDATES_FLAGS = 0u32;
 #[doc = "*Required features: 'Win32_UI_TextServices'*"]
 pub const TF_GTP_INCL_TEXT: GET_TEXT_AND_PROPERTY_UPDATES_FLAGS = 1u32;
 pub const GUID_APP_FUNCTIONPROVIDER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4caef01e_12af_4b0e_9db1_a6ec5b881208);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_APP_FUNCTIONPROVIDER ) , guid : :: windows :: core :: GUID::from_u128(0x4caef01e_12af_4b0e_9db1_a6ec5b881208) , } }
 pub const GUID_COMPARTMENT_CONVERSIONMODEBIAS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5497f516_ee91_436e_b946_aa2c05f1ac5b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_COMPARTMENT_CONVERSIONMODEBIAS ) , guid : :: windows :: core :: GUID::from_u128(0x5497f516_ee91_436e_b946_aa2c05f1ac5b) , } }
 pub const GUID_COMPARTMENT_EMPTYCONTEXT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd7487dbf_804e_41c5_894d_ad96fd4eea13);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_COMPARTMENT_EMPTYCONTEXT ) , guid : :: windows :: core :: GUID::from_u128(0xd7487dbf_804e_41c5_894d_ad96fd4eea13) , } }
 pub const GUID_COMPARTMENT_ENABLED_PROFILES_UPDATED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x92c1fd48_a9ae_4a7c_be08_4329e4723817);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_COMPARTMENT_ENABLED_PROFILES_UPDATED ) , guid : :: windows :: core :: GUID::from_u128(0x92c1fd48_a9ae_4a7c_be08_4329e4723817) , } }
 pub const GUID_COMPARTMENT_HANDWRITING_OPENCLOSE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf9ae2c6b_1866_4361_af72_7aa30948890e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_COMPARTMENT_HANDWRITING_OPENCLOSE ) , guid : :: windows :: core :: GUID::from_u128(0xf9ae2c6b_1866_4361_af72_7aa30948890e) , } }
 pub const GUID_COMPARTMENT_KEYBOARD_DISABLED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x71a5b253_1951_466b_9fbc_9c8808fa84f2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_COMPARTMENT_KEYBOARD_DISABLED ) , guid : :: windows :: core :: GUID::from_u128(0x71a5b253_1951_466b_9fbc_9c8808fa84f2) , } }
 pub const GUID_COMPARTMENT_KEYBOARD_INPUTMODE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb6592511_bcee_4122_a7c4_09f4b3fa4396);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_COMPARTMENT_KEYBOARD_INPUTMODE ) , guid : :: windows :: core :: GUID::from_u128(0xb6592511_bcee_4122_a7c4_09f4b3fa4396) , } }
 pub const GUID_COMPARTMENT_KEYBOARD_INPUTMODE_CONVERSION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xccf05dd8_4a87_11d7_a6e2_00065b84435c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_COMPARTMENT_KEYBOARD_INPUTMODE_CONVERSION ) , guid : :: windows :: core :: GUID::from_u128(0xccf05dd8_4a87_11d7_a6e2_00065b84435c) , } }
 pub const GUID_COMPARTMENT_KEYBOARD_INPUTMODE_SENTENCE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xccf05dd9_4a87_11d7_a6e2_00065b84435c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_COMPARTMENT_KEYBOARD_INPUTMODE_SENTENCE ) , guid : :: windows :: core :: GUID::from_u128(0xccf05dd9_4a87_11d7_a6e2_00065b84435c) , } }
 pub const GUID_COMPARTMENT_KEYBOARD_OPENCLOSE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x58273aad_01bb_4164_95c6_755ba0b5162d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_COMPARTMENT_KEYBOARD_OPENCLOSE ) , guid : :: windows :: core :: GUID::from_u128(0x58273aad_01bb_4164_95c6_755ba0b5162d) , } }
 pub const GUID_COMPARTMENT_SAPI_AUDIO: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x51af2086_cc6b_457d_b5aa_8b19dc290ab4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_COMPARTMENT_SAPI_AUDIO ) , guid : :: windows :: core :: GUID::from_u128(0x51af2086_cc6b_457d_b5aa_8b19dc290ab4) , } }
 pub const GUID_COMPARTMENT_SPEECH_CFGMENU: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfb6c5c2d_4e83_4bb6_91a2_e019bff6762d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_COMPARTMENT_SPEECH_CFGMENU ) , guid : :: windows :: core :: GUID::from_u128(0xfb6c5c2d_4e83_4bb6_91a2_e019bff6762d) , } }
 pub const GUID_COMPARTMENT_SPEECH_DISABLED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x56c5c607_0703_4e59_8e52_cbc84e8bbe35);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_COMPARTMENT_SPEECH_DISABLED ) , guid : :: windows :: core :: GUID::from_u128(0x56c5c607_0703_4e59_8e52_cbc84e8bbe35) , } }
 pub const GUID_COMPARTMENT_SPEECH_GLOBALSTATE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2a54fe8e_0d08_460c_a75d_87035ff436c5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_COMPARTMENT_SPEECH_GLOBALSTATE ) , guid : :: windows :: core :: GUID::from_u128(0x2a54fe8e_0d08_460c_a75d_87035ff436c5) , } }
 pub const GUID_COMPARTMENT_SPEECH_OPENCLOSE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x544d6a63_e2e8_4752_bbd1_000960bca083);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_COMPARTMENT_SPEECH_OPENCLOSE ) , guid : :: windows :: core :: GUID::from_u128(0x544d6a63_e2e8_4752_bbd1_000960bca083) , } }
 pub const GUID_COMPARTMENT_SPEECH_UI_STATUS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd92016f0_9367_4fe7_9abf_bc59dacbe0e3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_COMPARTMENT_SPEECH_UI_STATUS ) , guid : :: windows :: core :: GUID::from_u128(0xd92016f0_9367_4fe7_9abf_bc59dacbe0e3) , } }
 pub const GUID_COMPARTMENT_TIPUISTATUS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x148ca3ec_0366_401c_8d75_ed978d85fbc9);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_COMPARTMENT_TIPUISTATUS ) , guid : :: windows :: core :: GUID::from_u128(0x148ca3ec_0366_401c_8d75_ed978d85fbc9) , } }
 pub const GUID_COMPARTMENT_TRANSITORYEXTENSION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8be347f5_c7a0_11d7_b408_00065b84435c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_COMPARTMENT_TRANSITORYEXTENSION ) , guid : :: windows :: core :: GUID::from_u128(0x8be347f5_c7a0_11d7_b408_00065b84435c) , } }
 pub const GUID_COMPARTMENT_TRANSITORYEXTENSION_DOCUMENTMANAGER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8be347f7_c7a0_11d7_b408_00065b84435c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_COMPARTMENT_TRANSITORYEXTENSION_DOCUMENTMANAGER ) , guid : :: windows :: core :: GUID::from_u128(0x8be347f7_c7a0_11d7_b408_00065b84435c) , } }
 pub const GUID_COMPARTMENT_TRANSITORYEXTENSION_PARENT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8be347f8_c7a0_11d7_b408_00065b84435c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_COMPARTMENT_TRANSITORYEXTENSION_PARENT ) , guid : :: windows :: core :: GUID::from_u128(0x8be347f8_c7a0_11d7_b408_00065b84435c) , } }
 pub const GUID_INTEGRATIONSTYLE_SEARCHBOX: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe6d1bd11_82f7_4903_ae21_1a6397cde2eb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_INTEGRATIONSTYLE_SEARCHBOX ) , guid : :: windows :: core :: GUID::from_u128(0xe6d1bd11_82f7_4903_ae21_1a6397cde2eb) , } }
 pub const GUID_LBI_INPUTMODE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2c77a81e_41cc_4178_a3a7_5f8a987568e6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_LBI_INPUTMODE ) , guid : :: windows :: core :: GUID::from_u128(0x2c77a81e_41cc_4178_a3a7_5f8a987568e6) , } }
 pub const GUID_LBI_SAPILAYR_CFGMENUBUTTON: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd02f24a1_942d_422e_8d99_b4f2addee999);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_LBI_SAPILAYR_CFGMENUBUTTON ) , guid : :: windows :: core :: GUID::from_u128(0xd02f24a1_942d_422e_8d99_b4f2addee999) , } }
 pub const GUID_MODEBIAS_CHINESE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7add26de_4328_489b_83ae_6493750cad5c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MODEBIAS_CHINESE ) , guid : :: windows :: core :: GUID::from_u128(0x7add26de_4328_489b_83ae_6493750cad5c) , } }
 pub const GUID_MODEBIAS_CONVERSATION: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0f4ec104_1790_443b_95f1_e10f939d6546);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MODEBIAS_CONVERSATION ) , guid : :: windows :: core :: GUID::from_u128(0x0f4ec104_1790_443b_95f1_e10f939d6546) , } }
 pub const GUID_MODEBIAS_DATETIME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf2bdb372_7f61_4039_92ef_1c35599f0222);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MODEBIAS_DATETIME ) , guid : :: windows :: core :: GUID::from_u128(0xf2bdb372_7f61_4039_92ef_1c35599f0222) , } }
 pub const GUID_MODEBIAS_FILENAME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd7f707fe_44c6_4fca_8e76_86ab50c7931b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MODEBIAS_FILENAME ) , guid : :: windows :: core :: GUID::from_u128(0xd7f707fe_44c6_4fca_8e76_86ab50c7931b) , } }
 pub const GUID_MODEBIAS_FULLWIDTHALPHANUMERIC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x81489fb8_b36a_473d_8146_e4a2258b24ae);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MODEBIAS_FULLWIDTHALPHANUMERIC ) , guid : :: windows :: core :: GUID::from_u128(0x81489fb8_b36a_473d_8146_e4a2258b24ae) , } }
 pub const GUID_MODEBIAS_FULLWIDTHHANGUL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc01ae6c9_45b5_4fd0_9cb1_9f4cebc39fea);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MODEBIAS_FULLWIDTHHANGUL ) , guid : :: windows :: core :: GUID::from_u128(0xc01ae6c9_45b5_4fd0_9cb1_9f4cebc39fea) , } }
 pub const GUID_MODEBIAS_HALFWIDTHKATAKANA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x005f6b63_78d4_41cc_8859_485ca821a795);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MODEBIAS_HALFWIDTHKATAKANA ) , guid : :: windows :: core :: GUID::from_u128(0x005f6b63_78d4_41cc_8859_485ca821a795) , } }
 pub const GUID_MODEBIAS_HANGUL: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x76ef0541_23b3_4d77_a074_691801ccea17);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MODEBIAS_HANGUL ) , guid : :: windows :: core :: GUID::from_u128(0x76ef0541_23b3_4d77_a074_691801ccea17) , } }
 pub const GUID_MODEBIAS_HIRAGANA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd73d316e_9b91_46f1_a280_31597f52c694);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MODEBIAS_HIRAGANA ) , guid : :: windows :: core :: GUID::from_u128(0xd73d316e_9b91_46f1_a280_31597f52c694) , } }
 pub const GUID_MODEBIAS_KATAKANA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2e0eeddd_3a1a_499e_8543_3c7ee7949811);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MODEBIAS_KATAKANA ) , guid : :: windows :: core :: GUID::from_u128(0x2e0eeddd_3a1a_499e_8543_3c7ee7949811) , } }
 pub const GUID_MODEBIAS_NAME: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfddc10f0_d239_49bf_b8fc_5410caaa427e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MODEBIAS_NAME ) , guid : :: windows :: core :: GUID::from_u128(0xfddc10f0_d239_49bf_b8fc_5410caaa427e) , } }
 pub const GUID_MODEBIAS_NONE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x00000000_0000_0000_0000_000000000000);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MODEBIAS_NONE ) , guid : :: windows :: core :: GUID::from_u128(0x00000000_0000_0000_0000_000000000000) , } }
 pub const GUID_MODEBIAS_NUMERIC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4021766c_e872_48fd_9cee_4ec5c75e16c3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MODEBIAS_NUMERIC ) , guid : :: windows :: core :: GUID::from_u128(0x4021766c_e872_48fd_9cee_4ec5c75e16c3) , } }
 pub const GUID_MODEBIAS_READING: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe31643a3_6466_4cbf_8d8b_0bd4d8545461);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MODEBIAS_READING ) , guid : :: windows :: core :: GUID::from_u128(0xe31643a3_6466_4cbf_8d8b_0bd4d8545461) , } }
 pub const GUID_MODEBIAS_URLHISTORY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8b0e54d9_63f2_4c68_84d4_79aee7a59f09);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_MODEBIAS_URLHISTORY ) , guid : :: windows :: core :: GUID::from_u128(0x8b0e54d9_63f2_4c68_84d4_79aee7a59f09) , } }
 pub const GUID_PROP_ATTRIBUTE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x34b45670_7526_11d2_a147_00105a2799b5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROP_ATTRIBUTE ) , guid : :: windows :: core :: GUID::from_u128(0x34b45670_7526_11d2_a147_00105a2799b5) , } }
 pub const GUID_PROP_COMPOSING: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe12ac060_af15_11d2_afc5_00105a2799b5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROP_COMPOSING ) , guid : :: windows :: core :: GUID::from_u128(0xe12ac060_af15_11d2_afc5_00105a2799b5) , } }
 pub const GUID_PROP_INPUTSCOPE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1713dd5a_68e7_4a5b_9af6_592a595c778d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROP_INPUTSCOPE ) , guid : :: windows :: core :: GUID::from_u128(0x1713dd5a_68e7_4a5b_9af6_592a595c778d) , } }
 pub const GUID_PROP_LANGID: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3280ce20_8032_11d2_b603_00105a2799b5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROP_LANGID ) , guid : :: windows :: core :: GUID::from_u128(0x3280ce20_8032_11d2_b603_00105a2799b5) , } }
 pub const GUID_PROP_MODEBIAS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x372e0716_974f_40ac_a088_08cdc92ebfbc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROP_MODEBIAS ) , guid : :: windows :: core :: GUID::from_u128(0x372e0716_974f_40ac_a088_08cdc92ebfbc) , } }
 pub const GUID_PROP_READING: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5463f7c0_8e31_11d2_bf46_00105a2799b5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROP_READING ) , guid : :: windows :: core :: GUID::from_u128(0x5463f7c0_8e31_11d2_bf46_00105a2799b5) , } }
 pub const GUID_PROP_TEXTOWNER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf1e2d520_0969_11d3_8df0_00105a2799b5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROP_TEXTOWNER ) , guid : :: windows :: core :: GUID::from_u128(0xf1e2d520_0969_11d3_8df0_00105a2799b5) , } }
 pub const GUID_PROP_TKB_ALTERNATES: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x70b2a803_968d_462e_b93b_2164c91517f7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_PROP_TKB_ALTERNATES ) , guid : :: windows :: core :: GUID::from_u128(0x70b2a803_968d_462e_b93b_2164c91517f7) , } }
 pub const GUID_SYSTEM_FUNCTIONPROVIDER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9a698bb0_0f21_11d3_8df1_00105a2799b5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_SYSTEM_FUNCTIONPROVIDER ) , guid : :: windows :: core :: GUID::from_u128(0x9a698bb0_0f21_11d3_8df1_00105a2799b5) , } }
 pub const GUID_TFCAT_CATEGORY_OF_TIP: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x534c48c1_0607_4098_a521_4fc899c73e90);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TFCAT_CATEGORY_OF_TIP ) , guid : :: windows :: core :: GUID::from_u128(0x534c48c1_0607_4098_a521_4fc899c73e90) , } }
 pub const GUID_TFCAT_DISPLAYATTRIBUTEPROPERTY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb95f181b_ea4c_4af1_8056_7c321abbb091);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TFCAT_DISPLAYATTRIBUTEPROPERTY ) , guid : :: windows :: core :: GUID::from_u128(0xb95f181b_ea4c_4af1_8056_7c321abbb091) , } }
 pub const GUID_TFCAT_DISPLAYATTRIBUTEPROVIDER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x046b8c80_1647_40f7_9b21_b93b81aabc1b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TFCAT_DISPLAYATTRIBUTEPROVIDER ) , guid : :: windows :: core :: GUID::from_u128(0x046b8c80_1647_40f7_9b21_b93b81aabc1b) , } }
 pub const GUID_TFCAT_PROPSTYLE_STATIC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x565fb8d8_6bd4_4ca1_b223_0f2ccb8f4f96);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TFCAT_PROPSTYLE_STATIC ) , guid : :: windows :: core :: GUID::from_u128(0x565fb8d8_6bd4_4ca1_b223_0f2ccb8f4f96) , } }
 pub const GUID_TFCAT_PROP_AUDIODATA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9b7be3a9_e8ab_4d47_a8fe_254fa423436d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TFCAT_PROP_AUDIODATA ) , guid : :: windows :: core :: GUID::from_u128(0x9b7be3a9_e8ab_4d47_a8fe_254fa423436d) , } }
 pub const GUID_TFCAT_PROP_INKDATA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7c6a82ae_b0d7_4f14_a745_14f28b009d61);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TFCAT_PROP_INKDATA ) , guid : :: windows :: core :: GUID::from_u128(0x7c6a82ae_b0d7_4f14_a745_14f28b009d61) , } }
 pub const GUID_TFCAT_TIPCAP_COMLESS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x364215d9_75bc_11d7_a6ef_00065b84435c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TFCAT_TIPCAP_COMLESS ) , guid : :: windows :: core :: GUID::from_u128(0x364215d9_75bc_11d7_a6ef_00065b84435c) , } }
 pub const GUID_TFCAT_TIPCAP_DUALMODE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3af314a2_d79f_4b1b_9992_15086d339b05);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TFCAT_TIPCAP_DUALMODE ) , guid : :: windows :: core :: GUID::from_u128(0x3af314a2_d79f_4b1b_9992_15086d339b05) , } }
 pub const GUID_TFCAT_TIPCAP_IMMERSIVEONLY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3a4259ac_640d_4ad4_89f7_1eb67e7c4ee8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TFCAT_TIPCAP_IMMERSIVEONLY ) , guid : :: windows :: core :: GUID::from_u128(0x3a4259ac_640d_4ad4_89f7_1eb67e7c4ee8) , } }
 pub const GUID_TFCAT_TIPCAP_IMMERSIVESUPPORT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x13a016df_560b_46cd_947a_4c3af1e0e35d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TFCAT_TIPCAP_IMMERSIVESUPPORT ) , guid : :: windows :: core :: GUID::from_u128(0x13a016df_560b_46cd_947a_4c3af1e0e35d) , } }
 pub const GUID_TFCAT_TIPCAP_INPUTMODECOMPARTMENT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xccf05dd7_4a87_11d7_a6e2_00065b84435c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TFCAT_TIPCAP_INPUTMODECOMPARTMENT ) , guid : :: windows :: core :: GUID::from_u128(0xccf05dd7_4a87_11d7_a6e2_00065b84435c) , } }
 pub const GUID_TFCAT_TIPCAP_LOCALSERVER: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x74769ee9_4a66_4f9d_90d6_bf8b7c3eb461);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TFCAT_TIPCAP_LOCALSERVER ) , guid : :: windows :: core :: GUID::from_u128(0x74769ee9_4a66_4f9d_90d6_bf8b7c3eb461) , } }
 pub const GUID_TFCAT_TIPCAP_SECUREMODE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x49d2f9ce_1f5e_11d7_a6d3_00065b84435c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TFCAT_TIPCAP_SECUREMODE ) , guid : :: windows :: core :: GUID::from_u128(0x49d2f9ce_1f5e_11d7_a6d3_00065b84435c) , } }
 pub const GUID_TFCAT_TIPCAP_SYSTRAYSUPPORT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x25504fb4_7bab_4bc1_9c69_cf81890f0ef5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TFCAT_TIPCAP_SYSTRAYSUPPORT ) , guid : :: windows :: core :: GUID::from_u128(0x25504fb4_7bab_4bc1_9c69_cf81890f0ef5) , } }
 pub const GUID_TFCAT_TIPCAP_TSF3: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x07dcb4af_98de_4548_bef7_25bd45979a1f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TFCAT_TIPCAP_TSF3 ) , guid : :: windows :: core :: GUID::from_u128(0x07dcb4af_98de_4548_bef7_25bd45979a1f) , } }
 pub const GUID_TFCAT_TIPCAP_UIELEMENTENABLED: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x49d2f9cf_1f5e_11d7_a6d3_00065b84435c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TFCAT_TIPCAP_UIELEMENTENABLED ) , guid : :: windows :: core :: GUID::from_u128(0x49d2f9cf_1f5e_11d7_a6d3_00065b84435c) , } }
 pub const GUID_TFCAT_TIPCAP_WOW16: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x364215da_75bc_11d7_a6ef_00065b84435c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TFCAT_TIPCAP_WOW16 ) , guid : :: windows :: core :: GUID::from_u128(0x364215da_75bc_11d7_a6ef_00065b84435c) , } }
 pub const GUID_TFCAT_TIP_HANDWRITING: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x246ecb87_c2f2_4abe_905b_c8b38add2c43);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TFCAT_TIP_HANDWRITING ) , guid : :: windows :: core :: GUID::from_u128(0x246ecb87_c2f2_4abe_905b_c8b38add2c43) , } }
 pub const GUID_TFCAT_TIP_KEYBOARD: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x34745c63_b2f0_4784_8b67_5e12c8701a31);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TFCAT_TIP_KEYBOARD ) , guid : :: windows :: core :: GUID::from_u128(0x34745c63_b2f0_4784_8b67_5e12c8701a31) , } }
 pub const GUID_TFCAT_TIP_SPEECH: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb5a73cd1_8355_426b_a161_259808f26b14);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TFCAT_TIP_SPEECH ) , guid : :: windows :: core :: GUID::from_u128(0xb5a73cd1_8355_426b_a161_259808f26b14) , } }
 pub const GUID_TFCAT_TRANSITORYEXTENSIONUI: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6302de22_a5cf_4b02_bfe8_4d72b2bed3c6);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TFCAT_TRANSITORYEXTENSIONUI ) , guid : :: windows :: core :: GUID::from_u128(0x6302de22_a5cf_4b02_bfe8_4d72b2bed3c6) , } }
 pub const GUID_TS_SERVICE_ACCESSIBLE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf9786200_a5bf_4a0f_8c24_fb16f5d1aabb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TS_SERVICE_ACCESSIBLE ) , guid : :: windows :: core :: GUID::from_u128(0xf9786200_a5bf_4a0f_8c24_fb16f5d1aabb) , } }
 pub const GUID_TS_SERVICE_ACTIVEX: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xea937a50_c9a6_4b7d_894a_49d99b784834);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TS_SERVICE_ACTIVEX ) , guid : :: windows :: core :: GUID::from_u128(0xea937a50_c9a6_4b7d_894a_49d99b784834) , } }
 pub const GUID_TS_SERVICE_DATAOBJECT: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6086fbb5_e225_46ce_a770_c1bbd3e05d7b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( GUID_TS_SERVICE_DATAOBJECT ) , guid : :: windows :: core :: GUID::from_u128(0x6086fbb5_e225_46ce_a770_c1bbd3e05d7b) , } }
 #[doc = "*Required features: 'Win32_UI_TextServices'*"]
 pub const GXFPF_NEAREST: u32 = 2u32;
 #[doc = "*Required features: 'Win32_UI_TextServices'*"]
@@ -13874,6 +14034,8 @@ pub const TF_DTLBI_NONE: LANG_BAR_ITEM_ICON_MODE_FLAGS = 0u32;
 #[doc = "*Required features: 'Win32_UI_TextServices'*"]
 pub const TF_DTLBI_USEPROFILEICON: LANG_BAR_ITEM_ICON_MODE_FLAGS = 1u32;
 pub const LIBID_MSAATEXTLib: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x150e2d7a_dac1_4582_947d_2a8fd78b82cd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( LIBID_MSAATEXTLib ) , guid : :: windows :: core :: GUID::from_u128(0x150e2d7a_dac1_4582_947d_2a8fd78b82cd) , } }
 pub const MSAAControl: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x08cd963f_7a3e_4f5c_9bd8_d692bb043c5b);
 #[doc = "*Required features: 'Win32_UI_TextServices'*"]
 pub type TEXT_STORE_CHANGE_FLAGS = u32;
@@ -14565,19 +14727,47 @@ pub const TF_PROFILETYPE_INPUTPROCESSOR: u32 = 1u32;
 #[doc = "*Required features: 'Win32_UI_TextServices'*"]
 pub const TF_PROFILETYPE_KEYBOARDLAYOUT: u32 = 2u32;
 pub const TF_PROFILE_ARRAY: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd38eff65_aa46_4fd5_91a7_67845fb02f5b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TF_PROFILE_ARRAY ) , guid : :: windows :: core :: GUID::from_u128(0xd38eff65_aa46_4fd5_91a7_67845fb02f5b) , } }
 pub const TF_PROFILE_CANTONESE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0aec109c_7e96_11d4_b2ef_0080c882687e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TF_PROFILE_CANTONESE ) , guid : :: windows :: core :: GUID::from_u128(0x0aec109c_7e96_11d4_b2ef_0080c882687e) , } }
 pub const TF_PROFILE_CHANGJIE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x4bdf9f03_c7d3_11d4_b2ab_0080c882687e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TF_PROFILE_CHANGJIE ) , guid : :: windows :: core :: GUID::from_u128(0x4bdf9f03_c7d3_11d4_b2ab_0080c882687e) , } }
 pub const TF_PROFILE_DAYI: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x037b2c25_480c_4d7f_b027_d6ca6b69788a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TF_PROFILE_DAYI ) , guid : :: windows :: core :: GUID::from_u128(0x037b2c25_480c_4d7f_b027_d6ca6b69788a) , } }
 pub const TF_PROFILE_NEWCHANGJIE: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf3ba907a_6c7e_11d4_97fa_0080c882687e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TF_PROFILE_NEWCHANGJIE ) , guid : :: windows :: core :: GUID::from_u128(0xf3ba907a_6c7e_11d4_97fa_0080c882687e) , } }
 pub const TF_PROFILE_NEWPHONETIC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb2f9c502_1742_11d4_9790_0080c882687e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TF_PROFILE_NEWPHONETIC ) , guid : :: windows :: core :: GUID::from_u128(0xb2f9c502_1742_11d4_9790_0080c882687e) , } }
 pub const TF_PROFILE_NEWQUICK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0b883ba0_c1c7_11d4_87f9_0080c882687e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TF_PROFILE_NEWQUICK ) , guid : :: windows :: core :: GUID::from_u128(0x0b883ba0_c1c7_11d4_87f9_0080c882687e) , } }
 pub const TF_PROFILE_PHONETIC: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x761309de_317a_11d4_9b5d_0080c882687e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TF_PROFILE_PHONETIC ) , guid : :: windows :: core :: GUID::from_u128(0x761309de_317a_11d4_9b5d_0080c882687e) , } }
 pub const TF_PROFILE_PINYIN: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf3ba9077_6c7e_11d4_97fa_0080c882687e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TF_PROFILE_PINYIN ) , guid : :: windows :: core :: GUID::from_u128(0xf3ba9077_6c7e_11d4_97fa_0080c882687e) , } }
 pub const TF_PROFILE_QUICK: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6024b45f_5c54_11d4_b921_0080c882687e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TF_PROFILE_QUICK ) , guid : :: windows :: core :: GUID::from_u128(0x6024b45f_5c54_11d4_b921_0080c882687e) , } }
 pub const TF_PROFILE_SIMPLEFAST: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfa550b04_5ad7_411f_a5ac_ca038ec515d7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TF_PROFILE_SIMPLEFAST ) , guid : :: windows :: core :: GUID::from_u128(0xfa550b04_5ad7_411f_a5ac_ca038ec515d7) , } }
 pub const TF_PROFILE_TIGRINYA: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3cab88b7_cc3e_46a6_9765_b772ad7761ff);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TF_PROFILE_TIGRINYA ) , guid : :: windows :: core :: GUID::from_u128(0x3cab88b7_cc3e_46a6_9765_b772ad7761ff) , } }
 pub const TF_PROFILE_WUBI: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x82590c13_f4dd_44f4_ba1d_8667246fdf8e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TF_PROFILE_WUBI ) , guid : :: windows :: core :: GUID::from_u128(0x82590c13_f4dd_44f4_ba1d_8667246fdf8e) , } }
 pub const TF_PROFILE_YI: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x409c8376_007b_4357_ae8e_26316ee3fb0d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TF_PROFILE_YI ) , guid : :: windows :: core :: GUID::from_u128(0x409c8376_007b_4357_ae8e_26316ee3fb0d) , } }
 #[repr(C)]
 #[doc = "*Required features: 'Win32_UI_TextServices', 'Win32_Foundation', 'Win32_System_Com', 'Win32_System_Ole'*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -14856,89 +15046,257 @@ pub const TKB_ALTERNATES_FOR_PREDICTION: u32 = 3u32;
 #[doc = "*Required features: 'Win32_UI_TextServices'*"]
 pub const TKB_ALTERNATES_STANDARD: u32 = 1u32;
 pub const TSATTRID_App: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa80f77df_4237_40e5_849c_b5fa51c13ac7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_App ) , guid : :: windows :: core :: GUID::from_u128(0xa80f77df_4237_40e5_849c_b5fa51c13ac7) , } }
 pub const TSATTRID_App_IncorrectGrammar: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbd54e398_ad03_4b74_b6b3_5edb19996388);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_App_IncorrectGrammar ) , guid : :: windows :: core :: GUID::from_u128(0xbd54e398_ad03_4b74_b6b3_5edb19996388) , } }
 pub const TSATTRID_App_IncorrectSpelling: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf42de43c_ef12_430d_944c_9a08970a25d2);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_App_IncorrectSpelling ) , guid : :: windows :: core :: GUID::from_u128(0xf42de43c_ef12_430d_944c_9a08970a25d2) , } }
 pub const TSATTRID_Font: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x573ea825_749b_4f8a_9cfd_21c3605ca828);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font ) , guid : :: windows :: core :: GUID::from_u128(0x573ea825_749b_4f8a_9cfd_21c3605ca828) , } }
 pub const TSATTRID_Font_FaceName: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb536aeb6_053b_4eb8_b65a_50da1e81e72e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_FaceName ) , guid : :: windows :: core :: GUID::from_u128(0xb536aeb6_053b_4eb8_b65a_50da1e81e72e) , } }
 pub const TSATTRID_Font_SizePts: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc8493302_a5e9_456d_af04_8005e4130f03);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_SizePts ) , guid : :: windows :: core :: GUID::from_u128(0xc8493302_a5e9_456d_af04_8005e4130f03) , } }
 pub const TSATTRID_Font_Style: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x68b2a77f_6b0e_4f28_8177_571c2f3a42b1);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style ) , guid : :: windows :: core :: GUID::from_u128(0x68b2a77f_6b0e_4f28_8177_571c2f3a42b1) , } }
 pub const TSATTRID_Font_Style_Animation: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdcf73d22_e029_47b7_bb36_f263a3d004cc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Animation ) , guid : :: windows :: core :: GUID::from_u128(0xdcf73d22_e029_47b7_bb36_f263a3d004cc) , } }
 pub const TSATTRID_Font_Style_Animation_BlinkingBackground: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x86e5b104_0104_4b10_b585_00f2527522b5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Animation_BlinkingBackground ) , guid : :: windows :: core :: GUID::from_u128(0x86e5b104_0104_4b10_b585_00f2527522b5) , } }
 pub const TSATTRID_Font_Style_Animation_LasVegasLights: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xf40423d5_0f87_4f8f_bada_e6d60c25e152);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Animation_LasVegasLights ) , guid : :: windows :: core :: GUID::from_u128(0xf40423d5_0f87_4f8f_bada_e6d60c25e152) , } }
 pub const TSATTRID_Font_Style_Animation_MarchingBlackAnts: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7644e067_f186_4902_bfc6_ec815aa20e9d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Animation_MarchingBlackAnts ) , guid : :: windows :: core :: GUID::from_u128(0x7644e067_f186_4902_bfc6_ec815aa20e9d) , } }
 pub const TSATTRID_Font_Style_Animation_MarchingRedAnts: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x78368dad_50fb_4c6f_840b_d486bb6cf781);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Animation_MarchingRedAnts ) , guid : :: windows :: core :: GUID::from_u128(0x78368dad_50fb_4c6f_840b_d486bb6cf781) , } }
 pub const TSATTRID_Font_Style_Animation_Shimmer: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2ce31b58_5293_4c36_8809_bf8bb51a27b3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Animation_Shimmer ) , guid : :: windows :: core :: GUID::from_u128(0x2ce31b58_5293_4c36_8809_bf8bb51a27b3) , } }
 pub const TSATTRID_Font_Style_Animation_SparkleText: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x533aad20_962c_4e9f_8c09_b42ea4749711);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Animation_SparkleText ) , guid : :: windows :: core :: GUID::from_u128(0x533aad20_962c_4e9f_8c09_b42ea4749711) , } }
 pub const TSATTRID_Font_Style_Animation_WipeDown: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5872e874_367b_4803_b160_c90ff62569d0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Animation_WipeDown ) , guid : :: windows :: core :: GUID::from_u128(0x5872e874_367b_4803_b160_c90ff62569d0) , } }
 pub const TSATTRID_Font_Style_Animation_WipeRight: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb855cbe3_3d2c_4600_b1e9_e1c9ce02f842);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Animation_WipeRight ) , guid : :: windows :: core :: GUID::from_u128(0xb855cbe3_3d2c_4600_b1e9_e1c9ce02f842) , } }
 pub const TSATTRID_Font_Style_BackgroundColor: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb50eaa4e_3091_4468_81db_d79ea190c7c7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_BackgroundColor ) , guid : :: windows :: core :: GUID::from_u128(0xb50eaa4e_3091_4468_81db_d79ea190c7c7) , } }
 pub const TSATTRID_Font_Style_Blink: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbfb2c036_7acf_4532_b720_b416dd7765a8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Blink ) , guid : :: windows :: core :: GUID::from_u128(0xbfb2c036_7acf_4532_b720_b416dd7765a8) , } }
 pub const TSATTRID_Font_Style_Bold: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x48813a43_8a20_4940_8e58_97823f7b268a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Bold ) , guid : :: windows :: core :: GUID::from_u128(0x48813a43_8a20_4940_8e58_97823f7b268a) , } }
 pub const TSATTRID_Font_Style_Capitalize: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7d85a3ba_b4fd_43b3_befc_6b985c843141);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Capitalize ) , guid : :: windows :: core :: GUID::from_u128(0x7d85a3ba_b4fd_43b3_befc_6b985c843141) , } }
 pub const TSATTRID_Font_Style_Color: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x857a7a37_b8af_4e9a_81b4_acf700c8411b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Color ) , guid : :: windows :: core :: GUID::from_u128(0x857a7a37_b8af_4e9a_81b4_acf700c8411b) , } }
 pub const TSATTRID_Font_Style_Emboss: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbd8ed742_349e_4e37_82fb_437979cb53a7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Emboss ) , guid : :: windows :: core :: GUID::from_u128(0xbd8ed742_349e_4e37_82fb_437979cb53a7) , } }
 pub const TSATTRID_Font_Style_Engrave: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x9c3371de_8332_4897_be5d_89233223179a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Engrave ) , guid : :: windows :: core :: GUID::from_u128(0x9c3371de_8332_4897_be5d_89233223179a) , } }
 pub const TSATTRID_Font_Style_Height: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7e937477_12e6_458b_926a_1fa44ee8f391);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Height ) , guid : :: windows :: core :: GUID::from_u128(0x7e937477_12e6_458b_926a_1fa44ee8f391) , } }
 pub const TSATTRID_Font_Style_Hidden: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb1e28770_881c_475f_863f_887a647b1090);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Hidden ) , guid : :: windows :: core :: GUID::from_u128(0xb1e28770_881c_475f_863f_887a647b1090) , } }
 pub const TSATTRID_Font_Style_Italic: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8740682a_a765_48e1_acfc_d22222b2f810);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Italic ) , guid : :: windows :: core :: GUID::from_u128(0x8740682a_a765_48e1_acfc_d22222b2f810) , } }
 pub const TSATTRID_Font_Style_Kerning: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcc26e1b4_2f9a_47c8_8bff_bf1eb7cce0dd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Kerning ) , guid : :: windows :: core :: GUID::from_u128(0xcc26e1b4_2f9a_47c8_8bff_bf1eb7cce0dd) , } }
 pub const TSATTRID_Font_Style_Lowercase: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x76d8ccb5_ca7b_4498_8ee9_d5c4f6f74c60);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Lowercase ) , guid : :: windows :: core :: GUID::from_u128(0x76d8ccb5_ca7b_4498_8ee9_d5c4f6f74c60) , } }
 pub const TSATTRID_Font_Style_Outlined: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x10e6db31_db0d_4ac6_a7f5_9c9cff6f2ab4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Outlined ) , guid : :: windows :: core :: GUID::from_u128(0x10e6db31_db0d_4ac6_a7f5_9c9cff6f2ab4) , } }
 pub const TSATTRID_Font_Style_Overline: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe3989f4a_992b_4301_8ce1_a5b7c6d1f3c8);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Overline ) , guid : :: windows :: core :: GUID::from_u128(0xe3989f4a_992b_4301_8ce1_a5b7c6d1f3c8) , } }
 pub const TSATTRID_Font_Style_Overline_Double: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdc46063a_e115_46e3_bcd8_ca6772aa95b4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Overline_Double ) , guid : :: windows :: core :: GUID::from_u128(0xdc46063a_e115_46e3_bcd8_ca6772aa95b4) , } }
 pub const TSATTRID_Font_Style_Overline_Single: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8440d94c_51ce_47b2_8d4c_15751e5f721b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Overline_Single ) , guid : :: windows :: core :: GUID::from_u128(0x8440d94c_51ce_47b2_8d4c_15751e5f721b) , } }
 pub const TSATTRID_Font_Style_Position: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x15cd26ab_f2fb_4062_b5a6_9a49e1a5cc0b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Position ) , guid : :: windows :: core :: GUID::from_u128(0x15cd26ab_f2fb_4062_b5a6_9a49e1a5cc0b) , } }
 pub const TSATTRID_Font_Style_Protected: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1c557cb2_14cf_4554_a574_ecb2f7e7efd4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Protected ) , guid : :: windows :: core :: GUID::from_u128(0x1c557cb2_14cf_4554_a574_ecb2f7e7efd4) , } }
 pub const TSATTRID_Font_Style_Shadow: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5f686d2f_c6cd_4c56_8a1a_994a4b9766be);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Shadow ) , guid : :: windows :: core :: GUID::from_u128(0x5f686d2f_c6cd_4c56_8a1a_994a4b9766be) , } }
 pub const TSATTRID_Font_Style_SmallCaps: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfacb6bc6_9100_4cc6_b969_11eea45a86b4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_SmallCaps ) , guid : :: windows :: core :: GUID::from_u128(0xfacb6bc6_9100_4cc6_b969_11eea45a86b4) , } }
 pub const TSATTRID_Font_Style_Spacing: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x98c1200d_8f06_409a_8e49_6a554bf7c153);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Spacing ) , guid : :: windows :: core :: GUID::from_u128(0x98c1200d_8f06_409a_8e49_6a554bf7c153) , } }
 pub const TSATTRID_Font_Style_Strikethrough: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0c562193_2d08_4668_9601_ced41309d7af);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Strikethrough ) , guid : :: windows :: core :: GUID::from_u128(0x0c562193_2d08_4668_9601_ced41309d7af) , } }
 pub const TSATTRID_Font_Style_Strikethrough_Double: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x62489b31_a3e7_4f94_ac43_ebaf8fcc7a9f);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Strikethrough_Double ) , guid : :: windows :: core :: GUID::from_u128(0x62489b31_a3e7_4f94_ac43_ebaf8fcc7a9f) , } }
 pub const TSATTRID_Font_Style_Strikethrough_Single: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x75d736b6_3c8f_4b97_ab78_1877cb990d31);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Strikethrough_Single ) , guid : :: windows :: core :: GUID::from_u128(0x75d736b6_3c8f_4b97_ab78_1877cb990d31) , } }
 pub const TSATTRID_Font_Style_Subscript: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5774fb84_389b_43bc_a74b_1568347cf0f4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Subscript ) , guid : :: windows :: core :: GUID::from_u128(0x5774fb84_389b_43bc_a74b_1568347cf0f4) , } }
 pub const TSATTRID_Font_Style_Superscript: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2ea4993c_563c_49aa_9372_0bef09a9255b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Superscript ) , guid : :: windows :: core :: GUID::from_u128(0x2ea4993c_563c_49aa_9372_0bef09a9255b) , } }
 pub const TSATTRID_Font_Style_Underline: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xc3c9c9f3_7902_444b_9a7b_48e70f4b50f7);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Underline ) , guid : :: windows :: core :: GUID::from_u128(0xc3c9c9f3_7902_444b_9a7b_48e70f4b50f7) , } }
 pub const TSATTRID_Font_Style_Underline_Double: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x74d24aa6_1db3_4c69_a176_31120e7586d5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Underline_Double ) , guid : :: windows :: core :: GUID::from_u128(0x74d24aa6_1db3_4c69_a176_31120e7586d5) , } }
 pub const TSATTRID_Font_Style_Underline_Single: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1b6720e5_0f73_4951_a6b3_6f19e43c9461);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Underline_Single ) , guid : :: windows :: core :: GUID::from_u128(0x1b6720e5_0f73_4951_a6b3_6f19e43c9461) , } }
 pub const TSATTRID_Font_Style_Uppercase: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x33a300e8_e340_4937_b697_8f234045cd9a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Uppercase ) , guid : :: windows :: core :: GUID::from_u128(0x33a300e8_e340_4937_b697_8f234045cd9a) , } }
 pub const TSATTRID_Font_Style_Weight: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x12f3189c_8bb0_461b_b1fa_eaf907047fe0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Font_Style_Weight ) , guid : :: windows :: core :: GUID::from_u128(0x12f3189c_8bb0_461b_b1fa_eaf907047fe0) , } }
 pub const TSATTRID_List: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x436d673b_26f1_4aee_9e65_8f83a4ed4884);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_List ) , guid : :: windows :: core :: GUID::from_u128(0x436d673b_26f1_4aee_9e65_8f83a4ed4884) , } }
 pub const TSATTRID_List_LevelIndel: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7f7cc899_311f_487b_ad5d_e2a459e12d42);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_List_LevelIndel ) , guid : :: windows :: core :: GUID::from_u128(0x7f7cc899_311f_487b_ad5d_e2a459e12d42) , } }
 pub const TSATTRID_List_Type: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xae3e665e_4bce_49e3_a0fe_2db47d3a17ae);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_List_Type ) , guid : :: windows :: core :: GUID::from_u128(0xae3e665e_4bce_49e3_a0fe_2db47d3a17ae) , } }
 pub const TSATTRID_List_Type_Arabic: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x1338c5d6_98a3_4fa3_9bd1_7a60eef8e9e0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_List_Type_Arabic ) , guid : :: windows :: core :: GUID::from_u128(0x1338c5d6_98a3_4fa3_9bd1_7a60eef8e9e0) , } }
 pub const TSATTRID_List_Type_Bullet: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xbccd77c5_4c4d_4ce2_b102_559f3b2bfcea);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_List_Type_Bullet ) , guid : :: windows :: core :: GUID::from_u128(0xbccd77c5_4c4d_4ce2_b102_559f3b2bfcea) , } }
 pub const TSATTRID_List_Type_LowerLetter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x96372285_f3cf_491e_a925_3832347fd237);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_List_Type_LowerLetter ) , guid : :: windows :: core :: GUID::from_u128(0x96372285_f3cf_491e_a925_3832347fd237) , } }
 pub const TSATTRID_List_Type_LowerRoman: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x90466262_3980_4b8e_9368_918bd1218a41);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_List_Type_LowerRoman ) , guid : :: windows :: core :: GUID::from_u128(0x90466262_3980_4b8e_9368_918bd1218a41) , } }
 pub const TSATTRID_List_Type_UpperLetter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7987b7cd_ce52_428b_9b95_a357f6f10c45);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_List_Type_UpperLetter ) , guid : :: windows :: core :: GUID::from_u128(0x7987b7cd_ce52_428b_9b95_a357f6f10c45) , } }
 pub const TSATTRID_List_Type_UpperRoman: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0f6ab552_4a80_467f_b2f1_127e2aa3ba9e);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_List_Type_UpperRoman ) , guid : :: windows :: core :: GUID::from_u128(0x0f6ab552_4a80_467f_b2f1_127e2aa3ba9e) , } }
 pub const TSATTRID_OTHERS: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb3c32af9_57d0_46a9_bca8_dac238a13057);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_OTHERS ) , guid : :: windows :: core :: GUID::from_u128(0xb3c32af9_57d0_46a9_bca8_dac238a13057) , } }
 pub const TSATTRID_Text: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7edb8e68_81f9_449d_a15a_87a8388faac0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Text ) , guid : :: windows :: core :: GUID::from_u128(0x7edb8e68_81f9_449d_a15a_87a8388faac0) , } }
 pub const TSATTRID_Text_Alignment: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x139941e6_1767_456d_938e_35ba568b5cd4);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Text_Alignment ) , guid : :: windows :: core :: GUID::from_u128(0x139941e6_1767_456d_938e_35ba568b5cd4) , } }
 pub const TSATTRID_Text_Alignment_Center: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa4a95c16_53bf_4d55_8b87_4bdd8d4275fc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Text_Alignment_Center ) , guid : :: windows :: core :: GUID::from_u128(0xa4a95c16_53bf_4d55_8b87_4bdd8d4275fc) , } }
 pub const TSATTRID_Text_Alignment_Justify: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xed350740_a0f7_42d3_8ea8_f81b6488faf0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Text_Alignment_Justify ) , guid : :: windows :: core :: GUID::from_u128(0xed350740_a0f7_42d3_8ea8_f81b6488faf0) , } }
 pub const TSATTRID_Text_Alignment_Left: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x16ae95d3_6361_43a2_8495_d00f397f1693);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Text_Alignment_Left ) , guid : :: windows :: core :: GUID::from_u128(0x16ae95d3_6361_43a2_8495_d00f397f1693) , } }
 pub const TSATTRID_Text_Alignment_Right: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xb36f0f98_1b9e_4360_8616_03fb08a78456);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Text_Alignment_Right ) , guid : :: windows :: core :: GUID::from_u128(0xb36f0f98_1b9e_4360_8616_03fb08a78456) , } }
 pub const TSATTRID_Text_EmbeddedObject: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7edb8e68_81f9_449d_a15a_87a8388faac0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Text_EmbeddedObject ) , guid : :: windows :: core :: GUID::from_u128(0x7edb8e68_81f9_449d_a15a_87a8388faac0) , } }
 pub const TSATTRID_Text_Hyphenation: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xdadf4525_618e_49eb_b1a8_3b68bd7648e3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Text_Hyphenation ) , guid : :: windows :: core :: GUID::from_u128(0xdadf4525_618e_49eb_b1a8_3b68bd7648e3) , } }
 pub const TSATTRID_Text_Language: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xd8c04ef1_5753_4c25_8887_85443fe5f819);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Text_Language ) , guid : :: windows :: core :: GUID::from_u128(0xd8c04ef1_5753_4c25_8887_85443fe5f819) , } }
 pub const TSATTRID_Text_Link: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x47cd9051_3722_4cd8_b7c8_4e17ca1759f5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Text_Link ) , guid : :: windows :: core :: GUID::from_u128(0x47cd9051_3722_4cd8_b7c8_4e17ca1759f5) , } }
 pub const TSATTRID_Text_Orientation: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6bab707f_8785_4c39_8b52_96f878303ffb);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Text_Orientation ) , guid : :: windows :: core :: GUID::from_u128(0x6bab707f_8785_4c39_8b52_96f878303ffb) , } }
 pub const TSATTRID_Text_Para: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x5edc5822_99dc_4dd6_aec3_b62baa5b2e7c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Text_Para ) , guid : :: windows :: core :: GUID::from_u128(0x5edc5822_99dc_4dd6_aec3_b62baa5b2e7c) , } }
 pub const TSATTRID_Text_Para_FirstLineIndent: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x07c97a13_7472_4dd8_90a9_91e3d7e4f29c);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Text_Para_FirstLineIndent ) , guid : :: windows :: core :: GUID::from_u128(0x07c97a13_7472_4dd8_90a9_91e3d7e4f29c) , } }
 pub const TSATTRID_Text_Para_LeftIndent: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfb2848e9_7471_41c9_b6b3_8a1450e01897);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Text_Para_LeftIndent ) , guid : :: windows :: core :: GUID::from_u128(0xfb2848e9_7471_41c9_b6b3_8a1450e01897) , } }
 pub const TSATTRID_Text_Para_LineSpacing: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x699b380d_7f8c_46d6_a73b_dfe3d1538df3);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Text_Para_LineSpacing ) , guid : :: windows :: core :: GUID::from_u128(0x699b380d_7f8c_46d6_a73b_dfe3d1538df3) , } }
 pub const TSATTRID_Text_Para_LineSpacing_AtLeast: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xadfedf31_2d44_4434_a5ff_7f4c4990a905);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Text_Para_LineSpacing_AtLeast ) , guid : :: windows :: core :: GUID::from_u128(0xadfedf31_2d44_4434_a5ff_7f4c4990a905) , } }
 pub const TSATTRID_Text_Para_LineSpacing_Double: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x82fb1805_a6c4_4231_ac12_6260af2aba28);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Text_Para_LineSpacing_Double ) , guid : :: windows :: core :: GUID::from_u128(0x82fb1805_a6c4_4231_ac12_6260af2aba28) , } }
 pub const TSATTRID_Text_Para_LineSpacing_Exactly: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x3d45ad40_23de_48d7_a6b3_765420c620cc);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Text_Para_LineSpacing_Exactly ) , guid : :: windows :: core :: GUID::from_u128(0x3d45ad40_23de_48d7_a6b3_765420c620cc) , } }
 pub const TSATTRID_Text_Para_LineSpacing_Multiple: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x910f1e3c_d6d0_4f65_8a3c_42b4b31868c5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Text_Para_LineSpacing_Multiple ) , guid : :: windows :: core :: GUID::from_u128(0x910f1e3c_d6d0_4f65_8a3c_42b4b31868c5) , } }
 pub const TSATTRID_Text_Para_LineSpacing_OnePtFive: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x0428a021_0397_4b57_9a17_0795994cd3c5);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Text_Para_LineSpacing_OnePtFive ) , guid : :: windows :: core :: GUID::from_u128(0x0428a021_0397_4b57_9a17_0795994cd3c5) , } }
 pub const TSATTRID_Text_Para_LineSpacing_Single: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xed350740_a0f7_42d3_8ea8_f81b6488faf0);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Text_Para_LineSpacing_Single ) , guid : :: windows :: core :: GUID::from_u128(0xed350740_a0f7_42d3_8ea8_f81b6488faf0) , } }
 pub const TSATTRID_Text_Para_RightIndent: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x2c7f26f9_a5e2_48da_b98a_520cb16513bf);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Text_Para_RightIndent ) , guid : :: windows :: core :: GUID::from_u128(0x2c7f26f9_a5e2_48da_b98a_520cb16513bf) , } }
 pub const TSATTRID_Text_Para_SpaceAfter: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x7b0a3f55_22dc_425f_a411_93da1d8f9baa);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Text_Para_SpaceAfter ) , guid : :: windows :: core :: GUID::from_u128(0x7b0a3f55_22dc_425f_a411_93da1d8f9baa) , } }
 pub const TSATTRID_Text_Para_SpaceBefore: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x8df98589_194a_4601_b251_9865a3e906dd);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Text_Para_SpaceBefore ) , guid : :: windows :: core :: GUID::from_u128(0x8df98589_194a_4601_b251_9865a3e906dd) , } }
 pub const TSATTRID_Text_ReadOnly: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x85836617_de32_4afd_a50f_a2db110e6e4d);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Text_ReadOnly ) , guid : :: windows :: core :: GUID::from_u128(0x85836617_de32_4afd_a50f_a2db110e6e4d) , } }
 pub const TSATTRID_Text_RightToLeft: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xca666e71_1b08_453d_bfdd_28e08c8aaf7a);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Text_RightToLeft ) , guid : :: windows :: core :: GUID::from_u128(0xca666e71_1b08_453d_bfdd_28e08c8aaf7a) , } }
 pub const TSATTRID_Text_VerticalWriting: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x6bba8195_046f_4ea9_b311_97fd66c4274b);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( TSATTRID_Text_VerticalWriting ) , guid : :: windows :: core :: GUID::from_u128(0x6bba8195_046f_4ea9_b311_97fd66c4274b) , } }
 #[doc = "*Required features: 'Win32_UI_TextServices'*"]
 pub const TS_AS_ATTR_CHANGE: u32 = 8u32;
 #[doc = "*Required features: 'Win32_UI_TextServices'*"]

--- a/crates/libs/windows/src/Windows/Win32/UI/Wpf/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Wpf/mod.rs
@@ -1,10 +1,22 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 pub const CLSID_MILBitmapEffectBevel: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xfd361dbe_6c9b_4de0_8290_f6400c2737ed);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_MILBitmapEffectBevel ) , guid : :: windows :: core :: GUID::from_u128(0xfd361dbe_6c9b_4de0_8290_f6400c2737ed) , } }
 pub const CLSID_MILBitmapEffectBlur: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xa924df87_225d_4373_8f5b_b90ec85ae3de);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_MILBitmapEffectBlur ) , guid : :: windows :: core :: GUID::from_u128(0xa924df87_225d_4373_8f5b_b90ec85ae3de) , } }
 pub const CLSID_MILBitmapEffectDropShadow: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x459a3fbe_d8ac_4692_874b_7a265715aa16);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_MILBitmapEffectDropShadow ) , guid : :: windows :: core :: GUID::from_u128(0x459a3fbe_d8ac_4692_874b_7a265715aa16) , } }
 pub const CLSID_MILBitmapEffectEmboss: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xcd299846_824f_47ec_a007_12aa767f2816);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_MILBitmapEffectEmboss ) , guid : :: windows :: core :: GUID::from_u128(0xcd299846_824f_47ec_a007_12aa767f2816) , } }
 pub const CLSID_MILBitmapEffectGroup: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xac9c1a9a_7e18_4f64_ac7e_47cf7f051e95);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_MILBitmapEffectGroup ) , guid : :: windows :: core :: GUID::from_u128(0xac9c1a9a_7e18_4f64_ac7e_47cf7f051e95) , } }
 pub const CLSID_MILBitmapEffectOuterGlow: ::windows::core::GUID = ::windows::core::GUID::from_u128(0xe2161bdd_7eb6_4725_9c0b_8a2a1b4f0667);
+#[cfg(feature = "guid_hashmap")]
+inventory::submit! { crate :: core :: GuidConst { name : stringify ! ( CLSID_MILBitmapEffectOuterGlow ) , guid : :: windows :: core :: GUID::from_u128(0xe2161bdd_7eb6_4725_9c0b_8a2a1b4f0667) , } }
 #[doc = "*Required features: 'Win32_UI_Wpf'*"]
 #[repr(transparent)]
 pub struct IMILBitmapEffect(::windows::core::IUnknown);

--- a/crates/libs/windows/src/core/guid_hashmap.rs
+++ b/crates/libs/windows/src/core/guid_hashmap.rs
@@ -1,0 +1,13 @@
+use crate::core::GUID;
+use std::collections::HashMap;
+
+pub(crate) struct GuidConst {
+    pub name: &'static str,
+    pub guid: GUID,
+}
+
+inventory::collect!(GuidConst);
+
+pub fn build_guid_hashmap() -> HashMap<GUID, &'static str> {
+    inventory::iter::<GuidConst>().map(|gc| (gc.guid, gc.name)).collect()
+}

--- a/crates/libs/windows/src/core/mod.rs
+++ b/crates/libs/windows/src/core/mod.rs
@@ -7,6 +7,8 @@ mod delay_load;
 mod error;
 mod factory_cache;
 mod guid;
+#[cfg(feature = "guid_hashmap")]
+mod guid_hashmap;
 mod heap;
 mod hresult;
 mod hstring;
@@ -36,6 +38,8 @@ pub use error::*;
 #[doc(hidden)]
 pub use factory_cache::*;
 pub use guid::*;
+#[cfg(feature = "guid_hashmap")]
+pub use guid_hashmap::*;
 #[doc(hidden)]
 pub use heap::*;
 pub use hresult::*;

--- a/crates/tools/api/src/main.rs
+++ b/crates/tools/api/src/main.rs
@@ -57,12 +57,14 @@ windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.29.0" }
 windows_macros = { path = "../macros",  version = "0.29.0", optional = true }
 windows_reader = { path = "../reader", version = "0.29.0", optional = true }
 windows_gen = { path = "../gen",  version = "0.29.0", optional = true }
+inventory = { version = "0.2.1", optional = true }
 
 [features]
 default = []
 deprecated = []
 std = []
 alloc = []
+guid_hashmap = ["inventory", "std"]
 build = ["windows_gen", "windows_macros", "windows_reader"]
 "#
         .as_bytes(),


### PR DESCRIPTION
Adds the `guid_hashmap` optional feature. It's really common for Windows APIs to return GUID constants. These constants can make debugging pretty hard as there isn't a single queryable source of truth on which constants map to which names. In C++ the accepted solution has been to [refer to a hard coded list of these GUIDs](https://github.com/microsoft/Windows-classic-samples/blob/27ffb0811ca761741502feaefdb591aebf592193/Samples/Win7Samples/multimedia/mediafoundation/common/logmediatype.h#L182). So this PR gives the `windows` crate the ability to generate a `HashMap` which maps the `GUID` values to a `&'static str` containing the name of the GUID in the Windows api.