### PR TITLE
Add repository URLs to all library Cargo manifests

### DIFF
--- a/crates/libs/bindgen/Cargo.toml
+++ b/crates/libs/bindgen/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Code gen support for the windows crate"
+repository = "https://github.com/microsoft/windows-rs"
 
 [dependencies]
 quote = { package = "windows_quote", path = "../quote", version = "0.29.0" }

--- a/crates/libs/gen/Cargo.toml
+++ b/crates/libs/gen/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Code gen support for the windows crate"
+repository = "https://github.com/microsoft/windows-rs"
 
 [dependencies]
 quote = { package = "windows_quote", path = "../quote", version = "0.29.0" }

--- a/crates/libs/macros/Cargo.toml
+++ b/crates/libs/macros/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Macros for the windows crate"
+repository = "https://github.com/microsoft/windows-rs"
 
 [lib]
 proc-macro = true

--- a/crates/libs/quote/Cargo.toml
+++ b/crates/libs/quote/Cargo.toml
@@ -6,5 +6,6 @@ authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Code gen support for the windows crate"
+repository = "https://github.com/microsoft/windows-rs"
 
 [dependencies]

--- a/crates/libs/reader/Cargo.toml
+++ b/crates/libs/reader/Cargo.toml
@@ -5,5 +5,6 @@ authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Code gen support for the windows crate"
+repository = "https://github.com/microsoft/windows-rs"
 
 [dependencies]


### PR DESCRIPTION
This allows tools that collect information about dependencies to collect a more full set of information since the "non-public facing" library crates end up in lockfiles too.