### PR TITLE
Derive `PartialEq` and `Eq` for scoped enums to support constant patterns

### DIFF
--- a/crates/libs/bindgen/src/enums.rs
+++ b/crates/libs/bindgen/src/enums.rs
@@ -36,10 +36,20 @@ pub fn gen(def: &TypeDef, gen: &Gen) -> TokenStream {
             }
         });
 
+        let eq = if gen.sys {
+            quote! {}
+        } else {
+            quote! {
+                // Unfortunately, Rust requires these to be derived to allow constant patterns.
+                #[derive(::core::cmp::PartialEq, ::core::cmp::Eq)]
+            }
+        };
+
         quote! {
             #doc
             #features
             #[repr(transparent)]
+            #eq
             pub struct #ident(pub #underlying_type);
             #features
             impl #ident {
@@ -78,14 +88,6 @@ pub fn gen(def: &TypeDef, gen: &Gen) -> TokenStream {
                 unsafe impl ::windows::core::Abi for #ident {
                     type Abi = Self;
                 }
-                #features
-                impl ::core::cmp::PartialEq for #ident {
-                    fn eq(&self, other: &Self) -> bool {
-                        self.0 == other.0
-                    }
-                }
-                #features
-                impl ::core::cmp::Eq for #ident {}
                 #features
                 impl ::core::fmt::Debug for #ident {
                     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {

--- a/crates/libs/windows/src/Windows/AI/MachineLearning/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/AI/MachineLearning/Preview/mod.rs
@@ -2,6 +2,7 @@
 #[doc = "*Required features: 'AI_MachineLearning_Preview', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FeatureElementKindPreview(pub i32);
 #[cfg(feature = "deprecated")]
 impl FeatureElementKindPreview {
@@ -34,14 +35,6 @@ impl ::core::clone::Clone for FeatureElementKindPreview {
 unsafe impl ::windows::core::Abi for FeatureElementKindPreview {
     type Abi = Self;
 }
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for FeatureElementKindPreview {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for FeatureElementKindPreview {}
 #[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for FeatureElementKindPreview {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -1230,6 +1223,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Lear
 #[doc = "*Required features: 'AI_MachineLearning_Preview', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LearningModelDeviceKindPreview(pub i32);
 #[cfg(feature = "deprecated")]
 impl LearningModelDeviceKindPreview {
@@ -1252,14 +1246,6 @@ impl ::core::clone::Clone for LearningModelDeviceKindPreview {
 unsafe impl ::windows::core::Abi for LearningModelDeviceKindPreview {
     type Abi = Self;
 }
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for LearningModelDeviceKindPreview {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for LearningModelDeviceKindPreview {}
 #[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for LearningModelDeviceKindPreview {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -1383,6 +1369,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Lear
 #[doc = "*Required features: 'AI_MachineLearning_Preview', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LearningModelFeatureKindPreview(pub i32);
 #[cfg(feature = "deprecated")]
 impl LearningModelFeatureKindPreview {
@@ -1404,14 +1391,6 @@ impl ::core::clone::Clone for LearningModelFeatureKindPreview {
 unsafe impl ::windows::core::Abi for LearningModelFeatureKindPreview {
     type Abi = Self;
 }
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for LearningModelFeatureKindPreview {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for LearningModelFeatureKindPreview {}
 #[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for LearningModelFeatureKindPreview {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {

--- a/crates/libs/windows/src/Windows/AI/MachineLearning/mod.rs
+++ b/crates/libs/windows/src/Windows/AI/MachineLearning/mod.rs
@@ -2521,6 +2521,7 @@ unsafe impl ::core::marker::Send for LearningModelDevice {}
 unsafe impl ::core::marker::Sync for LearningModelDevice {}
 #[doc = "*Required features: 'AI_MachineLearning'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LearningModelDeviceKind(pub i32);
 impl LearningModelDeviceKind {
     pub const Default: Self = Self(0i32);
@@ -2538,12 +2539,6 @@ impl ::core::clone::Clone for LearningModelDeviceKind {
 unsafe impl ::windows::core::Abi for LearningModelDeviceKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LearningModelDeviceKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LearningModelDeviceKind {}
 impl ::core::fmt::Debug for LearningModelDeviceKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LearningModelDeviceKind").field(&self.0).finish()
@@ -2663,6 +2658,7 @@ unsafe impl ::core::marker::Send for LearningModelEvaluationResult {}
 unsafe impl ::core::marker::Sync for LearningModelEvaluationResult {}
 #[doc = "*Required features: 'AI_MachineLearning'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LearningModelFeatureKind(pub i32);
 impl LearningModelFeatureKind {
     pub const Tensor: Self = Self(0i32);
@@ -2679,12 +2675,6 @@ impl ::core::clone::Clone for LearningModelFeatureKind {
 unsafe impl ::windows::core::Abi for LearningModelFeatureKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LearningModelFeatureKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LearningModelFeatureKind {}
 impl ::core::fmt::Debug for LearningModelFeatureKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LearningModelFeatureKind").field(&self.0).finish()
@@ -2698,6 +2688,7 @@ impl ::windows::core::DefaultType for LearningModelFeatureKind {
 }
 #[doc = "*Required features: 'AI_MachineLearning'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LearningModelPixelRange(pub i32);
 impl LearningModelPixelRange {
     pub const ZeroTo255: Self = Self(0i32);
@@ -2713,12 +2704,6 @@ impl ::core::clone::Clone for LearningModelPixelRange {
 unsafe impl ::windows::core::Abi for LearningModelPixelRange {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LearningModelPixelRange {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LearningModelPixelRange {}
 impl ::core::fmt::Debug for LearningModelPixelRange {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LearningModelPixelRange").field(&self.0).finish()
@@ -5653,6 +5638,7 @@ unsafe impl ::core::marker::Send for TensorInt8Bit {}
 unsafe impl ::core::marker::Sync for TensorInt8Bit {}
 #[doc = "*Required features: 'AI_MachineLearning'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TensorKind(pub i32);
 impl TensorKind {
     pub const Undefined: Self = Self(0i32);
@@ -5681,12 +5667,6 @@ impl ::core::clone::Clone for TensorKind {
 unsafe impl ::windows::core::Abi for TensorKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TensorKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TensorKind {}
 impl ::core::fmt::Debug for TensorKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TensorKind").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/Activation/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Activation/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'ApplicationModel_Activation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ActivationKind(pub i32);
 impl ActivationKind {
     pub const Launch: Self = Self(0i32);
@@ -57,12 +58,6 @@ impl ::core::clone::Clone for ActivationKind {
 unsafe impl ::windows::core::Abi for ActivationKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ActivationKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ActivationKind {}
 impl ::core::fmt::Debug for ActivationKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ActivationKind").field(&self.0).finish()
@@ -76,6 +71,7 @@ impl ::windows::core::DefaultType for ActivationKind {
 }
 #[doc = "*Required features: 'ApplicationModel_Activation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ApplicationExecutionState(pub i32);
 impl ApplicationExecutionState {
     pub const NotRunning: Self = Self(0i32);
@@ -93,12 +89,6 @@ impl ::core::clone::Clone for ApplicationExecutionState {
 unsafe impl ::windows::core::Abi for ApplicationExecutionState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ApplicationExecutionState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ApplicationExecutionState {}
 impl ::core::fmt::Debug for ApplicationExecutionState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ApplicationExecutionState").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/AppService/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/AppService/mod.rs
@@ -102,6 +102,7 @@ unsafe impl ::core::marker::Send for AppServiceClosedEventArgs {}
 unsafe impl ::core::marker::Sync for AppServiceClosedEventArgs {}
 #[doc = "*Required features: 'ApplicationModel_AppService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppServiceClosedStatus(pub i32);
 impl AppServiceClosedStatus {
     pub const Completed: Self = Self(0i32);
@@ -118,12 +119,6 @@ impl ::core::clone::Clone for AppServiceClosedStatus {
 unsafe impl ::windows::core::Abi for AppServiceClosedStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppServiceClosedStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppServiceClosedStatus {}
 impl ::core::fmt::Debug for AppServiceClosedStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppServiceClosedStatus").field(&self.0).finish()
@@ -360,6 +355,7 @@ unsafe impl ::core::marker::Send for AppServiceConnection {}
 unsafe impl ::core::marker::Sync for AppServiceConnection {}
 #[doc = "*Required features: 'ApplicationModel_AppService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppServiceConnectionStatus(pub i32);
 impl AppServiceConnectionStatus {
     pub const Success: Self = Self(0i32);
@@ -384,12 +380,6 @@ impl ::core::clone::Clone for AppServiceConnectionStatus {
 unsafe impl ::windows::core::Abi for AppServiceConnectionStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppServiceConnectionStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppServiceConnectionStatus {}
 impl ::core::fmt::Debug for AppServiceConnectionStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppServiceConnectionStatus").field(&self.0).finish()
@@ -751,6 +741,7 @@ unsafe impl ::core::marker::Send for AppServiceResponse {}
 unsafe impl ::core::marker::Sync for AppServiceResponse {}
 #[doc = "*Required features: 'ApplicationModel_AppService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppServiceResponseStatus(pub i32);
 impl AppServiceResponseStatus {
     pub const Success: Self = Self(0i32);
@@ -774,12 +765,6 @@ impl ::core::clone::Clone for AppServiceResponseStatus {
 unsafe impl ::windows::core::Abi for AppServiceResponseStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppServiceResponseStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppServiceResponseStatus {}
 impl ::core::fmt::Debug for AppServiceResponseStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppServiceResponseStatus").field(&self.0).finish()
@@ -1290,6 +1275,7 @@ unsafe impl ::core::marker::Send for StatelessAppServiceResponse {}
 unsafe impl ::core::marker::Sync for StatelessAppServiceResponse {}
 #[doc = "*Required features: 'ApplicationModel_AppService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StatelessAppServiceResponseStatus(pub i32);
 impl StatelessAppServiceResponseStatus {
     pub const Success: Self = Self(0i32);
@@ -1317,12 +1303,6 @@ impl ::core::clone::Clone for StatelessAppServiceResponseStatus {
 unsafe impl ::windows::core::Abi for StatelessAppServiceResponseStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StatelessAppServiceResponseStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StatelessAppServiceResponseStatus {}
 impl ::core::fmt::Debug for StatelessAppServiceResponseStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StatelessAppServiceResponseStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/Appointments/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Appointments/mod.rs
@@ -431,6 +431,7 @@ unsafe impl ::core::marker::Send for Appointment {}
 unsafe impl ::core::marker::Sync for Appointment {}
 #[doc = "*Required features: 'ApplicationModel_Appointments'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppointmentBusyStatus(pub i32);
 impl AppointmentBusyStatus {
     pub const Busy: Self = Self(0i32);
@@ -448,12 +449,6 @@ impl ::core::clone::Clone for AppointmentBusyStatus {
 unsafe impl ::windows::core::Abi for AppointmentBusyStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppointmentBusyStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppointmentBusyStatus {}
 impl ::core::fmt::Debug for AppointmentBusyStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppointmentBusyStatus").field(&self.0).finish()
@@ -936,6 +931,7 @@ unsafe impl ::core::marker::Send for AppointmentCalendar {}
 unsafe impl ::core::marker::Sync for AppointmentCalendar {}
 #[doc = "*Required features: 'ApplicationModel_Appointments'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppointmentCalendarOtherAppReadAccess(pub i32);
 impl AppointmentCalendarOtherAppReadAccess {
     pub const SystemOnly: Self = Self(0i32);
@@ -952,12 +948,6 @@ impl ::core::clone::Clone for AppointmentCalendarOtherAppReadAccess {
 unsafe impl ::windows::core::Abi for AppointmentCalendarOtherAppReadAccess {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppointmentCalendarOtherAppReadAccess {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppointmentCalendarOtherAppReadAccess {}
 impl ::core::fmt::Debug for AppointmentCalendarOtherAppReadAccess {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppointmentCalendarOtherAppReadAccess").field(&self.0).finish()
@@ -971,6 +961,7 @@ impl ::windows::core::DefaultType for AppointmentCalendarOtherAppReadAccess {
 }
 #[doc = "*Required features: 'ApplicationModel_Appointments'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppointmentCalendarOtherAppWriteAccess(pub i32);
 impl AppointmentCalendarOtherAppWriteAccess {
     pub const None: Self = Self(0i32);
@@ -986,12 +977,6 @@ impl ::core::clone::Clone for AppointmentCalendarOtherAppWriteAccess {
 unsafe impl ::windows::core::Abi for AppointmentCalendarOtherAppWriteAccess {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppointmentCalendarOtherAppWriteAccess {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppointmentCalendarOtherAppWriteAccess {}
 impl ::core::fmt::Debug for AppointmentCalendarOtherAppWriteAccess {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppointmentCalendarOtherAppWriteAccess").field(&self.0).finish()
@@ -1145,6 +1130,7 @@ unsafe impl ::core::marker::Send for AppointmentCalendarSyncManager {}
 unsafe impl ::core::marker::Sync for AppointmentCalendarSyncManager {}
 #[doc = "*Required features: 'ApplicationModel_Appointments'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppointmentCalendarSyncStatus(pub i32);
 impl AppointmentCalendarSyncStatus {
     pub const Idle: Self = Self(0i32);
@@ -1164,12 +1150,6 @@ impl ::core::clone::Clone for AppointmentCalendarSyncStatus {
 unsafe impl ::windows::core::Abi for AppointmentCalendarSyncStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppointmentCalendarSyncStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppointmentCalendarSyncStatus {}
 impl ::core::fmt::Debug for AppointmentCalendarSyncStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppointmentCalendarSyncStatus").field(&self.0).finish()
@@ -1273,6 +1253,7 @@ unsafe impl ::core::marker::Send for AppointmentConflictResult {}
 unsafe impl ::core::marker::Sync for AppointmentConflictResult {}
 #[doc = "*Required features: 'ApplicationModel_Appointments'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppointmentConflictType(pub i32);
 impl AppointmentConflictType {
     pub const None: Self = Self(0i32);
@@ -1288,12 +1269,6 @@ impl ::core::clone::Clone for AppointmentConflictType {
 unsafe impl ::windows::core::Abi for AppointmentConflictType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppointmentConflictType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppointmentConflictType {}
 impl ::core::fmt::Debug for AppointmentConflictType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppointmentConflictType").field(&self.0).finish()
@@ -1307,6 +1282,7 @@ impl ::windows::core::DefaultType for AppointmentConflictType {
 }
 #[doc = "*Required features: 'ApplicationModel_Appointments'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppointmentDaysOfWeek(pub u32);
 impl AppointmentDaysOfWeek {
     pub const None: Self = Self(0u32);
@@ -1327,12 +1303,6 @@ impl ::core::clone::Clone for AppointmentDaysOfWeek {
 unsafe impl ::windows::core::Abi for AppointmentDaysOfWeek {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppointmentDaysOfWeek {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppointmentDaysOfWeek {}
 impl ::core::fmt::Debug for AppointmentDaysOfWeek {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppointmentDaysOfWeek").field(&self.0).finish()
@@ -1374,6 +1344,7 @@ impl ::windows::core::DefaultType for AppointmentDaysOfWeek {
 }
 #[doc = "*Required features: 'ApplicationModel_Appointments'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppointmentDetailsKind(pub i32);
 impl AppointmentDetailsKind {
     pub const PlainText: Self = Self(0i32);
@@ -1388,12 +1359,6 @@ impl ::core::clone::Clone for AppointmentDetailsKind {
 unsafe impl ::windows::core::Abi for AppointmentDetailsKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppointmentDetailsKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppointmentDetailsKind {}
 impl ::core::fmt::Debug for AppointmentDetailsKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppointmentDetailsKind").field(&self.0).finish()
@@ -2120,6 +2085,7 @@ unsafe impl ::core::marker::Send for AppointmentOrganizer {}
 unsafe impl ::core::marker::Sync for AppointmentOrganizer {}
 #[doc = "*Required features: 'ApplicationModel_Appointments'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppointmentParticipantResponse(pub i32);
 impl AppointmentParticipantResponse {
     pub const None: Self = Self(0i32);
@@ -2137,12 +2103,6 @@ impl ::core::clone::Clone for AppointmentParticipantResponse {
 unsafe impl ::windows::core::Abi for AppointmentParticipantResponse {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppointmentParticipantResponse {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppointmentParticipantResponse {}
 impl ::core::fmt::Debug for AppointmentParticipantResponse {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppointmentParticipantResponse").field(&self.0).finish()
@@ -2156,6 +2116,7 @@ impl ::windows::core::DefaultType for AppointmentParticipantResponse {
 }
 #[doc = "*Required features: 'ApplicationModel_Appointments'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppointmentParticipantRole(pub i32);
 impl AppointmentParticipantRole {
     pub const RequiredAttendee: Self = Self(0i32);
@@ -2171,12 +2132,6 @@ impl ::core::clone::Clone for AppointmentParticipantRole {
 unsafe impl ::windows::core::Abi for AppointmentParticipantRole {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppointmentParticipantRole {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppointmentParticipantRole {}
 impl ::core::fmt::Debug for AppointmentParticipantRole {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppointmentParticipantRole").field(&self.0).finish()
@@ -2607,6 +2562,7 @@ unsafe impl ::core::marker::Send for AppointmentRecurrence {}
 unsafe impl ::core::marker::Sync for AppointmentRecurrence {}
 #[doc = "*Required features: 'ApplicationModel_Appointments'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppointmentRecurrenceUnit(pub i32);
 impl AppointmentRecurrenceUnit {
     pub const Daily: Self = Self(0i32);
@@ -2625,12 +2581,6 @@ impl ::core::clone::Clone for AppointmentRecurrenceUnit {
 unsafe impl ::windows::core::Abi for AppointmentRecurrenceUnit {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppointmentRecurrenceUnit {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppointmentRecurrenceUnit {}
 impl ::core::fmt::Debug for AppointmentRecurrenceUnit {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppointmentRecurrenceUnit").field(&self.0).finish()
@@ -2644,6 +2594,7 @@ impl ::windows::core::DefaultType for AppointmentRecurrenceUnit {
 }
 #[doc = "*Required features: 'ApplicationModel_Appointments'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppointmentSensitivity(pub i32);
 impl AppointmentSensitivity {
     pub const Public: Self = Self(0i32);
@@ -2658,12 +2609,6 @@ impl ::core::clone::Clone for AppointmentSensitivity {
 unsafe impl ::windows::core::Abi for AppointmentSensitivity {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppointmentSensitivity {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppointmentSensitivity {}
 impl ::core::fmt::Debug for AppointmentSensitivity {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppointmentSensitivity").field(&self.0).finish()
@@ -2970,6 +2915,7 @@ unsafe impl ::core::marker::Send for AppointmentStore {}
 unsafe impl ::core::marker::Sync for AppointmentStore {}
 #[doc = "*Required features: 'ApplicationModel_Appointments'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppointmentStoreAccessType(pub i32);
 impl AppointmentStoreAccessType {
     pub const AppCalendarsReadWrite: Self = Self(0i32);
@@ -2985,12 +2931,6 @@ impl ::core::clone::Clone for AppointmentStoreAccessType {
 unsafe impl ::windows::core::Abi for AppointmentStoreAccessType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppointmentStoreAccessType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppointmentStoreAccessType {}
 impl ::core::fmt::Debug for AppointmentStoreAccessType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppointmentStoreAccessType").field(&self.0).finish()
@@ -3292,6 +3232,7 @@ unsafe impl ::core::marker::Send for AppointmentStoreChangeTracker {}
 unsafe impl ::core::marker::Sync for AppointmentStoreChangeTracker {}
 #[doc = "*Required features: 'ApplicationModel_Appointments'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppointmentStoreChangeType(pub i32);
 impl AppointmentStoreChangeType {
     pub const AppointmentCreated: Self = Self(0i32);
@@ -3311,12 +3252,6 @@ impl ::core::clone::Clone for AppointmentStoreChangeType {
 unsafe impl ::windows::core::Abi for AppointmentStoreChangeType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppointmentStoreChangeType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppointmentStoreChangeType {}
 impl ::core::fmt::Debug for AppointmentStoreChangeType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppointmentStoreChangeType").field(&self.0).finish()
@@ -3561,6 +3496,7 @@ unsafe impl ::core::marker::Send for AppointmentStoreNotificationTriggerDetails 
 unsafe impl ::core::marker::Sync for AppointmentStoreNotificationTriggerDetails {}
 #[doc = "*Required features: 'ApplicationModel_Appointments'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppointmentSummaryCardView(pub i32);
 impl AppointmentSummaryCardView {
     pub const System: Self = Self(0i32);
@@ -3575,12 +3511,6 @@ impl ::core::clone::Clone for AppointmentSummaryCardView {
 unsafe impl ::windows::core::Abi for AppointmentSummaryCardView {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppointmentSummaryCardView {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppointmentSummaryCardView {}
 impl ::core::fmt::Debug for AppointmentSummaryCardView {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppointmentSummaryCardView").field(&self.0).finish()
@@ -3594,6 +3524,7 @@ impl ::windows::core::DefaultType for AppointmentSummaryCardView {
 }
 #[doc = "*Required features: 'ApplicationModel_Appointments'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppointmentWeekOfMonth(pub i32);
 impl AppointmentWeekOfMonth {
     pub const First: Self = Self(0i32);
@@ -3611,12 +3542,6 @@ impl ::core::clone::Clone for AppointmentWeekOfMonth {
 unsafe impl ::windows::core::Abi for AppointmentWeekOfMonth {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppointmentWeekOfMonth {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppointmentWeekOfMonth {}
 impl ::core::fmt::Debug for AppointmentWeekOfMonth {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppointmentWeekOfMonth").field(&self.0).finish()
@@ -3630,6 +3555,7 @@ impl ::windows::core::DefaultType for AppointmentWeekOfMonth {
 }
 #[doc = "*Required features: 'ApplicationModel_Appointments'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FindAppointmentCalendarsOptions(pub u32);
 impl FindAppointmentCalendarsOptions {
     pub const None: Self = Self(0u32);
@@ -3644,12 +3570,6 @@ impl ::core::clone::Clone for FindAppointmentCalendarsOptions {
 unsafe impl ::windows::core::Abi for FindAppointmentCalendarsOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FindAppointmentCalendarsOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FindAppointmentCalendarsOptions {}
 impl ::core::fmt::Debug for FindAppointmentCalendarsOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FindAppointmentCalendarsOptions").field(&self.0).finish()
@@ -4806,6 +4726,7 @@ pub struct IFindAppointmentsOptionsVtbl(
 );
 #[doc = "*Required features: 'ApplicationModel_Appointments'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RecurrenceType(pub i32);
 impl RecurrenceType {
     pub const Master: Self = Self(0i32);
@@ -4821,12 +4742,6 @@ impl ::core::clone::Clone for RecurrenceType {
 unsafe impl ::windows::core::Abi for RecurrenceType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RecurrenceType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RecurrenceType {}
 impl ::core::fmt::Debug for RecurrenceType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RecurrenceType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/Background/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Background/mod.rs
@@ -142,6 +142,7 @@ unsafe impl ::core::marker::Send for ActivitySensorTrigger {}
 unsafe impl ::core::marker::Sync for ActivitySensorTrigger {}
 #[doc = "*Required features: 'ApplicationModel_Background'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AlarmAccessStatus(pub i32);
 impl AlarmAccessStatus {
     pub const Unspecified: Self = Self(0i32);
@@ -158,12 +159,6 @@ impl ::core::clone::Clone for AlarmAccessStatus {
 unsafe impl ::windows::core::Abi for AlarmAccessStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AlarmAccessStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AlarmAccessStatus {}
 impl ::core::fmt::Debug for AlarmAccessStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AlarmAccessStatus").field(&self.0).finish()
@@ -679,6 +674,7 @@ unsafe impl ::core::marker::Send for ApplicationTriggerDetails {}
 unsafe impl ::core::marker::Sync for ApplicationTriggerDetails {}
 #[doc = "*Required features: 'ApplicationModel_Background'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ApplicationTriggerResult(pub i32);
 impl ApplicationTriggerResult {
     pub const Allowed: Self = Self(0i32);
@@ -695,12 +691,6 @@ impl ::core::clone::Clone for ApplicationTriggerResult {
 unsafe impl ::windows::core::Abi for ApplicationTriggerResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ApplicationTriggerResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ApplicationTriggerResult {}
 impl ::core::fmt::Debug for ApplicationTriggerResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ApplicationTriggerResult").field(&self.0).finish()
@@ -816,6 +806,7 @@ unsafe impl ::core::marker::Send for AppointmentStoreNotificationTrigger {}
 unsafe impl ::core::marker::Sync for AppointmentStoreNotificationTrigger {}
 #[doc = "*Required features: 'ApplicationModel_Background'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BackgroundAccessRequestKind(pub i32);
 impl BackgroundAccessRequestKind {
     pub const AlwaysAllowed: Self = Self(0i32);
@@ -830,12 +821,6 @@ impl ::core::clone::Clone for BackgroundAccessRequestKind {
 unsafe impl ::windows::core::Abi for BackgroundAccessRequestKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BackgroundAccessRequestKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BackgroundAccessRequestKind {}
 impl ::core::fmt::Debug for BackgroundAccessRequestKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BackgroundAccessRequestKind").field(&self.0).finish()
@@ -849,6 +834,7 @@ impl ::windows::core::DefaultType for BackgroundAccessRequestKind {
 }
 #[doc = "*Required features: 'ApplicationModel_Background'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BackgroundAccessStatus(pub i32);
 impl BackgroundAccessStatus {
     pub const Unspecified: Self = Self(0i32);
@@ -869,12 +855,6 @@ impl ::core::clone::Clone for BackgroundAccessStatus {
 unsafe impl ::windows::core::Abi for BackgroundAccessStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BackgroundAccessStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BackgroundAccessStatus {}
 impl ::core::fmt::Debug for BackgroundAccessStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BackgroundAccessStatus").field(&self.0).finish()
@@ -1219,6 +1199,7 @@ unsafe impl ::windows::core::RuntimeType for BackgroundTaskCanceledEventHandler 
 pub struct BackgroundTaskCanceledEventHandlerVtbl(pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: ::windows::core::RawPtr, reason: BackgroundTaskCancellationReason) -> ::windows::core::HRESULT);
 #[doc = "*Required features: 'ApplicationModel_Background'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BackgroundTaskCancellationReason(pub i32);
 impl BackgroundTaskCancellationReason {
     pub const Abort: Self = Self(0i32);
@@ -1243,12 +1224,6 @@ impl ::core::clone::Clone for BackgroundTaskCancellationReason {
 unsafe impl ::windows::core::Abi for BackgroundTaskCancellationReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BackgroundTaskCancellationReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BackgroundTaskCancellationReason {}
 impl ::core::fmt::Debug for BackgroundTaskCancellationReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BackgroundTaskCancellationReason").field(&self.0).finish()
@@ -2036,6 +2011,7 @@ unsafe impl ::core::marker::Send for BackgroundTaskRegistrationGroup {}
 unsafe impl ::core::marker::Sync for BackgroundTaskRegistrationGroup {}
 #[doc = "*Required features: 'ApplicationModel_Background'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BackgroundTaskThrottleCounter(pub i32);
 impl BackgroundTaskThrottleCounter {
     pub const All: Self = Self(0i32);
@@ -2051,12 +2027,6 @@ impl ::core::clone::Clone for BackgroundTaskThrottleCounter {
 unsafe impl ::windows::core::Abi for BackgroundTaskThrottleCounter {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BackgroundTaskThrottleCounter {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BackgroundTaskThrottleCounter {}
 impl ::core::fmt::Debug for BackgroundTaskThrottleCounter {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BackgroundTaskThrottleCounter").field(&self.0).finish()
@@ -2089,6 +2059,7 @@ impl ::windows::core::RuntimeName for BackgroundWorkCost {
 }
 #[doc = "*Required features: 'ApplicationModel_Background'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BackgroundWorkCostValue(pub i32);
 impl BackgroundWorkCostValue {
     pub const Low: Self = Self(0i32);
@@ -2104,12 +2075,6 @@ impl ::core::clone::Clone for BackgroundWorkCostValue {
 unsafe impl ::windows::core::Abi for BackgroundWorkCostValue {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BackgroundWorkCostValue {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BackgroundWorkCostValue {}
 impl ::core::fmt::Debug for BackgroundWorkCostValue {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BackgroundWorkCostValue").field(&self.0).finish()
@@ -3421,6 +3386,7 @@ impl<'a> ::windows::core::IntoParam<'a, IBackgroundTrigger> for &CustomSystemEve
 }
 #[doc = "*Required features: 'ApplicationModel_Background'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CustomSystemEventTriggerRecurrence(pub i32);
 impl CustomSystemEventTriggerRecurrence {
     pub const Once: Self = Self(0i32);
@@ -3435,12 +3401,6 @@ impl ::core::clone::Clone for CustomSystemEventTriggerRecurrence {
 unsafe impl ::windows::core::Abi for CustomSystemEventTriggerRecurrence {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CustomSystemEventTriggerRecurrence {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CustomSystemEventTriggerRecurrence {}
 impl ::core::fmt::Debug for CustomSystemEventTriggerRecurrence {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CustomSystemEventTriggerRecurrence").field(&self.0).finish()
@@ -3857,6 +3817,7 @@ unsafe impl ::core::marker::Send for DeviceServicingTrigger {}
 unsafe impl ::core::marker::Sync for DeviceServicingTrigger {}
 #[doc = "*Required features: 'ApplicationModel_Background'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DeviceTriggerResult(pub i32);
 impl DeviceTriggerResult {
     pub const Allowed: Self = Self(0i32);
@@ -3873,12 +3834,6 @@ impl ::core::clone::Clone for DeviceTriggerResult {
 unsafe impl ::windows::core::Abi for DeviceTriggerResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DeviceTriggerResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DeviceTriggerResult {}
 impl ::core::fmt::Debug for DeviceTriggerResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DeviceTriggerResult").field(&self.0).finish()
@@ -7732,6 +7687,7 @@ unsafe impl ::core::marker::Send for LocationTrigger {}
 unsafe impl ::core::marker::Sync for LocationTrigger {}
 #[doc = "*Required features: 'ApplicationModel_Background'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LocationTriggerType(pub i32);
 impl LocationTriggerType {
     pub const Geofence: Self = Self(0i32);
@@ -7745,12 +7701,6 @@ impl ::core::clone::Clone for LocationTriggerType {
 unsafe impl ::windows::core::Abi for LocationTriggerType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LocationTriggerType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LocationTriggerType {}
 impl ::core::fmt::Debug for LocationTriggerType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LocationTriggerType").field(&self.0).finish()
@@ -8003,6 +7953,7 @@ impl<'a> ::windows::core::IntoParam<'a, IBackgroundTrigger> for &MediaProcessing
 }
 #[doc = "*Required features: 'ApplicationModel_Background'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaProcessingTriggerResult(pub i32);
 impl MediaProcessingTriggerResult {
     pub const Allowed: Self = Self(0i32);
@@ -8019,12 +7970,6 @@ impl ::core::clone::Clone for MediaProcessingTriggerResult {
 unsafe impl ::windows::core::Abi for MediaProcessingTriggerResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaProcessingTriggerResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaProcessingTriggerResult {}
 impl ::core::fmt::Debug for MediaProcessingTriggerResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaProcessingTriggerResult").field(&self.0).finish()
@@ -10366,6 +10311,7 @@ impl<'a> ::windows::core::IntoParam<'a, IBackgroundCondition> for &SystemConditi
 }
 #[doc = "*Required features: 'ApplicationModel_Background'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SystemConditionType(pub i32);
 impl SystemConditionType {
     pub const Invalid: Self = Self(0i32);
@@ -10387,12 +10333,6 @@ impl ::core::clone::Clone for SystemConditionType {
 unsafe impl ::windows::core::Abi for SystemConditionType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SystemConditionType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SystemConditionType {}
 impl ::core::fmt::Debug for SystemConditionType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SystemConditionType").field(&self.0).finish()
@@ -10527,6 +10467,7 @@ impl<'a> ::windows::core::IntoParam<'a, IBackgroundTrigger> for &SystemTrigger {
 }
 #[doc = "*Required features: 'ApplicationModel_Background'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SystemTriggerType(pub i32);
 impl SystemTriggerType {
     pub const Invalid: Self = Self(0i32);
@@ -10555,12 +10496,6 @@ impl ::core::clone::Clone for SystemTriggerType {
 unsafe impl ::windows::core::Abi for SystemTriggerType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SystemTriggerType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SystemTriggerType {}
 impl ::core::fmt::Debug for SystemTriggerType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SystemTriggerType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/Calls/Background/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Calls/Background/mod.rs
@@ -123,6 +123,7 @@ pub struct IPhoneNewVoicemailMessageTriggerDetailsVtbl(
 );
 #[doc = "*Required features: 'ApplicationModel_Calls_Background'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneCallBlockedReason(pub i32);
 impl PhoneCallBlockedReason {
     pub const InCallBlockingList: Self = Self(0i32);
@@ -138,12 +139,6 @@ impl ::core::clone::Clone for PhoneCallBlockedReason {
 unsafe impl ::windows::core::Abi for PhoneCallBlockedReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneCallBlockedReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneCallBlockedReason {}
 impl ::core::fmt::Debug for PhoneCallBlockedReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneCallBlockedReason").field(&self.0).finish()
@@ -343,6 +338,7 @@ unsafe impl ::core::marker::Send for PhoneCallOriginDataRequestTriggerDetails {}
 unsafe impl ::core::marker::Sync for PhoneCallOriginDataRequestTriggerDetails {}
 #[doc = "*Required features: 'ApplicationModel_Calls_Background'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneIncomingCallDismissedReason(pub i32);
 impl PhoneIncomingCallDismissedReason {
     pub const Unknown: Self = Self(0i32);
@@ -359,12 +355,6 @@ impl ::core::clone::Clone for PhoneIncomingCallDismissedReason {
 unsafe impl ::windows::core::Abi for PhoneIncomingCallDismissedReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneIncomingCallDismissedReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneIncomingCallDismissedReason {}
 impl ::core::fmt::Debug for PhoneIncomingCallDismissedReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneIncomingCallDismissedReason").field(&self.0).finish()
@@ -589,6 +579,7 @@ unsafe impl ::core::marker::Send for PhoneIncomingCallNotificationTriggerDetails
 unsafe impl ::core::marker::Sync for PhoneIncomingCallNotificationTriggerDetails {}
 #[doc = "*Required features: 'ApplicationModel_Calls_Background'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneLineChangeKind(pub i32);
 impl PhoneLineChangeKind {
     pub const Added: Self = Self(0i32);
@@ -604,12 +595,6 @@ impl ::core::clone::Clone for PhoneLineChangeKind {
 unsafe impl ::windows::core::Abi for PhoneLineChangeKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneLineChangeKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneLineChangeKind {}
 impl ::core::fmt::Debug for PhoneLineChangeKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneLineChangeKind").field(&self.0).finish()
@@ -720,6 +705,7 @@ unsafe impl ::core::marker::Send for PhoneLineChangedTriggerDetails {}
 unsafe impl ::core::marker::Sync for PhoneLineChangedTriggerDetails {}
 #[doc = "*Required features: 'ApplicationModel_Calls_Background'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneLineProperties(pub u32);
 impl PhoneLineProperties {
     pub const None: Self = Self(0u32);
@@ -742,12 +728,6 @@ impl ::core::clone::Clone for PhoneLineProperties {
 unsafe impl ::windows::core::Abi for PhoneLineProperties {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneLineProperties {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneLineProperties {}
 impl ::core::fmt::Debug for PhoneLineProperties {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneLineProperties").field(&self.0).finish()
@@ -886,6 +866,7 @@ unsafe impl ::core::marker::Send for PhoneNewVoicemailMessageTriggerDetails {}
 unsafe impl ::core::marker::Sync for PhoneNewVoicemailMessageTriggerDetails {}
 #[doc = "*Required features: 'ApplicationModel_Calls_Background'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneTriggerType(pub i32);
 impl PhoneTriggerType {
     pub const NewVoicemailMessage: Self = Self(0i32);
@@ -906,12 +887,6 @@ impl ::core::clone::Clone for PhoneTriggerType {
 unsafe impl ::windows::core::Abi for PhoneTriggerType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneTriggerType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneTriggerType {}
 impl ::core::fmt::Debug for PhoneTriggerType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneTriggerType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/Calls/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Calls/mod.rs
@@ -248,6 +248,7 @@ unsafe impl ::core::marker::Send for CallStateChangeEventArgs {}
 unsafe impl ::core::marker::Sync for CallStateChangeEventArgs {}
 #[doc = "*Required features: 'ApplicationModel_Calls'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CellularDtmfMode(pub i32);
 impl CellularDtmfMode {
     pub const Continuous: Self = Self(0i32);
@@ -262,12 +263,6 @@ impl ::core::clone::Clone for CellularDtmfMode {
 unsafe impl ::windows::core::Abi for CellularDtmfMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CellularDtmfMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CellularDtmfMode {}
 impl ::core::fmt::Debug for CellularDtmfMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CellularDtmfMode").field(&self.0).finish()
@@ -281,6 +276,7 @@ impl ::windows::core::DefaultType for CellularDtmfMode {
 }
 #[doc = "*Required features: 'ApplicationModel_Calls'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DtmfKey(pub i32);
 impl DtmfKey {
     pub const D0: Self = Self(0i32);
@@ -305,12 +301,6 @@ impl ::core::clone::Clone for DtmfKey {
 unsafe impl ::windows::core::Abi for DtmfKey {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DtmfKey {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DtmfKey {}
 impl ::core::fmt::Debug for DtmfKey {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DtmfKey").field(&self.0).finish()
@@ -324,6 +314,7 @@ impl ::windows::core::DefaultType for DtmfKey {
 }
 #[doc = "*Required features: 'ApplicationModel_Calls'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DtmfToneAudioPlayback(pub i32);
 impl DtmfToneAudioPlayback {
     pub const Play: Self = Self(0i32);
@@ -338,12 +329,6 @@ impl ::core::clone::Clone for DtmfToneAudioPlayback {
 unsafe impl ::windows::core::Abi for DtmfToneAudioPlayback {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DtmfToneAudioPlayback {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DtmfToneAudioPlayback {}
 impl ::core::fmt::Debug for DtmfToneAudioPlayback {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DtmfToneAudioPlayback").field(&self.0).finish()
@@ -1896,6 +1881,7 @@ unsafe impl ::core::marker::Send for MuteChangeEventArgs {}
 unsafe impl ::core::marker::Sync for MuteChangeEventArgs {}
 #[doc = "*Required features: 'ApplicationModel_Calls'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneAudioRoutingEndpoint(pub i32);
 impl PhoneAudioRoutingEndpoint {
     pub const Default: Self = Self(0i32);
@@ -1911,12 +1897,6 @@ impl ::core::clone::Clone for PhoneAudioRoutingEndpoint {
 unsafe impl ::windows::core::Abi for PhoneAudioRoutingEndpoint {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneAudioRoutingEndpoint {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneAudioRoutingEndpoint {}
 impl ::core::fmt::Debug for PhoneAudioRoutingEndpoint {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneAudioRoutingEndpoint").field(&self.0).finish()
@@ -2262,6 +2242,7 @@ unsafe impl ::core::marker::Send for PhoneCall {}
 unsafe impl ::core::marker::Sync for PhoneCall {}
 #[doc = "*Required features: 'ApplicationModel_Calls'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneCallAudioDevice(pub i32);
 impl PhoneCallAudioDevice {
     pub const Unknown: Self = Self(0i32);
@@ -2277,12 +2258,6 @@ impl ::core::clone::Clone for PhoneCallAudioDevice {
 unsafe impl ::windows::core::Abi for PhoneCallAudioDevice {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneCallAudioDevice {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneCallAudioDevice {}
 impl ::core::fmt::Debug for PhoneCallAudioDevice {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneCallAudioDevice").field(&self.0).finish()
@@ -2338,6 +2313,7 @@ impl ::windows::core::RuntimeName for PhoneCallBlocking {
 }
 #[doc = "*Required features: 'ApplicationModel_Calls'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneCallDirection(pub i32);
 impl PhoneCallDirection {
     pub const Unknown: Self = Self(0i32);
@@ -2353,12 +2329,6 @@ impl ::core::clone::Clone for PhoneCallDirection {
 unsafe impl ::windows::core::Abi for PhoneCallDirection {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneCallDirection {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneCallDirection {}
 impl ::core::fmt::Debug for PhoneCallDirection {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneCallDirection").field(&self.0).finish()
@@ -2824,6 +2794,7 @@ unsafe impl ::core::marker::Send for PhoneCallHistoryEntryAddress {}
 unsafe impl ::core::marker::Sync for PhoneCallHistoryEntryAddress {}
 #[doc = "*Required features: 'ApplicationModel_Calls'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneCallHistoryEntryMedia(pub i32);
 impl PhoneCallHistoryEntryMedia {
     pub const Audio: Self = Self(0i32);
@@ -2838,12 +2809,6 @@ impl ::core::clone::Clone for PhoneCallHistoryEntryMedia {
 unsafe impl ::windows::core::Abi for PhoneCallHistoryEntryMedia {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneCallHistoryEntryMedia {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneCallHistoryEntryMedia {}
 impl ::core::fmt::Debug for PhoneCallHistoryEntryMedia {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneCallHistoryEntryMedia").field(&self.0).finish()
@@ -2857,6 +2822,7 @@ impl ::windows::core::DefaultType for PhoneCallHistoryEntryMedia {
 }
 #[doc = "*Required features: 'ApplicationModel_Calls'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneCallHistoryEntryOtherAppReadAccess(pub i32);
 impl PhoneCallHistoryEntryOtherAppReadAccess {
     pub const Full: Self = Self(0i32);
@@ -2871,12 +2837,6 @@ impl ::core::clone::Clone for PhoneCallHistoryEntryOtherAppReadAccess {
 unsafe impl ::windows::core::Abi for PhoneCallHistoryEntryOtherAppReadAccess {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneCallHistoryEntryOtherAppReadAccess {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneCallHistoryEntryOtherAppReadAccess {}
 impl ::core::fmt::Debug for PhoneCallHistoryEntryOtherAppReadAccess {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneCallHistoryEntryOtherAppReadAccess").field(&self.0).finish()
@@ -2890,6 +2850,7 @@ impl ::windows::core::DefaultType for PhoneCallHistoryEntryOtherAppReadAccess {
 }
 #[doc = "*Required features: 'ApplicationModel_Calls'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneCallHistoryEntryQueryDesiredMedia(pub u32);
 impl PhoneCallHistoryEntryQueryDesiredMedia {
     pub const None: Self = Self(0u32);
@@ -2906,12 +2867,6 @@ impl ::core::clone::Clone for PhoneCallHistoryEntryQueryDesiredMedia {
 unsafe impl ::windows::core::Abi for PhoneCallHistoryEntryQueryDesiredMedia {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneCallHistoryEntryQueryDesiredMedia {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneCallHistoryEntryQueryDesiredMedia {}
 impl ::core::fmt::Debug for PhoneCallHistoryEntryQueryDesiredMedia {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneCallHistoryEntryQueryDesiredMedia").field(&self.0).finish()
@@ -3055,6 +3010,7 @@ unsafe impl ::core::marker::Send for PhoneCallHistoryEntryQueryOptions {}
 unsafe impl ::core::marker::Sync for PhoneCallHistoryEntryQueryOptions {}
 #[doc = "*Required features: 'ApplicationModel_Calls'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneCallHistoryEntryRawAddressKind(pub i32);
 impl PhoneCallHistoryEntryRawAddressKind {
     pub const PhoneNumber: Self = Self(0i32);
@@ -3069,12 +3025,6 @@ impl ::core::clone::Clone for PhoneCallHistoryEntryRawAddressKind {
 unsafe impl ::windows::core::Abi for PhoneCallHistoryEntryRawAddressKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneCallHistoryEntryRawAddressKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneCallHistoryEntryRawAddressKind {}
 impl ::core::fmt::Debug for PhoneCallHistoryEntryRawAddressKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneCallHistoryEntryRawAddressKind").field(&self.0).finish()
@@ -3294,6 +3244,7 @@ unsafe impl ::core::marker::Send for PhoneCallHistoryManagerForUser {}
 unsafe impl ::core::marker::Sync for PhoneCallHistoryManagerForUser {}
 #[doc = "*Required features: 'ApplicationModel_Calls'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneCallHistorySourceIdKind(pub i32);
 impl PhoneCallHistorySourceIdKind {
     pub const CellularPhoneLineId: Self = Self(0i32);
@@ -3308,12 +3259,6 @@ impl ::core::clone::Clone for PhoneCallHistorySourceIdKind {
 unsafe impl ::windows::core::Abi for PhoneCallHistorySourceIdKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneCallHistorySourceIdKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneCallHistorySourceIdKind {}
 impl ::core::fmt::Debug for PhoneCallHistorySourceIdKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneCallHistorySourceIdKind").field(&self.0).finish()
@@ -3506,6 +3451,7 @@ unsafe impl ::core::marker::Send for PhoneCallHistoryStore {}
 unsafe impl ::core::marker::Sync for PhoneCallHistoryStore {}
 #[doc = "*Required features: 'ApplicationModel_Calls'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneCallHistoryStoreAccessType(pub i32);
 impl PhoneCallHistoryStoreAccessType {
     pub const AppEntriesReadWrite: Self = Self(0i32);
@@ -3521,12 +3467,6 @@ impl ::core::clone::Clone for PhoneCallHistoryStoreAccessType {
 unsafe impl ::windows::core::Abi for PhoneCallHistoryStoreAccessType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneCallHistoryStoreAccessType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneCallHistoryStoreAccessType {}
 impl ::core::fmt::Debug for PhoneCallHistoryStoreAccessType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneCallHistoryStoreAccessType").field(&self.0).finish()
@@ -3722,6 +3662,7 @@ impl ::windows::core::RuntimeName for PhoneCallManager {
 }
 #[doc = "*Required features: 'ApplicationModel_Calls'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneCallMedia(pub i32);
 impl PhoneCallMedia {
     pub const Audio: Self = Self(0i32);
@@ -3737,12 +3678,6 @@ impl ::core::clone::Clone for PhoneCallMedia {
 unsafe impl ::windows::core::Abi for PhoneCallMedia {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneCallMedia {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneCallMedia {}
 impl ::core::fmt::Debug for PhoneCallMedia {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneCallMedia").field(&self.0).finish()
@@ -3756,6 +3691,7 @@ impl ::windows::core::DefaultType for PhoneCallMedia {
 }
 #[doc = "*Required features: 'ApplicationModel_Calls'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneCallOperationStatus(pub i32);
 impl PhoneCallOperationStatus {
     pub const Succeeded: Self = Self(0i32);
@@ -3773,12 +3709,6 @@ impl ::core::clone::Clone for PhoneCallOperationStatus {
 unsafe impl ::windows::core::Abi for PhoneCallOperationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneCallOperationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneCallOperationStatus {}
 impl ::core::fmt::Debug for PhoneCallOperationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneCallOperationStatus").field(&self.0).finish()
@@ -3792,6 +3722,7 @@ impl ::windows::core::DefaultType for PhoneCallOperationStatus {
 }
 #[doc = "*Required features: 'ApplicationModel_Calls'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneCallStatus(pub i32);
 impl PhoneCallStatus {
     pub const Lost: Self = Self(0i32);
@@ -3810,12 +3741,6 @@ impl ::core::clone::Clone for PhoneCallStatus {
 unsafe impl ::windows::core::Abi for PhoneCallStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneCallStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneCallStatus {}
 impl ::core::fmt::Debug for PhoneCallStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneCallStatus").field(&self.0).finish()
@@ -4837,6 +4762,7 @@ unsafe impl ::core::marker::Send for PhoneLineDialResult {}
 unsafe impl ::core::marker::Sync for PhoneLineDialResult {}
 #[doc = "*Required features: 'ApplicationModel_Calls'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneLineNetworkOperatorDisplayTextLocation(pub i32);
 impl PhoneLineNetworkOperatorDisplayTextLocation {
     pub const Default: Self = Self(0i32);
@@ -4853,12 +4779,6 @@ impl ::core::clone::Clone for PhoneLineNetworkOperatorDisplayTextLocation {
 unsafe impl ::windows::core::Abi for PhoneLineNetworkOperatorDisplayTextLocation {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneLineNetworkOperatorDisplayTextLocation {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneLineNetworkOperatorDisplayTextLocation {}
 impl ::core::fmt::Debug for PhoneLineNetworkOperatorDisplayTextLocation {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneLineNetworkOperatorDisplayTextLocation").field(&self.0).finish()
@@ -4872,6 +4792,7 @@ impl ::windows::core::DefaultType for PhoneLineNetworkOperatorDisplayTextLocatio
 }
 #[doc = "*Required features: 'ApplicationModel_Calls'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneLineOperationStatus(pub i32);
 impl PhoneLineOperationStatus {
     pub const Succeeded: Self = Self(0i32);
@@ -4889,12 +4810,6 @@ impl ::core::clone::Clone for PhoneLineOperationStatus {
 unsafe impl ::windows::core::Abi for PhoneLineOperationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneLineOperationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneLineOperationStatus {}
 impl ::core::fmt::Debug for PhoneLineOperationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneLineOperationStatus").field(&self.0).finish()
@@ -4908,6 +4823,7 @@ impl ::windows::core::DefaultType for PhoneLineOperationStatus {
 }
 #[doc = "*Required features: 'ApplicationModel_Calls'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneLineTransport(pub i32);
 impl PhoneLineTransport {
     pub const Cellular: Self = Self(0i32);
@@ -4923,12 +4839,6 @@ impl ::core::clone::Clone for PhoneLineTransport {
 unsafe impl ::windows::core::Abi for PhoneLineTransport {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneLineTransport {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneLineTransport {}
 impl ::core::fmt::Debug for PhoneLineTransport {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneLineTransport").field(&self.0).finish()
@@ -5406,6 +5316,7 @@ unsafe impl ::core::marker::Send for PhoneLineWatcherEventArgs {}
 unsafe impl ::core::marker::Sync for PhoneLineWatcherEventArgs {}
 #[doc = "*Required features: 'ApplicationModel_Calls'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneLineWatcherStatus(pub i32);
 impl PhoneLineWatcherStatus {
     pub const Created: Self = Self(0i32);
@@ -5422,12 +5333,6 @@ impl ::core::clone::Clone for PhoneLineWatcherStatus {
 unsafe impl ::windows::core::Abi for PhoneLineWatcherStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneLineWatcherStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneLineWatcherStatus {}
 impl ::core::fmt::Debug for PhoneLineWatcherStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneLineWatcherStatus").field(&self.0).finish()
@@ -5441,6 +5346,7 @@ impl ::windows::core::DefaultType for PhoneLineWatcherStatus {
 }
 #[doc = "*Required features: 'ApplicationModel_Calls'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneNetworkState(pub i32);
 impl PhoneNetworkState {
     pub const Unknown: Self = Self(0i32);
@@ -5461,12 +5367,6 @@ impl ::core::clone::Clone for PhoneNetworkState {
 unsafe impl ::windows::core::Abi for PhoneNetworkState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneNetworkState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneNetworkState {}
 impl ::core::fmt::Debug for PhoneNetworkState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneNetworkState").field(&self.0).finish()
@@ -5480,6 +5380,7 @@ impl ::windows::core::DefaultType for PhoneNetworkState {
 }
 #[doc = "*Required features: 'ApplicationModel_Calls'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneSimState(pub i32);
 impl PhoneSimState {
     pub const Unknown: Self = Self(0i32);
@@ -5500,12 +5401,6 @@ impl ::core::clone::Clone for PhoneSimState {
 unsafe impl ::windows::core::Abi for PhoneSimState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneSimState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneSimState {}
 impl ::core::fmt::Debug for PhoneSimState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneSimState").field(&self.0).finish()
@@ -5625,6 +5520,7 @@ unsafe impl ::core::marker::Send for PhoneVoicemail {}
 unsafe impl ::core::marker::Sync for PhoneVoicemail {}
 #[doc = "*Required features: 'ApplicationModel_Calls'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneVoicemailType(pub i32);
 impl PhoneVoicemailType {
     pub const None: Self = Self(0i32);
@@ -5640,12 +5536,6 @@ impl ::core::clone::Clone for PhoneVoicemailType {
 unsafe impl ::windows::core::Abi for PhoneVoicemailType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneVoicemailType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneVoicemailType {}
 impl ::core::fmt::Debug for PhoneVoicemailType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneVoicemailType").field(&self.0).finish()
@@ -5659,6 +5549,7 @@ impl ::windows::core::DefaultType for PhoneVoicemailType {
 }
 #[doc = "*Required features: 'ApplicationModel_Calls'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TransportDeviceAudioRoutingStatus(pub i32);
 impl TransportDeviceAudioRoutingStatus {
     pub const Unknown: Self = Self(0i32);
@@ -5674,12 +5565,6 @@ impl ::core::clone::Clone for TransportDeviceAudioRoutingStatus {
 unsafe impl ::windows::core::Abi for TransportDeviceAudioRoutingStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TransportDeviceAudioRoutingStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TransportDeviceAudioRoutingStatus {}
 impl ::core::fmt::Debug for TransportDeviceAudioRoutingStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TransportDeviceAudioRoutingStatus").field(&self.0).finish()
@@ -6145,6 +6030,7 @@ unsafe impl ::core::marker::Send for VoipPhoneCall {}
 unsafe impl ::core::marker::Sync for VoipPhoneCall {}
 #[doc = "*Required features: 'ApplicationModel_Calls'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VoipPhoneCallMedia(pub u32);
 impl VoipPhoneCallMedia {
     pub const None: Self = Self(0u32);
@@ -6160,12 +6046,6 @@ impl ::core::clone::Clone for VoipPhoneCallMedia {
 unsafe impl ::windows::core::Abi for VoipPhoneCallMedia {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VoipPhoneCallMedia {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VoipPhoneCallMedia {}
 impl ::core::fmt::Debug for VoipPhoneCallMedia {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VoipPhoneCallMedia").field(&self.0).finish()
@@ -6207,6 +6087,7 @@ impl ::windows::core::DefaultType for VoipPhoneCallMedia {
 }
 #[doc = "*Required features: 'ApplicationModel_Calls'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VoipPhoneCallRejectReason(pub i32);
 impl VoipPhoneCallRejectReason {
     pub const UserIgnored: Self = Self(0i32);
@@ -6224,12 +6105,6 @@ impl ::core::clone::Clone for VoipPhoneCallRejectReason {
 unsafe impl ::windows::core::Abi for VoipPhoneCallRejectReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VoipPhoneCallRejectReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VoipPhoneCallRejectReason {}
 impl ::core::fmt::Debug for VoipPhoneCallRejectReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VoipPhoneCallRejectReason").field(&self.0).finish()
@@ -6243,6 +6118,7 @@ impl ::windows::core::DefaultType for VoipPhoneCallRejectReason {
 }
 #[doc = "*Required features: 'ApplicationModel_Calls'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VoipPhoneCallResourceReservationStatus(pub i32);
 impl VoipPhoneCallResourceReservationStatus {
     pub const Success: Self = Self(0i32);
@@ -6257,12 +6133,6 @@ impl ::core::clone::Clone for VoipPhoneCallResourceReservationStatus {
 unsafe impl ::windows::core::Abi for VoipPhoneCallResourceReservationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VoipPhoneCallResourceReservationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VoipPhoneCallResourceReservationStatus {}
 impl ::core::fmt::Debug for VoipPhoneCallResourceReservationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VoipPhoneCallResourceReservationStatus").field(&self.0).finish()
@@ -6276,6 +6146,7 @@ impl ::windows::core::DefaultType for VoipPhoneCallResourceReservationStatus {
 }
 #[doc = "*Required features: 'ApplicationModel_Calls'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VoipPhoneCallState(pub i32);
 impl VoipPhoneCallState {
     pub const Ended: Self = Self(0i32);
@@ -6293,12 +6164,6 @@ impl ::core::clone::Clone for VoipPhoneCallState {
 unsafe impl ::windows::core::Abi for VoipPhoneCallState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VoipPhoneCallState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VoipPhoneCallState {}
 impl ::core::fmt::Debug for VoipPhoneCallState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VoipPhoneCallState").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/Chat/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Chat/mod.rs
@@ -647,6 +647,7 @@ unsafe impl ::core::marker::Send for ChatConversationThreadingInfo {}
 unsafe impl ::core::marker::Sync for ChatConversationThreadingInfo {}
 #[doc = "*Required features: 'ApplicationModel_Chat'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ChatConversationThreadingKind(pub i32);
 impl ChatConversationThreadingKind {
     pub const Participants: Self = Self(0i32);
@@ -663,12 +664,6 @@ impl ::core::clone::Clone for ChatConversationThreadingKind {
 unsafe impl ::windows::core::Abi for ChatConversationThreadingKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ChatConversationThreadingKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ChatConversationThreadingKind {}
 impl ::core::fmt::Debug for ChatConversationThreadingKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ChatConversationThreadingKind").field(&self.0).finish()
@@ -682,6 +677,7 @@ impl ::windows::core::DefaultType for ChatConversationThreadingKind {
 }
 #[doc = "*Required features: 'ApplicationModel_Chat'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ChatItemKind(pub i32);
 impl ChatItemKind {
     pub const Message: Self = Self(0i32);
@@ -696,12 +692,6 @@ impl ::core::clone::Clone for ChatItemKind {
 unsafe impl ::windows::core::Abi for ChatItemKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ChatItemKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ChatItemKind {}
 impl ::core::fmt::Debug for ChatItemKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ChatItemKind").field(&self.0).finish()
@@ -1630,6 +1620,7 @@ unsafe impl ::core::marker::Send for ChatMessageChangeTracker {}
 unsafe impl ::core::marker::Sync for ChatMessageChangeTracker {}
 #[doc = "*Required features: 'ApplicationModel_Chat'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ChatMessageChangeType(pub i32);
 impl ChatMessageChangeType {
     pub const MessageCreated: Self = Self(0i32);
@@ -1646,12 +1637,6 @@ impl ::core::clone::Clone for ChatMessageChangeType {
 unsafe impl ::windows::core::Abi for ChatMessageChangeType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ChatMessageChangeType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ChatMessageChangeType {}
 impl ::core::fmt::Debug for ChatMessageChangeType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ChatMessageChangeType").field(&self.0).finish()
@@ -1824,6 +1809,7 @@ unsafe impl ::core::marker::Send for ChatMessageChangedEventArgs {}
 unsafe impl ::core::marker::Sync for ChatMessageChangedEventArgs {}
 #[doc = "*Required features: 'ApplicationModel_Chat'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ChatMessageKind(pub i32);
 impl ChatMessageKind {
     pub const Standard: Self = Self(0i32);
@@ -1843,12 +1829,6 @@ impl ::core::clone::Clone for ChatMessageKind {
 unsafe impl ::windows::core::Abi for ChatMessageKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ChatMessageKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ChatMessageKind {}
 impl ::core::fmt::Debug for ChatMessageKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ChatMessageKind").field(&self.0).finish()
@@ -2049,6 +2029,7 @@ unsafe impl ::core::marker::Send for ChatMessageNotificationTriggerDetails {}
 unsafe impl ::core::marker::Sync for ChatMessageNotificationTriggerDetails {}
 #[doc = "*Required features: 'ApplicationModel_Chat'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ChatMessageOperatorKind(pub i32);
 impl ChatMessageOperatorKind {
     pub const Unspecified: Self = Self(0i32);
@@ -2065,12 +2046,6 @@ impl ::core::clone::Clone for ChatMessageOperatorKind {
 unsafe impl ::windows::core::Abi for ChatMessageOperatorKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ChatMessageOperatorKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ChatMessageOperatorKind {}
 impl ::core::fmt::Debug for ChatMessageOperatorKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ChatMessageOperatorKind").field(&self.0).finish()
@@ -2175,6 +2150,7 @@ unsafe impl ::core::marker::Send for ChatMessageReader {}
 unsafe impl ::core::marker::Sync for ChatMessageReader {}
 #[doc = "*Required features: 'ApplicationModel_Chat'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ChatMessageStatus(pub i32);
 impl ChatMessageStatus {
     pub const Draft: Self = Self(0i32);
@@ -2201,12 +2177,6 @@ impl ::core::clone::Clone for ChatMessageStatus {
 unsafe impl ::windows::core::Abi for ChatMessageStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ChatMessageStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ChatMessageStatus {}
 impl ::core::fmt::Debug for ChatMessageStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ChatMessageStatus").field(&self.0).finish()
@@ -2886,6 +2856,7 @@ unsafe impl ::core::marker::Send for ChatMessageTransportConfiguration {}
 unsafe impl ::core::marker::Sync for ChatMessageTransportConfiguration {}
 #[doc = "*Required features: 'ApplicationModel_Chat'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ChatMessageTransportKind(pub i32);
 impl ChatMessageTransportKind {
     pub const Text: Self = Self(0i32);
@@ -2902,12 +2873,6 @@ impl ::core::clone::Clone for ChatMessageTransportKind {
 unsafe impl ::windows::core::Abi for ChatMessageTransportKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ChatMessageTransportKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ChatMessageTransportKind {}
 impl ::core::fmt::Debug for ChatMessageTransportKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ChatMessageTransportKind").field(&self.0).finish()
@@ -3029,6 +2994,7 @@ unsafe impl ::core::marker::Send for ChatMessageValidationResult {}
 unsafe impl ::core::marker::Sync for ChatMessageValidationResult {}
 #[doc = "*Required features: 'ApplicationModel_Chat'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ChatMessageValidationStatus(pub i32);
 impl ChatMessageValidationStatus {
     pub const Valid: Self = Self(0i32);
@@ -3055,12 +3021,6 @@ impl ::core::clone::Clone for ChatMessageValidationStatus {
 unsafe impl ::windows::core::Abi for ChatMessageValidationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ChatMessageValidationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ChatMessageValidationStatus {}
 impl ::core::fmt::Debug for ChatMessageValidationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ChatMessageValidationStatus").field(&self.0).finish()
@@ -3330,6 +3290,7 @@ unsafe impl ::core::marker::Send for ChatRecipientDeliveryInfo {}
 unsafe impl ::core::marker::Sync for ChatRecipientDeliveryInfo {}
 #[doc = "*Required features: 'ApplicationModel_Chat'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ChatRestoreHistorySpan(pub i32);
 impl ChatRestoreHistorySpan {
     pub const LastMonth: Self = Self(0i32);
@@ -3345,12 +3306,6 @@ impl ::core::clone::Clone for ChatRestoreHistorySpan {
 unsafe impl ::windows::core::Abi for ChatRestoreHistorySpan {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ChatRestoreHistorySpan {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ChatRestoreHistorySpan {}
 impl ::core::fmt::Debug for ChatRestoreHistorySpan {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ChatRestoreHistorySpan").field(&self.0).finish()
@@ -3455,6 +3410,7 @@ unsafe impl ::core::marker::Send for ChatSearchReader {}
 unsafe impl ::core::marker::Sync for ChatSearchReader {}
 #[doc = "*Required features: 'ApplicationModel_Chat'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ChatStoreChangedEventKind(pub i32);
 impl ChatStoreChangedEventKind {
     pub const NotificationsMissed: Self = Self(0i32);
@@ -3475,12 +3431,6 @@ impl ::core::clone::Clone for ChatStoreChangedEventKind {
 unsafe impl ::windows::core::Abi for ChatStoreChangedEventKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ChatStoreChangedEventKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ChatStoreChangedEventKind {}
 impl ::core::fmt::Debug for ChatStoreChangedEventKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ChatStoreChangedEventKind").field(&self.0).finish()
@@ -3715,6 +3665,7 @@ unsafe impl ::core::marker::Send for ChatSyncManager {}
 unsafe impl ::core::marker::Sync for ChatSyncManager {}
 #[doc = "*Required features: 'ApplicationModel_Chat'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ChatTransportErrorCodeCategory(pub i32);
 impl ChatTransportErrorCodeCategory {
     pub const None: Self = Self(0i32);
@@ -3731,12 +3682,6 @@ impl ::core::clone::Clone for ChatTransportErrorCodeCategory {
 unsafe impl ::windows::core::Abi for ChatTransportErrorCodeCategory {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ChatTransportErrorCodeCategory {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ChatTransportErrorCodeCategory {}
 impl ::core::fmt::Debug for ChatTransportErrorCodeCategory {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ChatTransportErrorCodeCategory").field(&self.0).finish()
@@ -3750,6 +3695,7 @@ impl ::windows::core::DefaultType for ChatTransportErrorCodeCategory {
 }
 #[doc = "*Required features: 'ApplicationModel_Chat'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ChatTransportInterpretedErrorCode(pub i32);
 impl ChatTransportInterpretedErrorCode {
     pub const None: Self = Self(0i32);
@@ -3768,12 +3714,6 @@ impl ::core::clone::Clone for ChatTransportInterpretedErrorCode {
 unsafe impl ::windows::core::Abi for ChatTransportInterpretedErrorCode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ChatTransportInterpretedErrorCode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ChatTransportInterpretedErrorCode {}
 impl ::core::fmt::Debug for ChatTransportInterpretedErrorCode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ChatTransportInterpretedErrorCode").field(&self.0).finish()
@@ -5612,6 +5552,7 @@ impl ::windows::core::RuntimeName for RcsManager {
 }
 #[doc = "*Required features: 'ApplicationModel_Chat'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RcsServiceKind(pub i32);
 impl RcsServiceKind {
     pub const Chat: Self = Self(0i32);
@@ -5628,12 +5569,6 @@ impl ::core::clone::Clone for RcsServiceKind {
 unsafe impl ::windows::core::Abi for RcsServiceKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RcsServiceKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RcsServiceKind {}
 impl ::core::fmt::Debug for RcsServiceKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RcsServiceKind").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/Contacts/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Contacts/Provider/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'ApplicationModel_Contacts_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AddContactResult(pub i32);
 impl AddContactResult {
     pub const Added: Self = Self(0i32);
@@ -16,12 +17,6 @@ impl ::core::clone::Clone for AddContactResult {
 unsafe impl ::windows::core::Abi for AddContactResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AddContactResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AddContactResult {}
 impl ::core::fmt::Debug for AddContactResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AddContactResult").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/Contacts/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Contacts/mod.rs
@@ -803,6 +803,7 @@ unsafe impl ::core::marker::Send for ContactAddress {}
 unsafe impl ::core::marker::Sync for ContactAddress {}
 #[doc = "*Required features: 'ApplicationModel_Contacts'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ContactAddressKind(pub i32);
 impl ContactAddressKind {
     pub const Home: Self = Self(0i32);
@@ -818,12 +819,6 @@ impl ::core::clone::Clone for ContactAddressKind {
 unsafe impl ::windows::core::Abi for ContactAddressKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ContactAddressKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ContactAddressKind {}
 impl ::core::fmt::Debug for ContactAddressKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ContactAddressKind").field(&self.0).finish()
@@ -1153,6 +1148,7 @@ unsafe impl ::core::marker::Send for ContactAnnotationList {}
 unsafe impl ::core::marker::Sync for ContactAnnotationList {}
 #[doc = "*Required features: 'ApplicationModel_Contacts'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ContactAnnotationOperations(pub u32);
 impl ContactAnnotationOperations {
     pub const None: Self = Self(0u32);
@@ -1172,12 +1168,6 @@ impl ::core::clone::Clone for ContactAnnotationOperations {
 unsafe impl ::windows::core::Abi for ContactAnnotationOperations {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ContactAnnotationOperations {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ContactAnnotationOperations {}
 impl ::core::fmt::Debug for ContactAnnotationOperations {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ContactAnnotationOperations").field(&self.0).finish()
@@ -1373,6 +1363,7 @@ unsafe impl ::core::marker::Send for ContactAnnotationStore {}
 unsafe impl ::core::marker::Sync for ContactAnnotationStore {}
 #[doc = "*Required features: 'ApplicationModel_Contacts'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ContactAnnotationStoreAccessType(pub i32);
 impl ContactAnnotationStoreAccessType {
     pub const AppAnnotationsReadWrite: Self = Self(0i32);
@@ -1387,12 +1378,6 @@ impl ::core::clone::Clone for ContactAnnotationStoreAccessType {
 unsafe impl ::windows::core::Abi for ContactAnnotationStoreAccessType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ContactAnnotationStoreAccessType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ContactAnnotationStoreAccessType {}
 impl ::core::fmt::Debug for ContactAnnotationStoreAccessType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ContactAnnotationStoreAccessType").field(&self.0).finish()
@@ -1496,6 +1481,7 @@ unsafe impl ::core::marker::Send for ContactBatch {}
 unsafe impl ::core::marker::Sync for ContactBatch {}
 #[doc = "*Required features: 'ApplicationModel_Contacts'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ContactBatchStatus(pub i32);
 impl ContactBatchStatus {
     pub const Success: Self = Self(0i32);
@@ -1511,12 +1497,6 @@ impl ::core::clone::Clone for ContactBatchStatus {
 unsafe impl ::windows::core::Abi for ContactBatchStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ContactBatchStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ContactBatchStatus {}
 impl ::core::fmt::Debug for ContactBatchStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ContactBatchStatus").field(&self.0).finish()
@@ -1640,6 +1620,7 @@ unsafe impl ::core::marker::Send for ContactCardDelayedDataLoader {}
 unsafe impl ::core::marker::Sync for ContactCardDelayedDataLoader {}
 #[doc = "*Required features: 'ApplicationModel_Contacts'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ContactCardHeaderKind(pub i32);
 impl ContactCardHeaderKind {
     pub const Default: Self = Self(0i32);
@@ -1655,12 +1636,6 @@ impl ::core::clone::Clone for ContactCardHeaderKind {
 unsafe impl ::windows::core::Abi for ContactCardHeaderKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ContactCardHeaderKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ContactCardHeaderKind {}
 impl ::core::fmt::Debug for ContactCardHeaderKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ContactCardHeaderKind").field(&self.0).finish()
@@ -1789,6 +1764,7 @@ unsafe impl ::core::marker::Send for ContactCardOptions {}
 unsafe impl ::core::marker::Sync for ContactCardOptions {}
 #[doc = "*Required features: 'ApplicationModel_Contacts'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ContactCardTabKind(pub i32);
 impl ContactCardTabKind {
     pub const Default: Self = Self(0i32);
@@ -1807,12 +1783,6 @@ impl ::core::clone::Clone for ContactCardTabKind {
 unsafe impl ::windows::core::Abi for ContactCardTabKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ContactCardTabKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ContactCardTabKind {}
 impl ::core::fmt::Debug for ContactCardTabKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ContactCardTabKind").field(&self.0).finish()
@@ -2106,6 +2076,7 @@ unsafe impl ::core::marker::Send for ContactChangeTracker {}
 unsafe impl ::core::marker::Sync for ContactChangeTracker {}
 #[doc = "*Required features: 'ApplicationModel_Contacts'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ContactChangeType(pub i32);
 impl ContactChangeType {
     pub const Created: Self = Self(0i32);
@@ -2122,12 +2093,6 @@ impl ::core::clone::Clone for ContactChangeType {
 unsafe impl ::windows::core::Abi for ContactChangeType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ContactChangeType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ContactChangeType {}
 impl ::core::fmt::Debug for ContactChangeType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ContactChangeType").field(&self.0).finish()
@@ -2557,6 +2522,7 @@ unsafe impl ::core::marker::Send for ContactDate {}
 unsafe impl ::core::marker::Sync for ContactDate {}
 #[doc = "*Required features: 'ApplicationModel_Contacts'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ContactDateKind(pub i32);
 impl ContactDateKind {
     pub const Birthday: Self = Self(0i32);
@@ -2572,12 +2538,6 @@ impl ::core::clone::Clone for ContactDateKind {
 unsafe impl ::windows::core::Abi for ContactDateKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ContactDateKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ContactDateKind {}
 impl ::core::fmt::Debug for ContactDateKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ContactDateKind").field(&self.0).finish()
@@ -2710,6 +2670,7 @@ unsafe impl ::core::marker::Send for ContactEmail {}
 unsafe impl ::core::marker::Sync for ContactEmail {}
 #[doc = "*Required features: 'ApplicationModel_Contacts'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ContactEmailKind(pub i32);
 impl ContactEmailKind {
     pub const Personal: Self = Self(0i32);
@@ -2725,12 +2686,6 @@ impl ::core::clone::Clone for ContactEmailKind {
 unsafe impl ::windows::core::Abi for ContactEmailKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ContactEmailKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ContactEmailKind {}
 impl ::core::fmt::Debug for ContactEmailKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ContactEmailKind").field(&self.0).finish()
@@ -2897,6 +2852,7 @@ unsafe impl ::core::marker::Send for ContactField {}
 unsafe impl ::core::marker::Sync for ContactField {}
 #[doc = "*Required features: 'ApplicationModel_Contacts'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ContactFieldCategory(pub i32);
 impl ContactFieldCategory {
     pub const None: Self = Self(0i32);
@@ -2914,12 +2870,6 @@ impl ::core::clone::Clone for ContactFieldCategory {
 unsafe impl ::windows::core::Abi for ContactFieldCategory {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ContactFieldCategory {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ContactFieldCategory {}
 impl ::core::fmt::Debug for ContactFieldCategory {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ContactFieldCategory").field(&self.0).finish()
@@ -3152,6 +3102,7 @@ unsafe impl ::core::marker::Send for ContactFieldFactory {}
 unsafe impl ::core::marker::Sync for ContactFieldFactory {}
 #[doc = "*Required features: 'ApplicationModel_Contacts'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ContactFieldType(pub i32);
 impl ContactFieldType {
     pub const Email: Self = Self(0i32);
@@ -3176,12 +3127,6 @@ impl ::core::clone::Clone for ContactFieldType {
 unsafe impl ::windows::core::Abi for ContactFieldType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ContactFieldType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ContactFieldType {}
 impl ::core::fmt::Debug for ContactFieldType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ContactFieldType").field(&self.0).finish()
@@ -4223,6 +4168,7 @@ unsafe impl ::core::marker::Send for ContactListLimitedWriteOperations {}
 unsafe impl ::core::marker::Sync for ContactListLimitedWriteOperations {}
 #[doc = "*Required features: 'ApplicationModel_Contacts'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ContactListOtherAppReadAccess(pub i32);
 impl ContactListOtherAppReadAccess {
     pub const SystemOnly: Self = Self(0i32);
@@ -4239,12 +4185,6 @@ impl ::core::clone::Clone for ContactListOtherAppReadAccess {
 unsafe impl ::windows::core::Abi for ContactListOtherAppReadAccess {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ContactListOtherAppReadAccess {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ContactListOtherAppReadAccess {}
 impl ::core::fmt::Debug for ContactListOtherAppReadAccess {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ContactListOtherAppReadAccess").field(&self.0).finish()
@@ -4258,6 +4198,7 @@ impl ::windows::core::DefaultType for ContactListOtherAppReadAccess {
 }
 #[doc = "*Required features: 'ApplicationModel_Contacts'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ContactListOtherAppWriteAccess(pub i32);
 impl ContactListOtherAppWriteAccess {
     pub const None: Self = Self(0i32);
@@ -4273,12 +4214,6 @@ impl ::core::clone::Clone for ContactListOtherAppWriteAccess {
 unsafe impl ::windows::core::Abi for ContactListOtherAppWriteAccess {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ContactListOtherAppWriteAccess {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ContactListOtherAppWriteAccess {}
 impl ::core::fmt::Debug for ContactListOtherAppWriteAccess {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ContactListOtherAppWriteAccess").field(&self.0).finish()
@@ -4923,6 +4858,7 @@ unsafe impl ::core::marker::Send for ContactListSyncManager {}
 unsafe impl ::core::marker::Sync for ContactListSyncManager {}
 #[doc = "*Required features: 'ApplicationModel_Contacts'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ContactListSyncStatus(pub i32);
 impl ContactListSyncStatus {
     pub const Idle: Self = Self(0i32);
@@ -4942,12 +4878,6 @@ impl ::core::clone::Clone for ContactListSyncStatus {
 unsafe impl ::windows::core::Abi for ContactListSyncStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ContactListSyncStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ContactListSyncStatus {}
 impl ::core::fmt::Debug for ContactListSyncStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ContactListSyncStatus").field(&self.0).finish()
@@ -5596,6 +5526,7 @@ unsafe impl ::core::marker::Send for ContactMatchReason {}
 unsafe impl ::core::marker::Sync for ContactMatchReason {}
 #[doc = "*Required features: 'ApplicationModel_Contacts'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ContactMatchReasonKind(pub i32);
 impl ContactMatchReasonKind {
     pub const Name: Self = Self(0i32);
@@ -5614,12 +5545,6 @@ impl ::core::clone::Clone for ContactMatchReasonKind {
 unsafe impl ::windows::core::Abi for ContactMatchReasonKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ContactMatchReasonKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ContactMatchReasonKind {}
 impl ::core::fmt::Debug for ContactMatchReasonKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ContactMatchReasonKind").field(&self.0).finish()
@@ -5633,6 +5558,7 @@ impl ::windows::core::DefaultType for ContactMatchReasonKind {
 }
 #[doc = "*Required features: 'ApplicationModel_Contacts'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ContactNameOrder(pub i32);
 impl ContactNameOrder {
     pub const FirstNameLastName: Self = Self(0i32);
@@ -5647,12 +5573,6 @@ impl ::core::clone::Clone for ContactNameOrder {
 unsafe impl ::windows::core::Abi for ContactNameOrder {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ContactNameOrder {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ContactNameOrder {}
 impl ::core::fmt::Debug for ContactNameOrder {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ContactNameOrder").field(&self.0).finish()
@@ -6076,6 +5996,7 @@ unsafe impl ::core::marker::Send for ContactPhone {}
 unsafe impl ::core::marker::Sync for ContactPhone {}
 #[doc = "*Required features: 'ApplicationModel_Contacts'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ContactPhoneKind(pub i32);
 impl ContactPhoneKind {
     pub const Home: Self = Self(0i32);
@@ -6098,12 +6019,6 @@ impl ::core::clone::Clone for ContactPhoneKind {
 unsafe impl ::windows::core::Abi for ContactPhoneKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ContactPhoneKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ContactPhoneKind {}
 impl ::core::fmt::Debug for ContactPhoneKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ContactPhoneKind").field(&self.0).finish()
@@ -6305,6 +6220,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Cont
 }
 #[doc = "*Required features: 'ApplicationModel_Contacts'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ContactQueryDesiredFields(pub u32);
 impl ContactQueryDesiredFields {
     pub const None: Self = Self(0u32);
@@ -6321,12 +6237,6 @@ impl ::core::clone::Clone for ContactQueryDesiredFields {
 unsafe impl ::windows::core::Abi for ContactQueryDesiredFields {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ContactQueryDesiredFields {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ContactQueryDesiredFields {}
 impl ::core::fmt::Debug for ContactQueryDesiredFields {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ContactQueryDesiredFields").field(&self.0).finish()
@@ -6532,6 +6442,7 @@ unsafe impl ::core::marker::Send for ContactQueryOptions {}
 unsafe impl ::core::marker::Sync for ContactQueryOptions {}
 #[doc = "*Required features: 'ApplicationModel_Contacts'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ContactQuerySearchFields(pub u32);
 impl ContactQuerySearchFields {
     pub const None: Self = Self(0u32);
@@ -6549,12 +6460,6 @@ impl ::core::clone::Clone for ContactQuerySearchFields {
 unsafe impl ::windows::core::Abi for ContactQuerySearchFields {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ContactQuerySearchFields {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ContactQuerySearchFields {}
 impl ::core::fmt::Debug for ContactQuerySearchFields {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ContactQuerySearchFields").field(&self.0).finish()
@@ -6596,6 +6501,7 @@ impl ::windows::core::DefaultType for ContactQuerySearchFields {
 }
 #[doc = "*Required features: 'ApplicationModel_Contacts'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ContactQuerySearchScope(pub i32);
 impl ContactQuerySearchScope {
     pub const Local: Self = Self(0i32);
@@ -6610,12 +6516,6 @@ impl ::core::clone::Clone for ContactQuerySearchScope {
 unsafe impl ::windows::core::Abi for ContactQuerySearchScope {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ContactQuerySearchScope {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ContactQuerySearchScope {}
 impl ::core::fmt::Debug for ContactQuerySearchScope {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ContactQuerySearchScope").field(&self.0).finish()
@@ -6832,6 +6732,7 @@ unsafe impl ::core::marker::Send for ContactReader {}
 unsafe impl ::core::marker::Sync for ContactReader {}
 #[doc = "*Required features: 'ApplicationModel_Contacts'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ContactRelationship(pub i32);
 impl ContactRelationship {
     pub const Other: Self = Self(0i32);
@@ -6850,12 +6751,6 @@ impl ::core::clone::Clone for ContactRelationship {
 unsafe impl ::windows::core::Abi for ContactRelationship {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ContactRelationship {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ContactRelationship {}
 impl ::core::fmt::Debug for ContactRelationship {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ContactRelationship").field(&self.0).finish()
@@ -6869,6 +6764,7 @@ impl ::windows::core::DefaultType for ContactRelationship {
 }
 #[doc = "*Required features: 'ApplicationModel_Contacts'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ContactSelectionMode(pub i32);
 impl ContactSelectionMode {
     pub const Contacts: Self = Self(0i32);
@@ -6883,12 +6779,6 @@ impl ::core::clone::Clone for ContactSelectionMode {
 unsafe impl ::windows::core::Abi for ContactSelectionMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ContactSelectionMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ContactSelectionMode {}
 impl ::core::fmt::Debug for ContactSelectionMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ContactSelectionMode").field(&self.0).finish()
@@ -7221,6 +7111,7 @@ unsafe impl ::core::marker::Send for ContactStore {}
 unsafe impl ::core::marker::Sync for ContactStore {}
 #[doc = "*Required features: 'ApplicationModel_Contacts'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ContactStoreAccessType(pub i32);
 impl ContactStoreAccessType {
     pub const AppContactsReadWrite: Self = Self(0i32);
@@ -7236,12 +7127,6 @@ impl ::core::clone::Clone for ContactStoreAccessType {
 unsafe impl ::windows::core::Abi for ContactStoreAccessType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ContactStoreAccessType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ContactStoreAccessType {}
 impl ::core::fmt::Debug for ContactStoreAccessType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ContactStoreAccessType").field(&self.0).finish()
@@ -10106,6 +9991,7 @@ unsafe impl ::core::marker::Send for PinnedContactManager {}
 unsafe impl ::core::marker::Sync for PinnedContactManager {}
 #[doc = "*Required features: 'ApplicationModel_Contacts'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PinnedContactSurface(pub i32);
 impl PinnedContactSurface {
     pub const StartMenu: Self = Self(0i32);
@@ -10120,12 +10006,6 @@ impl ::core::clone::Clone for PinnedContactSurface {
 unsafe impl ::windows::core::Abi for PinnedContactSurface {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PinnedContactSurface {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PinnedContactSurface {}
 impl ::core::fmt::Debug for PinnedContactSurface {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PinnedContactSurface").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/ConversationalAgent/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/ConversationalAgent/mod.rs
@@ -427,6 +427,7 @@ unsafe impl ::core::marker::Send for ActivationSignalDetectionConfigurationCreat
 unsafe impl ::core::marker::Sync for ActivationSignalDetectionConfigurationCreationResult {}
 #[doc = "*Required features: 'ApplicationModel_ConversationalAgent'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ActivationSignalDetectionConfigurationCreationStatus(pub i32);
 impl ActivationSignalDetectionConfigurationCreationStatus {
     pub const Success: Self = Self(0i32);
@@ -447,12 +448,6 @@ impl ::core::clone::Clone for ActivationSignalDetectionConfigurationCreationStat
 unsafe impl ::windows::core::Abi for ActivationSignalDetectionConfigurationCreationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ActivationSignalDetectionConfigurationCreationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ActivationSignalDetectionConfigurationCreationStatus {}
 impl ::core::fmt::Debug for ActivationSignalDetectionConfigurationCreationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ActivationSignalDetectionConfigurationCreationStatus").field(&self.0).finish()
@@ -466,6 +461,7 @@ impl ::windows::core::DefaultType for ActivationSignalDetectionConfigurationCrea
 }
 #[doc = "*Required features: 'ApplicationModel_ConversationalAgent'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ActivationSignalDetectionConfigurationRemovalResult(pub i32);
 impl ActivationSignalDetectionConfigurationRemovalResult {
     pub const Success: Self = Self(0i32);
@@ -482,12 +478,6 @@ impl ::core::clone::Clone for ActivationSignalDetectionConfigurationRemovalResul
 unsafe impl ::windows::core::Abi for ActivationSignalDetectionConfigurationRemovalResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ActivationSignalDetectionConfigurationRemovalResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ActivationSignalDetectionConfigurationRemovalResult {}
 impl ::core::fmt::Debug for ActivationSignalDetectionConfigurationRemovalResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ActivationSignalDetectionConfigurationRemovalResult").field(&self.0).finish()
@@ -501,6 +491,7 @@ impl ::windows::core::DefaultType for ActivationSignalDetectionConfigurationRemo
 }
 #[doc = "*Required features: 'ApplicationModel_ConversationalAgent'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ActivationSignalDetectionConfigurationSetModelDataResult(pub i32);
 impl ActivationSignalDetectionConfigurationSetModelDataResult {
     pub const Success: Self = Self(0i32);
@@ -521,12 +512,6 @@ impl ::core::clone::Clone for ActivationSignalDetectionConfigurationSetModelData
 unsafe impl ::windows::core::Abi for ActivationSignalDetectionConfigurationSetModelDataResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ActivationSignalDetectionConfigurationSetModelDataResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ActivationSignalDetectionConfigurationSetModelDataResult {}
 impl ::core::fmt::Debug for ActivationSignalDetectionConfigurationSetModelDataResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ActivationSignalDetectionConfigurationSetModelDataResult").field(&self.0).finish()
@@ -540,6 +525,7 @@ impl ::windows::core::DefaultType for ActivationSignalDetectionConfigurationSetM
 }
 #[doc = "*Required features: 'ApplicationModel_ConversationalAgent'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ActivationSignalDetectionConfigurationStateChangeResult(pub i32);
 impl ActivationSignalDetectionConfigurationStateChangeResult {
     pub const Success: Self = Self(0i32);
@@ -555,12 +541,6 @@ impl ::core::clone::Clone for ActivationSignalDetectionConfigurationStateChangeR
 unsafe impl ::windows::core::Abi for ActivationSignalDetectionConfigurationStateChangeResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ActivationSignalDetectionConfigurationStateChangeResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ActivationSignalDetectionConfigurationStateChangeResult {}
 impl ::core::fmt::Debug for ActivationSignalDetectionConfigurationStateChangeResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ActivationSignalDetectionConfigurationStateChangeResult").field(&self.0).finish()
@@ -574,6 +554,7 @@ impl ::windows::core::DefaultType for ActivationSignalDetectionConfigurationStat
 }
 #[doc = "*Required features: 'ApplicationModel_ConversationalAgent'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ActivationSignalDetectionTrainingDataFormat(pub i32);
 impl ActivationSignalDetectionTrainingDataFormat {
     pub const Voice8kHz8BitMono: Self = Self(0i32);
@@ -597,12 +578,6 @@ impl ::core::clone::Clone for ActivationSignalDetectionTrainingDataFormat {
 unsafe impl ::windows::core::Abi for ActivationSignalDetectionTrainingDataFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ActivationSignalDetectionTrainingDataFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ActivationSignalDetectionTrainingDataFormat {}
 impl ::core::fmt::Debug for ActivationSignalDetectionTrainingDataFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ActivationSignalDetectionTrainingDataFormat").field(&self.0).finish()
@@ -881,6 +856,7 @@ unsafe impl ::core::marker::Send for ActivationSignalDetector {}
 unsafe impl ::core::marker::Sync for ActivationSignalDetector {}
 #[doc = "*Required features: 'ApplicationModel_ConversationalAgent'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ActivationSignalDetectorKind(pub i32);
 impl ActivationSignalDetectorKind {
     pub const AudioPattern: Self = Self(0i32);
@@ -896,12 +872,6 @@ impl ::core::clone::Clone for ActivationSignalDetectorKind {
 unsafe impl ::windows::core::Abi for ActivationSignalDetectorKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ActivationSignalDetectorKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ActivationSignalDetectorKind {}
 impl ::core::fmt::Debug for ActivationSignalDetectorKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ActivationSignalDetectorKind").field(&self.0).finish()
@@ -915,6 +885,7 @@ impl ::windows::core::DefaultType for ActivationSignalDetectorKind {
 }
 #[doc = "*Required features: 'ApplicationModel_ConversationalAgent'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ActivationSignalDetectorPowerState(pub i32);
 impl ActivationSignalDetectorPowerState {
     pub const HighPower: Self = Self(0i32);
@@ -930,12 +901,6 @@ impl ::core::clone::Clone for ActivationSignalDetectorPowerState {
 unsafe impl ::windows::core::Abi for ActivationSignalDetectorPowerState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ActivationSignalDetectorPowerState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ActivationSignalDetectorPowerState {}
 impl ::core::fmt::Debug for ActivationSignalDetectorPowerState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ActivationSignalDetectorPowerState").field(&self.0).finish()
@@ -949,6 +914,7 @@ impl ::windows::core::DefaultType for ActivationSignalDetectorPowerState {
 }
 #[doc = "*Required features: 'ApplicationModel_ConversationalAgent'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ConversationalAgentActivationKind(pub i32);
 impl ConversationalAgentActivationKind {
     pub const VoiceActivationPreview: Self = Self(0i32);
@@ -963,12 +929,6 @@ impl ::core::clone::Clone for ConversationalAgentActivationKind {
 unsafe impl ::windows::core::Abi for ConversationalAgentActivationKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ConversationalAgentActivationKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ConversationalAgentActivationKind {}
 impl ::core::fmt::Debug for ConversationalAgentActivationKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ConversationalAgentActivationKind").field(&self.0).finish()
@@ -982,6 +942,7 @@ impl ::windows::core::DefaultType for ConversationalAgentActivationKind {
 }
 #[doc = "*Required features: 'ApplicationModel_ConversationalAgent'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ConversationalAgentActivationResult(pub i32);
 impl ConversationalAgentActivationResult {
     pub const Success: Self = Self(0i32);
@@ -998,12 +959,6 @@ impl ::core::clone::Clone for ConversationalAgentActivationResult {
 unsafe impl ::windows::core::Abi for ConversationalAgentActivationResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ConversationalAgentActivationResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ConversationalAgentActivationResult {}
 impl ::core::fmt::Debug for ConversationalAgentActivationResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ConversationalAgentActivationResult").field(&self.0).finish()
@@ -1682,6 +1637,7 @@ unsafe impl ::core::marker::Send for ConversationalAgentSessionInterruptedEventA
 unsafe impl ::core::marker::Sync for ConversationalAgentSessionInterruptedEventArgs {}
 #[doc = "*Required features: 'ApplicationModel_ConversationalAgent'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ConversationalAgentSessionUpdateResponse(pub i32);
 impl ConversationalAgentSessionUpdateResponse {
     pub const Success: Self = Self(0i32);
@@ -1696,12 +1652,6 @@ impl ::core::clone::Clone for ConversationalAgentSessionUpdateResponse {
 unsafe impl ::windows::core::Abi for ConversationalAgentSessionUpdateResponse {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ConversationalAgentSessionUpdateResponse {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ConversationalAgentSessionUpdateResponse {}
 impl ::core::fmt::Debug for ConversationalAgentSessionUpdateResponse {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ConversationalAgentSessionUpdateResponse").field(&self.0).finish()
@@ -1958,6 +1908,7 @@ unsafe impl ::core::marker::Send for ConversationalAgentSignalDetectedEventArgs 
 unsafe impl ::core::marker::Sync for ConversationalAgentSignalDetectedEventArgs {}
 #[doc = "*Required features: 'ApplicationModel_ConversationalAgent'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ConversationalAgentState(pub i32);
 impl ConversationalAgentState {
     pub const Inactive: Self = Self(0i32);
@@ -1976,12 +1927,6 @@ impl ::core::clone::Clone for ConversationalAgentState {
 unsafe impl ::windows::core::Abi for ConversationalAgentState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ConversationalAgentState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ConversationalAgentState {}
 impl ::core::fmt::Debug for ConversationalAgentState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ConversationalAgentState").field(&self.0).finish()
@@ -1995,6 +1940,7 @@ impl ::windows::core::DefaultType for ConversationalAgentState {
 }
 #[doc = "*Required features: 'ApplicationModel_ConversationalAgent'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ConversationalAgentSystemStateChangeType(pub i32);
 impl ConversationalAgentSystemStateChangeType {
     pub const UserAuthentication: Self = Self(0i32);
@@ -2011,12 +1957,6 @@ impl ::core::clone::Clone for ConversationalAgentSystemStateChangeType {
 unsafe impl ::windows::core::Abi for ConversationalAgentSystemStateChangeType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ConversationalAgentSystemStateChangeType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ConversationalAgentSystemStateChangeType {}
 impl ::core::fmt::Debug for ConversationalAgentSystemStateChangeType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ConversationalAgentSystemStateChangeType").field(&self.0).finish()
@@ -2111,6 +2051,7 @@ unsafe impl ::core::marker::Send for ConversationalAgentSystemStateChangedEventA
 unsafe impl ::core::marker::Sync for ConversationalAgentSystemStateChangedEventArgs {}
 #[doc = "*Required features: 'ApplicationModel_ConversationalAgent'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ConversationalAgentVoiceActivationPrerequisiteKind(pub i32);
 impl ConversationalAgentVoiceActivationPrerequisiteKind {
     pub const MicrophonePermission: Self = Self(0i32);
@@ -2129,12 +2070,6 @@ impl ::core::clone::Clone for ConversationalAgentVoiceActivationPrerequisiteKind
 unsafe impl ::windows::core::Abi for ConversationalAgentVoiceActivationPrerequisiteKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ConversationalAgentVoiceActivationPrerequisiteKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ConversationalAgentVoiceActivationPrerequisiteKind {}
 impl ::core::fmt::Debug for ConversationalAgentVoiceActivationPrerequisiteKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ConversationalAgentVoiceActivationPrerequisiteKind").field(&self.0).finish()
@@ -2148,6 +2083,7 @@ impl ::windows::core::DefaultType for ConversationalAgentVoiceActivationPrerequi
 }
 #[doc = "*Required features: 'ApplicationModel_ConversationalAgent'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DetectionConfigurationAvailabilityChangeKind(pub i32);
 impl DetectionConfigurationAvailabilityChangeKind {
     pub const SystemResourceAccess: Self = Self(0i32);
@@ -2163,12 +2099,6 @@ impl ::core::clone::Clone for DetectionConfigurationAvailabilityChangeKind {
 unsafe impl ::windows::core::Abi for DetectionConfigurationAvailabilityChangeKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DetectionConfigurationAvailabilityChangeKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DetectionConfigurationAvailabilityChangeKind {}
 impl ::core::fmt::Debug for DetectionConfigurationAvailabilityChangeKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DetectionConfigurationAvailabilityChangeKind").field(&self.0).finish()
@@ -2377,6 +2307,7 @@ unsafe impl ::core::marker::Send for DetectionConfigurationAvailabilityInfo {}
 unsafe impl ::core::marker::Sync for DetectionConfigurationAvailabilityInfo {}
 #[doc = "*Required features: 'ApplicationModel_ConversationalAgent'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DetectionConfigurationTrainingStatus(pub i32);
 impl DetectionConfigurationTrainingStatus {
     pub const Success: Self = Self(0i32);
@@ -2399,12 +2330,6 @@ impl ::core::clone::Clone for DetectionConfigurationTrainingStatus {
 unsafe impl ::windows::core::Abi for DetectionConfigurationTrainingStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DetectionConfigurationTrainingStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DetectionConfigurationTrainingStatus {}
 impl ::core::fmt::Debug for DetectionConfigurationTrainingStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DetectionConfigurationTrainingStatus").field(&self.0).finish()
@@ -2927,6 +2852,7 @@ pub struct IDetectionConfigurationAvailabilityInfo2Vtbl(
 );
 #[doc = "*Required features: 'ApplicationModel_ConversationalAgent'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SignalDetectorResourceKind(pub i32);
 impl SignalDetectorResourceKind {
     pub const ParallelModelSupport: Self = Self(0i32);
@@ -2953,12 +2879,6 @@ impl ::core::clone::Clone for SignalDetectorResourceKind {
 unsafe impl ::windows::core::Abi for SignalDetectorResourceKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SignalDetectorResourceKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SignalDetectorResourceKind {}
 impl ::core::fmt::Debug for SignalDetectorResourceKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SignalDetectorResourceKind").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Core/mod.rs
@@ -116,6 +116,7 @@ unsafe impl ::core::marker::Send for AppListEntry {}
 unsafe impl ::core::marker::Sync for AppListEntry {}
 #[doc = "*Required features: 'ApplicationModel_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppRestartFailureReason(pub i32);
 impl AppRestartFailureReason {
     pub const RestartPending: Self = Self(0i32);
@@ -132,12 +133,6 @@ impl ::core::clone::Clone for AppRestartFailureReason {
 unsafe impl ::windows::core::Abi for AppRestartFailureReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppRestartFailureReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppRestartFailureReason {}
 impl ::core::fmt::Debug for AppRestartFailureReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppRestartFailureReason").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/DragDrop/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/DragDrop/Core/mod.rs
@@ -360,6 +360,7 @@ unsafe impl ::core::marker::Send for CoreDragOperation {}
 unsafe impl ::core::marker::Sync for CoreDragOperation {}
 #[doc = "*Required features: 'ApplicationModel_DataTransfer_DragDrop_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CoreDragUIContentMode(pub u32);
 impl CoreDragUIContentMode {
     pub const Auto: Self = Self(0u32);
@@ -374,12 +375,6 @@ impl ::core::clone::Clone for CoreDragUIContentMode {
 unsafe impl ::windows::core::Abi for CoreDragUIContentMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CoreDragUIContentMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CoreDragUIContentMode {}
 impl ::core::fmt::Debug for CoreDragUIContentMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CoreDragUIContentMode").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/DragDrop/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/DragDrop/mod.rs
@@ -3,6 +3,7 @@
 pub mod Core;
 #[doc = "*Required features: 'ApplicationModel_DataTransfer_DragDrop'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DragDropModifiers(pub u32);
 impl DragDropModifiers {
     pub const None: Self = Self(0u32);
@@ -22,12 +23,6 @@ impl ::core::clone::Clone for DragDropModifiers {
 unsafe impl ::windows::core::Abi for DragDropModifiers {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DragDropModifiers {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DragDropModifiers {}
 impl ::core::fmt::Debug for DragDropModifiers {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DragDropModifiers").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/DataTransfer/mod.rs
@@ -527,6 +527,7 @@ unsafe impl ::core::marker::Send for ClipboardHistoryItemsResult {}
 unsafe impl ::core::marker::Sync for ClipboardHistoryItemsResult {}
 #[doc = "*Required features: 'ApplicationModel_DataTransfer'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ClipboardHistoryItemsResultStatus(pub i32);
 impl ClipboardHistoryItemsResultStatus {
     pub const Success: Self = Self(0i32);
@@ -542,12 +543,6 @@ impl ::core::clone::Clone for ClipboardHistoryItemsResultStatus {
 unsafe impl ::windows::core::Abi for ClipboardHistoryItemsResultStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ClipboardHistoryItemsResultStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ClipboardHistoryItemsResultStatus {}
 impl ::core::fmt::Debug for ClipboardHistoryItemsResultStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ClipboardHistoryItemsResultStatus").field(&self.0).finish()
@@ -800,6 +795,7 @@ unsafe impl ::core::marker::Send for DataPackage {}
 unsafe impl ::core::marker::Sync for DataPackage {}
 #[doc = "*Required features: 'ApplicationModel_DataTransfer'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DataPackageOperation(pub u32);
 impl DataPackageOperation {
     pub const None: Self = Self(0u32);
@@ -816,12 +812,6 @@ impl ::core::clone::Clone for DataPackageOperation {
 unsafe impl ::windows::core::Abi for DataPackageOperation {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DataPackageOperation {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DataPackageOperation {}
 impl ::core::fmt::Debug for DataPackageOperation {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DataPackageOperation").field(&self.0).finish()
@@ -3650,6 +3640,7 @@ unsafe impl ::core::marker::Send for OperationCompletedEventArgs {}
 unsafe impl ::core::marker::Sync for OperationCompletedEventArgs {}
 #[doc = "*Required features: 'ApplicationModel_DataTransfer'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SetHistoryItemAsContentStatus(pub i32);
 impl SetHistoryItemAsContentStatus {
     pub const Success: Self = Self(0i32);
@@ -3665,12 +3656,6 @@ impl ::core::clone::Clone for SetHistoryItemAsContentStatus {
 unsafe impl ::windows::core::Abi for SetHistoryItemAsContentStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SetHistoryItemAsContentStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SetHistoryItemAsContentStatus {}
 impl ::core::fmt::Debug for SetHistoryItemAsContentStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SetHistoryItemAsContentStatus").field(&self.0).finish()
@@ -4355,6 +4340,7 @@ unsafe impl ::core::marker::Send for ShareUIOptions {}
 unsafe impl ::core::marker::Sync for ShareUIOptions {}
 #[doc = "*Required features: 'ApplicationModel_DataTransfer'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ShareUITheme(pub i32);
 impl ShareUITheme {
     pub const Default: Self = Self(0i32);
@@ -4370,12 +4356,6 @@ impl ::core::clone::Clone for ShareUITheme {
 unsafe impl ::windows::core::Abi for ShareUITheme {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ShareUITheme {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ShareUITheme {}
 impl ::core::fmt::Debug for ShareUITheme {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ShareUITheme").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/Email/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Email/mod.rs
@@ -231,6 +231,7 @@ unsafe impl ::core::marker::Send for EmailAttachment {}
 unsafe impl ::core::marker::Sync for EmailAttachment {}
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailAttachmentDownloadState(pub i32);
 impl EmailAttachmentDownloadState {
     pub const NotDownloaded: Self = Self(0i32);
@@ -247,12 +248,6 @@ impl ::core::clone::Clone for EmailAttachmentDownloadState {
 unsafe impl ::windows::core::Abi for EmailAttachmentDownloadState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailAttachmentDownloadState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailAttachmentDownloadState {}
 impl ::core::fmt::Debug for EmailAttachmentDownloadState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailAttachmentDownloadState").field(&self.0).finish()
@@ -266,6 +261,7 @@ impl ::windows::core::DefaultType for EmailAttachmentDownloadState {
 }
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailBatchStatus(pub i32);
 impl EmailBatchStatus {
     pub const Success: Self = Self(0i32);
@@ -281,12 +277,6 @@ impl ::core::clone::Clone for EmailBatchStatus {
 unsafe impl ::windows::core::Abi for EmailBatchStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailBatchStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailBatchStatus {}
 impl ::core::fmt::Debug for EmailBatchStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailBatchStatus").field(&self.0).finish()
@@ -300,6 +290,7 @@ impl ::windows::core::DefaultType for EmailBatchStatus {
 }
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailCertificateValidationStatus(pub i32);
 impl EmailCertificateValidationStatus {
     pub const Success: Self = Self(0i32);
@@ -323,12 +314,6 @@ impl ::core::clone::Clone for EmailCertificateValidationStatus {
 unsafe impl ::windows::core::Abi for EmailCertificateValidationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailCertificateValidationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailCertificateValidationStatus {}
 impl ::core::fmt::Debug for EmailCertificateValidationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailCertificateValidationStatus").field(&self.0).finish()
@@ -710,6 +695,7 @@ unsafe impl ::core::marker::Send for EmailConversationReader {}
 unsafe impl ::core::marker::Sync for EmailConversationReader {}
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailFlagState(pub i32);
 impl EmailFlagState {
     pub const Unflagged: Self = Self(0i32);
@@ -726,12 +712,6 @@ impl ::core::clone::Clone for EmailFlagState {
 unsafe impl ::windows::core::Abi for EmailFlagState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailFlagState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailFlagState {}
 impl ::core::fmt::Debug for EmailFlagState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailFlagState").field(&self.0).finish()
@@ -1017,6 +997,7 @@ unsafe impl ::core::marker::Send for EmailFolder {}
 unsafe impl ::core::marker::Sync for EmailFolder {}
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailImportance(pub i32);
 impl EmailImportance {
     pub const Normal: Self = Self(0i32);
@@ -1032,12 +1013,6 @@ impl ::core::clone::Clone for EmailImportance {
 unsafe impl ::windows::core::Abi for EmailImportance {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailImportance {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailImportance {}
 impl ::core::fmt::Debug for EmailImportance {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailImportance").field(&self.0).finish()
@@ -2200,6 +2175,7 @@ unsafe impl ::core::marker::Send for EmailMailboxAction {}
 unsafe impl ::core::marker::Sync for EmailMailboxAction {}
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailMailboxActionKind(pub i32);
 impl EmailMailboxActionKind {
     pub const MarkMessageAsSeen: Self = Self(0i32);
@@ -2223,12 +2199,6 @@ impl ::core::clone::Clone for EmailMailboxActionKind {
 unsafe impl ::windows::core::Abi for EmailMailboxActionKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailMailboxActionKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailMailboxActionKind {}
 impl ::core::fmt::Debug for EmailMailboxActionKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailMailboxActionKind").field(&self.0).finish()
@@ -2242,6 +2212,7 @@ impl ::windows::core::DefaultType for EmailMailboxActionKind {
 }
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailMailboxAllowedSmimeEncryptionAlgorithmNegotiation(pub i32);
 impl EmailMailboxAllowedSmimeEncryptionAlgorithmNegotiation {
     pub const None: Self = Self(0i32);
@@ -2257,12 +2228,6 @@ impl ::core::clone::Clone for EmailMailboxAllowedSmimeEncryptionAlgorithmNegotia
 unsafe impl ::windows::core::Abi for EmailMailboxAllowedSmimeEncryptionAlgorithmNegotiation {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailMailboxAllowedSmimeEncryptionAlgorithmNegotiation {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailMailboxAllowedSmimeEncryptionAlgorithmNegotiation {}
 impl ::core::fmt::Debug for EmailMailboxAllowedSmimeEncryptionAlgorithmNegotiation {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailMailboxAllowedSmimeEncryptionAlgorithmNegotiation").field(&self.0).finish()
@@ -2375,6 +2340,7 @@ unsafe impl ::core::marker::Send for EmailMailboxAutoReply {}
 unsafe impl ::core::marker::Sync for EmailMailboxAutoReply {}
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailMailboxAutoReplyMessageResponseKind(pub i32);
 impl EmailMailboxAutoReplyMessageResponseKind {
     pub const Html: Self = Self(0i32);
@@ -2389,12 +2355,6 @@ impl ::core::clone::Clone for EmailMailboxAutoReplyMessageResponseKind {
 unsafe impl ::windows::core::Abi for EmailMailboxAutoReplyMessageResponseKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailMailboxAutoReplyMessageResponseKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailMailboxAutoReplyMessageResponseKind {}
 impl ::core::fmt::Debug for EmailMailboxAutoReplyMessageResponseKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailMailboxAutoReplyMessageResponseKind").field(&self.0).finish()
@@ -3120,6 +3080,7 @@ unsafe impl ::core::marker::Send for EmailMailboxChangeTracker {}
 unsafe impl ::core::marker::Sync for EmailMailboxChangeTracker {}
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailMailboxChangeType(pub i32);
 impl EmailMailboxChangeType {
     pub const MessageCreated: Self = Self(0i32);
@@ -3139,12 +3100,6 @@ impl ::core::clone::Clone for EmailMailboxChangeType {
 unsafe impl ::windows::core::Abi for EmailMailboxChangeType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailMailboxChangeType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailMailboxChangeType {}
 impl ::core::fmt::Debug for EmailMailboxChangeType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailMailboxChangeType").field(&self.0).finish()
@@ -3406,6 +3361,7 @@ unsafe impl ::core::marker::Send for EmailMailboxCreateFolderResult {}
 unsafe impl ::core::marker::Sync for EmailMailboxCreateFolderResult {}
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailMailboxCreateFolderStatus(pub i32);
 impl EmailMailboxCreateFolderStatus {
     pub const Success: Self = Self(0i32);
@@ -3425,12 +3381,6 @@ impl ::core::clone::Clone for EmailMailboxCreateFolderStatus {
 unsafe impl ::windows::core::Abi for EmailMailboxCreateFolderStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailMailboxCreateFolderStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailMailboxCreateFolderStatus {}
 impl ::core::fmt::Debug for EmailMailboxCreateFolderStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailMailboxCreateFolderStatus").field(&self.0).finish()
@@ -3444,6 +3394,7 @@ impl ::windows::core::DefaultType for EmailMailboxCreateFolderStatus {
 }
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailMailboxDeleteFolderStatus(pub i32);
 impl EmailMailboxDeleteFolderStatus {
     pub const Success: Self = Self(0i32);
@@ -3462,12 +3413,6 @@ impl ::core::clone::Clone for EmailMailboxDeleteFolderStatus {
 unsafe impl ::windows::core::Abi for EmailMailboxDeleteFolderStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailMailboxDeleteFolderStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailMailboxDeleteFolderStatus {}
 impl ::core::fmt::Debug for EmailMailboxDeleteFolderStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailMailboxDeleteFolderStatus").field(&self.0).finish()
@@ -3481,6 +3426,7 @@ impl ::windows::core::DefaultType for EmailMailboxDeleteFolderStatus {
 }
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailMailboxEmptyFolderStatus(pub i32);
 impl EmailMailboxEmptyFolderStatus {
     pub const Success: Self = Self(0i32);
@@ -3499,12 +3445,6 @@ impl ::core::clone::Clone for EmailMailboxEmptyFolderStatus {
 unsafe impl ::windows::core::Abi for EmailMailboxEmptyFolderStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailMailboxEmptyFolderStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailMailboxEmptyFolderStatus {}
 impl ::core::fmt::Debug for EmailMailboxEmptyFolderStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailMailboxEmptyFolderStatus").field(&self.0).finish()
@@ -3518,6 +3458,7 @@ impl ::windows::core::DefaultType for EmailMailboxEmptyFolderStatus {
 }
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailMailboxOtherAppReadAccess(pub i32);
 impl EmailMailboxOtherAppReadAccess {
     pub const SystemOnly: Self = Self(0i32);
@@ -3533,12 +3474,6 @@ impl ::core::clone::Clone for EmailMailboxOtherAppReadAccess {
 unsafe impl ::windows::core::Abi for EmailMailboxOtherAppReadAccess {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailMailboxOtherAppReadAccess {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailMailboxOtherAppReadAccess {}
 impl ::core::fmt::Debug for EmailMailboxOtherAppReadAccess {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailMailboxOtherAppReadAccess").field(&self.0).finish()
@@ -3552,6 +3487,7 @@ impl ::windows::core::DefaultType for EmailMailboxOtherAppReadAccess {
 }
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailMailboxOtherAppWriteAccess(pub i32);
 impl EmailMailboxOtherAppWriteAccess {
     pub const None: Self = Self(0i32);
@@ -3566,12 +3502,6 @@ impl ::core::clone::Clone for EmailMailboxOtherAppWriteAccess {
 unsafe impl ::windows::core::Abi for EmailMailboxOtherAppWriteAccess {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailMailboxOtherAppWriteAccess {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailMailboxOtherAppWriteAccess {}
 impl ::core::fmt::Debug for EmailMailboxOtherAppWriteAccess {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailMailboxOtherAppWriteAccess").field(&self.0).finish()
@@ -3740,6 +3670,7 @@ unsafe impl ::core::marker::Send for EmailMailboxPolicies {}
 unsafe impl ::core::marker::Sync for EmailMailboxPolicies {}
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailMailboxSmimeEncryptionAlgorithm(pub i32);
 impl EmailMailboxSmimeEncryptionAlgorithm {
     pub const Any: Self = Self(0i32);
@@ -3758,12 +3689,6 @@ impl ::core::clone::Clone for EmailMailboxSmimeEncryptionAlgorithm {
 unsafe impl ::windows::core::Abi for EmailMailboxSmimeEncryptionAlgorithm {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailMailboxSmimeEncryptionAlgorithm {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailMailboxSmimeEncryptionAlgorithm {}
 impl ::core::fmt::Debug for EmailMailboxSmimeEncryptionAlgorithm {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailMailboxSmimeEncryptionAlgorithm").field(&self.0).finish()
@@ -3777,6 +3702,7 @@ impl ::windows::core::DefaultType for EmailMailboxSmimeEncryptionAlgorithm {
 }
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailMailboxSmimeSigningAlgorithm(pub i32);
 impl EmailMailboxSmimeSigningAlgorithm {
     pub const Any: Self = Self(0i32);
@@ -3792,12 +3718,6 @@ impl ::core::clone::Clone for EmailMailboxSmimeSigningAlgorithm {
 unsafe impl ::windows::core::Abi for EmailMailboxSmimeSigningAlgorithm {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailMailboxSmimeSigningAlgorithm {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailMailboxSmimeSigningAlgorithm {}
 impl ::core::fmt::Debug for EmailMailboxSmimeSigningAlgorithm {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailMailboxSmimeSigningAlgorithm").field(&self.0).finish()
@@ -3951,6 +3871,7 @@ unsafe impl ::core::marker::Send for EmailMailboxSyncManager {}
 unsafe impl ::core::marker::Sync for EmailMailboxSyncManager {}
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailMailboxSyncStatus(pub i32);
 impl EmailMailboxSyncStatus {
     pub const Idle: Self = Self(0i32);
@@ -3970,12 +3891,6 @@ impl ::core::clone::Clone for EmailMailboxSyncStatus {
 unsafe impl ::windows::core::Abi for EmailMailboxSyncStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailMailboxSyncStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailMailboxSyncStatus {}
 impl ::core::fmt::Debug for EmailMailboxSyncStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailMailboxSyncStatus").field(&self.0).finish()
@@ -4406,6 +4321,7 @@ unsafe impl ::core::marker::Send for EmailMeetingInfo {}
 unsafe impl ::core::marker::Sync for EmailMeetingInfo {}
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailMeetingResponseType(pub i32);
 impl EmailMeetingResponseType {
     pub const Accept: Self = Self(0i32);
@@ -4421,12 +4337,6 @@ impl ::core::clone::Clone for EmailMeetingResponseType {
 unsafe impl ::windows::core::Abi for EmailMeetingResponseType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailMeetingResponseType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailMeetingResponseType {}
 impl ::core::fmt::Debug for EmailMeetingResponseType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailMeetingResponseType").field(&self.0).finish()
@@ -5035,6 +4945,7 @@ unsafe impl ::core::marker::Send for EmailMessageBatch {}
 unsafe impl ::core::marker::Sync for EmailMessageBatch {}
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailMessageBodyKind(pub i32);
 impl EmailMessageBodyKind {
     pub const Html: Self = Self(0i32);
@@ -5049,12 +4960,6 @@ impl ::core::clone::Clone for EmailMessageBodyKind {
 unsafe impl ::windows::core::Abi for EmailMessageBodyKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailMessageBodyKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailMessageBodyKind {}
 impl ::core::fmt::Debug for EmailMessageBodyKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailMessageBodyKind").field(&self.0).finish()
@@ -5068,6 +4973,7 @@ impl ::windows::core::DefaultType for EmailMessageBodyKind {
 }
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailMessageDownloadState(pub i32);
 impl EmailMessageDownloadState {
     pub const PartiallyDownloaded: Self = Self(0i32);
@@ -5084,12 +4990,6 @@ impl ::core::clone::Clone for EmailMessageDownloadState {
 unsafe impl ::windows::core::Abi for EmailMessageDownloadState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailMessageDownloadState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailMessageDownloadState {}
 impl ::core::fmt::Debug for EmailMessageDownloadState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailMessageDownloadState").field(&self.0).finish()
@@ -5185,6 +5085,7 @@ unsafe impl ::core::marker::Send for EmailMessageReader {}
 unsafe impl ::core::marker::Sync for EmailMessageReader {}
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailMessageResponseKind(pub i32);
 impl EmailMessageResponseKind {
     pub const None: Self = Self(0i32);
@@ -5201,12 +5102,6 @@ impl ::core::clone::Clone for EmailMessageResponseKind {
 unsafe impl ::windows::core::Abi for EmailMessageResponseKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailMessageResponseKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailMessageResponseKind {}
 impl ::core::fmt::Debug for EmailMessageResponseKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailMessageResponseKind").field(&self.0).finish()
@@ -5220,6 +5115,7 @@ impl ::windows::core::DefaultType for EmailMessageResponseKind {
 }
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailMessageSmimeKind(pub i32);
 impl EmailMessageSmimeKind {
     pub const None: Self = Self(0i32);
@@ -5236,12 +5132,6 @@ impl ::core::clone::Clone for EmailMessageSmimeKind {
 unsafe impl ::windows::core::Abi for EmailMessageSmimeKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailMessageSmimeKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailMessageSmimeKind {}
 impl ::core::fmt::Debug for EmailMessageSmimeKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailMessageSmimeKind").field(&self.0).finish()
@@ -5255,6 +5145,7 @@ impl ::windows::core::DefaultType for EmailMessageSmimeKind {
 }
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailQueryKind(pub i32);
 impl EmailQueryKind {
     pub const All: Self = Self(0i32);
@@ -5273,12 +5164,6 @@ impl ::core::clone::Clone for EmailQueryKind {
 unsafe impl ::windows::core::Abi for EmailQueryKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailQueryKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailQueryKind {}
 impl ::core::fmt::Debug for EmailQueryKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailQueryKind").field(&self.0).finish()
@@ -5447,6 +5332,7 @@ unsafe impl ::core::marker::Send for EmailQueryOptions {}
 unsafe impl ::core::marker::Sync for EmailQueryOptions {}
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailQuerySearchFields(pub u32);
 impl EmailQuerySearchFields {
     pub const None: Self = Self(0u32);
@@ -5465,12 +5351,6 @@ impl ::core::clone::Clone for EmailQuerySearchFields {
 unsafe impl ::windows::core::Abi for EmailQuerySearchFields {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailQuerySearchFields {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailQuerySearchFields {}
 impl ::core::fmt::Debug for EmailQuerySearchFields {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailQuerySearchFields").field(&self.0).finish()
@@ -5512,6 +5392,7 @@ impl ::windows::core::DefaultType for EmailQuerySearchFields {
 }
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailQuerySearchScope(pub i32);
 impl EmailQuerySearchScope {
     pub const Local: Self = Self(0i32);
@@ -5526,12 +5407,6 @@ impl ::core::clone::Clone for EmailQuerySearchScope {
 unsafe impl ::windows::core::Abi for EmailQuerySearchScope {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailQuerySearchScope {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailQuerySearchScope {}
 impl ::core::fmt::Debug for EmailQuerySearchScope {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailQuerySearchScope").field(&self.0).finish()
@@ -5545,6 +5420,7 @@ impl ::windows::core::DefaultType for EmailQuerySearchScope {
 }
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailQuerySortDirection(pub i32);
 impl EmailQuerySortDirection {
     pub const Descending: Self = Self(0i32);
@@ -5559,12 +5435,6 @@ impl ::core::clone::Clone for EmailQuerySortDirection {
 unsafe impl ::windows::core::Abi for EmailQuerySortDirection {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailQuerySortDirection {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailQuerySortDirection {}
 impl ::core::fmt::Debug for EmailQuerySortDirection {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailQuerySortDirection").field(&self.0).finish()
@@ -5578,6 +5448,7 @@ impl ::windows::core::DefaultType for EmailQuerySortDirection {
 }
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailQuerySortProperty(pub i32);
 impl EmailQuerySortProperty {
     pub const Date: Self = Self(0i32);
@@ -5591,12 +5462,6 @@ impl ::core::clone::Clone for EmailQuerySortProperty {
 unsafe impl ::windows::core::Abi for EmailQuerySortProperty {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailQuerySortProperty {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailQuerySortProperty {}
 impl ::core::fmt::Debug for EmailQuerySortProperty {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailQuerySortProperty").field(&self.0).finish()
@@ -5955,6 +5820,7 @@ unsafe impl ::core::marker::Send for EmailRecipientResolutionResult {}
 unsafe impl ::core::marker::Sync for EmailRecipientResolutionResult {}
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailRecipientResolutionStatus(pub i32);
 impl EmailRecipientResolutionStatus {
     pub const Success: Self = Self(0i32);
@@ -5975,12 +5841,6 @@ impl ::core::clone::Clone for EmailRecipientResolutionStatus {
 unsafe impl ::windows::core::Abi for EmailRecipientResolutionStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailRecipientResolutionStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailRecipientResolutionStatus {}
 impl ::core::fmt::Debug for EmailRecipientResolutionStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailRecipientResolutionStatus").field(&self.0).finish()
@@ -5994,6 +5854,7 @@ impl ::windows::core::DefaultType for EmailRecipientResolutionStatus {
 }
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailSpecialFolderKind(pub i32);
 impl EmailSpecialFolderKind {
     pub const None: Self = Self(0i32);
@@ -6013,12 +5874,6 @@ impl ::core::clone::Clone for EmailSpecialFolderKind {
 unsafe impl ::windows::core::Abi for EmailSpecialFolderKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailSpecialFolderKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailSpecialFolderKind {}
 impl ::core::fmt::Debug for EmailSpecialFolderKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailSpecialFolderKind").field(&self.0).finish()
@@ -6200,6 +6055,7 @@ unsafe impl ::core::marker::Send for EmailStore {}
 unsafe impl ::core::marker::Sync for EmailStore {}
 #[doc = "*Required features: 'ApplicationModel_Email'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EmailStoreAccessType(pub i32);
 impl EmailStoreAccessType {
     pub const AppMailboxesReadWrite: Self = Self(0i32);
@@ -6214,12 +6070,6 @@ impl ::core::clone::Clone for EmailStoreAccessType {
 unsafe impl ::windows::core::Abi for EmailStoreAccessType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EmailStoreAccessType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EmailStoreAccessType {}
 impl ::core::fmt::Debug for EmailStoreAccessType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EmailStoreAccessType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/ExtendedExecution/Foreground/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/ExtendedExecution/Foreground/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'ApplicationModel_ExtendedExecution_Foreground'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ExtendedExecutionForegroundReason(pub i32);
 impl ExtendedExecutionForegroundReason {
     pub const Unspecified: Self = Self(0i32);
@@ -17,12 +18,6 @@ impl ::core::clone::Clone for ExtendedExecutionForegroundReason {
 unsafe impl ::windows::core::Abi for ExtendedExecutionForegroundReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ExtendedExecutionForegroundReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ExtendedExecutionForegroundReason {}
 impl ::core::fmt::Debug for ExtendedExecutionForegroundReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ExtendedExecutionForegroundReason").field(&self.0).finish()
@@ -36,6 +31,7 @@ impl ::windows::core::DefaultType for ExtendedExecutionForegroundReason {
 }
 #[doc = "*Required features: 'ApplicationModel_ExtendedExecution_Foreground'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ExtendedExecutionForegroundResult(pub i32);
 impl ExtendedExecutionForegroundResult {
     pub const Allowed: Self = Self(0i32);
@@ -50,12 +46,6 @@ impl ::core::clone::Clone for ExtendedExecutionForegroundResult {
 unsafe impl ::windows::core::Abi for ExtendedExecutionForegroundResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ExtendedExecutionForegroundResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ExtendedExecutionForegroundResult {}
 impl ::core::fmt::Debug for ExtendedExecutionForegroundResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ExtendedExecutionForegroundResult").field(&self.0).finish()
@@ -150,6 +140,7 @@ unsafe impl ::core::marker::Send for ExtendedExecutionForegroundRevokedEventArgs
 unsafe impl ::core::marker::Sync for ExtendedExecutionForegroundRevokedEventArgs {}
 #[doc = "*Required features: 'ApplicationModel_ExtendedExecution_Foreground'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ExtendedExecutionForegroundRevokedReason(pub i32);
 impl ExtendedExecutionForegroundRevokedReason {
     pub const Resumed: Self = Self(0i32);
@@ -164,12 +155,6 @@ impl ::core::clone::Clone for ExtendedExecutionForegroundRevokedReason {
 unsafe impl ::windows::core::Abi for ExtendedExecutionForegroundRevokedReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ExtendedExecutionForegroundRevokedReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ExtendedExecutionForegroundRevokedReason {}
 impl ::core::fmt::Debug for ExtendedExecutionForegroundRevokedReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ExtendedExecutionForegroundRevokedReason").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/ExtendedExecution/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/ExtendedExecution/mod.rs
@@ -3,6 +3,7 @@
 pub mod Foreground;
 #[doc = "*Required features: 'ApplicationModel_ExtendedExecution'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ExtendedExecutionReason(pub i32);
 impl ExtendedExecutionReason {
     pub const Unspecified: Self = Self(0i32);
@@ -18,12 +19,6 @@ impl ::core::clone::Clone for ExtendedExecutionReason {
 unsafe impl ::windows::core::Abi for ExtendedExecutionReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ExtendedExecutionReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ExtendedExecutionReason {}
 impl ::core::fmt::Debug for ExtendedExecutionReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ExtendedExecutionReason").field(&self.0).finish()
@@ -37,6 +32,7 @@ impl ::windows::core::DefaultType for ExtendedExecutionReason {
 }
 #[doc = "*Required features: 'ApplicationModel_ExtendedExecution'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ExtendedExecutionResult(pub i32);
 impl ExtendedExecutionResult {
     pub const Allowed: Self = Self(0i32);
@@ -51,12 +47,6 @@ impl ::core::clone::Clone for ExtendedExecutionResult {
 unsafe impl ::windows::core::Abi for ExtendedExecutionResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ExtendedExecutionResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ExtendedExecutionResult {}
 impl ::core::fmt::Debug for ExtendedExecutionResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ExtendedExecutionResult").field(&self.0).finish()
@@ -151,6 +141,7 @@ unsafe impl ::core::marker::Send for ExtendedExecutionRevokedEventArgs {}
 unsafe impl ::core::marker::Sync for ExtendedExecutionRevokedEventArgs {}
 #[doc = "*Required features: 'ApplicationModel_ExtendedExecution'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ExtendedExecutionRevokedReason(pub i32);
 impl ExtendedExecutionRevokedReason {
     pub const Resumed: Self = Self(0i32);
@@ -165,12 +156,6 @@ impl ::core::clone::Clone for ExtendedExecutionRevokedReason {
 unsafe impl ::windows::core::Abi for ExtendedExecutionRevokedReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ExtendedExecutionRevokedReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ExtendedExecutionRevokedReason {}
 impl ::core::fmt::Debug for ExtendedExecutionRevokedReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ExtendedExecutionRevokedReason").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/Payments/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Payments/mod.rs
@@ -1010,6 +1010,7 @@ unsafe impl ::core::marker::Send for PaymentCanMakePaymentResult {}
 unsafe impl ::core::marker::Sync for PaymentCanMakePaymentResult {}
 #[doc = "*Required features: 'ApplicationModel_Payments'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PaymentCanMakePaymentResultStatus(pub i32);
 impl PaymentCanMakePaymentResultStatus {
     pub const Unknown: Self = Self(0i32);
@@ -1029,12 +1030,6 @@ impl ::core::clone::Clone for PaymentCanMakePaymentResultStatus {
 unsafe impl ::windows::core::Abi for PaymentCanMakePaymentResultStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PaymentCanMakePaymentResultStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PaymentCanMakePaymentResultStatus {}
 impl ::core::fmt::Debug for PaymentCanMakePaymentResultStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PaymentCanMakePaymentResultStatus").field(&self.0).finish()
@@ -1934,6 +1929,7 @@ unsafe impl ::core::marker::Send for PaymentMethodData {}
 unsafe impl ::core::marker::Sync for PaymentMethodData {}
 #[doc = "*Required features: 'ApplicationModel_Payments'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PaymentOptionPresence(pub i32);
 impl PaymentOptionPresence {
     pub const None: Self = Self(0i32);
@@ -1949,12 +1945,6 @@ impl ::core::clone::Clone for PaymentOptionPresence {
 unsafe impl ::windows::core::Abi for PaymentOptionPresence {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PaymentOptionPresence {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PaymentOptionPresence {}
 impl ::core::fmt::Debug for PaymentOptionPresence {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PaymentOptionPresence").field(&self.0).finish()
@@ -2269,6 +2259,7 @@ unsafe impl ::core::marker::Send for PaymentRequest {}
 unsafe impl ::core::marker::Sync for PaymentRequest {}
 #[doc = "*Required features: 'ApplicationModel_Payments'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PaymentRequestChangeKind(pub i32);
 impl PaymentRequestChangeKind {
     pub const ShippingOption: Self = Self(0i32);
@@ -2283,12 +2274,6 @@ impl ::core::clone::Clone for PaymentRequestChangeKind {
 unsafe impl ::windows::core::Abi for PaymentRequestChangeKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PaymentRequestChangeKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PaymentRequestChangeKind {}
 impl ::core::fmt::Debug for PaymentRequestChangeKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PaymentRequestChangeKind").field(&self.0).finish()
@@ -2610,6 +2595,7 @@ unsafe impl ::core::marker::Send for PaymentRequestChangedResult {}
 unsafe impl ::core::marker::Sync for PaymentRequestChangedResult {}
 #[doc = "*Required features: 'ApplicationModel_Payments'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PaymentRequestCompletionStatus(pub i32);
 impl PaymentRequestCompletionStatus {
     pub const Succeeded: Self = Self(0i32);
@@ -2625,12 +2611,6 @@ impl ::core::clone::Clone for PaymentRequestCompletionStatus {
 unsafe impl ::windows::core::Abi for PaymentRequestCompletionStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PaymentRequestCompletionStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PaymentRequestCompletionStatus {}
 impl ::core::fmt::Debug for PaymentRequestCompletionStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PaymentRequestCompletionStatus").field(&self.0).finish()
@@ -2644,6 +2624,7 @@ impl ::windows::core::DefaultType for PaymentRequestCompletionStatus {
 }
 #[doc = "*Required features: 'ApplicationModel_Payments'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PaymentRequestStatus(pub i32);
 impl PaymentRequestStatus {
     pub const Succeeded: Self = Self(0i32);
@@ -2659,12 +2640,6 @@ impl ::core::clone::Clone for PaymentRequestStatus {
 unsafe impl ::windows::core::Abi for PaymentRequestStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PaymentRequestStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PaymentRequestStatus {}
 impl ::core::fmt::Debug for PaymentRequestStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PaymentRequestStatus").field(&self.0).finish()
@@ -3048,6 +3023,7 @@ unsafe impl ::core::marker::Send for PaymentShippingOption {}
 unsafe impl ::core::marker::Sync for PaymentShippingOption {}
 #[doc = "*Required features: 'ApplicationModel_Payments'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PaymentShippingType(pub i32);
 impl PaymentShippingType {
     pub const Shipping: Self = Self(0i32);
@@ -3063,12 +3039,6 @@ impl ::core::clone::Clone for PaymentShippingType {
 unsafe impl ::windows::core::Abi for PaymentShippingType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PaymentShippingType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PaymentShippingType {}
 impl ::core::fmt::Debug for PaymentShippingType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PaymentShippingType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/Resources/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Resources/Core/mod.rs
@@ -581,6 +581,7 @@ unsafe impl ::core::marker::Send for ResourceCandidate {}
 unsafe impl ::core::marker::Sync for ResourceCandidate {}
 #[doc = "*Required features: 'ApplicationModel_Resources_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ResourceCandidateKind(pub i32);
 impl ResourceCandidateKind {
     pub const String: Self = Self(0i32);
@@ -596,12 +597,6 @@ impl ::core::clone::Clone for ResourceCandidateKind {
 unsafe impl ::windows::core::Abi for ResourceCandidateKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ResourceCandidateKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ResourceCandidateKind {}
 impl ::core::fmt::Debug for ResourceCandidateKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ResourceCandidateKind").field(&self.0).finish()
@@ -2716,6 +2711,7 @@ unsafe impl ::core::marker::Send for ResourceQualifierObservableMap {}
 unsafe impl ::core::marker::Sync for ResourceQualifierObservableMap {}
 #[doc = "*Required features: 'ApplicationModel_Resources_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ResourceQualifierPersistence(pub i32);
 impl ResourceQualifierPersistence {
     pub const None: Self = Self(0i32);
@@ -2730,12 +2726,6 @@ impl ::core::clone::Clone for ResourceQualifierPersistence {
 unsafe impl ::windows::core::Abi for ResourceQualifierPersistence {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ResourceQualifierPersistence {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ResourceQualifierPersistence {}
 impl ::core::fmt::Debug for ResourceQualifierPersistence {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ResourceQualifierPersistence").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/Resources/Management/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Resources/Management/mod.rs
@@ -327,6 +327,7 @@ unsafe impl ::core::marker::Send for IndexedResourceQualifier {}
 unsafe impl ::core::marker::Sync for IndexedResourceQualifier {}
 #[doc = "*Required features: 'ApplicationModel_Resources_Management'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct IndexedResourceType(pub i32);
 impl IndexedResourceType {
     pub const String: Self = Self(0i32);
@@ -342,12 +343,6 @@ impl ::core::clone::Clone for IndexedResourceType {
 unsafe impl ::windows::core::Abi for IndexedResourceType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IndexedResourceType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for IndexedResourceType {}
 impl ::core::fmt::Debug for IndexedResourceType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IndexedResourceType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/Search/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Search/Core/mod.rs
@@ -293,6 +293,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Sear
 }
 #[doc = "*Required features: 'ApplicationModel_Search_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SearchSuggestionKind(pub i32);
 impl SearchSuggestionKind {
     pub const Query: Self = Self(0i32);
@@ -308,12 +309,6 @@ impl ::core::clone::Clone for SearchSuggestionKind {
 unsafe impl ::windows::core::Abi for SearchSuggestionKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SearchSuggestionKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SearchSuggestionKind {}
 impl ::core::fmt::Debug for SearchSuggestionKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SearchSuggestionKind").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/SocialInfo/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/SocialInfo/mod.rs
@@ -816,6 +816,7 @@ unsafe impl ::core::marker::Sync for SocialFeedItem {}
 #[doc = "*Required features: 'ApplicationModel_SocialInfo', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SocialFeedItemStyle(pub i32);
 #[cfg(feature = "deprecated")]
 impl SocialFeedItemStyle {
@@ -835,14 +836,6 @@ unsafe impl ::windows::core::Abi for SocialFeedItemStyle {
     type Abi = Self;
 }
 #[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for SocialFeedItemStyle {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for SocialFeedItemStyle {}
-#[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for SocialFeedItemStyle {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SocialFeedItemStyle").field(&self.0).finish()
@@ -859,6 +852,7 @@ impl ::windows::core::DefaultType for SocialFeedItemStyle {
 #[doc = "*Required features: 'ApplicationModel_SocialInfo', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SocialFeedKind(pub i32);
 #[cfg(feature = "deprecated")]
 impl SocialFeedKind {
@@ -878,14 +872,6 @@ impl ::core::clone::Clone for SocialFeedKind {
 unsafe impl ::windows::core::Abi for SocialFeedKind {
     type Abi = Self;
 }
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for SocialFeedKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for SocialFeedKind {}
 #[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for SocialFeedKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -1071,6 +1057,7 @@ unsafe impl ::core::marker::Sync for SocialFeedSharedItem {}
 #[doc = "*Required features: 'ApplicationModel_SocialInfo', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SocialFeedUpdateMode(pub i32);
 #[cfg(feature = "deprecated")]
 impl SocialFeedUpdateMode {
@@ -1090,14 +1077,6 @@ unsafe impl ::windows::core::Abi for SocialFeedUpdateMode {
     type Abi = Self;
 }
 #[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for SocialFeedUpdateMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for SocialFeedUpdateMode {}
-#[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for SocialFeedUpdateMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SocialFeedUpdateMode").field(&self.0).finish()
@@ -1114,6 +1093,7 @@ impl ::windows::core::DefaultType for SocialFeedUpdateMode {
 #[doc = "*Required features: 'ApplicationModel_SocialInfo', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SocialItemBadgeStyle(pub i32);
 #[cfg(feature = "deprecated")]
 impl SocialItemBadgeStyle {
@@ -1133,14 +1113,6 @@ impl ::core::clone::Clone for SocialItemBadgeStyle {
 unsafe impl ::windows::core::Abi for SocialItemBadgeStyle {
     type Abi = Self;
 }
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for SocialItemBadgeStyle {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for SocialItemBadgeStyle {}
 #[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for SocialItemBadgeStyle {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {

--- a/crates/libs/windows/src/Windows/ApplicationModel/Store/LicenseManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Store/LicenseManagement/mod.rs
@@ -126,6 +126,7 @@ impl ::windows::core::RuntimeName for LicenseManager {
 }
 #[doc = "*Required features: 'ApplicationModel_Store_LicenseManagement'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LicenseRefreshOption(pub i32);
 impl LicenseRefreshOption {
     pub const RunningLicenses: Self = Self(0i32);
@@ -140,12 +141,6 @@ impl ::core::clone::Clone for LicenseRefreshOption {
 unsafe impl ::windows::core::Abi for LicenseRefreshOption {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LicenseRefreshOption {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LicenseRefreshOption {}
 impl ::core::fmt::Debug for LicenseRefreshOption {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LicenseRefreshOption").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/Store/Preview/InstallControl/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Store/Preview/InstallControl/mod.rs
@@ -1115,6 +1115,7 @@ unsafe impl ::core::marker::Send for AppInstallOptions {}
 unsafe impl ::core::marker::Sync for AppInstallOptions {}
 #[doc = "*Required features: 'ApplicationModel_Store_Preview_InstallControl'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppInstallState(pub i32);
 impl AppInstallState {
     pub const Pending: Self = Self(0i32);
@@ -1141,12 +1142,6 @@ impl ::core::clone::Clone for AppInstallState {
 unsafe impl ::windows::core::Abi for AppInstallState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppInstallState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppInstallState {}
 impl ::core::fmt::Debug for AppInstallState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppInstallState").field(&self.0).finish()
@@ -1298,6 +1293,7 @@ unsafe impl ::core::marker::Send for AppInstallStatus {}
 unsafe impl ::core::marker::Sync for AppInstallStatus {}
 #[doc = "*Required features: 'ApplicationModel_Store_Preview_InstallControl'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppInstallType(pub i32);
 impl AppInstallType {
     pub const Install: Self = Self(0i32);
@@ -1313,12 +1309,6 @@ impl ::core::clone::Clone for AppInstallType {
 unsafe impl ::windows::core::Abi for AppInstallType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppInstallType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppInstallType {}
 impl ::core::fmt::Debug for AppInstallType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppInstallType").field(&self.0).finish()
@@ -1332,6 +1322,7 @@ impl ::windows::core::DefaultType for AppInstallType {
 }
 #[doc = "*Required features: 'ApplicationModel_Store_Preview_InstallControl'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppInstallationToastNotificationMode(pub i32);
 impl AppInstallationToastNotificationMode {
     pub const Default: Self = Self(0i32);
@@ -1348,12 +1339,6 @@ impl ::core::clone::Clone for AppInstallationToastNotificationMode {
 unsafe impl ::windows::core::Abi for AppInstallationToastNotificationMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppInstallationToastNotificationMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppInstallationToastNotificationMode {}
 impl ::core::fmt::Debug for AppInstallationToastNotificationMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppInstallationToastNotificationMode").field(&self.0).finish()
@@ -1486,6 +1471,7 @@ unsafe impl ::core::marker::Send for AppUpdateOptions {}
 unsafe impl ::core::marker::Sync for AppUpdateOptions {}
 #[doc = "*Required features: 'ApplicationModel_Store_Preview_InstallControl'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AutoUpdateSetting(pub i32);
 impl AutoUpdateSetting {
     pub const Disabled: Self = Self(0i32);
@@ -1502,12 +1488,6 @@ impl ::core::clone::Clone for AutoUpdateSetting {
 unsafe impl ::windows::core::Abi for AutoUpdateSetting {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AutoUpdateSetting {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AutoUpdateSetting {}
 impl ::core::fmt::Debug for AutoUpdateSetting {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AutoUpdateSetting").field(&self.0).finish()
@@ -1602,6 +1582,7 @@ unsafe impl ::core::marker::Send for GetEntitlementResult {}
 unsafe impl ::core::marker::Sync for GetEntitlementResult {}
 #[doc = "*Required features: 'ApplicationModel_Store_Preview_InstallControl'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GetEntitlementStatus(pub i32);
 impl GetEntitlementStatus {
     pub const Succeeded: Self = Self(0i32);
@@ -1618,12 +1599,6 @@ impl ::core::clone::Clone for GetEntitlementStatus {
 unsafe impl ::windows::core::Abi for GetEntitlementStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GetEntitlementStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GetEntitlementStatus {}
 impl ::core::fmt::Debug for GetEntitlementStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GetEntitlementStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/Store/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Store/Preview/mod.rs
@@ -3,6 +3,7 @@
 pub mod InstallControl;
 #[doc = "*Required features: 'ApplicationModel_Store_Preview'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DeliveryOptimizationDownloadMode(pub i32);
 impl DeliveryOptimizationDownloadMode {
     pub const Simple: Self = Self(0i32);
@@ -21,12 +22,6 @@ impl ::core::clone::Clone for DeliveryOptimizationDownloadMode {
 unsafe impl ::windows::core::Abi for DeliveryOptimizationDownloadMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DeliveryOptimizationDownloadMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DeliveryOptimizationDownloadMode {}
 impl ::core::fmt::Debug for DeliveryOptimizationDownloadMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DeliveryOptimizationDownloadMode").field(&self.0).finish()
@@ -40,6 +35,7 @@ impl ::windows::core::DefaultType for DeliveryOptimizationDownloadMode {
 }
 #[doc = "*Required features: 'ApplicationModel_Store_Preview'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DeliveryOptimizationDownloadModeSource(pub i32);
 impl DeliveryOptimizationDownloadModeSource {
     pub const Default: Self = Self(0i32);
@@ -54,12 +50,6 @@ impl ::core::clone::Clone for DeliveryOptimizationDownloadModeSource {
 unsafe impl ::windows::core::Abi for DeliveryOptimizationDownloadModeSource {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DeliveryOptimizationDownloadModeSource {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DeliveryOptimizationDownloadModeSource {}
 impl ::core::fmt::Debug for DeliveryOptimizationDownloadModeSource {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DeliveryOptimizationDownloadModeSource").field(&self.0).finish()
@@ -787,6 +777,7 @@ unsafe impl ::core::marker::Send for StoreHardwareManufacturerInfo {}
 unsafe impl ::core::marker::Sync for StoreHardwareManufacturerInfo {}
 #[doc = "*Required features: 'ApplicationModel_Store_Preview'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StoreLogOptions(pub u32);
 impl StoreLogOptions {
     pub const None: Self = Self(0u32);
@@ -801,12 +792,6 @@ impl ::core::clone::Clone for StoreLogOptions {
 unsafe impl ::windows::core::Abi for StoreLogOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StoreLogOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StoreLogOptions {}
 impl ::core::fmt::Debug for StoreLogOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StoreLogOptions").field(&self.0).finish()
@@ -990,6 +975,7 @@ unsafe impl ::core::marker::Send for StorePreviewProductInfo {}
 unsafe impl ::core::marker::Sync for StorePreviewProductInfo {}
 #[doc = "*Required features: 'ApplicationModel_Store_Preview'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StorePreviewProductPurchaseStatus(pub i32);
 impl StorePreviewProductPurchaseStatus {
     pub const Succeeded: Self = Self(0i32);
@@ -1006,12 +992,6 @@ impl ::core::clone::Clone for StorePreviewProductPurchaseStatus {
 unsafe impl ::windows::core::Abi for StorePreviewProductPurchaseStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StorePreviewProductPurchaseStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StorePreviewProductPurchaseStatus {}
 impl ::core::fmt::Debug for StorePreviewProductPurchaseStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StorePreviewProductPurchaseStatus").field(&self.0).finish()
@@ -1251,6 +1231,7 @@ unsafe impl ::core::marker::Send for StorePreviewSkuInfo {}
 unsafe impl ::core::marker::Sync for StorePreviewSkuInfo {}
 #[doc = "*Required features: 'ApplicationModel_Store_Preview'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StoreSystemFeature(pub i32);
 impl StoreSystemFeature {
     pub const ArchitectureX86: Self = Self(0i32);
@@ -1298,12 +1279,6 @@ impl ::core::clone::Clone for StoreSystemFeature {
 unsafe impl ::windows::core::Abi for StoreSystemFeature {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StoreSystemFeature {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StoreSystemFeature {}
 impl ::core::fmt::Debug for StoreSystemFeature {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StoreSystemFeature").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/Store/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Store/mod.rs
@@ -328,6 +328,7 @@ impl ::windows::core::RuntimeName for CurrentAppSimulator {
 }
 #[doc = "*Required features: 'ApplicationModel_Store'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FulfillmentResult(pub i32);
 impl FulfillmentResult {
     pub const Succeeded: Self = Self(0i32);
@@ -345,12 +346,6 @@ impl ::core::clone::Clone for FulfillmentResult {
 unsafe impl ::windows::core::Abi for FulfillmentResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FulfillmentResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FulfillmentResult {}
 impl ::core::fmt::Debug for FulfillmentResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FulfillmentResult").field(&self.0).finish()
@@ -1623,6 +1618,7 @@ unsafe impl ::core::marker::Send for ProductPurchaseDisplayProperties {}
 unsafe impl ::core::marker::Sync for ProductPurchaseDisplayProperties {}
 #[doc = "*Required features: 'ApplicationModel_Store'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ProductPurchaseStatus(pub i32);
 impl ProductPurchaseStatus {
     pub const Succeeded: Self = Self(0i32);
@@ -1639,12 +1635,6 @@ impl ::core::clone::Clone for ProductPurchaseStatus {
 unsafe impl ::windows::core::Abi for ProductPurchaseStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ProductPurchaseStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ProductPurchaseStatus {}
 impl ::core::fmt::Debug for ProductPurchaseStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ProductPurchaseStatus").field(&self.0).finish()
@@ -1658,6 +1648,7 @@ impl ::windows::core::DefaultType for ProductPurchaseStatus {
 }
 #[doc = "*Required features: 'ApplicationModel_Store'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ProductType(pub i32);
 impl ProductType {
     pub const Unknown: Self = Self(0i32);
@@ -1673,12 +1664,6 @@ impl ::core::clone::Clone for ProductType {
 unsafe impl ::windows::core::Abi for ProductType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ProductType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ProductType {}
 impl ::core::fmt::Debug for ProductType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ProductType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserActivities/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserActivities/mod.rs
@@ -1669,6 +1669,7 @@ unsafe impl ::core::marker::Send for UserActivitySessionHistoryItem {}
 unsafe impl ::core::marker::Sync for UserActivitySessionHistoryItem {}
 #[doc = "*Required features: 'ApplicationModel_UserActivities'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserActivityState(pub i32);
 impl UserActivityState {
     pub const New: Self = Self(0i32);
@@ -1683,12 +1684,6 @@ impl ::core::clone::Clone for UserActivityState {
 unsafe impl ::windows::core::Abi for UserActivityState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserActivityState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserActivityState {}
 impl ::core::fmt::Debug for UserActivityState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserActivityState").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/Provider/mod.rs
@@ -389,6 +389,7 @@ unsafe impl ::core::marker::Send for UserDataAccountProviderAddAccountOperation 
 unsafe impl ::core::marker::Sync for UserDataAccountProviderAddAccountOperation {}
 #[doc = "*Required features: 'ApplicationModel_UserDataAccounts_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserDataAccountProviderOperationKind(pub i32);
 impl UserDataAccountProviderOperationKind {
     pub const AddAccount: Self = Self(0i32);
@@ -404,12 +405,6 @@ impl ::core::clone::Clone for UserDataAccountProviderOperationKind {
 unsafe impl ::windows::core::Abi for UserDataAccountProviderOperationKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserDataAccountProviderOperationKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserDataAccountProviderOperationKind {}
 impl ::core::fmt::Debug for UserDataAccountProviderOperationKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserDataAccountProviderOperationKind").field(&self.0).finish()
@@ -423,6 +418,7 @@ impl ::windows::core::DefaultType for UserDataAccountProviderOperationKind {
 }
 #[doc = "*Required features: 'ApplicationModel_UserDataAccounts_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserDataAccountProviderPartnerAccountKind(pub i32);
 impl UserDataAccountProviderPartnerAccountKind {
     pub const Exchange: Self = Self(0i32);
@@ -437,12 +433,6 @@ impl ::core::clone::Clone for UserDataAccountProviderPartnerAccountKind {
 unsafe impl ::windows::core::Abi for UserDataAccountProviderPartnerAccountKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserDataAccountProviderPartnerAccountKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserDataAccountProviderPartnerAccountKind {}
 impl ::core::fmt::Debug for UserDataAccountProviderPartnerAccountKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserDataAccountProviderPartnerAccountKind").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/SystemAccess/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/SystemAccess/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'ApplicationModel_UserDataAccounts_SystemAccess'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DeviceAccountAuthenticationType(pub i32);
 impl DeviceAccountAuthenticationType {
     pub const Basic: Self = Self(0i32);
@@ -16,12 +17,6 @@ impl ::core::clone::Clone for DeviceAccountAuthenticationType {
 unsafe impl ::windows::core::Abi for DeviceAccountAuthenticationType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DeviceAccountAuthenticationType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DeviceAccountAuthenticationType {}
 impl ::core::fmt::Debug for DeviceAccountAuthenticationType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DeviceAccountAuthenticationType").field(&self.0).finish()
@@ -698,6 +693,7 @@ unsafe impl ::core::marker::Send for DeviceAccountConfiguration {}
 unsafe impl ::core::marker::Sync for DeviceAccountConfiguration {}
 #[doc = "*Required features: 'ApplicationModel_UserDataAccounts_SystemAccess'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DeviceAccountIconId(pub i32);
 impl DeviceAccountIconId {
     pub const Exchange: Self = Self(0i32);
@@ -714,12 +710,6 @@ impl ::core::clone::Clone for DeviceAccountIconId {
 unsafe impl ::windows::core::Abi for DeviceAccountIconId {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DeviceAccountIconId {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DeviceAccountIconId {}
 impl ::core::fmt::Debug for DeviceAccountIconId {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DeviceAccountIconId").field(&self.0).finish()
@@ -733,6 +723,7 @@ impl ::windows::core::DefaultType for DeviceAccountIconId {
 }
 #[doc = "*Required features: 'ApplicationModel_UserDataAccounts_SystemAccess'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DeviceAccountMailAgeFilter(pub i32);
 impl DeviceAccountMailAgeFilter {
     pub const All: Self = Self(0i32);
@@ -752,12 +743,6 @@ impl ::core::clone::Clone for DeviceAccountMailAgeFilter {
 unsafe impl ::windows::core::Abi for DeviceAccountMailAgeFilter {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DeviceAccountMailAgeFilter {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DeviceAccountMailAgeFilter {}
 impl ::core::fmt::Debug for DeviceAccountMailAgeFilter {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DeviceAccountMailAgeFilter").field(&self.0).finish()
@@ -771,6 +756,7 @@ impl ::windows::core::DefaultType for DeviceAccountMailAgeFilter {
 }
 #[doc = "*Required features: 'ApplicationModel_UserDataAccounts_SystemAccess'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DeviceAccountServerType(pub i32);
 impl DeviceAccountServerType {
     pub const Exchange: Self = Self(0i32);
@@ -786,12 +772,6 @@ impl ::core::clone::Clone for DeviceAccountServerType {
 unsafe impl ::windows::core::Abi for DeviceAccountServerType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DeviceAccountServerType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DeviceAccountServerType {}
 impl ::core::fmt::Debug for DeviceAccountServerType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DeviceAccountServerType").field(&self.0).finish()
@@ -805,6 +785,7 @@ impl ::windows::core::DefaultType for DeviceAccountServerType {
 }
 #[doc = "*Required features: 'ApplicationModel_UserDataAccounts_SystemAccess'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DeviceAccountSyncScheduleKind(pub i32);
 impl DeviceAccountSyncScheduleKind {
     pub const Manual: Self = Self(0i32);
@@ -824,12 +805,6 @@ impl ::core::clone::Clone for DeviceAccountSyncScheduleKind {
 unsafe impl ::windows::core::Abi for DeviceAccountSyncScheduleKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DeviceAccountSyncScheduleKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DeviceAccountSyncScheduleKind {}
 impl ::core::fmt::Debug for DeviceAccountSyncScheduleKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DeviceAccountSyncScheduleKind").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserDataAccounts/mod.rs
@@ -546,6 +546,7 @@ unsafe impl ::core::marker::Send for UserDataAccount {}
 unsafe impl ::core::marker::Sync for UserDataAccount {}
 #[doc = "*Required features: 'ApplicationModel_UserDataAccounts'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserDataAccountContentKinds(pub u32);
 impl UserDataAccountContentKinds {
     pub const Email: Self = Self(1u32);
@@ -561,12 +562,6 @@ impl ::core::clone::Clone for UserDataAccountContentKinds {
 unsafe impl ::windows::core::Abi for UserDataAccountContentKinds {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserDataAccountContentKinds {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserDataAccountContentKinds {}
 impl ::core::fmt::Debug for UserDataAccountContentKinds {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserDataAccountContentKinds").field(&self.0).finish()
@@ -756,6 +751,7 @@ unsafe impl ::core::marker::Send for UserDataAccountManagerForUser {}
 unsafe impl ::core::marker::Sync for UserDataAccountManagerForUser {}
 #[doc = "*Required features: 'ApplicationModel_UserDataAccounts'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserDataAccountOtherAppReadAccess(pub i32);
 impl UserDataAccountOtherAppReadAccess {
     pub const SystemOnly: Self = Self(0i32);
@@ -771,12 +767,6 @@ impl ::core::clone::Clone for UserDataAccountOtherAppReadAccess {
 unsafe impl ::windows::core::Abi for UserDataAccountOtherAppReadAccess {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserDataAccountOtherAppReadAccess {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserDataAccountOtherAppReadAccess {}
 impl ::core::fmt::Debug for UserDataAccountOtherAppReadAccess {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserDataAccountOtherAppReadAccess").field(&self.0).finish()
@@ -923,6 +913,7 @@ unsafe impl ::core::marker::Send for UserDataAccountStore {}
 unsafe impl ::core::marker::Sync for UserDataAccountStore {}
 #[doc = "*Required features: 'ApplicationModel_UserDataAccounts'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserDataAccountStoreAccessType(pub i32);
 impl UserDataAccountStoreAccessType {
     pub const AllAccountsReadOnly: Self = Self(0i32);
@@ -937,12 +928,6 @@ impl ::core::clone::Clone for UserDataAccountStoreAccessType {
 unsafe impl ::windows::core::Abi for UserDataAccountStoreAccessType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserDataAccountStoreAccessType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserDataAccountStoreAccessType {}
 impl ::core::fmt::Debug for UserDataAccountStoreAccessType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserDataAccountStoreAccessType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/UserDataTasks/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/UserDataTasks/mod.rs
@@ -704,6 +704,7 @@ unsafe impl ::core::marker::Send for UserDataTaskBatch {}
 unsafe impl ::core::marker::Sync for UserDataTaskBatch {}
 #[doc = "*Required features: 'ApplicationModel_UserDataTasks'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserDataTaskDaysOfWeek(pub u32);
 impl UserDataTaskDaysOfWeek {
     pub const None: Self = Self(0u32);
@@ -724,12 +725,6 @@ impl ::core::clone::Clone for UserDataTaskDaysOfWeek {
 unsafe impl ::windows::core::Abi for UserDataTaskDaysOfWeek {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserDataTaskDaysOfWeek {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserDataTaskDaysOfWeek {}
 impl ::core::fmt::Debug for UserDataTaskDaysOfWeek {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserDataTaskDaysOfWeek").field(&self.0).finish()
@@ -771,6 +766,7 @@ impl ::windows::core::DefaultType for UserDataTaskDaysOfWeek {
 }
 #[doc = "*Required features: 'ApplicationModel_UserDataTasks'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserDataTaskDetailsKind(pub i32);
 impl UserDataTaskDetailsKind {
     pub const PlainText: Self = Self(0i32);
@@ -785,12 +781,6 @@ impl ::core::clone::Clone for UserDataTaskDetailsKind {
 unsafe impl ::windows::core::Abi for UserDataTaskDetailsKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserDataTaskDetailsKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserDataTaskDetailsKind {}
 impl ::core::fmt::Debug for UserDataTaskDetailsKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserDataTaskDetailsKind").field(&self.0).finish()
@@ -804,6 +794,7 @@ impl ::windows::core::DefaultType for UserDataTaskDetailsKind {
 }
 #[doc = "*Required features: 'ApplicationModel_UserDataTasks'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserDataTaskKind(pub i32);
 impl UserDataTaskKind {
     pub const Single: Self = Self(0i32);
@@ -819,12 +810,6 @@ impl ::core::clone::Clone for UserDataTaskKind {
 unsafe impl ::windows::core::Abi for UserDataTaskKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserDataTaskKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserDataTaskKind {}
 impl ::core::fmt::Debug for UserDataTaskKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserDataTaskKind").field(&self.0).finish()
@@ -1169,6 +1154,7 @@ unsafe impl ::core::marker::Send for UserDataTaskListLimitedWriteOperations {}
 unsafe impl ::core::marker::Sync for UserDataTaskListLimitedWriteOperations {}
 #[doc = "*Required features: 'ApplicationModel_UserDataTasks'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserDataTaskListOtherAppReadAccess(pub i32);
 impl UserDataTaskListOtherAppReadAccess {
     pub const Full: Self = Self(0i32);
@@ -1184,12 +1170,6 @@ impl ::core::clone::Clone for UserDataTaskListOtherAppReadAccess {
 unsafe impl ::windows::core::Abi for UserDataTaskListOtherAppReadAccess {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserDataTaskListOtherAppReadAccess {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserDataTaskListOtherAppReadAccess {}
 impl ::core::fmt::Debug for UserDataTaskListOtherAppReadAccess {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserDataTaskListOtherAppReadAccess").field(&self.0).finish()
@@ -1203,6 +1183,7 @@ impl ::windows::core::DefaultType for UserDataTaskListOtherAppReadAccess {
 }
 #[doc = "*Required features: 'ApplicationModel_UserDataTasks'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserDataTaskListOtherAppWriteAccess(pub i32);
 impl UserDataTaskListOtherAppWriteAccess {
     pub const Limited: Self = Self(0i32);
@@ -1217,12 +1198,6 @@ impl ::core::clone::Clone for UserDataTaskListOtherAppWriteAccess {
 unsafe impl ::windows::core::Abi for UserDataTaskListOtherAppWriteAccess {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserDataTaskListOtherAppWriteAccess {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserDataTaskListOtherAppWriteAccess {}
 impl ::core::fmt::Debug for UserDataTaskListOtherAppWriteAccess {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserDataTaskListOtherAppWriteAccess").field(&self.0).finish()
@@ -1376,6 +1351,7 @@ unsafe impl ::core::marker::Send for UserDataTaskListSyncManager {}
 unsafe impl ::core::marker::Sync for UserDataTaskListSyncManager {}
 #[doc = "*Required features: 'ApplicationModel_UserDataTasks'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserDataTaskListSyncStatus(pub i32);
 impl UserDataTaskListSyncStatus {
     pub const Idle: Self = Self(0i32);
@@ -1394,12 +1370,6 @@ impl ::core::clone::Clone for UserDataTaskListSyncStatus {
 unsafe impl ::windows::core::Abi for UserDataTaskListSyncStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserDataTaskListSyncStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserDataTaskListSyncStatus {}
 impl ::core::fmt::Debug for UserDataTaskListSyncStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserDataTaskListSyncStatus").field(&self.0).finish()
@@ -1524,6 +1494,7 @@ unsafe impl ::core::marker::Send for UserDataTaskManager {}
 unsafe impl ::core::marker::Sync for UserDataTaskManager {}
 #[doc = "*Required features: 'ApplicationModel_UserDataTasks'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserDataTaskPriority(pub i32);
 impl UserDataTaskPriority {
     pub const Normal: Self = Self(0i32);
@@ -1539,12 +1510,6 @@ impl ::core::clone::Clone for UserDataTaskPriority {
 unsafe impl ::windows::core::Abi for UserDataTaskPriority {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserDataTaskPriority {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserDataTaskPriority {}
 impl ::core::fmt::Debug for UserDataTaskPriority {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserDataTaskPriority").field(&self.0).finish()
@@ -1558,6 +1523,7 @@ impl ::windows::core::DefaultType for UserDataTaskPriority {
 }
 #[doc = "*Required features: 'ApplicationModel_UserDataTasks'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserDataTaskQueryKind(pub i32);
 impl UserDataTaskQueryKind {
     pub const All: Self = Self(0i32);
@@ -1573,12 +1539,6 @@ impl ::core::clone::Clone for UserDataTaskQueryKind {
 unsafe impl ::windows::core::Abi for UserDataTaskQueryKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserDataTaskQueryKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserDataTaskQueryKind {}
 impl ::core::fmt::Debug for UserDataTaskQueryKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserDataTaskQueryKind").field(&self.0).finish()
@@ -1698,6 +1658,7 @@ unsafe impl ::core::marker::Send for UserDataTaskQueryOptions {}
 unsafe impl ::core::marker::Sync for UserDataTaskQueryOptions {}
 #[doc = "*Required features: 'ApplicationModel_UserDataTasks'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserDataTaskQuerySortProperty(pub i32);
 impl UserDataTaskQuerySortProperty {
     pub const DueDate: Self = Self(0i32);
@@ -1711,12 +1672,6 @@ impl ::core::clone::Clone for UserDataTaskQuerySortProperty {
 unsafe impl ::windows::core::Abi for UserDataTaskQuerySortProperty {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserDataTaskQuerySortProperty {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserDataTaskQuerySortProperty {}
 impl ::core::fmt::Debug for UserDataTaskQuerySortProperty {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserDataTaskQuerySortProperty").field(&self.0).finish()
@@ -2008,6 +1963,7 @@ unsafe impl ::core::marker::Send for UserDataTaskRecurrenceProperties {}
 unsafe impl ::core::marker::Sync for UserDataTaskRecurrenceProperties {}
 #[doc = "*Required features: 'ApplicationModel_UserDataTasks'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserDataTaskRecurrenceUnit(pub i32);
 impl UserDataTaskRecurrenceUnit {
     pub const Daily: Self = Self(0i32);
@@ -2026,12 +1982,6 @@ impl ::core::clone::Clone for UserDataTaskRecurrenceUnit {
 unsafe impl ::windows::core::Abi for UserDataTaskRecurrenceUnit {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserDataTaskRecurrenceUnit {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserDataTaskRecurrenceUnit {}
 impl ::core::fmt::Debug for UserDataTaskRecurrenceUnit {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserDataTaskRecurrenceUnit").field(&self.0).finish()
@@ -2181,6 +2131,7 @@ unsafe impl ::core::marker::Send for UserDataTaskRegenerationProperties {}
 unsafe impl ::core::marker::Sync for UserDataTaskRegenerationProperties {}
 #[doc = "*Required features: 'ApplicationModel_UserDataTasks'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserDataTaskRegenerationUnit(pub i32);
 impl UserDataTaskRegenerationUnit {
     pub const Daily: Self = Self(0i32);
@@ -2197,12 +2148,6 @@ impl ::core::clone::Clone for UserDataTaskRegenerationUnit {
 unsafe impl ::windows::core::Abi for UserDataTaskRegenerationUnit {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserDataTaskRegenerationUnit {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserDataTaskRegenerationUnit {}
 impl ::core::fmt::Debug for UserDataTaskRegenerationUnit {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserDataTaskRegenerationUnit").field(&self.0).finish()
@@ -2216,6 +2161,7 @@ impl ::windows::core::DefaultType for UserDataTaskRegenerationUnit {
 }
 #[doc = "*Required features: 'ApplicationModel_UserDataTasks'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserDataTaskSensitivity(pub i32);
 impl UserDataTaskSensitivity {
     pub const Public: Self = Self(0i32);
@@ -2230,12 +2176,6 @@ impl ::core::clone::Clone for UserDataTaskSensitivity {
 unsafe impl ::windows::core::Abi for UserDataTaskSensitivity {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserDataTaskSensitivity {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserDataTaskSensitivity {}
 impl ::core::fmt::Debug for UserDataTaskSensitivity {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserDataTaskSensitivity").field(&self.0).finish()
@@ -2358,6 +2298,7 @@ unsafe impl ::core::marker::Send for UserDataTaskStore {}
 unsafe impl ::core::marker::Sync for UserDataTaskStore {}
 #[doc = "*Required features: 'ApplicationModel_UserDataTasks'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserDataTaskStoreAccessType(pub i32);
 impl UserDataTaskStoreAccessType {
     pub const AppTasksReadWrite: Self = Self(0i32);
@@ -2372,12 +2313,6 @@ impl ::core::clone::Clone for UserDataTaskStoreAccessType {
 unsafe impl ::windows::core::Abi for UserDataTaskStoreAccessType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserDataTaskStoreAccessType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserDataTaskStoreAccessType {}
 impl ::core::fmt::Debug for UserDataTaskStoreAccessType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserDataTaskStoreAccessType").field(&self.0).finish()
@@ -2391,6 +2326,7 @@ impl ::windows::core::DefaultType for UserDataTaskStoreAccessType {
 }
 #[doc = "*Required features: 'ApplicationModel_UserDataTasks'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserDataTaskWeekOfMonth(pub i32);
 impl UserDataTaskWeekOfMonth {
     pub const First: Self = Self(0i32);
@@ -2408,12 +2344,6 @@ impl ::core::clone::Clone for UserDataTaskWeekOfMonth {
 unsafe impl ::windows::core::Abi for UserDataTaskWeekOfMonth {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserDataTaskWeekOfMonth {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserDataTaskWeekOfMonth {}
 impl ::core::fmt::Debug for UserDataTaskWeekOfMonth {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserDataTaskWeekOfMonth").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/VoiceCommands/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/VoiceCommands/mod.rs
@@ -460,6 +460,7 @@ unsafe impl ::core::marker::Send for VoiceCommandCompletedEventArgs {}
 unsafe impl ::core::marker::Sync for VoiceCommandCompletedEventArgs {}
 #[doc = "*Required features: 'ApplicationModel_VoiceCommands'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VoiceCommandCompletionReason(pub i32);
 impl VoiceCommandCompletionReason {
     pub const Unknown: Self = Self(0i32);
@@ -479,12 +480,6 @@ impl ::core::clone::Clone for VoiceCommandCompletionReason {
 unsafe impl ::windows::core::Abi for VoiceCommandCompletionReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VoiceCommandCompletionReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VoiceCommandCompletionReason {}
 impl ::core::fmt::Debug for VoiceCommandCompletionReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VoiceCommandCompletionReason").field(&self.0).finish()
@@ -765,6 +760,7 @@ unsafe impl ::core::marker::Send for VoiceCommandContentTile {}
 unsafe impl ::core::marker::Sync for VoiceCommandContentTile {}
 #[doc = "*Required features: 'ApplicationModel_VoiceCommands'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VoiceCommandContentTileType(pub i32);
 impl VoiceCommandContentTileType {
     pub const TitleOnly: Self = Self(0i32);
@@ -785,12 +781,6 @@ impl ::core::clone::Clone for VoiceCommandContentTileType {
 unsafe impl ::windows::core::Abi for VoiceCommandContentTileType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VoiceCommandContentTileType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VoiceCommandContentTileType {}
 impl ::core::fmt::Debug for VoiceCommandContentTileType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VoiceCommandContentTileType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/Wallet/System/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Wallet/System/mod.rs
@@ -67,6 +67,7 @@ pub struct IWalletManagerSystemStaticsVtbl(
 );
 #[doc = "*Required features: 'ApplicationModel_Wallet_System'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WalletItemAppAssociation(pub i32);
 impl WalletItemAppAssociation {
     pub const None: Self = Self(0i32);
@@ -82,12 +83,6 @@ impl ::core::clone::Clone for WalletItemAppAssociation {
 unsafe impl ::windows::core::Abi for WalletItemAppAssociation {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WalletItemAppAssociation {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WalletItemAppAssociation {}
 impl ::core::fmt::Debug for WalletItemAppAssociation {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WalletItemAppAssociation").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/Wallet/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/Wallet/mod.rs
@@ -376,6 +376,7 @@ pub struct IWalletVerbFactoryVtbl(
 );
 #[doc = "*Required features: 'ApplicationModel_Wallet'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WalletActionKind(pub i32);
 impl WalletActionKind {
     pub const OpenItem: Self = Self(0i32);
@@ -393,12 +394,6 @@ impl ::core::clone::Clone for WalletActionKind {
 unsafe impl ::windows::core::Abi for WalletActionKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WalletActionKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WalletActionKind {}
 impl ::core::fmt::Debug for WalletActionKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WalletActionKind").field(&self.0).finish()
@@ -530,6 +525,7 @@ unsafe impl ::core::marker::Send for WalletBarcode {}
 unsafe impl ::core::marker::Sync for WalletBarcode {}
 #[doc = "*Required features: 'ApplicationModel_Wallet'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WalletBarcodeSymbology(pub i32);
 impl WalletBarcodeSymbology {
     pub const Invalid: Self = Self(0i32);
@@ -554,12 +550,6 @@ impl ::core::clone::Clone for WalletBarcodeSymbology {
 unsafe impl ::windows::core::Abi for WalletBarcodeSymbology {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WalletBarcodeSymbology {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WalletBarcodeSymbology {}
 impl ::core::fmt::Debug for WalletBarcodeSymbology {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WalletBarcodeSymbology").field(&self.0).finish()
@@ -573,6 +563,7 @@ impl ::windows::core::DefaultType for WalletBarcodeSymbology {
 }
 #[doc = "*Required features: 'ApplicationModel_Wallet'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WalletDetailViewPosition(pub i32);
 impl WalletDetailViewPosition {
     pub const Hidden: Self = Self(0i32);
@@ -600,12 +591,6 @@ impl ::core::clone::Clone for WalletDetailViewPosition {
 unsafe impl ::windows::core::Abi for WalletDetailViewPosition {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WalletDetailViewPosition {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WalletDetailViewPosition {}
 impl ::core::fmt::Debug for WalletDetailViewPosition {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WalletDetailViewPosition").field(&self.0).finish()
@@ -1233,6 +1218,7 @@ unsafe impl ::core::marker::Send for WalletItemCustomProperty {}
 unsafe impl ::core::marker::Sync for WalletItemCustomProperty {}
 #[doc = "*Required features: 'ApplicationModel_Wallet'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WalletItemKind(pub i32);
 impl WalletItemKind {
     pub const Invalid: Self = Self(0i32);
@@ -1252,12 +1238,6 @@ impl ::core::clone::Clone for WalletItemKind {
 unsafe impl ::windows::core::Abi for WalletItemKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WalletItemKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WalletItemKind {}
 impl ::core::fmt::Debug for WalletItemKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WalletItemKind").field(&self.0).finish()
@@ -1562,6 +1542,7 @@ unsafe impl ::core::marker::Send for WalletRelevantLocation {}
 unsafe impl ::core::marker::Sync for WalletRelevantLocation {}
 #[doc = "*Required features: 'ApplicationModel_Wallet'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WalletSummaryViewPosition(pub i32);
 impl WalletSummaryViewPosition {
     pub const Hidden: Self = Self(0i32);
@@ -1577,12 +1558,6 @@ impl ::core::clone::Clone for WalletSummaryViewPosition {
 unsafe impl ::windows::core::Abi for WalletSummaryViewPosition {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WalletSummaryViewPosition {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WalletSummaryViewPosition {}
 impl ::core::fmt::Debug for WalletSummaryViewPosition {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WalletSummaryViewPosition").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/ApplicationModel/mod.rs
+++ b/crates/libs/windows/src/Windows/ApplicationModel/mod.rs
@@ -55,6 +55,7 @@ pub mod VoiceCommands;
 pub mod Wallet;
 #[doc = "*Required features: 'ApplicationModel'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AddResourcePackageOptions(pub u32);
 impl AddResourcePackageOptions {
     pub const None: Self = Self(0u32);
@@ -70,12 +71,6 @@ impl ::core::clone::Clone for AddResourcePackageOptions {
 unsafe impl ::windows::core::Abi for AddResourcePackageOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AddResourcePackageOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AddResourcePackageOptions {}
 impl ::core::fmt::Debug for AddResourcePackageOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AddResourcePackageOptions").field(&self.0).finish()
@@ -215,6 +210,7 @@ unsafe impl ::core::marker::Send for AppDisplayInfo {}
 unsafe impl ::core::marker::Sync for AppDisplayInfo {}
 #[doc = "*Required features: 'ApplicationModel'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppExecutionContext(pub i32);
 impl AppExecutionContext {
     pub const Unknown: Self = Self(0i32);
@@ -230,12 +226,6 @@ impl ::core::clone::Clone for AppExecutionContext {
 unsafe impl ::windows::core::Abi for AppExecutionContext {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppExecutionContext {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppExecutionContext {}
 impl ::core::fmt::Debug for AppExecutionContext {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppExecutionContext").field(&self.0).finish()
@@ -613,6 +603,7 @@ unsafe impl ::core::marker::Send for AppInstallerInfo {}
 unsafe impl ::core::marker::Sync for AppInstallerInfo {}
 #[doc = "*Required features: 'ApplicationModel'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppInstallerPolicySource(pub i32);
 impl AppInstallerPolicySource {
     pub const Default: Self = Self(0i32);
@@ -627,12 +618,6 @@ impl ::core::clone::Clone for AppInstallerPolicySource {
 unsafe impl ::windows::core::Abi for AppInstallerPolicySource {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppInstallerPolicySource {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppInstallerPolicySource {}
 impl ::core::fmt::Debug for AppInstallerPolicySource {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppInstallerPolicySource").field(&self.0).finish()
@@ -930,6 +915,7 @@ unsafe impl ::core::marker::Send for EnteredBackgroundEventArgs {}
 unsafe impl ::core::marker::Sync for EnteredBackgroundEventArgs {}
 #[doc = "*Required features: 'ApplicationModel'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FullTrustLaunchResult(pub i32);
 impl FullTrustLaunchResult {
     pub const Success: Self = Self(0i32);
@@ -946,12 +932,6 @@ impl ::core::clone::Clone for FullTrustLaunchResult {
 unsafe impl ::windows::core::Abi for FullTrustLaunchResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FullTrustLaunchResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FullTrustLaunchResult {}
 impl ::core::fmt::Debug for FullTrustLaunchResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FullTrustLaunchResult").field(&self.0).finish()
@@ -2899,6 +2879,7 @@ unsafe impl ::core::marker::Send for LimitedAccessFeatureRequestResult {}
 unsafe impl ::core::marker::Sync for LimitedAccessFeatureRequestResult {}
 #[doc = "*Required features: 'ApplicationModel'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LimitedAccessFeatureStatus(pub i32);
 impl LimitedAccessFeatureStatus {
     pub const Unavailable: Self = Self(0i32);
@@ -2915,12 +2896,6 @@ impl ::core::clone::Clone for LimitedAccessFeatureStatus {
 unsafe impl ::windows::core::Abi for LimitedAccessFeatureStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LimitedAccessFeatureStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LimitedAccessFeatureStatus {}
 impl ::core::fmt::Debug for LimitedAccessFeatureStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LimitedAccessFeatureStatus").field(&self.0).finish()
@@ -4208,6 +4183,7 @@ unsafe impl ::core::marker::Send for PackageContentGroupStagingEventArgs {}
 unsafe impl ::core::marker::Sync for PackageContentGroupStagingEventArgs {}
 #[doc = "*Required features: 'ApplicationModel'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PackageContentGroupState(pub i32);
 impl PackageContentGroupState {
     pub const NotStaged: Self = Self(0i32);
@@ -4224,12 +4200,6 @@ impl ::core::clone::Clone for PackageContentGroupState {
 unsafe impl ::windows::core::Abi for PackageContentGroupState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PackageContentGroupState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PackageContentGroupState {}
 impl ::core::fmt::Debug for PackageContentGroupState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PackageContentGroupState").field(&self.0).finish()
@@ -4546,6 +4516,7 @@ unsafe impl ::core::marker::Send for PackageInstallingEventArgs {}
 unsafe impl ::core::marker::Sync for PackageInstallingEventArgs {}
 #[doc = "*Required features: 'ApplicationModel'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PackageSignatureKind(pub i32);
 impl PackageSignatureKind {
     pub const None: Self = Self(0i32);
@@ -4563,12 +4534,6 @@ impl ::core::clone::Clone for PackageSignatureKind {
 unsafe impl ::windows::core::Abi for PackageSignatureKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PackageSignatureKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PackageSignatureKind {}
 impl ::core::fmt::Debug for PackageSignatureKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PackageSignatureKind").field(&self.0).finish()
@@ -5066,6 +5031,7 @@ unsafe impl ::core::marker::Send for PackageUninstallingEventArgs {}
 unsafe impl ::core::marker::Sync for PackageUninstallingEventArgs {}
 #[doc = "*Required features: 'ApplicationModel'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PackageUpdateAvailability(pub i32);
 impl PackageUpdateAvailability {
     pub const Unknown: Self = Self(0i32);
@@ -5083,12 +5049,6 @@ impl ::core::clone::Clone for PackageUpdateAvailability {
 unsafe impl ::windows::core::Abi for PackageUpdateAvailability {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PackageUpdateAvailability {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PackageUpdateAvailability {}
 impl ::core::fmt::Debug for PackageUpdateAvailability {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PackageUpdateAvailability").field(&self.0).finish()
@@ -5475,6 +5435,7 @@ unsafe impl ::core::marker::Send for StartupTask {}
 unsafe impl ::core::marker::Sync for StartupTask {}
 #[doc = "*Required features: 'ApplicationModel'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StartupTaskState(pub i32);
 impl StartupTaskState {
     pub const Disabled: Self = Self(0i32);
@@ -5492,12 +5453,6 @@ impl ::core::clone::Clone for StartupTaskState {
 unsafe impl ::windows::core::Abi for StartupTaskState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StartupTaskState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StartupTaskState {}
 impl ::core::fmt::Debug for StartupTaskState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StartupTaskState").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Data/Json/mod.rs
+++ b/crates/libs/windows/src/Windows/Data/Json/mod.rs
@@ -742,6 +742,7 @@ impl ::windows::core::RuntimeName for JsonError {
 }
 #[doc = "*Required features: 'Data_Json'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct JsonErrorStatus(pub i32);
 impl JsonErrorStatus {
     pub const Unknown: Self = Self(0i32);
@@ -759,12 +760,6 @@ impl ::core::clone::Clone for JsonErrorStatus {
 unsafe impl ::windows::core::Abi for JsonErrorStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JsonErrorStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for JsonErrorStatus {}
 impl ::core::fmt::Debug for JsonErrorStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("JsonErrorStatus").field(&self.0).finish()
@@ -1463,6 +1458,7 @@ unsafe impl ::core::marker::Send for JsonValue {}
 unsafe impl ::core::marker::Sync for JsonValue {}
 #[doc = "*Required features: 'Data_Json'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct JsonValueType(pub i32);
 impl JsonValueType {
     pub const Null: Self = Self(0i32);
@@ -1481,12 +1477,6 @@ impl ::core::clone::Clone for JsonValueType {
 unsafe impl ::windows::core::Abi for JsonValueType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JsonValueType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for JsonValueType {}
 impl ::core::fmt::Debug for JsonValueType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("JsonValueType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Data/Pdf/mod.rs
+++ b/crates/libs/windows/src/Windows/Data/Pdf/mod.rs
@@ -722,6 +722,7 @@ unsafe impl ::core::marker::Send for PdfPageRenderOptions {}
 unsafe impl ::core::marker::Sync for PdfPageRenderOptions {}
 #[doc = "*Required features: 'Data_Pdf'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PdfPageRotation(pub i32);
 impl PdfPageRotation {
     pub const Normal: Self = Self(0i32);
@@ -738,12 +739,6 @@ impl ::core::clone::Clone for PdfPageRotation {
 unsafe impl ::windows::core::Abi for PdfPageRotation {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PdfPageRotation {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PdfPageRotation {}
 impl ::core::fmt::Debug for PdfPageRotation {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PdfPageRotation").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Data/Text/mod.rs
+++ b/crates/libs/windows/src/Windows/Data/Text/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'Data_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AlternateNormalizationFormat(pub i32);
 impl AlternateNormalizationFormat {
     pub const NotNormalized: Self = Self(0i32);
@@ -18,12 +19,6 @@ impl ::core::clone::Clone for AlternateNormalizationFormat {
 unsafe impl ::windows::core::Abi for AlternateNormalizationFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AlternateNormalizationFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AlternateNormalizationFormat {}
 impl ::core::fmt::Debug for AlternateNormalizationFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AlternateNormalizationFormat").field(&self.0).finish()
@@ -1306,6 +1301,7 @@ unsafe impl ::core::marker::Send for TextPredictionGenerator {}
 unsafe impl ::core::marker::Sync for TextPredictionGenerator {}
 #[doc = "*Required features: 'Data_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TextPredictionOptions(pub u32);
 impl TextPredictionOptions {
     pub const None: Self = Self(0u32);
@@ -1321,12 +1317,6 @@ impl ::core::clone::Clone for TextPredictionOptions {
 unsafe impl ::windows::core::Abi for TextPredictionOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TextPredictionOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TextPredictionOptions {}
 impl ::core::fmt::Debug for TextPredictionOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TextPredictionOptions").field(&self.0).finish()
@@ -1652,6 +1642,7 @@ impl ::windows::core::RuntimeName for UnicodeCharacters {
 }
 #[doc = "*Required features: 'Data_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UnicodeGeneralCategory(pub i32);
 impl UnicodeGeneralCategory {
     pub const UppercaseLetter: Self = Self(0i32);
@@ -1694,12 +1685,6 @@ impl ::core::clone::Clone for UnicodeGeneralCategory {
 unsafe impl ::windows::core::Abi for UnicodeGeneralCategory {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UnicodeGeneralCategory {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UnicodeGeneralCategory {}
 impl ::core::fmt::Debug for UnicodeGeneralCategory {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UnicodeGeneralCategory").field(&self.0).finish()
@@ -1713,6 +1698,7 @@ impl ::windows::core::DefaultType for UnicodeGeneralCategory {
 }
 #[doc = "*Required features: 'Data_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UnicodeNumericType(pub i32);
 impl UnicodeNumericType {
     pub const None: Self = Self(0i32);
@@ -1729,12 +1715,6 @@ impl ::core::clone::Clone for UnicodeNumericType {
 unsafe impl ::windows::core::Abi for UnicodeNumericType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UnicodeNumericType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UnicodeNumericType {}
 impl ::core::fmt::Debug for UnicodeNumericType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UnicodeNumericType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Data/Xml/Dom/mod.rs
+++ b/crates/libs/windows/src/Windows/Data/Xml/Dom/mod.rs
@@ -2633,6 +2633,7 @@ pub struct IXmlTextVtbl(
 );
 #[doc = "*Required features: 'Data_Xml_Dom'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct NodeType(pub i32);
 impl NodeType {
     pub const Invalid: Self = Self(0i32);
@@ -2658,12 +2659,6 @@ impl ::core::clone::Clone for NodeType {
 unsafe impl ::windows::core::Abi for NodeType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NodeType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for NodeType {}
 impl ::core::fmt::Debug for NodeType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NodeType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Adc/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Adc/Provider/mod.rs
@@ -249,6 +249,7 @@ pub struct IAdcProviderVtbl(
 );
 #[doc = "*Required features: 'Devices_Adc_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ProviderAdcChannelMode(pub i32);
 impl ProviderAdcChannelMode {
     pub const SingleEnded: Self = Self(0i32);
@@ -263,12 +264,6 @@ impl ::core::clone::Clone for ProviderAdcChannelMode {
 unsafe impl ::windows::core::Abi for ProviderAdcChannelMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ProviderAdcChannelMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ProviderAdcChannelMode {}
 impl ::core::fmt::Debug for ProviderAdcChannelMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ProviderAdcChannelMode").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Adc/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Adc/mod.rs
@@ -132,6 +132,7 @@ unsafe impl ::core::marker::Send for AdcChannel {}
 unsafe impl ::core::marker::Sync for AdcChannel {}
 #[doc = "*Required features: 'Devices_Adc'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AdcChannelMode(pub i32);
 impl AdcChannelMode {
     pub const SingleEnded: Self = Self(0i32);
@@ -146,12 +147,6 @@ impl ::core::clone::Clone for AdcChannelMode {
 unsafe impl ::windows::core::Abi for AdcChannelMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AdcChannelMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AdcChannelMode {}
 impl ::core::fmt::Debug for AdcChannelMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AdcChannelMode").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/AllJoyn/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/AllJoyn/mod.rs
@@ -790,6 +790,7 @@ unsafe impl ::core::marker::Sync for AllJoynAuthenticationCompleteEventArgs {}
 #[doc = "*Required features: 'Devices_AllJoyn', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AllJoynAuthenticationMechanism(pub i32);
 #[cfg(feature = "deprecated")]
 impl AllJoynAuthenticationMechanism {
@@ -813,14 +814,6 @@ impl ::core::clone::Clone for AllJoynAuthenticationMechanism {
 unsafe impl ::windows::core::Abi for AllJoynAuthenticationMechanism {
     type Abi = Self;
 }
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for AllJoynAuthenticationMechanism {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for AllJoynAuthenticationMechanism {}
 #[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for AllJoynAuthenticationMechanism {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -1147,6 +1140,7 @@ unsafe impl ::core::marker::Sync for AllJoynBusAttachment {}
 #[doc = "*Required features: 'Devices_AllJoyn', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AllJoynBusAttachmentState(pub i32);
 #[cfg(feature = "deprecated")]
 impl AllJoynBusAttachmentState {
@@ -1167,14 +1161,6 @@ impl ::core::clone::Clone for AllJoynBusAttachmentState {
 unsafe impl ::windows::core::Abi for AllJoynBusAttachmentState {
     type Abi = Self;
 }
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for AllJoynBusAttachmentState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for AllJoynBusAttachmentState {}
 #[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for AllJoynBusAttachmentState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -2941,6 +2927,7 @@ unsafe impl ::core::marker::Sync for AllJoynSessionLostEventArgs {}
 #[doc = "*Required features: 'Devices_AllJoyn', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AllJoynSessionLostReason(pub i32);
 #[cfg(feature = "deprecated")]
 impl AllJoynSessionLostReason {
@@ -2963,14 +2950,6 @@ impl ::core::clone::Clone for AllJoynSessionLostReason {
 unsafe impl ::windows::core::Abi for AllJoynSessionLostReason {
     type Abi = Self;
 }
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for AllJoynSessionLostReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for AllJoynSessionLostReason {}
 #[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for AllJoynSessionLostReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -3378,6 +3357,7 @@ impl ::windows::core::RuntimeName for AllJoynStatus {
 #[doc = "*Required features: 'Devices_AllJoyn', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AllJoynTrafficType(pub i32);
 #[cfg(feature = "deprecated")]
 impl AllJoynTrafficType {
@@ -3398,14 +3378,6 @@ impl ::core::clone::Clone for AllJoynTrafficType {
 unsafe impl ::windows::core::Abi for AllJoynTrafficType {
     type Abi = Self;
 }
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for AllJoynTrafficType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for AllJoynTrafficType {}
 #[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for AllJoynTrafficType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {

--- a/crates/libs/windows/src/Windows/Devices/Bluetooth/Advertisement/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Bluetooth/Advertisement/mod.rs
@@ -677,6 +677,7 @@ unsafe impl ::core::marker::Send for BluetoothLEAdvertisementFilter {}
 unsafe impl ::core::marker::Sync for BluetoothLEAdvertisementFilter {}
 #[doc = "*Required features: 'Devices_Bluetooth_Advertisement'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BluetoothLEAdvertisementFlags(pub u32);
 impl BluetoothLEAdvertisementFlags {
     pub const None: Self = Self(0u32);
@@ -695,12 +696,6 @@ impl ::core::clone::Clone for BluetoothLEAdvertisementFlags {
 unsafe impl ::windows::core::Abi for BluetoothLEAdvertisementFlags {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BluetoothLEAdvertisementFlags {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BluetoothLEAdvertisementFlags {}
 impl ::core::fmt::Debug for BluetoothLEAdvertisementFlags {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BluetoothLEAdvertisementFlags").field(&self.0).finish()
@@ -929,6 +924,7 @@ unsafe impl ::core::marker::Send for BluetoothLEAdvertisementPublisher {}
 unsafe impl ::core::marker::Sync for BluetoothLEAdvertisementPublisher {}
 #[doc = "*Required features: 'Devices_Bluetooth_Advertisement'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BluetoothLEAdvertisementPublisherStatus(pub i32);
 impl BluetoothLEAdvertisementPublisherStatus {
     pub const Created: Self = Self(0i32);
@@ -947,12 +943,6 @@ impl ::core::clone::Clone for BluetoothLEAdvertisementPublisherStatus {
 unsafe impl ::windows::core::Abi for BluetoothLEAdvertisementPublisherStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BluetoothLEAdvertisementPublisherStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BluetoothLEAdvertisementPublisherStatus {}
 impl ::core::fmt::Debug for BluetoothLEAdvertisementPublisherStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BluetoothLEAdvertisementPublisherStatus").field(&self.0).finish()
@@ -1235,6 +1225,7 @@ unsafe impl ::core::marker::Send for BluetoothLEAdvertisementReceivedEventArgs {
 unsafe impl ::core::marker::Sync for BluetoothLEAdvertisementReceivedEventArgs {}
 #[doc = "*Required features: 'Devices_Bluetooth_Advertisement'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BluetoothLEAdvertisementType(pub i32);
 impl BluetoothLEAdvertisementType {
     pub const ConnectableUndirected: Self = Self(0i32);
@@ -1253,12 +1244,6 @@ impl ::core::clone::Clone for BluetoothLEAdvertisementType {
 unsafe impl ::windows::core::Abi for BluetoothLEAdvertisementType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BluetoothLEAdvertisementType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BluetoothLEAdvertisementType {}
 impl ::core::fmt::Debug for BluetoothLEAdvertisementType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BluetoothLEAdvertisementType").field(&self.0).finish()
@@ -1500,6 +1485,7 @@ unsafe impl ::core::marker::Send for BluetoothLEAdvertisementWatcher {}
 unsafe impl ::core::marker::Sync for BluetoothLEAdvertisementWatcher {}
 #[doc = "*Required features: 'Devices_Bluetooth_Advertisement'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BluetoothLEAdvertisementWatcherStatus(pub i32);
 impl BluetoothLEAdvertisementWatcherStatus {
     pub const Created: Self = Self(0i32);
@@ -1517,12 +1503,6 @@ impl ::core::clone::Clone for BluetoothLEAdvertisementWatcherStatus {
 unsafe impl ::windows::core::Abi for BluetoothLEAdvertisementWatcherStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BluetoothLEAdvertisementWatcherStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BluetoothLEAdvertisementWatcherStatus {}
 impl ::core::fmt::Debug for BluetoothLEAdvertisementWatcherStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BluetoothLEAdvertisementWatcherStatus").field(&self.0).finish()
@@ -1738,6 +1718,7 @@ unsafe impl ::core::marker::Send for BluetoothLEManufacturerData {}
 unsafe impl ::core::marker::Sync for BluetoothLEManufacturerData {}
 #[doc = "*Required features: 'Devices_Bluetooth_Advertisement'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BluetoothLEScanningMode(pub i32);
 impl BluetoothLEScanningMode {
     pub const Passive: Self = Self(0i32);
@@ -1753,12 +1734,6 @@ impl ::core::clone::Clone for BluetoothLEScanningMode {
 unsafe impl ::windows::core::Abi for BluetoothLEScanningMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BluetoothLEScanningMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BluetoothLEScanningMode {}
 impl ::core::fmt::Debug for BluetoothLEScanningMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BluetoothLEScanningMode").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Bluetooth/Background/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Bluetooth/Background/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'Devices_Bluetooth_Background'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BluetoothEventTriggeringMode(pub i32);
 impl BluetoothEventTriggeringMode {
     pub const Serial: Self = Self(0i32);
@@ -16,12 +17,6 @@ impl ::core::clone::Clone for BluetoothEventTriggeringMode {
 unsafe impl ::windows::core::Abi for BluetoothEventTriggeringMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BluetoothEventTriggeringMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BluetoothEventTriggeringMode {}
 impl ::core::fmt::Debug for BluetoothEventTriggeringMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BluetoothEventTriggeringMode").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Bluetooth/GenericAttributeProfile/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Bluetooth/GenericAttributeProfile/mod.rs
@@ -299,6 +299,7 @@ unsafe impl ::core::marker::Send for GattCharacteristic {}
 unsafe impl ::core::marker::Sync for GattCharacteristic {}
 #[doc = "*Required features: 'Devices_Bluetooth_GenericAttributeProfile'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GattCharacteristicProperties(pub u32);
 impl GattCharacteristicProperties {
     pub const None: Self = Self(0u32);
@@ -322,12 +323,6 @@ impl ::core::clone::Clone for GattCharacteristicProperties {
 unsafe impl ::windows::core::Abi for GattCharacteristicProperties {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GattCharacteristicProperties {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GattCharacteristicProperties {}
 impl ::core::fmt::Debug for GattCharacteristicProperties {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GattCharacteristicProperties").field(&self.0).finish()
@@ -1052,6 +1047,7 @@ unsafe impl ::core::marker::Send for GattCharacteristicsResult {}
 unsafe impl ::core::marker::Sync for GattCharacteristicsResult {}
 #[doc = "*Required features: 'Devices_Bluetooth_GenericAttributeProfile'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GattClientCharacteristicConfigurationDescriptorValue(pub i32);
 impl GattClientCharacteristicConfigurationDescriptorValue {
     pub const None: Self = Self(0i32);
@@ -1067,12 +1063,6 @@ impl ::core::clone::Clone for GattClientCharacteristicConfigurationDescriptorVal
 unsafe impl ::windows::core::Abi for GattClientCharacteristicConfigurationDescriptorValue {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GattClientCharacteristicConfigurationDescriptorValue {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GattClientCharacteristicConfigurationDescriptorValue {}
 impl ::core::fmt::Debug for GattClientCharacteristicConfigurationDescriptorValue {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GattClientCharacteristicConfigurationDescriptorValue").field(&self.0).finish()
@@ -1192,6 +1182,7 @@ unsafe impl ::core::marker::Send for GattClientNotificationResult {}
 unsafe impl ::core::marker::Sync for GattClientNotificationResult {}
 #[doc = "*Required features: 'Devices_Bluetooth_GenericAttributeProfile'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GattCommunicationStatus(pub i32);
 impl GattCommunicationStatus {
     pub const Success: Self = Self(0i32);
@@ -1208,12 +1199,6 @@ impl ::core::clone::Clone for GattCommunicationStatus {
 unsafe impl ::windows::core::Abi for GattCommunicationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GattCommunicationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GattCommunicationStatus {}
 impl ::core::fmt::Debug for GattCommunicationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GattCommunicationStatus").field(&self.0).finish()
@@ -2916,6 +2901,7 @@ unsafe impl ::core::marker::Send for GattLocalService {}
 unsafe impl ::core::marker::Sync for GattLocalService {}
 #[doc = "*Required features: 'Devices_Bluetooth_GenericAttributeProfile'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GattOpenStatus(pub i32);
 impl GattOpenStatus {
     pub const Unspecified: Self = Self(0i32);
@@ -2934,12 +2920,6 @@ impl ::core::clone::Clone for GattOpenStatus {
 unsafe impl ::windows::core::Abi for GattOpenStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GattOpenStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GattOpenStatus {}
 impl ::core::fmt::Debug for GattOpenStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GattOpenStatus").field(&self.0).finish()
@@ -3291,6 +3271,7 @@ impl ::windows::core::RuntimeName for GattPresentationFormatTypes {
 }
 #[doc = "*Required features: 'Devices_Bluetooth_GenericAttributeProfile'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GattProtectionLevel(pub i32);
 impl GattProtectionLevel {
     pub const Plain: Self = Self(0i32);
@@ -3307,12 +3288,6 @@ impl ::core::clone::Clone for GattProtectionLevel {
 unsafe impl ::windows::core::Abi for GattProtectionLevel {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GattProtectionLevel {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GattProtectionLevel {}
 impl ::core::fmt::Debug for GattProtectionLevel {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GattProtectionLevel").field(&self.0).finish()
@@ -3980,6 +3955,7 @@ unsafe impl ::core::marker::Send for GattReliableWriteTransaction {}
 unsafe impl ::core::marker::Sync for GattReliableWriteTransaction {}
 #[doc = "*Required features: 'Devices_Bluetooth_GenericAttributeProfile'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GattRequestState(pub i32);
 impl GattRequestState {
     pub const Pending: Self = Self(0i32);
@@ -3995,12 +3971,6 @@ impl ::core::clone::Clone for GattRequestState {
 unsafe impl ::windows::core::Abi for GattRequestState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GattRequestState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GattRequestState {}
 impl ::core::fmt::Debug for GattRequestState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GattRequestState").field(&self.0).finish()
@@ -4235,6 +4205,7 @@ unsafe impl ::core::marker::Send for GattServiceProvider {}
 unsafe impl ::core::marker::Sync for GattServiceProvider {}
 #[doc = "*Required features: 'Devices_Bluetooth_GenericAttributeProfile'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GattServiceProviderAdvertisementStatus(pub i32);
 impl GattServiceProviderAdvertisementStatus {
     pub const Created: Self = Self(0i32);
@@ -4252,12 +4223,6 @@ impl ::core::clone::Clone for GattServiceProviderAdvertisementStatus {
 unsafe impl ::windows::core::Abi for GattServiceProviderAdvertisementStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GattServiceProviderAdvertisementStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GattServiceProviderAdvertisementStatus {}
 impl ::core::fmt::Debug for GattServiceProviderAdvertisementStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GattServiceProviderAdvertisementStatus").field(&self.0).finish()
@@ -4934,6 +4899,7 @@ unsafe impl ::core::marker::Send for GattSession {}
 unsafe impl ::core::marker::Sync for GattSession {}
 #[doc = "*Required features: 'Devices_Bluetooth_GenericAttributeProfile'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GattSessionStatus(pub i32);
 impl GattSessionStatus {
     pub const Closed: Self = Self(0i32);
@@ -4948,12 +4914,6 @@ impl ::core::clone::Clone for GattSessionStatus {
 unsafe impl ::windows::core::Abi for GattSessionStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GattSessionStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GattSessionStatus {}
 impl ::core::fmt::Debug for GattSessionStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GattSessionStatus").field(&self.0).finish()
@@ -5056,6 +5016,7 @@ unsafe impl ::core::marker::Send for GattSessionStatusChangedEventArgs {}
 unsafe impl ::core::marker::Sync for GattSessionStatusChangedEventArgs {}
 #[doc = "*Required features: 'Devices_Bluetooth_GenericAttributeProfile'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GattSharingMode(pub i32);
 impl GattSharingMode {
     pub const Unspecified: Self = Self(0i32);
@@ -5072,12 +5033,6 @@ impl ::core::clone::Clone for GattSharingMode {
 unsafe impl ::windows::core::Abi for GattSharingMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GattSharingMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GattSharingMode {}
 impl ::core::fmt::Debug for GattSharingMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GattSharingMode").field(&self.0).finish()
@@ -5286,6 +5241,7 @@ unsafe impl ::core::marker::Send for GattValueChangedEventArgs {}
 unsafe impl ::core::marker::Sync for GattValueChangedEventArgs {}
 #[doc = "*Required features: 'Devices_Bluetooth_GenericAttributeProfile'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GattWriteOption(pub i32);
 impl GattWriteOption {
     pub const WriteWithResponse: Self = Self(0i32);
@@ -5300,12 +5256,6 @@ impl ::core::clone::Clone for GattWriteOption {
 unsafe impl ::windows::core::Abi for GattWriteOption {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GattWriteOption {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GattWriteOption {}
 impl ::core::fmt::Debug for GattWriteOption {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GattWriteOption").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Bluetooth/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Bluetooth/mod.rs
@@ -207,6 +207,7 @@ unsafe impl ::core::marker::Send for BluetoothAdapter {}
 unsafe impl ::core::marker::Sync for BluetoothAdapter {}
 #[doc = "*Required features: 'Devices_Bluetooth'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BluetoothAddressType(pub i32);
 impl BluetoothAddressType {
     pub const Public: Self = Self(0i32);
@@ -222,12 +223,6 @@ impl ::core::clone::Clone for BluetoothAddressType {
 unsafe impl ::windows::core::Abi for BluetoothAddressType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BluetoothAddressType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BluetoothAddressType {}
 impl ::core::fmt::Debug for BluetoothAddressType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BluetoothAddressType").field(&self.0).finish()
@@ -241,6 +236,7 @@ impl ::windows::core::DefaultType for BluetoothAddressType {
 }
 #[doc = "*Required features: 'Devices_Bluetooth'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BluetoothCacheMode(pub i32);
 impl BluetoothCacheMode {
     pub const Cached: Self = Self(0i32);
@@ -255,12 +251,6 @@ impl ::core::clone::Clone for BluetoothCacheMode {
 unsafe impl ::windows::core::Abi for BluetoothCacheMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BluetoothCacheMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BluetoothCacheMode {}
 impl ::core::fmt::Debug for BluetoothCacheMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BluetoothCacheMode").field(&self.0).finish()
@@ -398,6 +388,7 @@ unsafe impl ::core::marker::Send for BluetoothClassOfDevice {}
 unsafe impl ::core::marker::Sync for BluetoothClassOfDevice {}
 #[doc = "*Required features: 'Devices_Bluetooth'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BluetoothConnectionStatus(pub i32);
 impl BluetoothConnectionStatus {
     pub const Disconnected: Self = Self(0i32);
@@ -412,12 +403,6 @@ impl ::core::clone::Clone for BluetoothConnectionStatus {
 unsafe impl ::windows::core::Abi for BluetoothConnectionStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BluetoothConnectionStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BluetoothConnectionStatus {}
 impl ::core::fmt::Debug for BluetoothConnectionStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BluetoothConnectionStatus").field(&self.0).finish()
@@ -912,6 +897,7 @@ unsafe impl ::core::marker::Send for BluetoothDeviceId {}
 unsafe impl ::core::marker::Sync for BluetoothDeviceId {}
 #[doc = "*Required features: 'Devices_Bluetooth'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BluetoothError(pub i32);
 impl BluetoothError {
     pub const Success: Self = Self(0i32);
@@ -934,12 +920,6 @@ impl ::core::clone::Clone for BluetoothError {
 unsafe impl ::windows::core::Abi for BluetoothError {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BluetoothError {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BluetoothError {}
 impl ::core::fmt::Debug for BluetoothError {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BluetoothError").field(&self.0).finish()
@@ -2402,6 +2382,7 @@ unsafe impl ::core::marker::Send for BluetoothLEPreferredConnectionParametersReq
 unsafe impl ::core::marker::Sync for BluetoothLEPreferredConnectionParametersRequest {}
 #[doc = "*Required features: 'Devices_Bluetooth'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BluetoothLEPreferredConnectionParametersRequestStatus(pub i32);
 impl BluetoothLEPreferredConnectionParametersRequestStatus {
     pub const Unspecified: Self = Self(0i32);
@@ -2418,12 +2399,6 @@ impl ::core::clone::Clone for BluetoothLEPreferredConnectionParametersRequestSta
 unsafe impl ::windows::core::Abi for BluetoothLEPreferredConnectionParametersRequestStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BluetoothLEPreferredConnectionParametersRequestStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BluetoothLEPreferredConnectionParametersRequestStatus {}
 impl ::core::fmt::Debug for BluetoothLEPreferredConnectionParametersRequestStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BluetoothLEPreferredConnectionParametersRequestStatus").field(&self.0).finish()
@@ -2437,6 +2412,7 @@ impl ::windows::core::DefaultType for BluetoothLEPreferredConnectionParametersRe
 }
 #[doc = "*Required features: 'Devices_Bluetooth'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BluetoothMajorClass(pub i32);
 impl BluetoothMajorClass {
     pub const Miscellaneous: Self = Self(0i32);
@@ -2459,12 +2435,6 @@ impl ::core::clone::Clone for BluetoothMajorClass {
 unsafe impl ::windows::core::Abi for BluetoothMajorClass {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BluetoothMajorClass {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BluetoothMajorClass {}
 impl ::core::fmt::Debug for BluetoothMajorClass {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BluetoothMajorClass").field(&self.0).finish()
@@ -2478,6 +2448,7 @@ impl ::windows::core::DefaultType for BluetoothMajorClass {
 }
 #[doc = "*Required features: 'Devices_Bluetooth'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BluetoothMinorClass(pub i32);
 impl BluetoothMinorClass {
     pub const Uncategorized: Self = Self(0i32);
@@ -2561,12 +2532,6 @@ impl ::core::clone::Clone for BluetoothMinorClass {
 unsafe impl ::windows::core::Abi for BluetoothMinorClass {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BluetoothMinorClass {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BluetoothMinorClass {}
 impl ::core::fmt::Debug for BluetoothMinorClass {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BluetoothMinorClass").field(&self.0).finish()
@@ -2580,6 +2545,7 @@ impl ::windows::core::DefaultType for BluetoothMinorClass {
 }
 #[doc = "*Required features: 'Devices_Bluetooth'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BluetoothServiceCapabilities(pub u32);
 impl BluetoothServiceCapabilities {
     pub const None: Self = Self(0u32);
@@ -2602,12 +2568,6 @@ impl ::core::clone::Clone for BluetoothServiceCapabilities {
 unsafe impl ::windows::core::Abi for BluetoothServiceCapabilities {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BluetoothServiceCapabilities {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BluetoothServiceCapabilities {}
 impl ::core::fmt::Debug for BluetoothServiceCapabilities {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BluetoothServiceCapabilities").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Custom/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Custom/mod.rs
@@ -130,6 +130,7 @@ unsafe impl ::core::marker::Send for CustomDevice {}
 unsafe impl ::core::marker::Sync for CustomDevice {}
 #[doc = "*Required features: 'Devices_Custom'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DeviceAccessMode(pub i32);
 impl DeviceAccessMode {
     pub const Read: Self = Self(0i32);
@@ -145,12 +146,6 @@ impl ::core::clone::Clone for DeviceAccessMode {
 unsafe impl ::windows::core::Abi for DeviceAccessMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DeviceAccessMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DeviceAccessMode {}
 impl ::core::fmt::Debug for DeviceAccessMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DeviceAccessMode").field(&self.0).finish()
@@ -164,6 +159,7 @@ impl ::windows::core::DefaultType for DeviceAccessMode {
 }
 #[doc = "*Required features: 'Devices_Custom'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DeviceSharingMode(pub i32);
 impl DeviceSharingMode {
     pub const Shared: Self = Self(0i32);
@@ -178,12 +174,6 @@ impl ::core::clone::Clone for DeviceSharingMode {
 unsafe impl ::windows::core::Abi for DeviceSharingMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DeviceSharingMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DeviceSharingMode {}
 impl ::core::fmt::Debug for DeviceSharingMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DeviceSharingMode").field(&self.0).finish()
@@ -401,6 +391,7 @@ pub struct IKnownDeviceTypesStaticsVtbl(
 );
 #[doc = "*Required features: 'Devices_Custom'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct IOControlAccessMode(pub i32);
 impl IOControlAccessMode {
     pub const Any: Self = Self(0i32);
@@ -417,12 +408,6 @@ impl ::core::clone::Clone for IOControlAccessMode {
 unsafe impl ::windows::core::Abi for IOControlAccessMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IOControlAccessMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for IOControlAccessMode {}
 impl ::core::fmt::Debug for IOControlAccessMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IOControlAccessMode").field(&self.0).finish()
@@ -436,6 +421,7 @@ impl ::windows::core::DefaultType for IOControlAccessMode {
 }
 #[doc = "*Required features: 'Devices_Custom'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct IOControlBufferingMethod(pub i32);
 impl IOControlBufferingMethod {
     pub const Buffered: Self = Self(0i32);
@@ -452,12 +438,6 @@ impl ::core::clone::Clone for IOControlBufferingMethod {
 unsafe impl ::windows::core::Abi for IOControlBufferingMethod {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IOControlBufferingMethod {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for IOControlBufferingMethod {}
 impl ::core::fmt::Debug for IOControlBufferingMethod {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IOControlBufferingMethod").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Display/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Display/Core/mod.rs
@@ -153,6 +153,7 @@ unsafe impl ::core::marker::Send for DisplayAdapter {}
 unsafe impl ::core::marker::Sync for DisplayAdapter {}
 #[doc = "*Required features: 'Devices_Display_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DisplayBitsPerChannel(pub u32);
 impl DisplayBitsPerChannel {
     pub const None: Self = Self(0u32);
@@ -172,12 +173,6 @@ impl ::core::clone::Clone for DisplayBitsPerChannel {
 unsafe impl ::windows::core::Abi for DisplayBitsPerChannel {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DisplayBitsPerChannel {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DisplayBitsPerChannel {}
 impl ::core::fmt::Debug for DisplayBitsPerChannel {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayBitsPerChannel").field(&self.0).finish()
@@ -355,6 +350,7 @@ unsafe impl ::core::marker::Send for DisplayDevice {}
 unsafe impl ::core::marker::Sync for DisplayDevice {}
 #[doc = "*Required features: 'Devices_Display_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DisplayDeviceCapability(pub i32);
 impl DisplayDeviceCapability {
     pub const FlipOverride: Self = Self(0i32);
@@ -368,12 +364,6 @@ impl ::core::clone::Clone for DisplayDeviceCapability {
 unsafe impl ::windows::core::Abi for DisplayDeviceCapability {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DisplayDeviceCapability {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DisplayDeviceCapability {}
 impl ::core::fmt::Debug for DisplayDeviceCapability {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayDeviceCapability").field(&self.0).finish()
@@ -1005,6 +995,7 @@ unsafe impl ::core::marker::Send for DisplayManagerEnabledEventArgs {}
 unsafe impl ::core::marker::Sync for DisplayManagerEnabledEventArgs {}
 #[doc = "*Required features: 'Devices_Display_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DisplayManagerOptions(pub u32);
 impl DisplayManagerOptions {
     pub const None: Self = Self(0u32);
@@ -1020,12 +1011,6 @@ impl ::core::clone::Clone for DisplayManagerOptions {
 unsafe impl ::windows::core::Abi for DisplayManagerOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DisplayManagerOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DisplayManagerOptions {}
 impl ::core::fmt::Debug for DisplayManagerOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayManagerOptions").field(&self.0).finish()
@@ -1162,6 +1147,7 @@ unsafe impl ::core::marker::Send for DisplayManagerPathsFailedOrInvalidatedEvent
 unsafe impl ::core::marker::Sync for DisplayManagerPathsFailedOrInvalidatedEventArgs {}
 #[doc = "*Required features: 'Devices_Display_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DisplayManagerResult(pub i32);
 impl DisplayManagerResult {
     pub const Success: Self = Self(0i32);
@@ -1179,12 +1165,6 @@ impl ::core::clone::Clone for DisplayManagerResult {
 unsafe impl ::windows::core::Abi for DisplayManagerResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DisplayManagerResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DisplayManagerResult {}
 impl ::core::fmt::Debug for DisplayManagerResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayManagerResult").field(&self.0).finish()
@@ -1454,6 +1434,7 @@ unsafe impl ::core::marker::Send for DisplayModeInfo {}
 unsafe impl ::core::marker::Sync for DisplayModeInfo {}
 #[doc = "*Required features: 'Devices_Display_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DisplayModeQueryOptions(pub u32);
 impl DisplayModeQueryOptions {
     pub const None: Self = Self(0u32);
@@ -1468,12 +1449,6 @@ impl ::core::clone::Clone for DisplayModeQueryOptions {
 unsafe impl ::windows::core::Abi for DisplayModeQueryOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DisplayModeQueryOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DisplayModeQueryOptions {}
 impl ::core::fmt::Debug for DisplayModeQueryOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayModeQueryOptions").field(&self.0).finish()
@@ -1777,6 +1752,7 @@ unsafe impl ::core::marker::Send for DisplayPath {}
 unsafe impl ::core::marker::Sync for DisplayPath {}
 #[doc = "*Required features: 'Devices_Display_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DisplayPathScaling(pub i32);
 impl DisplayPathScaling {
     pub const Identity: Self = Self(0i32);
@@ -1795,12 +1771,6 @@ impl ::core::clone::Clone for DisplayPathScaling {
 unsafe impl ::windows::core::Abi for DisplayPathScaling {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DisplayPathScaling {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DisplayPathScaling {}
 impl ::core::fmt::Debug for DisplayPathScaling {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayPathScaling").field(&self.0).finish()
@@ -1814,6 +1784,7 @@ impl ::windows::core::DefaultType for DisplayPathScaling {
 }
 #[doc = "*Required features: 'Devices_Display_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DisplayPathStatus(pub i32);
 impl DisplayPathStatus {
     pub const Unknown: Self = Self(0i32);
@@ -1832,12 +1803,6 @@ impl ::core::clone::Clone for DisplayPathStatus {
 unsafe impl ::windows::core::Abi for DisplayPathStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DisplayPathStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DisplayPathStatus {}
 impl ::core::fmt::Debug for DisplayPathStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayPathStatus").field(&self.0).finish()
@@ -1851,6 +1816,7 @@ impl ::windows::core::DefaultType for DisplayPathStatus {
 }
 #[doc = "*Required features: 'Devices_Display_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DisplayPresentStatus(pub i32);
 impl DisplayPresentStatus {
     pub const Success: Self = Self(0i32);
@@ -1869,12 +1835,6 @@ impl ::core::clone::Clone for DisplayPresentStatus {
 unsafe impl ::windows::core::Abi for DisplayPresentStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DisplayPresentStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DisplayPresentStatus {}
 impl ::core::fmt::Debug for DisplayPresentStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayPresentStatus").field(&self.0).finish()
@@ -2094,6 +2054,7 @@ unsafe impl ::core::marker::Send for DisplayPrimaryDescription {}
 unsafe impl ::core::marker::Sync for DisplayPrimaryDescription {}
 #[doc = "*Required features: 'Devices_Display_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DisplayRotation(pub i32);
 impl DisplayRotation {
     pub const None: Self = Self(0i32);
@@ -2110,12 +2071,6 @@ impl ::core::clone::Clone for DisplayRotation {
 unsafe impl ::windows::core::Abi for DisplayRotation {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DisplayRotation {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DisplayRotation {}
 impl ::core::fmt::Debug for DisplayRotation {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayRotation").field(&self.0).finish()
@@ -2201,6 +2156,7 @@ unsafe impl ::core::marker::Send for DisplayScanout {}
 unsafe impl ::core::marker::Sync for DisplayScanout {}
 #[doc = "*Required features: 'Devices_Display_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DisplayScanoutOptions(pub u32);
 impl DisplayScanoutOptions {
     pub const None: Self = Self(0u32);
@@ -2215,12 +2171,6 @@ impl ::core::clone::Clone for DisplayScanoutOptions {
 unsafe impl ::windows::core::Abi for DisplayScanoutOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DisplayScanoutOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DisplayScanoutOptions {}
 impl ::core::fmt::Debug for DisplayScanoutOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayScanoutOptions").field(&self.0).finish()
@@ -2384,6 +2334,7 @@ unsafe impl ::core::marker::Send for DisplaySource {}
 unsafe impl ::core::marker::Sync for DisplaySource {}
 #[doc = "*Required features: 'Devices_Display_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DisplaySourceStatus(pub i32);
 impl DisplaySourceStatus {
     pub const Active: Self = Self(0i32);
@@ -2401,12 +2352,6 @@ impl ::core::clone::Clone for DisplaySourceStatus {
 unsafe impl ::windows::core::Abi for DisplaySourceStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DisplaySourceStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DisplaySourceStatus {}
 impl ::core::fmt::Debug for DisplaySourceStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplaySourceStatus").field(&self.0).finish()
@@ -2605,6 +2550,7 @@ unsafe impl ::core::marker::Send for DisplayState {}
 unsafe impl ::core::marker::Sync for DisplayState {}
 #[doc = "*Required features: 'Devices_Display_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DisplayStateApplyOptions(pub u32);
 impl DisplayStateApplyOptions {
     pub const None: Self = Self(0u32);
@@ -2621,12 +2567,6 @@ impl ::core::clone::Clone for DisplayStateApplyOptions {
 unsafe impl ::windows::core::Abi for DisplayStateApplyOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DisplayStateApplyOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DisplayStateApplyOptions {}
 impl ::core::fmt::Debug for DisplayStateApplyOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayStateApplyOptions").field(&self.0).finish()
@@ -2668,6 +2608,7 @@ impl ::windows::core::DefaultType for DisplayStateApplyOptions {
 }
 #[doc = "*Required features: 'Devices_Display_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DisplayStateFunctionalizeOptions(pub u32);
 impl DisplayStateFunctionalizeOptions {
     pub const None: Self = Self(0u32);
@@ -2683,12 +2624,6 @@ impl ::core::clone::Clone for DisplayStateFunctionalizeOptions {
 unsafe impl ::windows::core::Abi for DisplayStateFunctionalizeOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DisplayStateFunctionalizeOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DisplayStateFunctionalizeOptions {}
 impl ::core::fmt::Debug for DisplayStateFunctionalizeOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayStateFunctionalizeOptions").field(&self.0).finish()
@@ -2819,6 +2754,7 @@ unsafe impl ::core::marker::Send for DisplayStateOperationResult {}
 unsafe impl ::core::marker::Sync for DisplayStateOperationResult {}
 #[doc = "*Required features: 'Devices_Display_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DisplayStateOperationStatus(pub i32);
 impl DisplayStateOperationStatus {
     pub const Success: Self = Self(0i32);
@@ -2839,12 +2775,6 @@ impl ::core::clone::Clone for DisplayStateOperationStatus {
 unsafe impl ::windows::core::Abi for DisplayStateOperationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DisplayStateOperationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DisplayStateOperationStatus {}
 impl ::core::fmt::Debug for DisplayStateOperationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayStateOperationStatus").field(&self.0).finish()
@@ -3116,6 +3046,7 @@ unsafe impl ::core::marker::Send for DisplayTarget {}
 unsafe impl ::core::marker::Sync for DisplayTarget {}
 #[doc = "*Required features: 'Devices_Display_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DisplayTargetPersistence(pub i32);
 impl DisplayTargetPersistence {
     pub const None: Self = Self(0i32);
@@ -3132,12 +3063,6 @@ impl ::core::clone::Clone for DisplayTargetPersistence {
 unsafe impl ::windows::core::Abi for DisplayTargetPersistence {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DisplayTargetPersistence {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DisplayTargetPersistence {}
 impl ::core::fmt::Debug for DisplayTargetPersistence {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayTargetPersistence").field(&self.0).finish()
@@ -3431,6 +3356,7 @@ unsafe impl ::core::marker::Send for DisplayTaskResult {}
 unsafe impl ::core::marker::Sync for DisplayTaskResult {}
 #[doc = "*Required features: 'Devices_Display_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DisplayTaskSignalKind(pub i32);
 impl DisplayTaskSignalKind {
     pub const OnPresentFlipAway: Self = Self(0i32);
@@ -3445,12 +3371,6 @@ impl ::core::clone::Clone for DisplayTaskSignalKind {
 unsafe impl ::windows::core::Abi for DisplayTaskSignalKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DisplayTaskSignalKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DisplayTaskSignalKind {}
 impl ::core::fmt::Debug for DisplayTaskSignalKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayTaskSignalKind").field(&self.0).finish()
@@ -3722,6 +3642,7 @@ unsafe impl ::core::marker::Send for DisplayWireFormat {}
 unsafe impl ::core::marker::Sync for DisplayWireFormat {}
 #[doc = "*Required features: 'Devices_Display_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DisplayWireFormatColorSpace(pub i32);
 impl DisplayWireFormatColorSpace {
     pub const BT709: Self = Self(0i32);
@@ -3737,12 +3658,6 @@ impl ::core::clone::Clone for DisplayWireFormatColorSpace {
 unsafe impl ::windows::core::Abi for DisplayWireFormatColorSpace {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DisplayWireFormatColorSpace {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DisplayWireFormatColorSpace {}
 impl ::core::fmt::Debug for DisplayWireFormatColorSpace {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayWireFormatColorSpace").field(&self.0).finish()
@@ -3756,6 +3671,7 @@ impl ::windows::core::DefaultType for DisplayWireFormatColorSpace {
 }
 #[doc = "*Required features: 'Devices_Display_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DisplayWireFormatEotf(pub i32);
 impl DisplayWireFormatEotf {
     pub const Sdr: Self = Self(0i32);
@@ -3770,12 +3686,6 @@ impl ::core::clone::Clone for DisplayWireFormatEotf {
 unsafe impl ::windows::core::Abi for DisplayWireFormatEotf {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DisplayWireFormatEotf {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DisplayWireFormatEotf {}
 impl ::core::fmt::Debug for DisplayWireFormatEotf {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayWireFormatEotf").field(&self.0).finish()
@@ -3789,6 +3699,7 @@ impl ::windows::core::DefaultType for DisplayWireFormatEotf {
 }
 #[doc = "*Required features: 'Devices_Display_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DisplayWireFormatHdrMetadata(pub i32);
 impl DisplayWireFormatHdrMetadata {
     pub const None: Self = Self(0i32);
@@ -3805,12 +3716,6 @@ impl ::core::clone::Clone for DisplayWireFormatHdrMetadata {
 unsafe impl ::windows::core::Abi for DisplayWireFormatHdrMetadata {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DisplayWireFormatHdrMetadata {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DisplayWireFormatHdrMetadata {}
 impl ::core::fmt::Debug for DisplayWireFormatHdrMetadata {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayWireFormatHdrMetadata").field(&self.0).finish()
@@ -3824,6 +3729,7 @@ impl ::windows::core::DefaultType for DisplayWireFormatHdrMetadata {
 }
 #[doc = "*Required features: 'Devices_Display_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DisplayWireFormatPixelEncoding(pub i32);
 impl DisplayWireFormatPixelEncoding {
     pub const Rgb444: Self = Self(0i32);
@@ -3841,12 +3747,6 @@ impl ::core::clone::Clone for DisplayWireFormatPixelEncoding {
 unsafe impl ::windows::core::Abi for DisplayWireFormatPixelEncoding {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DisplayWireFormatPixelEncoding {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DisplayWireFormatPixelEncoding {}
 impl ::core::fmt::Debug for DisplayWireFormatPixelEncoding {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayWireFormatPixelEncoding").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Display/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Display/mod.rs
@@ -279,6 +279,7 @@ unsafe impl ::core::marker::Send for DisplayMonitor {}
 unsafe impl ::core::marker::Sync for DisplayMonitor {}
 #[doc = "*Required features: 'Devices_Display'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DisplayMonitorConnectionKind(pub i32);
 impl DisplayMonitorConnectionKind {
     pub const Internal: Self = Self(0i32);
@@ -295,12 +296,6 @@ impl ::core::clone::Clone for DisplayMonitorConnectionKind {
 unsafe impl ::windows::core::Abi for DisplayMonitorConnectionKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DisplayMonitorConnectionKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DisplayMonitorConnectionKind {}
 impl ::core::fmt::Debug for DisplayMonitorConnectionKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayMonitorConnectionKind").field(&self.0).finish()
@@ -314,6 +309,7 @@ impl ::windows::core::DefaultType for DisplayMonitorConnectionKind {
 }
 #[doc = "*Required features: 'Devices_Display'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DisplayMonitorDescriptorKind(pub i32);
 impl DisplayMonitorDescriptorKind {
     pub const Edid: Self = Self(0i32);
@@ -328,12 +324,6 @@ impl ::core::clone::Clone for DisplayMonitorDescriptorKind {
 unsafe impl ::windows::core::Abi for DisplayMonitorDescriptorKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DisplayMonitorDescriptorKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DisplayMonitorDescriptorKind {}
 impl ::core::fmt::Debug for DisplayMonitorDescriptorKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayMonitorDescriptorKind").field(&self.0).finish()
@@ -347,6 +337,7 @@ impl ::windows::core::DefaultType for DisplayMonitorDescriptorKind {
 }
 #[doc = "*Required features: 'Devices_Display'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DisplayMonitorPhysicalConnectorKind(pub i32);
 impl DisplayMonitorPhysicalConnectorKind {
     pub const Unknown: Self = Self(0i32);
@@ -367,12 +358,6 @@ impl ::core::clone::Clone for DisplayMonitorPhysicalConnectorKind {
 unsafe impl ::windows::core::Abi for DisplayMonitorPhysicalConnectorKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DisplayMonitorPhysicalConnectorKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DisplayMonitorPhysicalConnectorKind {}
 impl ::core::fmt::Debug for DisplayMonitorPhysicalConnectorKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayMonitorPhysicalConnectorKind").field(&self.0).finish()
@@ -386,6 +371,7 @@ impl ::windows::core::DefaultType for DisplayMonitorPhysicalConnectorKind {
 }
 #[doc = "*Required features: 'Devices_Display'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DisplayMonitorUsageKind(pub i32);
 impl DisplayMonitorUsageKind {
     pub const Standard: Self = Self(0i32);
@@ -401,12 +387,6 @@ impl ::core::clone::Clone for DisplayMonitorUsageKind {
 unsafe impl ::windows::core::Abi for DisplayMonitorUsageKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DisplayMonitorUsageKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DisplayMonitorUsageKind {}
 impl ::core::fmt::Debug for DisplayMonitorUsageKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayMonitorUsageKind").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Enumeration/Pnp/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Enumeration/Pnp/mod.rs
@@ -464,6 +464,7 @@ unsafe impl ::core::marker::Send for PnpObjectCollection {}
 unsafe impl ::core::marker::Sync for PnpObjectCollection {}
 #[doc = "*Required features: 'Devices_Enumeration_Pnp'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PnpObjectType(pub i32);
 impl PnpObjectType {
     pub const Unknown: Self = Self(0i32);
@@ -485,12 +486,6 @@ impl ::core::clone::Clone for PnpObjectType {
 unsafe impl ::windows::core::Abi for PnpObjectType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PnpObjectType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PnpObjectType {}
 impl ::core::fmt::Debug for PnpObjectType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PnpObjectType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Enumeration/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Enumeration/mod.rs
@@ -214,6 +214,7 @@ unsafe impl ::core::marker::Send for DeviceAccessInformation {}
 unsafe impl ::core::marker::Sync for DeviceAccessInformation {}
 #[doc = "*Required features: 'Devices_Enumeration'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DeviceAccessStatus(pub i32);
 impl DeviceAccessStatus {
     pub const Unspecified: Self = Self(0i32);
@@ -230,12 +231,6 @@ impl ::core::clone::Clone for DeviceAccessStatus {
 unsafe impl ::windows::core::Abi for DeviceAccessStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DeviceAccessStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DeviceAccessStatus {}
 impl ::core::fmt::Debug for DeviceAccessStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DeviceAccessStatus").field(&self.0).finish()
@@ -249,6 +244,7 @@ impl ::windows::core::DefaultType for DeviceAccessStatus {
 }
 #[doc = "*Required features: 'Devices_Enumeration'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DeviceClass(pub i32);
 impl DeviceClass {
     pub const All: Self = Self(0i32);
@@ -268,12 +264,6 @@ impl ::core::clone::Clone for DeviceClass {
 unsafe impl ::windows::core::Abi for DeviceClass {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DeviceClass {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DeviceClass {}
 impl ::core::fmt::Debug for DeviceClass {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DeviceClass").field(&self.0).finish()
@@ -1048,6 +1038,7 @@ unsafe impl ::core::marker::Send for DeviceInformationCustomPairing {}
 unsafe impl ::core::marker::Sync for DeviceInformationCustomPairing {}
 #[doc = "*Required features: 'Devices_Enumeration'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DeviceInformationKind(pub i32);
 impl DeviceInformationKind {
     pub const Unknown: Self = Self(0i32);
@@ -1069,12 +1060,6 @@ impl ::core::clone::Clone for DeviceInformationKind {
 unsafe impl ::windows::core::Abi for DeviceInformationKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DeviceInformationKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DeviceInformationKind {}
 impl ::core::fmt::Debug for DeviceInformationKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DeviceInformationKind").field(&self.0).finish()
@@ -1351,6 +1336,7 @@ unsafe impl ::core::marker::Send for DeviceInformationUpdate {}
 unsafe impl ::core::marker::Sync for DeviceInformationUpdate {}
 #[doc = "*Required features: 'Devices_Enumeration'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DevicePairingKinds(pub u32);
 impl DevicePairingKinds {
     pub const None: Self = Self(0u32);
@@ -1369,12 +1355,6 @@ impl ::core::clone::Clone for DevicePairingKinds {
 unsafe impl ::windows::core::Abi for DevicePairingKinds {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DevicePairingKinds {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DevicePairingKinds {}
 impl ::core::fmt::Debug for DevicePairingKinds {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DevicePairingKinds").field(&self.0).finish()
@@ -1416,6 +1396,7 @@ impl ::windows::core::DefaultType for DevicePairingKinds {
 }
 #[doc = "*Required features: 'Devices_Enumeration'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DevicePairingProtectionLevel(pub i32);
 impl DevicePairingProtectionLevel {
     pub const Default: Self = Self(0i32);
@@ -1432,12 +1413,6 @@ impl ::core::clone::Clone for DevicePairingProtectionLevel {
 unsafe impl ::windows::core::Abi for DevicePairingProtectionLevel {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DevicePairingProtectionLevel {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DevicePairingProtectionLevel {}
 impl ::core::fmt::Debug for DevicePairingProtectionLevel {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DevicePairingProtectionLevel").field(&self.0).finish()
@@ -1662,6 +1637,7 @@ unsafe impl ::core::marker::Send for DevicePairingResult {}
 unsafe impl ::core::marker::Sync for DevicePairingResult {}
 #[doc = "*Required features: 'Devices_Enumeration'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DevicePairingResultStatus(pub i32);
 impl DevicePairingResultStatus {
     pub const Paired: Self = Self(0i32);
@@ -1694,12 +1670,6 @@ impl ::core::clone::Clone for DevicePairingResultStatus {
 unsafe impl ::windows::core::Abi for DevicePairingResultStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DevicePairingResultStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DevicePairingResultStatus {}
 impl ::core::fmt::Debug for DevicePairingResultStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DevicePairingResultStatus").field(&self.0).finish()
@@ -2079,6 +2049,7 @@ unsafe impl ::core::marker::Send for DevicePickerAppearance {}
 unsafe impl ::core::marker::Sync for DevicePickerAppearance {}
 #[doc = "*Required features: 'Devices_Enumeration'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DevicePickerDisplayStatusOptions(pub u32);
 impl DevicePickerDisplayStatusOptions {
     pub const None: Self = Self(0u32);
@@ -2095,12 +2066,6 @@ impl ::core::clone::Clone for DevicePickerDisplayStatusOptions {
 unsafe impl ::windows::core::Abi for DevicePickerDisplayStatusOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DevicePickerDisplayStatusOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DevicePickerDisplayStatusOptions {}
 impl ::core::fmt::Debug for DevicePickerDisplayStatusOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DevicePickerDisplayStatusOptions").field(&self.0).finish()
@@ -2760,6 +2725,7 @@ unsafe impl ::core::marker::Send for DeviceUnpairingResult {}
 unsafe impl ::core::marker::Sync for DeviceUnpairingResult {}
 #[doc = "*Required features: 'Devices_Enumeration'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DeviceUnpairingResultStatus(pub i32);
 impl DeviceUnpairingResultStatus {
     pub const Unpaired: Self = Self(0i32);
@@ -2777,12 +2743,6 @@ impl ::core::clone::Clone for DeviceUnpairingResultStatus {
 unsafe impl ::windows::core::Abi for DeviceUnpairingResultStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DeviceUnpairingResultStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DeviceUnpairingResultStatus {}
 impl ::core::fmt::Debug for DeviceUnpairingResultStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DeviceUnpairingResultStatus").field(&self.0).finish()
@@ -3068,6 +3028,7 @@ unsafe impl ::core::marker::Send for DeviceWatcherEvent {}
 unsafe impl ::core::marker::Sync for DeviceWatcherEvent {}
 #[doc = "*Required features: 'Devices_Enumeration'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DeviceWatcherEventKind(pub i32);
 impl DeviceWatcherEventKind {
     pub const Add: Self = Self(0i32);
@@ -3083,12 +3044,6 @@ impl ::core::clone::Clone for DeviceWatcherEventKind {
 unsafe impl ::windows::core::Abi for DeviceWatcherEventKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DeviceWatcherEventKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DeviceWatcherEventKind {}
 impl ::core::fmt::Debug for DeviceWatcherEventKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DeviceWatcherEventKind").field(&self.0).finish()
@@ -3102,6 +3057,7 @@ impl ::windows::core::DefaultType for DeviceWatcherEventKind {
 }
 #[doc = "*Required features: 'Devices_Enumeration'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DeviceWatcherStatus(pub i32);
 impl DeviceWatcherStatus {
     pub const Created: Self = Self(0i32);
@@ -3120,12 +3076,6 @@ impl ::core::clone::Clone for DeviceWatcherStatus {
 unsafe impl ::windows::core::Abi for DeviceWatcherStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DeviceWatcherStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DeviceWatcherStatus {}
 impl ::core::fmt::Debug for DeviceWatcherStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DeviceWatcherStatus").field(&self.0).finish()
@@ -4111,6 +4061,7 @@ pub struct IEnclosureLocation2Vtbl(
 );
 #[doc = "*Required features: 'Devices_Enumeration'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct Panel(pub i32);
 impl Panel {
     pub const Unknown: Self = Self(0i32);
@@ -4130,12 +4081,6 @@ impl ::core::clone::Clone for Panel {
 unsafe impl ::windows::core::Abi for Panel {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for Panel {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for Panel {}
 impl ::core::fmt::Debug for Panel {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("Panel").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Geolocation/Geofencing/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Geolocation/Geofencing/mod.rs
@@ -317,6 +317,7 @@ unsafe impl ::core::marker::Send for GeofenceMonitor {}
 unsafe impl ::core::marker::Sync for GeofenceMonitor {}
 #[doc = "*Required features: 'Devices_Geolocation_Geofencing'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GeofenceMonitorStatus(pub i32);
 impl GeofenceMonitorStatus {
     pub const Ready: Self = Self(0i32);
@@ -335,12 +336,6 @@ impl ::core::clone::Clone for GeofenceMonitorStatus {
 unsafe impl ::windows::core::Abi for GeofenceMonitorStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GeofenceMonitorStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GeofenceMonitorStatus {}
 impl ::core::fmt::Debug for GeofenceMonitorStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GeofenceMonitorStatus").field(&self.0).finish()
@@ -354,6 +349,7 @@ impl ::windows::core::DefaultType for GeofenceMonitorStatus {
 }
 #[doc = "*Required features: 'Devices_Geolocation_Geofencing'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GeofenceRemovalReason(pub i32);
 impl GeofenceRemovalReason {
     pub const Used: Self = Self(0i32);
@@ -368,12 +364,6 @@ impl ::core::clone::Clone for GeofenceRemovalReason {
 unsafe impl ::windows::core::Abi for GeofenceRemovalReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GeofenceRemovalReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GeofenceRemovalReason {}
 impl ::core::fmt::Debug for GeofenceRemovalReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GeofenceRemovalReason").field(&self.0).finish()
@@ -387,6 +377,7 @@ impl ::windows::core::DefaultType for GeofenceRemovalReason {
 }
 #[doc = "*Required features: 'Devices_Geolocation_Geofencing'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GeofenceState(pub u32);
 impl GeofenceState {
     pub const None: Self = Self(0u32);
@@ -403,12 +394,6 @@ impl ::core::clone::Clone for GeofenceState {
 unsafe impl ::windows::core::Abi for GeofenceState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GeofenceState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GeofenceState {}
 impl ::core::fmt::Debug for GeofenceState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GeofenceState").field(&self.0).finish()
@@ -675,6 +660,7 @@ pub struct IGeofenceStateChangeReportVtbl(
 );
 #[doc = "*Required features: 'Devices_Geolocation_Geofencing'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MonitoredGeofenceStates(pub u32);
 impl MonitoredGeofenceStates {
     pub const None: Self = Self(0u32);
@@ -691,12 +677,6 @@ impl ::core::clone::Clone for MonitoredGeofenceStates {
 unsafe impl ::windows::core::Abi for MonitoredGeofenceStates {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MonitoredGeofenceStates {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MonitoredGeofenceStates {}
 impl ::core::fmt::Debug for MonitoredGeofenceStates {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MonitoredGeofenceStates").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Geolocation/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Geolocation/mod.rs
@@ -3,6 +3,7 @@
 pub mod Geofencing;
 #[doc = "*Required features: 'Devices_Geolocation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AltitudeReferenceSystem(pub i32);
 impl AltitudeReferenceSystem {
     pub const Unspecified: Self = Self(0i32);
@@ -20,12 +21,6 @@ impl ::core::clone::Clone for AltitudeReferenceSystem {
 unsafe impl ::windows::core::Abi for AltitudeReferenceSystem {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AltitudeReferenceSystem {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AltitudeReferenceSystem {}
 impl ::core::fmt::Debug for AltitudeReferenceSystem {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AltitudeReferenceSystem").field(&self.0).finish()
@@ -869,6 +864,7 @@ unsafe impl ::core::marker::Send for GeocoordinateSatelliteData {}
 unsafe impl ::core::marker::Sync for GeocoordinateSatelliteData {}
 #[doc = "*Required features: 'Devices_Geolocation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GeolocationAccessStatus(pub i32);
 impl GeolocationAccessStatus {
     pub const Unspecified: Self = Self(0i32);
@@ -884,12 +880,6 @@ impl ::core::clone::Clone for GeolocationAccessStatus {
 unsafe impl ::windows::core::Abi for GeolocationAccessStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GeolocationAccessStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GeolocationAccessStatus {}
 impl ::core::fmt::Debug for GeolocationAccessStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GeolocationAccessStatus").field(&self.0).finish()
@@ -1559,6 +1549,7 @@ unsafe impl ::core::marker::Send for Geoposition {}
 unsafe impl ::core::marker::Sync for Geoposition {}
 #[doc = "*Required features: 'Devices_Geolocation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GeoshapeType(pub i32);
 impl GeoshapeType {
     pub const Geopoint: Self = Self(0i32);
@@ -1575,12 +1566,6 @@ impl ::core::clone::Clone for GeoshapeType {
 unsafe impl ::windows::core::Abi for GeoshapeType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GeoshapeType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GeoshapeType {}
 impl ::core::fmt::Debug for GeoshapeType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GeoshapeType").field(&self.0).finish()
@@ -2756,6 +2741,7 @@ pub struct IVenueDataVtbl(
 );
 #[doc = "*Required features: 'Devices_Geolocation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PositionAccuracy(pub i32);
 impl PositionAccuracy {
     pub const Default: Self = Self(0i32);
@@ -2770,12 +2756,6 @@ impl ::core::clone::Clone for PositionAccuracy {
 unsafe impl ::windows::core::Abi for PositionAccuracy {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PositionAccuracy {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PositionAccuracy {}
 impl ::core::fmt::Debug for PositionAccuracy {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PositionAccuracy").field(&self.0).finish()
@@ -2870,6 +2850,7 @@ unsafe impl ::core::marker::Send for PositionChangedEventArgs {}
 unsafe impl ::core::marker::Sync for PositionChangedEventArgs {}
 #[doc = "*Required features: 'Devices_Geolocation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PositionSource(pub i32);
 impl PositionSource {
     pub const Cellular: Self = Self(0i32);
@@ -2889,12 +2870,6 @@ impl ::core::clone::Clone for PositionSource {
 unsafe impl ::windows::core::Abi for PositionSource {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PositionSource {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PositionSource {}
 impl ::core::fmt::Debug for PositionSource {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PositionSource").field(&self.0).finish()
@@ -2908,6 +2883,7 @@ impl ::windows::core::DefaultType for PositionSource {
 }
 #[doc = "*Required features: 'Devices_Geolocation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PositionStatus(pub i32);
 impl PositionStatus {
     pub const Ready: Self = Self(0i32);
@@ -2926,12 +2902,6 @@ impl ::core::clone::Clone for PositionStatus {
 unsafe impl ::windows::core::Abi for PositionStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PositionStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PositionStatus {}
 impl ::core::fmt::Debug for PositionStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PositionStatus").field(&self.0).finish()
@@ -3115,6 +3085,7 @@ unsafe impl ::core::marker::Send for VenueData {}
 unsafe impl ::core::marker::Sync for VenueData {}
 #[doc = "*Required features: 'Devices_Geolocation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VisitMonitoringScope(pub i32);
 impl VisitMonitoringScope {
     pub const Venue: Self = Self(0i32);
@@ -3129,12 +3100,6 @@ impl ::core::clone::Clone for VisitMonitoringScope {
 unsafe impl ::windows::core::Abi for VisitMonitoringScope {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VisitMonitoringScope {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VisitMonitoringScope {}
 impl ::core::fmt::Debug for VisitMonitoringScope {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VisitMonitoringScope").field(&self.0).finish()
@@ -3148,6 +3113,7 @@ impl ::windows::core::DefaultType for VisitMonitoringScope {
 }
 #[doc = "*Required features: 'Devices_Geolocation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VisitStateChange(pub i32);
 impl VisitStateChange {
     pub const TrackingLost: Self = Self(0i32);
@@ -3164,12 +3130,6 @@ impl ::core::clone::Clone for VisitStateChange {
 unsafe impl ::windows::core::Abi for VisitStateChange {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VisitStateChange {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VisitStateChange {}
 impl ::core::fmt::Debug for VisitStateChange {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VisitStateChange").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Gpio/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Gpio/Provider/mod.rs
@@ -488,6 +488,7 @@ pub struct IGpioProviderVtbl(
 );
 #[doc = "*Required features: 'Devices_Gpio_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ProviderGpioPinDriveMode(pub i32);
 impl ProviderGpioPinDriveMode {
     pub const Input: Self = Self(0i32);
@@ -508,12 +509,6 @@ impl ::core::clone::Clone for ProviderGpioPinDriveMode {
 unsafe impl ::windows::core::Abi for ProviderGpioPinDriveMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ProviderGpioPinDriveMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ProviderGpioPinDriveMode {}
 impl ::core::fmt::Debug for ProviderGpioPinDriveMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ProviderGpioPinDriveMode").field(&self.0).finish()
@@ -527,6 +522,7 @@ impl ::windows::core::DefaultType for ProviderGpioPinDriveMode {
 }
 #[doc = "*Required features: 'Devices_Gpio_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ProviderGpioPinEdge(pub i32);
 impl ProviderGpioPinEdge {
     pub const FallingEdge: Self = Self(0i32);
@@ -541,12 +537,6 @@ impl ::core::clone::Clone for ProviderGpioPinEdge {
 unsafe impl ::windows::core::Abi for ProviderGpioPinEdge {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ProviderGpioPinEdge {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ProviderGpioPinEdge {}
 impl ::core::fmt::Debug for ProviderGpioPinEdge {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ProviderGpioPinEdge").field(&self.0).finish()
@@ -560,6 +550,7 @@ impl ::windows::core::DefaultType for ProviderGpioPinEdge {
 }
 #[doc = "*Required features: 'Devices_Gpio_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ProviderGpioPinValue(pub i32);
 impl ProviderGpioPinValue {
     pub const Low: Self = Self(0i32);
@@ -574,12 +565,6 @@ impl ::core::clone::Clone for ProviderGpioPinValue {
 unsafe impl ::windows::core::Abi for ProviderGpioPinValue {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ProviderGpioPinValue {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ProviderGpioPinValue {}
 impl ::core::fmt::Debug for ProviderGpioPinValue {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ProviderGpioPinValue").field(&self.0).finish()
@@ -593,6 +578,7 @@ impl ::windows::core::DefaultType for ProviderGpioPinValue {
 }
 #[doc = "*Required features: 'Devices_Gpio_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ProviderGpioSharingMode(pub i32);
 impl ProviderGpioSharingMode {
     pub const Exclusive: Self = Self(0i32);
@@ -607,12 +593,6 @@ impl ::core::clone::Clone for ProviderGpioSharingMode {
 unsafe impl ::windows::core::Abi for ProviderGpioSharingMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ProviderGpioSharingMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ProviderGpioSharingMode {}
 impl ::core::fmt::Debug for ProviderGpioSharingMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ProviderGpioSharingMode").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Gpio/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Gpio/mod.rs
@@ -216,6 +216,7 @@ unsafe impl ::core::marker::Send for GpioChangeCounter {}
 unsafe impl ::core::marker::Sync for GpioChangeCounter {}
 #[doc = "*Required features: 'Devices_Gpio'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GpioChangePolarity(pub i32);
 impl GpioChangePolarity {
     pub const Falling: Self = Self(0i32);
@@ -231,12 +232,6 @@ impl ::core::clone::Clone for GpioChangePolarity {
 unsafe impl ::windows::core::Abi for GpioChangePolarity {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GpioChangePolarity {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GpioChangePolarity {}
 impl ::core::fmt::Debug for GpioChangePolarity {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GpioChangePolarity").field(&self.0).finish()
@@ -663,6 +658,7 @@ unsafe impl ::core::marker::Send for GpioController {}
 unsafe impl ::core::marker::Sync for GpioController {}
 #[doc = "*Required features: 'Devices_Gpio'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GpioOpenStatus(pub i32);
 impl GpioOpenStatus {
     pub const PinOpened: Self = Self(0i32);
@@ -680,12 +676,6 @@ impl ::core::clone::Clone for GpioOpenStatus {
 unsafe impl ::windows::core::Abi for GpioOpenStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GpioOpenStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GpioOpenStatus {}
 impl ::core::fmt::Debug for GpioOpenStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GpioOpenStatus").field(&self.0).finish()
@@ -884,6 +874,7 @@ unsafe impl ::core::marker::Send for GpioPin {}
 unsafe impl ::core::marker::Sync for GpioPin {}
 #[doc = "*Required features: 'Devices_Gpio'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GpioPinDriveMode(pub i32);
 impl GpioPinDriveMode {
     pub const Input: Self = Self(0i32);
@@ -904,12 +895,6 @@ impl ::core::clone::Clone for GpioPinDriveMode {
 unsafe impl ::windows::core::Abi for GpioPinDriveMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GpioPinDriveMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GpioPinDriveMode {}
 impl ::core::fmt::Debug for GpioPinDriveMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GpioPinDriveMode").field(&self.0).finish()
@@ -923,6 +908,7 @@ impl ::windows::core::DefaultType for GpioPinDriveMode {
 }
 #[doc = "*Required features: 'Devices_Gpio'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GpioPinEdge(pub i32);
 impl GpioPinEdge {
     pub const FallingEdge: Self = Self(0i32);
@@ -937,12 +923,6 @@ impl ::core::clone::Clone for GpioPinEdge {
 unsafe impl ::windows::core::Abi for GpioPinEdge {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GpioPinEdge {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GpioPinEdge {}
 impl ::core::fmt::Debug for GpioPinEdge {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GpioPinEdge").field(&self.0).finish()
@@ -956,6 +936,7 @@ impl ::windows::core::DefaultType for GpioPinEdge {
 }
 #[doc = "*Required features: 'Devices_Gpio'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GpioPinValue(pub i32);
 impl GpioPinValue {
     pub const Low: Self = Self(0i32);
@@ -970,12 +951,6 @@ impl ::core::clone::Clone for GpioPinValue {
 unsafe impl ::windows::core::Abi for GpioPinValue {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GpioPinValue {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GpioPinValue {}
 impl ::core::fmt::Debug for GpioPinValue {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GpioPinValue").field(&self.0).finish()
@@ -1070,6 +1045,7 @@ unsafe impl ::core::marker::Send for GpioPinValueChangedEventArgs {}
 unsafe impl ::core::marker::Sync for GpioPinValueChangedEventArgs {}
 #[doc = "*Required features: 'Devices_Gpio'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GpioSharingMode(pub i32);
 impl GpioSharingMode {
     pub const Exclusive: Self = Self(0i32);
@@ -1084,12 +1060,6 @@ impl ::core::clone::Clone for GpioSharingMode {
 unsafe impl ::windows::core::Abi for GpioSharingMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GpioSharingMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GpioSharingMode {}
 impl ::core::fmt::Debug for GpioSharingMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GpioSharingMode").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Haptics/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Haptics/mod.rs
@@ -507,6 +507,7 @@ unsafe impl ::core::marker::Send for SimpleHapticsControllerFeedback {}
 unsafe impl ::core::marker::Sync for SimpleHapticsControllerFeedback {}
 #[doc = "*Required features: 'Devices_Haptics'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VibrationAccessStatus(pub i32);
 impl VibrationAccessStatus {
     pub const Allowed: Self = Self(0i32);
@@ -523,12 +524,6 @@ impl ::core::clone::Clone for VibrationAccessStatus {
 unsafe impl ::windows::core::Abi for VibrationAccessStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VibrationAccessStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VibrationAccessStatus {}
 impl ::core::fmt::Debug for VibrationAccessStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VibrationAccessStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/HumanInterfaceDevice/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/HumanInterfaceDevice/mod.rs
@@ -354,6 +354,7 @@ unsafe impl ::core::marker::Send for HidCollection {}
 unsafe impl ::core::marker::Sync for HidCollection {}
 #[doc = "*Required features: 'Devices_HumanInterfaceDevice'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HidCollectionType(pub i32);
 impl HidCollectionType {
     pub const Physical: Self = Self(0i32);
@@ -374,12 +375,6 @@ impl ::core::clone::Clone for HidCollectionType {
 unsafe impl ::windows::core::Abi for HidCollectionType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HidCollectionType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HidCollectionType {}
 impl ::core::fmt::Debug for HidCollectionType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HidCollectionType").field(&self.0).finish()
@@ -1502,6 +1497,7 @@ unsafe impl ::core::marker::Send for HidOutputReport {}
 unsafe impl ::core::marker::Sync for HidOutputReport {}
 #[doc = "*Required features: 'Devices_HumanInterfaceDevice'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HidReportType(pub i32);
 impl HidReportType {
     pub const Input: Self = Self(0i32);
@@ -1517,12 +1513,6 @@ impl ::core::clone::Clone for HidReportType {
 unsafe impl ::windows::core::Abi for HidReportType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HidReportType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HidReportType {}
 impl ::core::fmt::Debug for HidReportType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HidReportType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/I2c/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/I2c/Provider/mod.rs
@@ -364,6 +364,7 @@ pub struct IProviderI2cConnectionSettingsVtbl(
 );
 #[doc = "*Required features: 'Devices_I2c_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ProviderI2cBusSpeed(pub i32);
 impl ProviderI2cBusSpeed {
     pub const StandardMode: Self = Self(0i32);
@@ -378,12 +379,6 @@ impl ::core::clone::Clone for ProviderI2cBusSpeed {
 unsafe impl ::windows::core::Abi for ProviderI2cBusSpeed {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ProviderI2cBusSpeed {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ProviderI2cBusSpeed {}
 impl ::core::fmt::Debug for ProviderI2cBusSpeed {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ProviderI2cBusSpeed").field(&self.0).finish()
@@ -509,6 +504,7 @@ unsafe impl ::core::marker::Send for ProviderI2cConnectionSettings {}
 unsafe impl ::core::marker::Sync for ProviderI2cConnectionSettings {}
 #[doc = "*Required features: 'Devices_I2c_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ProviderI2cSharingMode(pub i32);
 impl ProviderI2cSharingMode {
     pub const Exclusive: Self = Self(0i32);
@@ -523,12 +519,6 @@ impl ::core::clone::Clone for ProviderI2cSharingMode {
 unsafe impl ::windows::core::Abi for ProviderI2cSharingMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ProviderI2cSharingMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ProviderI2cSharingMode {}
 impl ::core::fmt::Debug for ProviderI2cSharingMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ProviderI2cSharingMode").field(&self.0).finish()
@@ -579,6 +569,7 @@ impl ::core::default::Default for ProviderI2cTransferResult {
 }
 #[doc = "*Required features: 'Devices_I2c_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ProviderI2cTransferStatus(pub i32);
 impl ProviderI2cTransferStatus {
     pub const FullTransfer: Self = Self(0i32);
@@ -594,12 +585,6 @@ impl ::core::clone::Clone for ProviderI2cTransferStatus {
 unsafe impl ::windows::core::Abi for ProviderI2cTransferStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ProviderI2cTransferStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ProviderI2cTransferStatus {}
 impl ::core::fmt::Debug for ProviderI2cTransferStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ProviderI2cTransferStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/I2c/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/I2c/mod.rs
@@ -3,6 +3,7 @@
 pub mod Provider;
 #[doc = "*Required features: 'Devices_I2c'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct I2cBusSpeed(pub i32);
 impl I2cBusSpeed {
     pub const StandardMode: Self = Self(0i32);
@@ -17,12 +18,6 @@ impl ::core::clone::Clone for I2cBusSpeed {
 unsafe impl ::windows::core::Abi for I2cBusSpeed {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for I2cBusSpeed {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for I2cBusSpeed {}
 impl ::core::fmt::Debug for I2cBusSpeed {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("I2cBusSpeed").field(&self.0).finish()
@@ -449,6 +444,7 @@ unsafe impl ::core::marker::Send for I2cDevice {}
 unsafe impl ::core::marker::Sync for I2cDevice {}
 #[doc = "*Required features: 'Devices_I2c'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct I2cSharingMode(pub i32);
 impl I2cSharingMode {
     pub const Exclusive: Self = Self(0i32);
@@ -463,12 +459,6 @@ impl ::core::clone::Clone for I2cSharingMode {
 unsafe impl ::windows::core::Abi for I2cSharingMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for I2cSharingMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for I2cSharingMode {}
 impl ::core::fmt::Debug for I2cSharingMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("I2cSharingMode").field(&self.0).finish()
@@ -519,6 +509,7 @@ impl ::core::default::Default for I2cTransferResult {
 }
 #[doc = "*Required features: 'Devices_I2c'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct I2cTransferStatus(pub i32);
 impl I2cTransferStatus {
     pub const FullTransfer: Self = Self(0i32);
@@ -536,12 +527,6 @@ impl ::core::clone::Clone for I2cTransferStatus {
 unsafe impl ::windows::core::Abi for I2cTransferStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for I2cTransferStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for I2cTransferStatus {}
 impl ::core::fmt::Debug for I2cTransferStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("I2cTransferStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Input/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Input/Preview/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'Devices_Input_Preview'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GazeDeviceConfigurationStatePreview(pub i32);
 impl GazeDeviceConfigurationStatePreview {
     pub const Unknown: Self = Self(0i32);
@@ -18,12 +19,6 @@ impl ::core::clone::Clone for GazeDeviceConfigurationStatePreview {
 unsafe impl ::windows::core::Abi for GazeDeviceConfigurationStatePreview {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GazeDeviceConfigurationStatePreview {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GazeDeviceConfigurationStatePreview {}
 impl ::core::fmt::Debug for GazeDeviceConfigurationStatePreview {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GazeDeviceConfigurationStatePreview").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Input/mod.rs
@@ -1748,6 +1748,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Poin
 }
 #[doc = "*Required features: 'Devices_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PointerDeviceType(pub i32);
 impl PointerDeviceType {
     pub const Touch: Self = Self(0i32);
@@ -1763,12 +1764,6 @@ impl ::core::clone::Clone for PointerDeviceType {
 unsafe impl ::windows::core::Abi for PointerDeviceType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PointerDeviceType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PointerDeviceType {}
 impl ::core::fmt::Debug for PointerDeviceType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PointerDeviceType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Lights/Effects/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Lights/Effects/mod.rs
@@ -1310,6 +1310,7 @@ unsafe impl ::core::marker::Send for LampArrayCustomEffect {}
 unsafe impl ::core::marker::Sync for LampArrayCustomEffect {}
 #[doc = "*Required features: 'Devices_Lights_Effects'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LampArrayEffectCompletionBehavior(pub i32);
 impl LampArrayEffectCompletionBehavior {
     pub const ClearState: Self = Self(0i32);
@@ -1324,12 +1325,6 @@ impl ::core::clone::Clone for LampArrayEffectCompletionBehavior {
 unsafe impl ::windows::core::Abi for LampArrayEffectCompletionBehavior {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LampArrayEffectCompletionBehavior {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LampArrayEffectCompletionBehavior {}
 impl ::core::fmt::Debug for LampArrayEffectCompletionBehavior {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LampArrayEffectCompletionBehavior").field(&self.0).finish()
@@ -1620,6 +1615,7 @@ unsafe impl ::core::marker::Send for LampArrayEffectPlaylist {}
 unsafe impl ::core::marker::Sync for LampArrayEffectPlaylist {}
 #[doc = "*Required features: 'Devices_Lights_Effects'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LampArrayEffectStartMode(pub i32);
 impl LampArrayEffectStartMode {
     pub const Sequential: Self = Self(0i32);
@@ -1634,12 +1630,6 @@ impl ::core::clone::Clone for LampArrayEffectStartMode {
 unsafe impl ::windows::core::Abi for LampArrayEffectStartMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LampArrayEffectStartMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LampArrayEffectStartMode {}
 impl ::core::fmt::Debug for LampArrayEffectStartMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LampArrayEffectStartMode").field(&self.0).finish()
@@ -1653,6 +1643,7 @@ impl ::windows::core::DefaultType for LampArrayEffectStartMode {
 }
 #[doc = "*Required features: 'Devices_Lights_Effects'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LampArrayRepetitionMode(pub i32);
 impl LampArrayRepetitionMode {
     pub const Occurrences: Self = Self(0i32);
@@ -1667,12 +1658,6 @@ impl ::core::clone::Clone for LampArrayRepetitionMode {
 unsafe impl ::windows::core::Abi for LampArrayRepetitionMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LampArrayRepetitionMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LampArrayRepetitionMode {}
 impl ::core::fmt::Debug for LampArrayRepetitionMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LampArrayRepetitionMode").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Lights/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Lights/mod.rs
@@ -671,6 +671,7 @@ unsafe impl ::core::marker::Send for LampArray {}
 unsafe impl ::core::marker::Sync for LampArray {}
 #[doc = "*Required features: 'Devices_Lights'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LampArrayKind(pub i32);
 impl LampArrayKind {
     pub const Undefined: Self = Self(0i32);
@@ -694,12 +695,6 @@ impl ::core::clone::Clone for LampArrayKind {
 unsafe impl ::windows::core::Abi for LampArrayKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LampArrayKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LampArrayKind {}
 impl ::core::fmt::Debug for LampArrayKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LampArrayKind").field(&self.0).finish()
@@ -951,6 +946,7 @@ unsafe impl ::core::marker::Send for LampInfo {}
 unsafe impl ::core::marker::Sync for LampInfo {}
 #[doc = "*Required features: 'Devices_Lights'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LampPurposes(pub u32);
 impl LampPurposes {
     pub const Undefined: Self = Self(0u32);
@@ -970,12 +966,6 @@ impl ::core::clone::Clone for LampPurposes {
 unsafe impl ::windows::core::Abi for LampPurposes {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LampPurposes {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LampPurposes {}
 impl ::core::fmt::Debug for LampPurposes {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LampPurposes").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Midi/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Midi/mod.rs
@@ -1549,6 +1549,7 @@ unsafe impl ::core::marker::Send for MidiMessageReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for MidiMessageReceivedEventArgs {}
 #[doc = "*Required features: 'Devices_Midi'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MidiMessageType(pub i32);
 impl MidiMessageType {
     pub const None: Self = Self(0i32);
@@ -1581,12 +1582,6 @@ impl ::core::clone::Clone for MidiMessageType {
 unsafe impl ::windows::core::Abi for MidiMessageType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MidiMessageType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MidiMessageType {}
 impl ::core::fmt::Debug for MidiMessageType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MidiMessageType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Perception/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Perception/mod.rs
@@ -4388,6 +4388,7 @@ unsafe impl ::core::marker::Sync for PerceptionDepthFrameSourceWatcher {}
 #[doc = "*Required features: 'Devices_Perception', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PerceptionFrameSourceAccessStatus(pub i32);
 #[cfg(feature = "deprecated")]
 impl PerceptionFrameSourceAccessStatus {
@@ -4408,14 +4409,6 @@ impl ::core::clone::Clone for PerceptionFrameSourceAccessStatus {
 unsafe impl ::windows::core::Abi for PerceptionFrameSourceAccessStatus {
     type Abi = Self;
 }
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for PerceptionFrameSourceAccessStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for PerceptionFrameSourceAccessStatus {}
 #[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for PerceptionFrameSourceAccessStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -4653,6 +4646,7 @@ unsafe impl ::core::marker::Sync for PerceptionFrameSourcePropertyChangeResult {
 #[doc = "*Required features: 'Devices_Perception', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PerceptionFrameSourcePropertyChangeStatus(pub i32);
 #[cfg(feature = "deprecated")]
 impl PerceptionFrameSourcePropertyChangeStatus {
@@ -4675,14 +4669,6 @@ impl ::core::clone::Clone for PerceptionFrameSourcePropertyChangeStatus {
 unsafe impl ::windows::core::Abi for PerceptionFrameSourcePropertyChangeStatus {
     type Abi = Self;
 }
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for PerceptionFrameSourcePropertyChangeStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for PerceptionFrameSourcePropertyChangeStatus {}
 #[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for PerceptionFrameSourcePropertyChangeStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {

--- a/crates/libs/windows/src/Windows/Devices/PointOfService/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/PointOfService/Provider/mod.rs
@@ -2301,6 +2301,7 @@ unsafe impl ::core::marker::Send for BarcodeScannerStopSoftwareTriggerRequestEve
 unsafe impl ::core::marker::Sync for BarcodeScannerStopSoftwareTriggerRequestEventArgs {}
 #[doc = "*Required features: 'Devices_PointOfService_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BarcodeScannerTriggerState(pub i32);
 impl BarcodeScannerTriggerState {
     pub const Released: Self = Self(0i32);
@@ -2315,12 +2316,6 @@ impl ::core::clone::Clone for BarcodeScannerTriggerState {
 unsafe impl ::windows::core::Abi for BarcodeScannerTriggerState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BarcodeScannerTriggerState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BarcodeScannerTriggerState {}
 impl ::core::fmt::Debug for BarcodeScannerTriggerState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BarcodeScannerTriggerState").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/PointOfService/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/PointOfService/mod.rs
@@ -742,6 +742,7 @@ unsafe impl ::core::marker::Send for BarcodeScannerReport {}
 unsafe impl ::core::marker::Sync for BarcodeScannerReport {}
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BarcodeScannerStatus(pub i32);
 impl BarcodeScannerStatus {
     pub const Online: Self = Self(0i32);
@@ -759,12 +760,6 @@ impl ::core::clone::Clone for BarcodeScannerStatus {
 unsafe impl ::windows::core::Abi for BarcodeScannerStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BarcodeScannerStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BarcodeScannerStatus {}
 impl ::core::fmt::Debug for BarcodeScannerStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BarcodeScannerStatus").field(&self.0).finish()
@@ -1711,6 +1706,7 @@ unsafe impl ::core::marker::Send for BarcodeSymbologyAttributes {}
 unsafe impl ::core::marker::Sync for BarcodeSymbologyAttributes {}
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BarcodeSymbologyDecodeLengthKind(pub i32);
 impl BarcodeSymbologyDecodeLengthKind {
     pub const AnyLength: Self = Self(0i32);
@@ -1726,12 +1722,6 @@ impl ::core::clone::Clone for BarcodeSymbologyDecodeLengthKind {
 unsafe impl ::windows::core::Abi for BarcodeSymbologyDecodeLengthKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BarcodeSymbologyDecodeLengthKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BarcodeSymbologyDecodeLengthKind {}
 impl ::core::fmt::Debug for BarcodeSymbologyDecodeLengthKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BarcodeSymbologyDecodeLengthKind").field(&self.0).finish()
@@ -2646,6 +2636,7 @@ unsafe impl ::core::marker::Send for CashDrawerStatus {}
 unsafe impl ::core::marker::Sync for CashDrawerStatus {}
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CashDrawerStatusKind(pub i32);
 impl CashDrawerStatusKind {
     pub const Online: Self = Self(0i32);
@@ -2663,12 +2654,6 @@ impl ::core::clone::Clone for CashDrawerStatusKind {
 unsafe impl ::windows::core::Abi for CashDrawerStatusKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CashDrawerStatusKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CashDrawerStatusKind {}
 impl ::core::fmt::Debug for CashDrawerStatusKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CashDrawerStatusKind").field(&self.0).finish()
@@ -10465,6 +10450,7 @@ unsafe impl ::core::marker::Send for LineDisplayCursorAttributes {}
 unsafe impl ::core::marker::Sync for LineDisplayCursorAttributes {}
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LineDisplayCursorType(pub i32);
 impl LineDisplayCursorType {
     pub const None: Self = Self(0i32);
@@ -10483,12 +10469,6 @@ impl ::core::clone::Clone for LineDisplayCursorType {
 unsafe impl ::windows::core::Abi for LineDisplayCursorType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LineDisplayCursorType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LineDisplayCursorType {}
 impl ::core::fmt::Debug for LineDisplayCursorType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LineDisplayCursorType").field(&self.0).finish()
@@ -10602,6 +10582,7 @@ unsafe impl ::core::marker::Send for LineDisplayCustomGlyphs {}
 unsafe impl ::core::marker::Sync for LineDisplayCustomGlyphs {}
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LineDisplayDescriptorState(pub i32);
 impl LineDisplayDescriptorState {
     pub const Off: Self = Self(0i32);
@@ -10617,12 +10598,6 @@ impl ::core::clone::Clone for LineDisplayDescriptorState {
 unsafe impl ::windows::core::Abi for LineDisplayDescriptorState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LineDisplayDescriptorState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LineDisplayDescriptorState {}
 impl ::core::fmt::Debug for LineDisplayDescriptorState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LineDisplayDescriptorState").field(&self.0).finish()
@@ -10636,6 +10611,7 @@ impl ::windows::core::DefaultType for LineDisplayDescriptorState {
 }
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LineDisplayHorizontalAlignment(pub i32);
 impl LineDisplayHorizontalAlignment {
     pub const Left: Self = Self(0i32);
@@ -10651,12 +10627,6 @@ impl ::core::clone::Clone for LineDisplayHorizontalAlignment {
 unsafe impl ::windows::core::Abi for LineDisplayHorizontalAlignment {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LineDisplayHorizontalAlignment {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LineDisplayHorizontalAlignment {}
 impl ::core::fmt::Debug for LineDisplayHorizontalAlignment {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LineDisplayHorizontalAlignment").field(&self.0).finish()
@@ -10804,6 +10774,7 @@ unsafe impl ::core::marker::Send for LineDisplayMarquee {}
 unsafe impl ::core::marker::Sync for LineDisplayMarquee {}
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LineDisplayMarqueeFormat(pub i32);
 impl LineDisplayMarqueeFormat {
     pub const None: Self = Self(0i32);
@@ -10819,12 +10790,6 @@ impl ::core::clone::Clone for LineDisplayMarqueeFormat {
 unsafe impl ::windows::core::Abi for LineDisplayMarqueeFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LineDisplayMarqueeFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LineDisplayMarqueeFormat {}
 impl ::core::fmt::Debug for LineDisplayMarqueeFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LineDisplayMarqueeFormat").field(&self.0).finish()
@@ -10838,6 +10803,7 @@ impl ::windows::core::DefaultType for LineDisplayMarqueeFormat {
 }
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LineDisplayPowerStatus(pub i32);
 impl LineDisplayPowerStatus {
     pub const Unknown: Self = Self(0i32);
@@ -10855,12 +10821,6 @@ impl ::core::clone::Clone for LineDisplayPowerStatus {
 unsafe impl ::windows::core::Abi for LineDisplayPowerStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LineDisplayPowerStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LineDisplayPowerStatus {}
 impl ::core::fmt::Debug for LineDisplayPowerStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LineDisplayPowerStatus").field(&self.0).finish()
@@ -10874,6 +10834,7 @@ impl ::windows::core::DefaultType for LineDisplayPowerStatus {
 }
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LineDisplayScrollDirection(pub i32);
 impl LineDisplayScrollDirection {
     pub const Up: Self = Self(0i32);
@@ -10890,12 +10851,6 @@ impl ::core::clone::Clone for LineDisplayScrollDirection {
 unsafe impl ::windows::core::Abi for LineDisplayScrollDirection {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LineDisplayScrollDirection {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LineDisplayScrollDirection {}
 impl ::core::fmt::Debug for LineDisplayScrollDirection {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LineDisplayScrollDirection").field(&self.0).finish()
@@ -11177,6 +11132,7 @@ unsafe impl ::core::marker::Send for LineDisplayStoredBitmap {}
 unsafe impl ::core::marker::Sync for LineDisplayStoredBitmap {}
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LineDisplayTextAttribute(pub i32);
 impl LineDisplayTextAttribute {
     pub const Normal: Self = Self(0i32);
@@ -11193,12 +11149,6 @@ impl ::core::clone::Clone for LineDisplayTextAttribute {
 unsafe impl ::windows::core::Abi for LineDisplayTextAttribute {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LineDisplayTextAttribute {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LineDisplayTextAttribute {}
 impl ::core::fmt::Debug for LineDisplayTextAttribute {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LineDisplayTextAttribute").field(&self.0).finish()
@@ -11212,6 +11162,7 @@ impl ::windows::core::DefaultType for LineDisplayTextAttribute {
 }
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LineDisplayTextAttributeGranularity(pub i32);
 impl LineDisplayTextAttributeGranularity {
     pub const NotSupported: Self = Self(0i32);
@@ -11227,12 +11178,6 @@ impl ::core::clone::Clone for LineDisplayTextAttributeGranularity {
 unsafe impl ::windows::core::Abi for LineDisplayTextAttributeGranularity {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LineDisplayTextAttributeGranularity {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LineDisplayTextAttributeGranularity {}
 impl ::core::fmt::Debug for LineDisplayTextAttributeGranularity {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LineDisplayTextAttributeGranularity").field(&self.0).finish()
@@ -11246,6 +11191,7 @@ impl ::windows::core::DefaultType for LineDisplayTextAttributeGranularity {
 }
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LineDisplayVerticalAlignment(pub i32);
 impl LineDisplayVerticalAlignment {
     pub const Top: Self = Self(0i32);
@@ -11261,12 +11207,6 @@ impl ::core::clone::Clone for LineDisplayVerticalAlignment {
 unsafe impl ::windows::core::Abi for LineDisplayVerticalAlignment {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LineDisplayVerticalAlignment {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LineDisplayVerticalAlignment {}
 impl ::core::fmt::Debug for LineDisplayVerticalAlignment {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LineDisplayVerticalAlignment").field(&self.0).finish()
@@ -11994,6 +11934,7 @@ unsafe impl ::core::marker::Send for MagneticStripeReaderAamvaCardDataReceivedEv
 unsafe impl ::core::marker::Sync for MagneticStripeReaderAamvaCardDataReceivedEventArgs {}
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MagneticStripeReaderAuthenticationLevel(pub i32);
 impl MagneticStripeReaderAuthenticationLevel {
     pub const NotSupported: Self = Self(0i32);
@@ -12009,12 +11950,6 @@ impl ::core::clone::Clone for MagneticStripeReaderAuthenticationLevel {
 unsafe impl ::windows::core::Abi for MagneticStripeReaderAuthenticationLevel {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MagneticStripeReaderAuthenticationLevel {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MagneticStripeReaderAuthenticationLevel {}
 impl ::core::fmt::Debug for MagneticStripeReaderAuthenticationLevel {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MagneticStripeReaderAuthenticationLevel").field(&self.0).finish()
@@ -12028,6 +11963,7 @@ impl ::windows::core::DefaultType for MagneticStripeReaderAuthenticationLevel {
 }
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MagneticStripeReaderAuthenticationProtocol(pub i32);
 impl MagneticStripeReaderAuthenticationProtocol {
     pub const None: Self = Self(0i32);
@@ -12042,12 +11978,6 @@ impl ::core::clone::Clone for MagneticStripeReaderAuthenticationProtocol {
 unsafe impl ::windows::core::Abi for MagneticStripeReaderAuthenticationProtocol {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MagneticStripeReaderAuthenticationProtocol {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MagneticStripeReaderAuthenticationProtocol {}
 impl ::core::fmt::Debug for MagneticStripeReaderAuthenticationProtocol {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MagneticStripeReaderAuthenticationProtocol").field(&self.0).finish()
@@ -12561,6 +12491,7 @@ unsafe impl ::core::marker::Send for MagneticStripeReaderErrorOccurredEventArgs 
 unsafe impl ::core::marker::Sync for MagneticStripeReaderErrorOccurredEventArgs {}
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MagneticStripeReaderErrorReportingType(pub i32);
 impl MagneticStripeReaderErrorReportingType {
     pub const CardLevel: Self = Self(0i32);
@@ -12575,12 +12506,6 @@ impl ::core::clone::Clone for MagneticStripeReaderErrorReportingType {
 unsafe impl ::windows::core::Abi for MagneticStripeReaderErrorReportingType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MagneticStripeReaderErrorReportingType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MagneticStripeReaderErrorReportingType {}
 impl ::core::fmt::Debug for MagneticStripeReaderErrorReportingType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MagneticStripeReaderErrorReportingType").field(&self.0).finish()
@@ -12742,6 +12667,7 @@ unsafe impl ::core::marker::Send for MagneticStripeReaderReport {}
 unsafe impl ::core::marker::Sync for MagneticStripeReaderReport {}
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MagneticStripeReaderStatus(pub i32);
 impl MagneticStripeReaderStatus {
     pub const Unauthenticated: Self = Self(0i32);
@@ -12757,12 +12683,6 @@ impl ::core::clone::Clone for MagneticStripeReaderStatus {
 unsafe impl ::windows::core::Abi for MagneticStripeReaderStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MagneticStripeReaderStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MagneticStripeReaderStatus {}
 impl ::core::fmt::Debug for MagneticStripeReaderStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MagneticStripeReaderStatus").field(&self.0).finish()
@@ -12965,6 +12885,7 @@ unsafe impl ::core::marker::Send for MagneticStripeReaderTrackData {}
 unsafe impl ::core::marker::Sync for MagneticStripeReaderTrackData {}
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MagneticStripeReaderTrackErrorType(pub i32);
 impl MagneticStripeReaderTrackErrorType {
     pub const None: Self = Self(0i32);
@@ -12983,12 +12904,6 @@ impl ::core::clone::Clone for MagneticStripeReaderTrackErrorType {
 unsafe impl ::windows::core::Abi for MagneticStripeReaderTrackErrorType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MagneticStripeReaderTrackErrorType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MagneticStripeReaderTrackErrorType {}
 impl ::core::fmt::Debug for MagneticStripeReaderTrackErrorType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MagneticStripeReaderTrackErrorType").field(&self.0).finish()
@@ -13002,6 +12917,7 @@ impl ::windows::core::DefaultType for MagneticStripeReaderTrackErrorType {
 }
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MagneticStripeReaderTrackIds(pub i32);
 impl MagneticStripeReaderTrackIds {
     pub const None: Self = Self(0i32);
@@ -13019,12 +12935,6 @@ impl ::core::clone::Clone for MagneticStripeReaderTrackIds {
 unsafe impl ::windows::core::Abi for MagneticStripeReaderTrackIds {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MagneticStripeReaderTrackIds {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MagneticStripeReaderTrackIds {}
 impl ::core::fmt::Debug for MagneticStripeReaderTrackIds {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MagneticStripeReaderTrackIds").field(&self.0).finish()
@@ -13119,6 +13029,7 @@ unsafe impl ::core::marker::Send for MagneticStripeReaderVendorSpecificCardDataR
 unsafe impl ::core::marker::Sync for MagneticStripeReaderVendorSpecificCardDataReceivedEventArgs {}
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PosConnectionTypes(pub u32);
 impl PosConnectionTypes {
     pub const Local: Self = Self(1u32);
@@ -13135,12 +13046,6 @@ impl ::core::clone::Clone for PosConnectionTypes {
 unsafe impl ::windows::core::Abi for PosConnectionTypes {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PosConnectionTypes {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PosConnectionTypes {}
 impl ::core::fmt::Debug for PosConnectionTypes {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PosConnectionTypes").field(&self.0).finish()
@@ -13428,6 +13333,7 @@ unsafe impl ::core::marker::Send for PosPrinter {}
 unsafe impl ::core::marker::Sync for PosPrinter {}
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PosPrinterAlignment(pub i32);
 impl PosPrinterAlignment {
     pub const Left: Self = Self(0i32);
@@ -13443,12 +13349,6 @@ impl ::core::clone::Clone for PosPrinterAlignment {
 unsafe impl ::windows::core::Abi for PosPrinterAlignment {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PosPrinterAlignment {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PosPrinterAlignment {}
 impl ::core::fmt::Debug for PosPrinterAlignment {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PosPrinterAlignment").field(&self.0).finish()
@@ -13462,6 +13362,7 @@ impl ::windows::core::DefaultType for PosPrinterAlignment {
 }
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PosPrinterBarcodeTextPosition(pub i32);
 impl PosPrinterBarcodeTextPosition {
     pub const None: Self = Self(0i32);
@@ -13477,12 +13378,6 @@ impl ::core::clone::Clone for PosPrinterBarcodeTextPosition {
 unsafe impl ::windows::core::Abi for PosPrinterBarcodeTextPosition {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PosPrinterBarcodeTextPosition {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PosPrinterBarcodeTextPosition {}
 impl ::core::fmt::Debug for PosPrinterBarcodeTextPosition {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PosPrinterBarcodeTextPosition").field(&self.0).finish()
@@ -13649,6 +13544,7 @@ unsafe impl ::core::marker::Send for PosPrinterCapabilities {}
 unsafe impl ::core::marker::Sync for PosPrinterCapabilities {}
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PosPrinterCartridgeSensors(pub u32);
 impl PosPrinterCartridgeSensors {
     pub const None: Self = Self(0u32);
@@ -13666,12 +13562,6 @@ impl ::core::clone::Clone for PosPrinterCartridgeSensors {
 unsafe impl ::windows::core::Abi for PosPrinterCartridgeSensors {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PosPrinterCartridgeSensors {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PosPrinterCartridgeSensors {}
 impl ::core::fmt::Debug for PosPrinterCartridgeSensors {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PosPrinterCartridgeSensors").field(&self.0).finish()
@@ -13746,6 +13636,7 @@ impl ::windows::core::RuntimeName for PosPrinterCharacterSetIds {
 }
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PosPrinterColorCapabilities(pub u32);
 impl PosPrinterColorCapabilities {
     pub const None: Self = Self(0u32);
@@ -13770,12 +13661,6 @@ impl ::core::clone::Clone for PosPrinterColorCapabilities {
 unsafe impl ::windows::core::Abi for PosPrinterColorCapabilities {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PosPrinterColorCapabilities {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PosPrinterColorCapabilities {}
 impl ::core::fmt::Debug for PosPrinterColorCapabilities {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PosPrinterColorCapabilities").field(&self.0).finish()
@@ -13817,6 +13702,7 @@ impl ::windows::core::DefaultType for PosPrinterColorCapabilities {
 }
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PosPrinterColorCartridge(pub i32);
 impl PosPrinterColorCartridge {
     pub const Unknown: Self = Self(0i32);
@@ -13840,12 +13726,6 @@ impl ::core::clone::Clone for PosPrinterColorCartridge {
 unsafe impl ::windows::core::Abi for PosPrinterColorCartridge {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PosPrinterColorCartridge {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PosPrinterColorCartridge {}
 impl ::core::fmt::Debug for PosPrinterColorCartridge {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PosPrinterColorCartridge").field(&self.0).finish()
@@ -13957,6 +13837,7 @@ unsafe impl ::core::marker::Send for PosPrinterFontProperty {}
 unsafe impl ::core::marker::Sync for PosPrinterFontProperty {}
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PosPrinterLineDirection(pub i32);
 impl PosPrinterLineDirection {
     pub const Horizontal: Self = Self(0i32);
@@ -13971,12 +13852,6 @@ impl ::core::clone::Clone for PosPrinterLineDirection {
 unsafe impl ::windows::core::Abi for PosPrinterLineDirection {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PosPrinterLineDirection {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PosPrinterLineDirection {}
 impl ::core::fmt::Debug for PosPrinterLineDirection {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PosPrinterLineDirection").field(&self.0).finish()
@@ -13990,6 +13865,7 @@ impl ::windows::core::DefaultType for PosPrinterLineDirection {
 }
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PosPrinterLineStyle(pub i32);
 impl PosPrinterLineStyle {
     pub const SingleSolid: Self = Self(0i32);
@@ -14006,12 +13882,6 @@ impl ::core::clone::Clone for PosPrinterLineStyle {
 unsafe impl ::windows::core::Abi for PosPrinterLineStyle {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PosPrinterLineStyle {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PosPrinterLineStyle {}
 impl ::core::fmt::Debug for PosPrinterLineStyle {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PosPrinterLineStyle").field(&self.0).finish()
@@ -14025,6 +13895,7 @@ impl ::windows::core::DefaultType for PosPrinterLineStyle {
 }
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PosPrinterMapMode(pub i32);
 impl PosPrinterMapMode {
     pub const Dots: Self = Self(0i32);
@@ -14041,12 +13912,6 @@ impl ::core::clone::Clone for PosPrinterMapMode {
 unsafe impl ::windows::core::Abi for PosPrinterMapMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PosPrinterMapMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PosPrinterMapMode {}
 impl ::core::fmt::Debug for PosPrinterMapMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PosPrinterMapMode").field(&self.0).finish()
@@ -14060,6 +13925,7 @@ impl ::windows::core::DefaultType for PosPrinterMapMode {
 }
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PosPrinterMarkFeedCapabilities(pub u32);
 impl PosPrinterMarkFeedCapabilities {
     pub const None: Self = Self(0u32);
@@ -14077,12 +13943,6 @@ impl ::core::clone::Clone for PosPrinterMarkFeedCapabilities {
 unsafe impl ::windows::core::Abi for PosPrinterMarkFeedCapabilities {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PosPrinterMarkFeedCapabilities {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PosPrinterMarkFeedCapabilities {}
 impl ::core::fmt::Debug for PosPrinterMarkFeedCapabilities {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PosPrinterMarkFeedCapabilities").field(&self.0).finish()
@@ -14124,6 +13984,7 @@ impl ::windows::core::DefaultType for PosPrinterMarkFeedCapabilities {
 }
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PosPrinterMarkFeedKind(pub i32);
 impl PosPrinterMarkFeedKind {
     pub const ToTakeUp: Self = Self(0i32);
@@ -14140,12 +14001,6 @@ impl ::core::clone::Clone for PosPrinterMarkFeedKind {
 unsafe impl ::windows::core::Abi for PosPrinterMarkFeedKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PosPrinterMarkFeedKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PosPrinterMarkFeedKind {}
 impl ::core::fmt::Debug for PosPrinterMarkFeedKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PosPrinterMarkFeedKind").field(&self.0).finish()
@@ -14408,6 +14263,7 @@ unsafe impl ::core::marker::Send for PosPrinterPrintOptions {}
 unsafe impl ::core::marker::Sync for PosPrinterPrintOptions {}
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PosPrinterPrintSide(pub i32);
 impl PosPrinterPrintSide {
     pub const Unknown: Self = Self(0i32);
@@ -14423,12 +14279,6 @@ impl ::core::clone::Clone for PosPrinterPrintSide {
 unsafe impl ::windows::core::Abi for PosPrinterPrintSide {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PosPrinterPrintSide {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PosPrinterPrintSide {}
 impl ::core::fmt::Debug for PosPrinterPrintSide {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PosPrinterPrintSide").field(&self.0).finish()
@@ -14514,6 +14364,7 @@ unsafe impl ::core::marker::Send for PosPrinterReleaseDeviceRequestedEventArgs {
 unsafe impl ::core::marker::Sync for PosPrinterReleaseDeviceRequestedEventArgs {}
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PosPrinterRotation(pub i32);
 impl PosPrinterRotation {
     pub const Normal: Self = Self(0i32);
@@ -14530,12 +14381,6 @@ impl ::core::clone::Clone for PosPrinterRotation {
 unsafe impl ::windows::core::Abi for PosPrinterRotation {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PosPrinterRotation {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PosPrinterRotation {}
 impl ::core::fmt::Debug for PosPrinterRotation {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PosPrinterRotation").field(&self.0).finish()
@@ -14549,6 +14394,7 @@ impl ::windows::core::DefaultType for PosPrinterRotation {
 }
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PosPrinterRuledLineCapabilities(pub u32);
 impl PosPrinterRuledLineCapabilities {
     pub const None: Self = Self(0u32);
@@ -14564,12 +14410,6 @@ impl ::core::clone::Clone for PosPrinterRuledLineCapabilities {
 unsafe impl ::windows::core::Abi for PosPrinterRuledLineCapabilities {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PosPrinterRuledLineCapabilities {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PosPrinterRuledLineCapabilities {}
 impl ::core::fmt::Debug for PosPrinterRuledLineCapabilities {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PosPrinterRuledLineCapabilities").field(&self.0).finish()
@@ -14700,6 +14540,7 @@ unsafe impl ::core::marker::Send for PosPrinterStatus {}
 unsafe impl ::core::marker::Sync for PosPrinterStatus {}
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PosPrinterStatusKind(pub i32);
 impl PosPrinterStatusKind {
     pub const Online: Self = Self(0i32);
@@ -14717,12 +14558,6 @@ impl ::core::clone::Clone for PosPrinterStatusKind {
 unsafe impl ::windows::core::Abi for PosPrinterStatusKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PosPrinterStatusKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PosPrinterStatusKind {}
 impl ::core::fmt::Debug for PosPrinterStatusKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PosPrinterStatusKind").field(&self.0).finish()
@@ -16199,6 +16034,7 @@ unsafe impl ::core::marker::Send for UnifiedPosErrorData {}
 unsafe impl ::core::marker::Sync for UnifiedPosErrorData {}
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UnifiedPosErrorReason(pub i32);
 impl UnifiedPosErrorReason {
     pub const UnknownErrorReason: Self = Self(0i32);
@@ -16222,12 +16058,6 @@ impl ::core::clone::Clone for UnifiedPosErrorReason {
 unsafe impl ::windows::core::Abi for UnifiedPosErrorReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UnifiedPosErrorReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UnifiedPosErrorReason {}
 impl ::core::fmt::Debug for UnifiedPosErrorReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UnifiedPosErrorReason").field(&self.0).finish()
@@ -16241,6 +16071,7 @@ impl ::windows::core::DefaultType for UnifiedPosErrorReason {
 }
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UnifiedPosErrorSeverity(pub i32);
 impl UnifiedPosErrorSeverity {
     pub const UnknownErrorSeverity: Self = Self(0i32);
@@ -16259,12 +16090,6 @@ impl ::core::clone::Clone for UnifiedPosErrorSeverity {
 unsafe impl ::windows::core::Abi for UnifiedPosErrorSeverity {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UnifiedPosErrorSeverity {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UnifiedPosErrorSeverity {}
 impl ::core::fmt::Debug for UnifiedPosErrorSeverity {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UnifiedPosErrorSeverity").field(&self.0).finish()
@@ -16278,6 +16103,7 @@ impl ::windows::core::DefaultType for UnifiedPosErrorSeverity {
 }
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UnifiedPosHealthCheckLevel(pub i32);
 impl UnifiedPosHealthCheckLevel {
     pub const UnknownHealthCheckLevel: Self = Self(0i32);
@@ -16294,12 +16120,6 @@ impl ::core::clone::Clone for UnifiedPosHealthCheckLevel {
 unsafe impl ::windows::core::Abi for UnifiedPosHealthCheckLevel {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UnifiedPosHealthCheckLevel {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UnifiedPosHealthCheckLevel {}
 impl ::core::fmt::Debug for UnifiedPosHealthCheckLevel {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UnifiedPosHealthCheckLevel").field(&self.0).finish()
@@ -16313,6 +16133,7 @@ impl ::windows::core::DefaultType for UnifiedPosHealthCheckLevel {
 }
 #[doc = "*Required features: 'Devices_PointOfService'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UnifiedPosPowerReportingType(pub i32);
 impl UnifiedPosPowerReportingType {
     pub const UnknownPowerReportingType: Self = Self(0i32);
@@ -16328,12 +16149,6 @@ impl ::core::clone::Clone for UnifiedPosPowerReportingType {
 unsafe impl ::windows::core::Abi for UnifiedPosPowerReportingType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UnifiedPosPowerReportingType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UnifiedPosPowerReportingType {}
 impl ::core::fmt::Debug for UnifiedPosPowerReportingType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UnifiedPosPowerReportingType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Portable/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Portable/mod.rs
@@ -66,6 +66,7 @@ impl ::windows::core::RuntimeName for ServiceDevice {
 }
 #[doc = "*Required features: 'Devices_Portable'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ServiceDeviceType(pub i32);
 impl ServiceDeviceType {
     pub const CalendarService: Self = Self(0i32);
@@ -85,12 +86,6 @@ impl ::core::clone::Clone for ServiceDeviceType {
 unsafe impl ::windows::core::Abi for ServiceDeviceType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ServiceDeviceType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ServiceDeviceType {}
 impl ::core::fmt::Debug for ServiceDeviceType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ServiceDeviceType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Printers/Extensions/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Printers/Extensions/mod.rs
@@ -336,6 +336,7 @@ unsafe impl ::core::marker::Send for Print3DWorkflow {}
 unsafe impl ::core::marker::Sync for Print3DWorkflow {}
 #[doc = "*Required features: 'Devices_Printers_Extensions'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct Print3DWorkflowDetail(pub i32);
 impl Print3DWorkflowDetail {
     pub const Unknown: Self = Self(0i32);
@@ -355,12 +356,6 @@ impl ::core::clone::Clone for Print3DWorkflowDetail {
 unsafe impl ::windows::core::Abi for Print3DWorkflowDetail {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for Print3DWorkflowDetail {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for Print3DWorkflowDetail {}
 impl ::core::fmt::Debug for Print3DWorkflowDetail {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("Print3DWorkflowDetail").field(&self.0).finish()
@@ -551,6 +546,7 @@ unsafe impl ::core::marker::Send for Print3DWorkflowPrinterChangedEventArgs {}
 unsafe impl ::core::marker::Sync for Print3DWorkflowPrinterChangedEventArgs {}
 #[doc = "*Required features: 'Devices_Printers_Extensions'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct Print3DWorkflowStatus(pub i32);
 impl Print3DWorkflowStatus {
     pub const Abandoned: Self = Self(0i32);
@@ -568,12 +564,6 @@ impl ::core::clone::Clone for Print3DWorkflowStatus {
 unsafe impl ::windows::core::Abi for Print3DWorkflowStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for Print3DWorkflowStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for Print3DWorkflowStatus {}
 impl ::core::fmt::Debug for Print3DWorkflowStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("Print3DWorkflowStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Printers/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Printers/mod.rs
@@ -475,6 +475,7 @@ unsafe impl ::core::marker::Send for IppAttributeError {}
 unsafe impl ::core::marker::Sync for IppAttributeError {}
 #[doc = "*Required features: 'Devices_Printers'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct IppAttributeErrorReason(pub i32);
 impl IppAttributeErrorReason {
     pub const RequestEntityTooLarge: Self = Self(0i32);
@@ -492,12 +493,6 @@ impl ::core::clone::Clone for IppAttributeErrorReason {
 unsafe impl ::windows::core::Abi for IppAttributeErrorReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IppAttributeErrorReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for IppAttributeErrorReason {}
 impl ::core::fmt::Debug for IppAttributeErrorReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IppAttributeErrorReason").field(&self.0).finish()
@@ -1054,6 +1049,7 @@ unsafe impl ::core::marker::Send for IppAttributeValue {}
 unsafe impl ::core::marker::Sync for IppAttributeValue {}
 #[doc = "*Required features: 'Devices_Printers'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct IppAttributeValueKind(pub i32);
 impl IppAttributeValueKind {
     pub const Unsupported: Self = Self(0i32);
@@ -1087,12 +1083,6 @@ impl ::core::clone::Clone for IppAttributeValueKind {
 unsafe impl ::windows::core::Abi for IppAttributeValueKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IppAttributeValueKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for IppAttributeValueKind {}
 impl ::core::fmt::Debug for IppAttributeValueKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IppAttributeValueKind").field(&self.0).finish()
@@ -1442,6 +1432,7 @@ unsafe impl ::core::marker::Send for IppResolution {}
 unsafe impl ::core::marker::Sync for IppResolution {}
 #[doc = "*Required features: 'Devices_Printers'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct IppResolutionUnit(pub i32);
 impl IppResolutionUnit {
     pub const DotsPerInch: Self = Self(0i32);
@@ -1456,12 +1447,6 @@ impl ::core::clone::Clone for IppResolutionUnit {
 unsafe impl ::windows::core::Abi for IppResolutionUnit {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IppResolutionUnit {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for IppResolutionUnit {}
 impl ::core::fmt::Debug for IppResolutionUnit {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IppResolutionUnit").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Pwm/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Pwm/mod.rs
@@ -441,6 +441,7 @@ unsafe impl ::core::marker::Send for PwmPin {}
 unsafe impl ::core::marker::Sync for PwmPin {}
 #[doc = "*Required features: 'Devices_Pwm'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PwmPulsePolarity(pub i32);
 impl PwmPulsePolarity {
     pub const ActiveHigh: Self = Self(0i32);
@@ -455,12 +456,6 @@ impl ::core::clone::Clone for PwmPulsePolarity {
 unsafe impl ::windows::core::Abi for PwmPulsePolarity {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PwmPulsePolarity {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PwmPulsePolarity {}
 impl ::core::fmt::Debug for PwmPulsePolarity {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PwmPulsePolarity").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Radios/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Radios/mod.rs
@@ -208,6 +208,7 @@ unsafe impl ::core::marker::Send for Radio {}
 unsafe impl ::core::marker::Sync for Radio {}
 #[doc = "*Required features: 'Devices_Radios'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RadioAccessStatus(pub i32);
 impl RadioAccessStatus {
     pub const Unspecified: Self = Self(0i32);
@@ -224,12 +225,6 @@ impl ::core::clone::Clone for RadioAccessStatus {
 unsafe impl ::windows::core::Abi for RadioAccessStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RadioAccessStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RadioAccessStatus {}
 impl ::core::fmt::Debug for RadioAccessStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RadioAccessStatus").field(&self.0).finish()
@@ -243,6 +238,7 @@ impl ::windows::core::DefaultType for RadioAccessStatus {
 }
 #[doc = "*Required features: 'Devices_Radios'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RadioKind(pub i32);
 impl RadioKind {
     pub const Other: Self = Self(0i32);
@@ -260,12 +256,6 @@ impl ::core::clone::Clone for RadioKind {
 unsafe impl ::windows::core::Abi for RadioKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RadioKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RadioKind {}
 impl ::core::fmt::Debug for RadioKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RadioKind").field(&self.0).finish()
@@ -279,6 +269,7 @@ impl ::windows::core::DefaultType for RadioKind {
 }
 #[doc = "*Required features: 'Devices_Radios'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RadioState(pub i32);
 impl RadioState {
     pub const Unknown: Self = Self(0i32);
@@ -295,12 +286,6 @@ impl ::core::clone::Clone for RadioState {
 unsafe impl ::windows::core::Abi for RadioState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RadioState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RadioState {}
 impl ::core::fmt::Debug for RadioState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RadioState").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Scanners/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Scanners/mod.rs
@@ -909,6 +909,7 @@ unsafe impl ::core::marker::Send for ImageScannerAutoConfiguration {}
 unsafe impl ::core::marker::Sync for ImageScannerAutoConfiguration {}
 #[doc = "*Required features: 'Devices_Scanners'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ImageScannerAutoCroppingMode(pub i32);
 impl ImageScannerAutoCroppingMode {
     pub const Disabled: Self = Self(0i32);
@@ -924,12 +925,6 @@ impl ::core::clone::Clone for ImageScannerAutoCroppingMode {
 unsafe impl ::windows::core::Abi for ImageScannerAutoCroppingMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ImageScannerAutoCroppingMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ImageScannerAutoCroppingMode {}
 impl ::core::fmt::Debug for ImageScannerAutoCroppingMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ImageScannerAutoCroppingMode").field(&self.0).finish()
@@ -943,6 +938,7 @@ impl ::windows::core::DefaultType for ImageScannerAutoCroppingMode {
 }
 #[doc = "*Required features: 'Devices_Scanners'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ImageScannerColorMode(pub i32);
 impl ImageScannerColorMode {
     pub const Color: Self = Self(0i32);
@@ -959,12 +955,6 @@ impl ::core::clone::Clone for ImageScannerColorMode {
 unsafe impl ::windows::core::Abi for ImageScannerColorMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ImageScannerColorMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ImageScannerColorMode {}
 impl ::core::fmt::Debug for ImageScannerColorMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ImageScannerColorMode").field(&self.0).finish()
@@ -1830,6 +1820,7 @@ unsafe impl ::core::marker::Send for ImageScannerFlatbedConfiguration {}
 unsafe impl ::core::marker::Sync for ImageScannerFlatbedConfiguration {}
 #[doc = "*Required features: 'Devices_Scanners'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ImageScannerFormat(pub i32);
 impl ImageScannerFormat {
     pub const Jpeg: Self = Self(0i32);
@@ -1849,12 +1840,6 @@ impl ::core::clone::Clone for ImageScannerFormat {
 unsafe impl ::windows::core::Abi for ImageScannerFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ImageScannerFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ImageScannerFormat {}
 impl ::core::fmt::Debug for ImageScannerFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ImageScannerFormat").field(&self.0).finish()
@@ -2076,6 +2061,7 @@ unsafe impl ::core::marker::Send for ImageScannerScanResult {}
 unsafe impl ::core::marker::Sync for ImageScannerScanResult {}
 #[doc = "*Required features: 'Devices_Scanners'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ImageScannerScanSource(pub i32);
 impl ImageScannerScanSource {
     pub const Default: Self = Self(0i32);
@@ -2092,12 +2078,6 @@ impl ::core::clone::Clone for ImageScannerScanSource {
 unsafe impl ::windows::core::Abi for ImageScannerScanSource {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ImageScannerScanSource {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ImageScannerScanSource {}
 impl ::core::fmt::Debug for ImageScannerScanSource {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ImageScannerScanSource").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Sensors/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Sensors/mod.rs
@@ -556,6 +556,7 @@ unsafe impl ::core::marker::Send for AccelerometerReadingChangedEventArgs {}
 unsafe impl ::core::marker::Sync for AccelerometerReadingChangedEventArgs {}
 #[doc = "*Required features: 'Devices_Sensors'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AccelerometerReadingType(pub i32);
 impl AccelerometerReadingType {
     pub const Standard: Self = Self(0i32);
@@ -571,12 +572,6 @@ impl ::core::clone::Clone for AccelerometerReadingType {
 unsafe impl ::windows::core::Abi for AccelerometerReadingType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AccelerometerReadingType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AccelerometerReadingType {}
 impl ::core::fmt::Debug for AccelerometerReadingType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AccelerometerReadingType").field(&self.0).finish()
@@ -1115,6 +1110,7 @@ unsafe impl ::core::marker::Send for ActivitySensorReadingChangedEventArgs {}
 unsafe impl ::core::marker::Sync for ActivitySensorReadingChangedEventArgs {}
 #[doc = "*Required features: 'Devices_Sensors'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ActivitySensorReadingConfidence(pub i32);
 impl ActivitySensorReadingConfidence {
     pub const High: Self = Self(0i32);
@@ -1129,12 +1125,6 @@ impl ::core::clone::Clone for ActivitySensorReadingConfidence {
 unsafe impl ::windows::core::Abi for ActivitySensorReadingConfidence {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ActivitySensorReadingConfidence {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ActivitySensorReadingConfidence {}
 impl ::core::fmt::Debug for ActivitySensorReadingConfidence {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ActivitySensorReadingConfidence").field(&self.0).finish()
@@ -1230,6 +1220,7 @@ unsafe impl ::core::marker::Send for ActivitySensorTriggerDetails {}
 unsafe impl ::core::marker::Sync for ActivitySensorTriggerDetails {}
 #[doc = "*Required features: 'Devices_Sensors'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ActivityType(pub i32);
 impl ActivityType {
     pub const Unknown: Self = Self(0i32);
@@ -1250,12 +1241,6 @@ impl ::core::clone::Clone for ActivityType {
 unsafe impl ::windows::core::Abi for ActivityType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ActivityType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ActivityType {}
 impl ::core::fmt::Debug for ActivityType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ActivityType").field(&self.0).finish()
@@ -7412,6 +7397,7 @@ unsafe impl ::core::marker::Send for Magnetometer {}
 unsafe impl ::core::marker::Sync for Magnetometer {}
 #[doc = "*Required features: 'Devices_Sensors'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MagnetometerAccuracy(pub i32);
 impl MagnetometerAccuracy {
     pub const Unknown: Self = Self(0i32);
@@ -7428,12 +7414,6 @@ impl ::core::clone::Clone for MagnetometerAccuracy {
 unsafe impl ::windows::core::Abi for MagnetometerAccuracy {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MagnetometerAccuracy {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MagnetometerAccuracy {}
 impl ::core::fmt::Debug for MagnetometerAccuracy {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MagnetometerAccuracy").field(&self.0).finish()
@@ -8702,6 +8682,7 @@ unsafe impl ::core::marker::Send for PedometerReadingChangedEventArgs {}
 unsafe impl ::core::marker::Sync for PedometerReadingChangedEventArgs {}
 #[doc = "*Required features: 'Devices_Sensors'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PedometerStepKind(pub i32);
 impl PedometerStepKind {
     pub const Unknown: Self = Self(0i32);
@@ -8717,12 +8698,6 @@ impl ::core::clone::Clone for PedometerStepKind {
 unsafe impl ::windows::core::Abi for PedometerStepKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PedometerStepKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PedometerStepKind {}
 impl ::core::fmt::Debug for PedometerStepKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PedometerStepKind").field(&self.0).finish()
@@ -9399,6 +9374,7 @@ unsafe impl ::core::marker::Send for SensorDataThresholdTriggerDetails {}
 unsafe impl ::core::marker::Sync for SensorDataThresholdTriggerDetails {}
 #[doc = "*Required features: 'Devices_Sensors'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SensorOptimizationGoal(pub i32);
 impl SensorOptimizationGoal {
     pub const Precision: Self = Self(0i32);
@@ -9413,12 +9389,6 @@ impl ::core::clone::Clone for SensorOptimizationGoal {
 unsafe impl ::windows::core::Abi for SensorOptimizationGoal {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SensorOptimizationGoal {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SensorOptimizationGoal {}
 impl ::core::fmt::Debug for SensorOptimizationGoal {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SensorOptimizationGoal").field(&self.0).finish()
@@ -9537,6 +9507,7 @@ unsafe impl ::core::marker::Send for SensorQuaternion {}
 unsafe impl ::core::marker::Sync for SensorQuaternion {}
 #[doc = "*Required features: 'Devices_Sensors'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SensorReadingType(pub i32);
 impl SensorReadingType {
     pub const Absolute: Self = Self(0i32);
@@ -9551,12 +9522,6 @@ impl ::core::clone::Clone for SensorReadingType {
 unsafe impl ::windows::core::Abi for SensorReadingType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SensorReadingType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SensorReadingType {}
 impl ::core::fmt::Debug for SensorReadingType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SensorReadingType").field(&self.0).finish()
@@ -9715,6 +9680,7 @@ unsafe impl ::core::marker::Send for SensorRotationMatrix {}
 unsafe impl ::core::marker::Sync for SensorRotationMatrix {}
 #[doc = "*Required features: 'Devices_Sensors'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SensorType(pub i32);
 impl SensorType {
     pub const Accelerometer: Self = Self(0i32);
@@ -9741,12 +9707,6 @@ impl ::core::clone::Clone for SensorType {
 unsafe impl ::windows::core::Abi for SensorType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SensorType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SensorType {}
 impl ::core::fmt::Debug for SensorType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SensorType").field(&self.0).finish()
@@ -9760,6 +9720,7 @@ impl ::windows::core::DefaultType for SensorType {
 }
 #[doc = "*Required features: 'Devices_Sensors'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SimpleOrientation(pub i32);
 impl SimpleOrientation {
     pub const NotRotated: Self = Self(0i32);
@@ -9778,12 +9739,6 @@ impl ::core::clone::Clone for SimpleOrientation {
 unsafe impl ::windows::core::Abi for SimpleOrientation {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SimpleOrientation {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SimpleOrientation {}
 impl ::core::fmt::Debug for SimpleOrientation {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SimpleOrientation").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/SerialCommunication/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/SerialCommunication/mod.rs
@@ -658,6 +658,7 @@ unsafe impl ::core::marker::Send for SerialDevice {}
 unsafe impl ::core::marker::Sync for SerialDevice {}
 #[doc = "*Required features: 'Devices_SerialCommunication'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SerialError(pub i32);
 impl SerialError {
     pub const Frame: Self = Self(0i32);
@@ -675,12 +676,6 @@ impl ::core::clone::Clone for SerialError {
 unsafe impl ::windows::core::Abi for SerialError {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SerialError {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SerialError {}
 impl ::core::fmt::Debug for SerialError {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SerialError").field(&self.0).finish()
@@ -694,6 +689,7 @@ impl ::windows::core::DefaultType for SerialError {
 }
 #[doc = "*Required features: 'Devices_SerialCommunication'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SerialHandshake(pub i32);
 impl SerialHandshake {
     pub const None: Self = Self(0i32);
@@ -710,12 +706,6 @@ impl ::core::clone::Clone for SerialHandshake {
 unsafe impl ::windows::core::Abi for SerialHandshake {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SerialHandshake {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SerialHandshake {}
 impl ::core::fmt::Debug for SerialHandshake {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SerialHandshake").field(&self.0).finish()
@@ -729,6 +719,7 @@ impl ::windows::core::DefaultType for SerialHandshake {
 }
 #[doc = "*Required features: 'Devices_SerialCommunication'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SerialParity(pub i32);
 impl SerialParity {
     pub const None: Self = Self(0i32);
@@ -746,12 +737,6 @@ impl ::core::clone::Clone for SerialParity {
 unsafe impl ::windows::core::Abi for SerialParity {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SerialParity {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SerialParity {}
 impl ::core::fmt::Debug for SerialParity {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SerialParity").field(&self.0).finish()
@@ -765,6 +750,7 @@ impl ::windows::core::DefaultType for SerialParity {
 }
 #[doc = "*Required features: 'Devices_SerialCommunication'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SerialPinChange(pub i32);
 impl SerialPinChange {
     pub const BreakSignal: Self = Self(0i32);
@@ -782,12 +768,6 @@ impl ::core::clone::Clone for SerialPinChange {
 unsafe impl ::windows::core::Abi for SerialPinChange {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SerialPinChange {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SerialPinChange {}
 impl ::core::fmt::Debug for SerialPinChange {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SerialPinChange").field(&self.0).finish()
@@ -801,6 +781,7 @@ impl ::windows::core::DefaultType for SerialPinChange {
 }
 #[doc = "*Required features: 'Devices_SerialCommunication'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SerialStopBitCount(pub i32);
 impl SerialStopBitCount {
     pub const One: Self = Self(0i32);
@@ -816,12 +797,6 @@ impl ::core::clone::Clone for SerialStopBitCount {
 unsafe impl ::windows::core::Abi for SerialStopBitCount {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SerialStopBitCount {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SerialStopBitCount {}
 impl ::core::fmt::Debug for SerialStopBitCount {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SerialStopBitCount").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/SmartCards/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/SmartCards/mod.rs
@@ -1503,6 +1503,7 @@ unsafe impl ::core::marker::Send for SmartCard {}
 unsafe impl ::core::marker::Sync for SmartCard {}
 #[doc = "*Required features: 'Devices_SmartCards'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmartCardActivationPolicyChangeResult(pub i32);
 impl SmartCardActivationPolicyChangeResult {
     pub const Denied: Self = Self(0i32);
@@ -1517,12 +1518,6 @@ impl ::core::clone::Clone for SmartCardActivationPolicyChangeResult {
 unsafe impl ::windows::core::Abi for SmartCardActivationPolicyChangeResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmartCardActivationPolicyChangeResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmartCardActivationPolicyChangeResult {}
 impl ::core::fmt::Debug for SmartCardActivationPolicyChangeResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmartCardActivationPolicyChangeResult").field(&self.0).finish()
@@ -1752,6 +1747,7 @@ unsafe impl ::core::marker::Send for SmartCardAppletIdGroup {}
 unsafe impl ::core::marker::Sync for SmartCardAppletIdGroup {}
 #[doc = "*Required features: 'Devices_SmartCards'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmartCardAppletIdGroupActivationPolicy(pub i32);
 impl SmartCardAppletIdGroupActivationPolicy {
     pub const Disabled: Self = Self(0i32);
@@ -1767,12 +1763,6 @@ impl ::core::clone::Clone for SmartCardAppletIdGroupActivationPolicy {
 unsafe impl ::windows::core::Abi for SmartCardAppletIdGroupActivationPolicy {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmartCardAppletIdGroupActivationPolicy {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmartCardAppletIdGroupActivationPolicy {}
 impl ::core::fmt::Debug for SmartCardAppletIdGroupActivationPolicy {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmartCardAppletIdGroupActivationPolicy").field(&self.0).finish()
@@ -2120,6 +2110,7 @@ unsafe impl ::core::marker::Send for SmartCardAutomaticResponseApdu {}
 unsafe impl ::core::marker::Sync for SmartCardAutomaticResponseApdu {}
 #[doc = "*Required features: 'Devices_SmartCards'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmartCardAutomaticResponseStatus(pub i32);
 impl SmartCardAutomaticResponseStatus {
     pub const None: Self = Self(0i32);
@@ -2135,12 +2126,6 @@ impl ::core::clone::Clone for SmartCardAutomaticResponseStatus {
 unsafe impl ::windows::core::Abi for SmartCardAutomaticResponseStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmartCardAutomaticResponseStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmartCardAutomaticResponseStatus {}
 impl ::core::fmt::Debug for SmartCardAutomaticResponseStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmartCardAutomaticResponseStatus").field(&self.0).finish()
@@ -2418,6 +2403,7 @@ unsafe impl ::core::marker::Send for SmartCardConnection {}
 unsafe impl ::core::marker::Sync for SmartCardConnection {}
 #[doc = "*Required features: 'Devices_SmartCards'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmartCardCryptogramAlgorithm(pub i32);
 impl SmartCardCryptogramAlgorithm {
     pub const None: Self = Self(0i32);
@@ -2439,12 +2425,6 @@ impl ::core::clone::Clone for SmartCardCryptogramAlgorithm {
 unsafe impl ::windows::core::Abi for SmartCardCryptogramAlgorithm {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmartCardCryptogramAlgorithm {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmartCardCryptogramAlgorithm {}
 impl ::core::fmt::Debug for SmartCardCryptogramAlgorithm {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmartCardCryptogramAlgorithm").field(&self.0).finish()
@@ -2709,6 +2689,7 @@ unsafe impl ::core::marker::Send for SmartCardCryptogramGenerator {}
 unsafe impl ::core::marker::Sync for SmartCardCryptogramGenerator {}
 #[doc = "*Required features: 'Devices_SmartCards'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmartCardCryptogramGeneratorOperationStatus(pub i32);
 impl SmartCardCryptogramGeneratorOperationStatus {
     pub const Success: Self = Self(0i32);
@@ -2735,12 +2716,6 @@ impl ::core::clone::Clone for SmartCardCryptogramGeneratorOperationStatus {
 unsafe impl ::windows::core::Abi for SmartCardCryptogramGeneratorOperationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmartCardCryptogramGeneratorOperationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmartCardCryptogramGeneratorOperationStatus {}
 impl ::core::fmt::Debug for SmartCardCryptogramGeneratorOperationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmartCardCryptogramGeneratorOperationStatus").field(&self.0).finish()
@@ -3305,6 +3280,7 @@ unsafe impl ::core::marker::Send for SmartCardCryptogramMaterialPackageCharacter
 unsafe impl ::core::marker::Sync for SmartCardCryptogramMaterialPackageCharacteristics {}
 #[doc = "*Required features: 'Devices_SmartCards'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmartCardCryptogramMaterialPackageConfirmationResponseFormat(pub i32);
 impl SmartCardCryptogramMaterialPackageConfirmationResponseFormat {
     pub const None: Self = Self(0i32);
@@ -3319,12 +3295,6 @@ impl ::core::clone::Clone for SmartCardCryptogramMaterialPackageConfirmationResp
 unsafe impl ::windows::core::Abi for SmartCardCryptogramMaterialPackageConfirmationResponseFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmartCardCryptogramMaterialPackageConfirmationResponseFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmartCardCryptogramMaterialPackageConfirmationResponseFormat {}
 impl ::core::fmt::Debug for SmartCardCryptogramMaterialPackageConfirmationResponseFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmartCardCryptogramMaterialPackageConfirmationResponseFormat").field(&self.0).finish()
@@ -3338,6 +3308,7 @@ impl ::windows::core::DefaultType for SmartCardCryptogramMaterialPackageConfirma
 }
 #[doc = "*Required features: 'Devices_SmartCards'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmartCardCryptogramMaterialPackageFormat(pub i32);
 impl SmartCardCryptogramMaterialPackageFormat {
     pub const None: Self = Self(0i32);
@@ -3352,12 +3323,6 @@ impl ::core::clone::Clone for SmartCardCryptogramMaterialPackageFormat {
 unsafe impl ::windows::core::Abi for SmartCardCryptogramMaterialPackageFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmartCardCryptogramMaterialPackageFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmartCardCryptogramMaterialPackageFormat {}
 impl ::core::fmt::Debug for SmartCardCryptogramMaterialPackageFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmartCardCryptogramMaterialPackageFormat").field(&self.0).finish()
@@ -3461,6 +3426,7 @@ unsafe impl ::core::marker::Send for SmartCardCryptogramMaterialPossessionProof 
 unsafe impl ::core::marker::Sync for SmartCardCryptogramMaterialPossessionProof {}
 #[doc = "*Required features: 'Devices_SmartCards'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmartCardCryptogramMaterialProtectionMethod(pub i32);
 impl SmartCardCryptogramMaterialProtectionMethod {
     pub const None: Self = Self(0i32);
@@ -3475,12 +3441,6 @@ impl ::core::clone::Clone for SmartCardCryptogramMaterialProtectionMethod {
 unsafe impl ::windows::core::Abi for SmartCardCryptogramMaterialProtectionMethod {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmartCardCryptogramMaterialProtectionMethod {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmartCardCryptogramMaterialProtectionMethod {}
 impl ::core::fmt::Debug for SmartCardCryptogramMaterialProtectionMethod {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmartCardCryptogramMaterialProtectionMethod").field(&self.0).finish()
@@ -3494,6 +3454,7 @@ impl ::windows::core::DefaultType for SmartCardCryptogramMaterialProtectionMetho
 }
 #[doc = "*Required features: 'Devices_SmartCards'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmartCardCryptogramMaterialType(pub i32);
 impl SmartCardCryptogramMaterialType {
     pub const None: Self = Self(0i32);
@@ -3511,12 +3472,6 @@ impl ::core::clone::Clone for SmartCardCryptogramMaterialType {
 unsafe impl ::windows::core::Abi for SmartCardCryptogramMaterialType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmartCardCryptogramMaterialType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmartCardCryptogramMaterialType {}
 impl ::core::fmt::Debug for SmartCardCryptogramMaterialType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmartCardCryptogramMaterialType").field(&self.0).finish()
@@ -3530,6 +3485,7 @@ impl ::windows::core::DefaultType for SmartCardCryptogramMaterialType {
 }
 #[doc = "*Required features: 'Devices_SmartCards'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmartCardCryptogramPlacementOptions(pub u32);
 impl SmartCardCryptogramPlacementOptions {
     pub const None: Self = Self(0u32);
@@ -3545,12 +3501,6 @@ impl ::core::clone::Clone for SmartCardCryptogramPlacementOptions {
 unsafe impl ::windows::core::Abi for SmartCardCryptogramPlacementOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmartCardCryptogramPlacementOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmartCardCryptogramPlacementOptions {}
 impl ::core::fmt::Debug for SmartCardCryptogramPlacementOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmartCardCryptogramPlacementOptions").field(&self.0).finish()
@@ -3791,6 +3741,7 @@ unsafe impl ::core::marker::Send for SmartCardCryptogramPlacementStep {}
 unsafe impl ::core::marker::Sync for SmartCardCryptogramPlacementStep {}
 #[doc = "*Required features: 'Devices_SmartCards'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmartCardCryptogramStorageKeyAlgorithm(pub i32);
 impl SmartCardCryptogramStorageKeyAlgorithm {
     pub const None: Self = Self(0i32);
@@ -3805,12 +3756,6 @@ impl ::core::clone::Clone for SmartCardCryptogramStorageKeyAlgorithm {
 unsafe impl ::windows::core::Abi for SmartCardCryptogramStorageKeyAlgorithm {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmartCardCryptogramStorageKeyAlgorithm {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmartCardCryptogramStorageKeyAlgorithm {}
 impl ::core::fmt::Debug for SmartCardCryptogramStorageKeyAlgorithm {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmartCardCryptogramStorageKeyAlgorithm").field(&self.0).finish()
@@ -3824,6 +3769,7 @@ impl ::windows::core::DefaultType for SmartCardCryptogramStorageKeyAlgorithm {
 }
 #[doc = "*Required features: 'Devices_SmartCards'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmartCardCryptogramStorageKeyCapabilities(pub u32);
 impl SmartCardCryptogramStorageKeyCapabilities {
     pub const None: Self = Self(0u32);
@@ -3839,12 +3785,6 @@ impl ::core::clone::Clone for SmartCardCryptogramStorageKeyCapabilities {
 unsafe impl ::windows::core::Abi for SmartCardCryptogramStorageKeyCapabilities {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmartCardCryptogramStorageKeyCapabilities {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmartCardCryptogramStorageKeyCapabilities {}
 impl ::core::fmt::Debug for SmartCardCryptogramStorageKeyCapabilities {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmartCardCryptogramStorageKeyCapabilities").field(&self.0).finish()
@@ -4140,6 +4080,7 @@ unsafe impl ::core::marker::Send for SmartCardCryptogramStorageKeyInfo {}
 unsafe impl ::core::marker::Sync for SmartCardCryptogramStorageKeyInfo {}
 #[doc = "*Required features: 'Devices_SmartCards'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmartCardCryptographicKeyAttestationStatus(pub i32);
 impl SmartCardCryptographicKeyAttestationStatus {
     pub const NoAttestation: Self = Self(0i32);
@@ -4160,12 +4101,6 @@ impl ::core::clone::Clone for SmartCardCryptographicKeyAttestationStatus {
 unsafe impl ::windows::core::Abi for SmartCardCryptographicKeyAttestationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmartCardCryptographicKeyAttestationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmartCardCryptographicKeyAttestationStatus {}
 impl ::core::fmt::Debug for SmartCardCryptographicKeyAttestationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmartCardCryptographicKeyAttestationStatus").field(&self.0).finish()
@@ -4179,6 +4114,7 @@ impl ::windows::core::DefaultType for SmartCardCryptographicKeyAttestationStatus
 }
 #[doc = "*Required features: 'Devices_SmartCards'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmartCardEmulationCategory(pub i32);
 impl SmartCardEmulationCategory {
     pub const Other: Self = Self(0i32);
@@ -4193,12 +4129,6 @@ impl ::core::clone::Clone for SmartCardEmulationCategory {
 unsafe impl ::windows::core::Abi for SmartCardEmulationCategory {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmartCardEmulationCategory {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmartCardEmulationCategory {}
 impl ::core::fmt::Debug for SmartCardEmulationCategory {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmartCardEmulationCategory").field(&self.0).finish()
@@ -4212,6 +4142,7 @@ impl ::windows::core::DefaultType for SmartCardEmulationCategory {
 }
 #[doc = "*Required features: 'Devices_SmartCards'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmartCardEmulationType(pub i32);
 impl SmartCardEmulationType {
     pub const Host: Self = Self(0i32);
@@ -4227,12 +4158,6 @@ impl ::core::clone::Clone for SmartCardEmulationType {
 unsafe impl ::windows::core::Abi for SmartCardEmulationType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmartCardEmulationType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmartCardEmulationType {}
 impl ::core::fmt::Debug for SmartCardEmulationType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmartCardEmulationType").field(&self.0).finish()
@@ -4662,6 +4587,7 @@ unsafe impl ::core::marker::Send for SmartCardEmulatorConnectionDeactivatedEvent
 unsafe impl ::core::marker::Sync for SmartCardEmulatorConnectionDeactivatedEventArgs {}
 #[doc = "*Required features: 'Devices_SmartCards'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmartCardEmulatorConnectionDeactivatedReason(pub i32);
 impl SmartCardEmulatorConnectionDeactivatedReason {
     pub const ConnectionLost: Self = Self(0i32);
@@ -4676,12 +4602,6 @@ impl ::core::clone::Clone for SmartCardEmulatorConnectionDeactivatedReason {
 unsafe impl ::windows::core::Abi for SmartCardEmulatorConnectionDeactivatedReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmartCardEmulatorConnectionDeactivatedReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmartCardEmulatorConnectionDeactivatedReason {}
 impl ::core::fmt::Debug for SmartCardEmulatorConnectionDeactivatedReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmartCardEmulatorConnectionDeactivatedReason").field(&self.0).finish()
@@ -4784,6 +4704,7 @@ unsafe impl ::core::marker::Send for SmartCardEmulatorConnectionProperties {}
 unsafe impl ::core::marker::Sync for SmartCardEmulatorConnectionProperties {}
 #[doc = "*Required features: 'Devices_SmartCards'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmartCardEmulatorConnectionSource(pub i32);
 impl SmartCardEmulatorConnectionSource {
     pub const Unknown: Self = Self(0i32);
@@ -4798,12 +4719,6 @@ impl ::core::clone::Clone for SmartCardEmulatorConnectionSource {
 unsafe impl ::windows::core::Abi for SmartCardEmulatorConnectionSource {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmartCardEmulatorConnectionSource {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmartCardEmulatorConnectionSource {}
 impl ::core::fmt::Debug for SmartCardEmulatorConnectionSource {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmartCardEmulatorConnectionSource").field(&self.0).finish()
@@ -4817,6 +4732,7 @@ impl ::windows::core::DefaultType for SmartCardEmulatorConnectionSource {
 }
 #[doc = "*Required features: 'Devices_SmartCards'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmartCardEmulatorEnablementPolicy(pub i32);
 impl SmartCardEmulatorEnablementPolicy {
     pub const Never: Self = Self(0i32);
@@ -4833,12 +4749,6 @@ impl ::core::clone::Clone for SmartCardEmulatorEnablementPolicy {
 unsafe impl ::windows::core::Abi for SmartCardEmulatorEnablementPolicy {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmartCardEmulatorEnablementPolicy {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmartCardEmulatorEnablementPolicy {}
 impl ::core::fmt::Debug for SmartCardEmulatorEnablementPolicy {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmartCardEmulatorEnablementPolicy").field(&self.0).finish()
@@ -4852,6 +4762,7 @@ impl ::windows::core::DefaultType for SmartCardEmulatorEnablementPolicy {
 }
 #[doc = "*Required features: 'Devices_SmartCards'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmartCardLaunchBehavior(pub i32);
 impl SmartCardLaunchBehavior {
     pub const Default: Self = Self(0i32);
@@ -4866,12 +4777,6 @@ impl ::core::clone::Clone for SmartCardLaunchBehavior {
 unsafe impl ::windows::core::Abi for SmartCardLaunchBehavior {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmartCardLaunchBehavior {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmartCardLaunchBehavior {}
 impl ::core::fmt::Debug for SmartCardLaunchBehavior {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmartCardLaunchBehavior").field(&self.0).finish()
@@ -4885,6 +4790,7 @@ impl ::windows::core::DefaultType for SmartCardLaunchBehavior {
 }
 #[doc = "*Required features: 'Devices_SmartCards'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmartCardPinCharacterPolicyOption(pub i32);
 impl SmartCardPinCharacterPolicyOption {
     pub const Allow: Self = Self(0i32);
@@ -4900,12 +4806,6 @@ impl ::core::clone::Clone for SmartCardPinCharacterPolicyOption {
 unsafe impl ::windows::core::Abi for SmartCardPinCharacterPolicyOption {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmartCardPinCharacterPolicyOption {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmartCardPinCharacterPolicyOption {}
 impl ::core::fmt::Debug for SmartCardPinCharacterPolicyOption {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmartCardPinCharacterPolicyOption").field(&self.0).finish()
@@ -5700,6 +5600,7 @@ unsafe impl ::core::marker::Send for SmartCardReader {}
 unsafe impl ::core::marker::Sync for SmartCardReader {}
 #[doc = "*Required features: 'Devices_SmartCards'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmartCardReaderKind(pub i32);
 impl SmartCardReaderKind {
     pub const Any: Self = Self(0i32);
@@ -5718,12 +5619,6 @@ impl ::core::clone::Clone for SmartCardReaderKind {
 unsafe impl ::windows::core::Abi for SmartCardReaderKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmartCardReaderKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmartCardReaderKind {}
 impl ::core::fmt::Debug for SmartCardReaderKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmartCardReaderKind").field(&self.0).finish()
@@ -5737,6 +5632,7 @@ impl ::windows::core::DefaultType for SmartCardReaderKind {
 }
 #[doc = "*Required features: 'Devices_SmartCards'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmartCardReaderStatus(pub i32);
 impl SmartCardReaderStatus {
     pub const Disconnected: Self = Self(0i32);
@@ -5752,12 +5648,6 @@ impl ::core::clone::Clone for SmartCardReaderStatus {
 unsafe impl ::windows::core::Abi for SmartCardReaderStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmartCardReaderStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmartCardReaderStatus {}
 impl ::core::fmt::Debug for SmartCardReaderStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmartCardReaderStatus").field(&self.0).finish()
@@ -5771,6 +5661,7 @@ impl ::windows::core::DefaultType for SmartCardReaderStatus {
 }
 #[doc = "*Required features: 'Devices_SmartCards'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmartCardStatus(pub i32);
 impl SmartCardStatus {
     pub const Disconnected: Self = Self(0i32);
@@ -5788,12 +5679,6 @@ impl ::core::clone::Clone for SmartCardStatus {
 unsafe impl ::windows::core::Abi for SmartCardStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmartCardStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmartCardStatus {}
 impl ::core::fmt::Debug for SmartCardStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmartCardStatus").field(&self.0).finish()
@@ -5940,6 +5825,7 @@ unsafe impl ::core::marker::Send for SmartCardTriggerDetails {}
 unsafe impl ::core::marker::Sync for SmartCardTriggerDetails {}
 #[doc = "*Required features: 'Devices_SmartCards'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmartCardTriggerType(pub i32);
 impl SmartCardTriggerType {
     pub const EmulatorTransaction: Self = Self(0i32);
@@ -5958,12 +5844,6 @@ impl ::core::clone::Clone for SmartCardTriggerType {
 unsafe impl ::windows::core::Abi for SmartCardTriggerType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmartCardTriggerType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmartCardTriggerType {}
 impl ::core::fmt::Debug for SmartCardTriggerType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmartCardTriggerType").field(&self.0).finish()
@@ -5977,6 +5857,7 @@ impl ::windows::core::DefaultType for SmartCardTriggerType {
 }
 #[doc = "*Required features: 'Devices_SmartCards'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmartCardUnlockPromptingBehavior(pub i32);
 impl SmartCardUnlockPromptingBehavior {
     pub const AllowUnlockPrompt: Self = Self(0i32);
@@ -5992,12 +5873,6 @@ impl ::core::clone::Clone for SmartCardUnlockPromptingBehavior {
 unsafe impl ::windows::core::Abi for SmartCardUnlockPromptingBehavior {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmartCardUnlockPromptingBehavior {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmartCardUnlockPromptingBehavior {}
 impl ::core::fmt::Debug for SmartCardUnlockPromptingBehavior {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmartCardUnlockPromptingBehavior").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Sms/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Sms/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'Devices_Sms'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CellularClass(pub i32);
 impl CellularClass {
     pub const None: Self = Self(0i32);
@@ -16,12 +17,6 @@ impl ::core::clone::Clone for CellularClass {
 unsafe impl ::windows::core::Abi for CellularClass {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CellularClass {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CellularClass {}
 impl ::core::fmt::Debug for CellularClass {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CellularClass").field(&self.0).finish()
@@ -3608,6 +3603,7 @@ unsafe impl ::core::marker::Send for SmsBroadcastMessage {}
 unsafe impl ::core::marker::Sync for SmsBroadcastMessage {}
 #[doc = "*Required features: 'Devices_Sms'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmsBroadcastType(pub i32);
 impl SmsBroadcastType {
     pub const Other: Self = Self(0i32);
@@ -3635,12 +3631,6 @@ impl ::core::clone::Clone for SmsBroadcastType {
 unsafe impl ::windows::core::Abi for SmsBroadcastType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmsBroadcastType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmsBroadcastType {}
 impl ::core::fmt::Debug for SmsBroadcastType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmsBroadcastType").field(&self.0).finish()
@@ -3654,6 +3644,7 @@ impl ::windows::core::DefaultType for SmsBroadcastType {
 }
 #[doc = "*Required features: 'Devices_Sms'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmsDataFormat(pub i32);
 impl SmsDataFormat {
     pub const Unknown: Self = Self(0i32);
@@ -3671,12 +3662,6 @@ impl ::core::clone::Clone for SmsDataFormat {
 unsafe impl ::windows::core::Abi for SmsDataFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmsDataFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmsDataFormat {}
 impl ::core::fmt::Debug for SmsDataFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmsDataFormat").field(&self.0).finish()
@@ -4254,6 +4239,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &SmsD
 }
 #[doc = "*Required features: 'Devices_Sms'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmsDeviceStatus(pub i32);
 impl SmsDeviceStatus {
     pub const Off: Self = Self(0i32);
@@ -4274,12 +4260,6 @@ impl ::core::clone::Clone for SmsDeviceStatus {
 unsafe impl ::windows::core::Abi for SmsDeviceStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmsDeviceStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmsDeviceStatus {}
 impl ::core::fmt::Debug for SmsDeviceStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmsDeviceStatus").field(&self.0).finish()
@@ -4426,6 +4406,7 @@ impl ::core::default::Default for SmsEncodedLength {
 }
 #[doc = "*Required features: 'Devices_Sms'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmsEncoding(pub i32);
 impl SmsEncoding {
     pub const Unknown: Self = Self(0i32);
@@ -4449,12 +4430,6 @@ impl ::core::clone::Clone for SmsEncoding {
 unsafe impl ::windows::core::Abi for SmsEncoding {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmsEncoding {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmsEncoding {}
 impl ::core::fmt::Debug for SmsEncoding {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmsEncoding").field(&self.0).finish()
@@ -4468,6 +4443,7 @@ impl ::windows::core::DefaultType for SmsEncoding {
 }
 #[doc = "*Required features: 'Devices_Sms'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmsFilterActionType(pub i32);
 impl SmsFilterActionType {
     pub const AcceptImmediately: Self = Self(0i32);
@@ -4484,12 +4460,6 @@ impl ::core::clone::Clone for SmsFilterActionType {
 unsafe impl ::windows::core::Abi for SmsFilterActionType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmsFilterActionType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmsFilterActionType {}
 impl ::core::fmt::Debug for SmsFilterActionType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmsFilterActionType").field(&self.0).finish()
@@ -4810,6 +4780,7 @@ unsafe impl ::core::marker::Send for SmsFilterRules {}
 unsafe impl ::core::marker::Sync for SmsFilterRules {}
 #[doc = "*Required features: 'Devices_Sms'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmsGeographicalScope(pub i32);
 impl SmsGeographicalScope {
     pub const None: Self = Self(0i32);
@@ -4827,12 +4798,6 @@ impl ::core::clone::Clone for SmsGeographicalScope {
 unsafe impl ::windows::core::Abi for SmsGeographicalScope {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmsGeographicalScope {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmsGeographicalScope {}
 impl ::core::fmt::Debug for SmsGeographicalScope {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmsGeographicalScope").field(&self.0).finish()
@@ -4846,6 +4811,7 @@ impl ::windows::core::DefaultType for SmsGeographicalScope {
 }
 #[doc = "*Required features: 'Devices_Sms'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmsMessageClass(pub i32);
 impl SmsMessageClass {
     pub const None: Self = Self(0i32);
@@ -4863,12 +4829,6 @@ impl ::core::clone::Clone for SmsMessageClass {
 unsafe impl ::windows::core::Abi for SmsMessageClass {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmsMessageClass {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmsMessageClass {}
 impl ::core::fmt::Debug for SmsMessageClass {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmsMessageClass").field(&self.0).finish()
@@ -4883,6 +4843,7 @@ impl ::windows::core::DefaultType for SmsMessageClass {
 #[doc = "*Required features: 'Devices_Sms', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmsMessageFilter(pub i32);
 #[cfg(feature = "deprecated")]
 impl SmsMessageFilter {
@@ -4904,14 +4865,6 @@ impl ::core::clone::Clone for SmsMessageFilter {
 unsafe impl ::windows::core::Abi for SmsMessageFilter {
     type Abi = Self;
 }
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for SmsMessageFilter {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for SmsMessageFilter {}
 #[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for SmsMessageFilter {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -5385,6 +5338,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &SmsM
 }
 #[doc = "*Required features: 'Devices_Sms'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmsMessageType(pub i32);
 impl SmsMessageType {
     pub const Binary: Self = Self(0i32);
@@ -5404,12 +5358,6 @@ impl ::core::clone::Clone for SmsMessageType {
 unsafe impl ::windows::core::Abi for SmsMessageType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmsMessageType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmsMessageType {}
 impl ::core::fmt::Debug for SmsMessageType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmsMessageType").field(&self.0).finish()
@@ -5423,6 +5371,7 @@ impl ::windows::core::DefaultType for SmsMessageType {
 }
 #[doc = "*Required features: 'Devices_Sms'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SmsModemErrorCode(pub i32);
 impl SmsModemErrorCode {
     pub const Other: Self = Self(0i32);
@@ -5447,12 +5396,6 @@ impl ::core::clone::Clone for SmsModemErrorCode {
 unsafe impl ::windows::core::Abi for SmsModemErrorCode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SmsModemErrorCode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SmsModemErrorCode {}
 impl ::core::fmt::Debug for SmsModemErrorCode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SmsModemErrorCode").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Spi/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Spi/Provider/mod.rs
@@ -524,6 +524,7 @@ unsafe impl ::core::marker::Send for ProviderSpiConnectionSettings {}
 unsafe impl ::core::marker::Sync for ProviderSpiConnectionSettings {}
 #[doc = "*Required features: 'Devices_Spi_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ProviderSpiMode(pub i32);
 impl ProviderSpiMode {
     pub const Mode0: Self = Self(0i32);
@@ -540,12 +541,6 @@ impl ::core::clone::Clone for ProviderSpiMode {
 unsafe impl ::windows::core::Abi for ProviderSpiMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ProviderSpiMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ProviderSpiMode {}
 impl ::core::fmt::Debug for ProviderSpiMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ProviderSpiMode").field(&self.0).finish()
@@ -559,6 +554,7 @@ impl ::windows::core::DefaultType for ProviderSpiMode {
 }
 #[doc = "*Required features: 'Devices_Spi_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ProviderSpiSharingMode(pub i32);
 impl ProviderSpiSharingMode {
     pub const Exclusive: Self = Self(0i32);
@@ -573,12 +569,6 @@ impl ::core::clone::Clone for ProviderSpiSharingMode {
 unsafe impl ::windows::core::Abi for ProviderSpiSharingMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ProviderSpiSharingMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ProviderSpiSharingMode {}
 impl ::core::fmt::Debug for ProviderSpiSharingMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ProviderSpiSharingMode").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Spi/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Spi/mod.rs
@@ -781,6 +781,7 @@ unsafe impl ::core::marker::Send for SpiDevice {}
 unsafe impl ::core::marker::Sync for SpiDevice {}
 #[doc = "*Required features: 'Devices_Spi'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SpiMode(pub i32);
 impl SpiMode {
     pub const Mode0: Self = Self(0i32);
@@ -797,12 +798,6 @@ impl ::core::clone::Clone for SpiMode {
 unsafe impl ::windows::core::Abi for SpiMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpiMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SpiMode {}
 impl ::core::fmt::Debug for SpiMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SpiMode").field(&self.0).finish()
@@ -816,6 +811,7 @@ impl ::windows::core::DefaultType for SpiMode {
 }
 #[doc = "*Required features: 'Devices_Spi'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SpiSharingMode(pub i32);
 impl SpiSharingMode {
     pub const Exclusive: Self = Self(0i32);
@@ -830,12 +826,6 @@ impl ::core::clone::Clone for SpiSharingMode {
 unsafe impl ::windows::core::Abi for SpiSharingMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpiSharingMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SpiSharingMode {}
 impl ::core::fmt::Debug for SpiSharingMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SpiSharingMode").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/Usb/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/Usb/mod.rs
@@ -1299,6 +1299,7 @@ unsafe impl ::core::marker::Send for UsbConfigurationDescriptor {}
 unsafe impl ::core::marker::Sync for UsbConfigurationDescriptor {}
 #[doc = "*Required features: 'Devices_Usb'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UsbControlRecipient(pub i32);
 impl UsbControlRecipient {
     pub const Device: Self = Self(0i32);
@@ -1316,12 +1317,6 @@ impl ::core::clone::Clone for UsbControlRecipient {
 unsafe impl ::windows::core::Abi for UsbControlRecipient {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UsbControlRecipient {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UsbControlRecipient {}
 impl ::core::fmt::Debug for UsbControlRecipient {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UsbControlRecipient").field(&self.0).finish()
@@ -1467,6 +1462,7 @@ unsafe impl ::core::marker::Send for UsbControlRequestType {}
 unsafe impl ::core::marker::Sync for UsbControlRequestType {}
 #[doc = "*Required features: 'Devices_Usb'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UsbControlTransferType(pub i32);
 impl UsbControlTransferType {
     pub const Standard: Self = Self(0i32);
@@ -1482,12 +1478,6 @@ impl ::core::clone::Clone for UsbControlTransferType {
 unsafe impl ::windows::core::Abi for UsbControlTransferType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UsbControlTransferType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UsbControlTransferType {}
 impl ::core::fmt::Debug for UsbControlTransferType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UsbControlTransferType").field(&self.0).finish()
@@ -2335,6 +2325,7 @@ unsafe impl ::core::marker::Send for UsbEndpointDescriptor {}
 unsafe impl ::core::marker::Sync for UsbEndpointDescriptor {}
 #[doc = "*Required features: 'Devices_Usb'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UsbEndpointType(pub i32);
 impl UsbEndpointType {
     pub const Control: Self = Self(0i32);
@@ -2351,12 +2342,6 @@ impl ::core::clone::Clone for UsbEndpointType {
 unsafe impl ::windows::core::Abi for UsbEndpointType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UsbEndpointType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UsbEndpointType {}
 impl ::core::fmt::Debug for UsbEndpointType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UsbEndpointType").field(&self.0).finish()
@@ -3291,6 +3276,7 @@ unsafe impl ::core::marker::Send for UsbInterruptOutPipe {}
 unsafe impl ::core::marker::Sync for UsbInterruptOutPipe {}
 #[doc = "*Required features: 'Devices_Usb'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UsbReadOptions(pub u32);
 impl UsbReadOptions {
     pub const None: Self = Self(0u32);
@@ -3308,12 +3294,6 @@ impl ::core::clone::Clone for UsbReadOptions {
 unsafe impl ::windows::core::Abi for UsbReadOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UsbReadOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UsbReadOptions {}
 impl ::core::fmt::Debug for UsbReadOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UsbReadOptions").field(&self.0).finish()
@@ -3513,6 +3493,7 @@ unsafe impl ::core::marker::Send for UsbSetupPacket {}
 unsafe impl ::core::marker::Sync for UsbSetupPacket {}
 #[doc = "*Required features: 'Devices_Usb'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UsbTransferDirection(pub i32);
 impl UsbTransferDirection {
     pub const Out: Self = Self(0i32);
@@ -3527,12 +3508,6 @@ impl ::core::clone::Clone for UsbTransferDirection {
 unsafe impl ::windows::core::Abi for UsbTransferDirection {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UsbTransferDirection {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UsbTransferDirection {}
 impl ::core::fmt::Debug for UsbTransferDirection {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UsbTransferDirection").field(&self.0).finish()
@@ -3546,6 +3521,7 @@ impl ::windows::core::DefaultType for UsbTransferDirection {
 }
 #[doc = "*Required features: 'Devices_Usb'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UsbWriteOptions(pub u32);
 impl UsbWriteOptions {
     pub const None: Self = Self(0u32);
@@ -3561,12 +3537,6 @@ impl ::core::clone::Clone for UsbWriteOptions {
 unsafe impl ::windows::core::Abi for UsbWriteOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UsbWriteOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UsbWriteOptions {}
 impl ::core::fmt::Debug for UsbWriteOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UsbWriteOptions").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/WiFi/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/WiFi/mod.rs
@@ -169,6 +169,7 @@ pub struct IWiFiWpsConfigurationResultVtbl(
 );
 #[doc = "*Required features: 'Devices_WiFi'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WiFiAccessStatus(pub i32);
 impl WiFiAccessStatus {
     pub const Unspecified: Self = Self(0i32);
@@ -185,12 +186,6 @@ impl ::core::clone::Clone for WiFiAccessStatus {
 unsafe impl ::windows::core::Abi for WiFiAccessStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WiFiAccessStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WiFiAccessStatus {}
 impl ::core::fmt::Debug for WiFiAccessStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WiFiAccessStatus").field(&self.0).finish()
@@ -568,6 +563,7 @@ unsafe impl ::core::marker::Send for WiFiAvailableNetwork {}
 unsafe impl ::core::marker::Sync for WiFiAvailableNetwork {}
 #[doc = "*Required features: 'Devices_WiFi'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WiFiConnectionMethod(pub i32);
 impl WiFiConnectionMethod {
     pub const Default: Self = Self(0i32);
@@ -583,12 +579,6 @@ impl ::core::clone::Clone for WiFiConnectionMethod {
 unsafe impl ::windows::core::Abi for WiFiConnectionMethod {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WiFiConnectionMethod {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WiFiConnectionMethod {}
 impl ::core::fmt::Debug for WiFiConnectionMethod {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WiFiConnectionMethod").field(&self.0).finish()
@@ -683,6 +673,7 @@ unsafe impl ::core::marker::Send for WiFiConnectionResult {}
 unsafe impl ::core::marker::Sync for WiFiConnectionResult {}
 #[doc = "*Required features: 'Devices_WiFi'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WiFiConnectionStatus(pub i32);
 impl WiFiConnectionStatus {
     pub const UnspecifiedFailure: Self = Self(0i32);
@@ -702,12 +693,6 @@ impl ::core::clone::Clone for WiFiConnectionStatus {
 unsafe impl ::windows::core::Abi for WiFiConnectionStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WiFiConnectionStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WiFiConnectionStatus {}
 impl ::core::fmt::Debug for WiFiConnectionStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WiFiConnectionStatus").field(&self.0).finish()
@@ -721,6 +706,7 @@ impl ::windows::core::DefaultType for WiFiConnectionStatus {
 }
 #[doc = "*Required features: 'Devices_WiFi'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WiFiNetworkKind(pub i32);
 impl WiFiNetworkKind {
     pub const Any: Self = Self(0i32);
@@ -736,12 +722,6 @@ impl ::core::clone::Clone for WiFiNetworkKind {
 unsafe impl ::windows::core::Abi for WiFiNetworkKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WiFiNetworkKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WiFiNetworkKind {}
 impl ::core::fmt::Debug for WiFiNetworkKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WiFiNetworkKind").field(&self.0).finish()
@@ -846,6 +826,7 @@ unsafe impl ::core::marker::Send for WiFiNetworkReport {}
 unsafe impl ::core::marker::Sync for WiFiNetworkReport {}
 #[doc = "*Required features: 'Devices_WiFi'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WiFiPhyKind(pub i32);
 impl WiFiPhyKind {
     pub const Unknown: Self = Self(0i32);
@@ -869,12 +850,6 @@ impl ::core::clone::Clone for WiFiPhyKind {
 unsafe impl ::windows::core::Abi for WiFiPhyKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WiFiPhyKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WiFiPhyKind {}
 impl ::core::fmt::Debug for WiFiPhyKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WiFiPhyKind").field(&self.0).finish()
@@ -888,6 +863,7 @@ impl ::windows::core::DefaultType for WiFiPhyKind {
 }
 #[doc = "*Required features: 'Devices_WiFi'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WiFiReconnectionKind(pub i32);
 impl WiFiReconnectionKind {
     pub const Automatic: Self = Self(0i32);
@@ -902,12 +878,6 @@ impl ::core::clone::Clone for WiFiReconnectionKind {
 unsafe impl ::windows::core::Abi for WiFiReconnectionKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WiFiReconnectionKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WiFiReconnectionKind {}
 impl ::core::fmt::Debug for WiFiReconnectionKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WiFiReconnectionKind").field(&self.0).finish()
@@ -1011,6 +981,7 @@ unsafe impl ::core::marker::Send for WiFiWpsConfigurationResult {}
 unsafe impl ::core::marker::Sync for WiFiWpsConfigurationResult {}
 #[doc = "*Required features: 'Devices_WiFi'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WiFiWpsConfigurationStatus(pub i32);
 impl WiFiWpsConfigurationStatus {
     pub const UnspecifiedFailure: Self = Self(0i32);
@@ -1026,12 +997,6 @@ impl ::core::clone::Clone for WiFiWpsConfigurationStatus {
 unsafe impl ::windows::core::Abi for WiFiWpsConfigurationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WiFiWpsConfigurationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WiFiWpsConfigurationStatus {}
 impl ::core::fmt::Debug for WiFiWpsConfigurationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WiFiWpsConfigurationStatus").field(&self.0).finish()
@@ -1045,6 +1010,7 @@ impl ::windows::core::DefaultType for WiFiWpsConfigurationStatus {
 }
 #[doc = "*Required features: 'Devices_WiFi'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WiFiWpsKind(pub i32);
 impl WiFiWpsKind {
     pub const Unknown: Self = Self(0i32);
@@ -1063,12 +1029,6 @@ impl ::core::clone::Clone for WiFiWpsKind {
 unsafe impl ::windows::core::Abi for WiFiWpsKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WiFiWpsKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WiFiWpsKind {}
 impl ::core::fmt::Debug for WiFiWpsKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WiFiWpsKind").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/WiFiDirect/Services/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/WiFiDirect/Services/mod.rs
@@ -490,6 +490,7 @@ unsafe impl ::core::marker::Send for WiFiDirectService {}
 unsafe impl ::core::marker::Sync for WiFiDirectService {}
 #[doc = "*Required features: 'Devices_WiFiDirect_Services'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WiFiDirectServiceAdvertisementStatus(pub i32);
 impl WiFiDirectServiceAdvertisementStatus {
     pub const Created: Self = Self(0i32);
@@ -506,12 +507,6 @@ impl ::core::clone::Clone for WiFiDirectServiceAdvertisementStatus {
 unsafe impl ::windows::core::Abi for WiFiDirectServiceAdvertisementStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WiFiDirectServiceAdvertisementStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WiFiDirectServiceAdvertisementStatus {}
 impl ::core::fmt::Debug for WiFiDirectServiceAdvertisementStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WiFiDirectServiceAdvertisementStatus").field(&self.0).finish()
@@ -897,6 +892,7 @@ unsafe impl ::core::marker::Send for WiFiDirectServiceAutoAcceptSessionConnected
 unsafe impl ::core::marker::Sync for WiFiDirectServiceAutoAcceptSessionConnectedEventArgs {}
 #[doc = "*Required features: 'Devices_WiFiDirect_Services'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WiFiDirectServiceConfigurationMethod(pub i32);
 impl WiFiDirectServiceConfigurationMethod {
     pub const Default: Self = Self(0i32);
@@ -912,12 +908,6 @@ impl ::core::clone::Clone for WiFiDirectServiceConfigurationMethod {
 unsafe impl ::windows::core::Abi for WiFiDirectServiceConfigurationMethod {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WiFiDirectServiceConfigurationMethod {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WiFiDirectServiceConfigurationMethod {}
 impl ::core::fmt::Debug for WiFiDirectServiceConfigurationMethod {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WiFiDirectServiceConfigurationMethod").field(&self.0).finish()
@@ -931,6 +921,7 @@ impl ::windows::core::DefaultType for WiFiDirectServiceConfigurationMethod {
 }
 #[doc = "*Required features: 'Devices_WiFiDirect_Services'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WiFiDirectServiceError(pub i32);
 impl WiFiDirectServiceError {
     pub const Success: Self = Self(0i32);
@@ -948,12 +939,6 @@ impl ::core::clone::Clone for WiFiDirectServiceError {
 unsafe impl ::windows::core::Abi for WiFiDirectServiceError {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WiFiDirectServiceError {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WiFiDirectServiceError {}
 impl ::core::fmt::Debug for WiFiDirectServiceError {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WiFiDirectServiceError").field(&self.0).finish()
@@ -967,6 +952,7 @@ impl ::windows::core::DefaultType for WiFiDirectServiceError {
 }
 #[doc = "*Required features: 'Devices_WiFiDirect_Services'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WiFiDirectServiceIPProtocol(pub i32);
 impl WiFiDirectServiceIPProtocol {
     pub const Tcp: Self = Self(6i32);
@@ -981,12 +967,6 @@ impl ::core::clone::Clone for WiFiDirectServiceIPProtocol {
 unsafe impl ::windows::core::Abi for WiFiDirectServiceIPProtocol {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WiFiDirectServiceIPProtocol {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WiFiDirectServiceIPProtocol {}
 impl ::core::fmt::Debug for WiFiDirectServiceIPProtocol {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WiFiDirectServiceIPProtocol").field(&self.0).finish()
@@ -1479,6 +1459,7 @@ unsafe impl ::core::marker::Send for WiFiDirectServiceSessionDeferredEventArgs {
 unsafe impl ::core::marker::Sync for WiFiDirectServiceSessionDeferredEventArgs {}
 #[doc = "*Required features: 'Devices_WiFiDirect_Services'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WiFiDirectServiceSessionErrorStatus(pub i32);
 impl WiFiDirectServiceSessionErrorStatus {
     pub const Ok: Self = Self(0i32);
@@ -1497,12 +1478,6 @@ impl ::core::clone::Clone for WiFiDirectServiceSessionErrorStatus {
 unsafe impl ::windows::core::Abi for WiFiDirectServiceSessionErrorStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WiFiDirectServiceSessionErrorStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WiFiDirectServiceSessionErrorStatus {}
 impl ::core::fmt::Debug for WiFiDirectServiceSessionErrorStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WiFiDirectServiceSessionErrorStatus").field(&self.0).finish()
@@ -1728,6 +1703,7 @@ unsafe impl ::core::marker::Send for WiFiDirectServiceSessionRequestedEventArgs 
 unsafe impl ::core::marker::Sync for WiFiDirectServiceSessionRequestedEventArgs {}
 #[doc = "*Required features: 'Devices_WiFiDirect_Services'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WiFiDirectServiceSessionStatus(pub i32);
 impl WiFiDirectServiceSessionStatus {
     pub const Closed: Self = Self(0i32);
@@ -1744,12 +1720,6 @@ impl ::core::clone::Clone for WiFiDirectServiceSessionStatus {
 unsafe impl ::windows::core::Abi for WiFiDirectServiceSessionStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WiFiDirectServiceSessionStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WiFiDirectServiceSessionStatus {}
 impl ::core::fmt::Debug for WiFiDirectServiceSessionStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WiFiDirectServiceSessionStatus").field(&self.0).finish()
@@ -1763,6 +1733,7 @@ impl ::windows::core::DefaultType for WiFiDirectServiceSessionStatus {
 }
 #[doc = "*Required features: 'Devices_WiFiDirect_Services'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WiFiDirectServiceStatus(pub i32);
 impl WiFiDirectServiceStatus {
     pub const Available: Self = Self(0i32);
@@ -1778,12 +1749,6 @@ impl ::core::clone::Clone for WiFiDirectServiceStatus {
 unsafe impl ::windows::core::Abi for WiFiDirectServiceStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WiFiDirectServiceStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WiFiDirectServiceStatus {}
 impl ::core::fmt::Debug for WiFiDirectServiceStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WiFiDirectServiceStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Devices/WiFiDirect/mod.rs
+++ b/crates/libs/windows/src/Windows/Devices/WiFiDirect/mod.rs
@@ -478,6 +478,7 @@ unsafe impl ::core::marker::Send for WiFiDirectAdvertisement {}
 unsafe impl ::core::marker::Sync for WiFiDirectAdvertisement {}
 #[doc = "*Required features: 'Devices_WiFiDirect'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WiFiDirectAdvertisementListenStateDiscoverability(pub i32);
 impl WiFiDirectAdvertisementListenStateDiscoverability {
     pub const None: Self = Self(0i32);
@@ -493,12 +494,6 @@ impl ::core::clone::Clone for WiFiDirectAdvertisementListenStateDiscoverability 
 unsafe impl ::windows::core::Abi for WiFiDirectAdvertisementListenStateDiscoverability {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WiFiDirectAdvertisementListenStateDiscoverability {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WiFiDirectAdvertisementListenStateDiscoverability {}
 impl ::core::fmt::Debug for WiFiDirectAdvertisementListenStateDiscoverability {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WiFiDirectAdvertisementListenStateDiscoverability").field(&self.0).finish()
@@ -633,6 +628,7 @@ unsafe impl ::core::marker::Send for WiFiDirectAdvertisementPublisher {}
 unsafe impl ::core::marker::Sync for WiFiDirectAdvertisementPublisher {}
 #[doc = "*Required features: 'Devices_WiFiDirect'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WiFiDirectAdvertisementPublisherStatus(pub i32);
 impl WiFiDirectAdvertisementPublisherStatus {
     pub const Created: Self = Self(0i32);
@@ -649,12 +645,6 @@ impl ::core::clone::Clone for WiFiDirectAdvertisementPublisherStatus {
 unsafe impl ::windows::core::Abi for WiFiDirectAdvertisementPublisherStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WiFiDirectAdvertisementPublisherStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WiFiDirectAdvertisementPublisherStatus {}
 impl ::core::fmt::Debug for WiFiDirectAdvertisementPublisherStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WiFiDirectAdvertisementPublisherStatus").field(&self.0).finish()
@@ -757,6 +747,7 @@ unsafe impl ::core::marker::Send for WiFiDirectAdvertisementPublisherStatusChang
 unsafe impl ::core::marker::Sync for WiFiDirectAdvertisementPublisherStatusChangedEventArgs {}
 #[doc = "*Required features: 'Devices_WiFiDirect'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WiFiDirectConfigurationMethod(pub i32);
 impl WiFiDirectConfigurationMethod {
     pub const ProvidePin: Self = Self(0i32);
@@ -772,12 +763,6 @@ impl ::core::clone::Clone for WiFiDirectConfigurationMethod {
 unsafe impl ::windows::core::Abi for WiFiDirectConfigurationMethod {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WiFiDirectConfigurationMethod {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WiFiDirectConfigurationMethod {}
 impl ::core::fmt::Debug for WiFiDirectConfigurationMethod {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WiFiDirectConfigurationMethod").field(&self.0).finish()
@@ -1235,6 +1220,7 @@ unsafe impl ::core::marker::Send for WiFiDirectConnectionRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for WiFiDirectConnectionRequestedEventArgs {}
 #[doc = "*Required features: 'Devices_WiFiDirect'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WiFiDirectConnectionStatus(pub i32);
 impl WiFiDirectConnectionStatus {
     pub const Disconnected: Self = Self(0i32);
@@ -1249,12 +1235,6 @@ impl ::core::clone::Clone for WiFiDirectConnectionStatus {
 unsafe impl ::windows::core::Abi for WiFiDirectConnectionStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WiFiDirectConnectionStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WiFiDirectConnectionStatus {}
 impl ::core::fmt::Debug for WiFiDirectConnectionStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WiFiDirectConnectionStatus").field(&self.0).finish()
@@ -1453,6 +1433,7 @@ unsafe impl ::core::marker::Send for WiFiDirectDevice {}
 unsafe impl ::core::marker::Sync for WiFiDirectDevice {}
 #[doc = "*Required features: 'Devices_WiFiDirect'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WiFiDirectDeviceSelectorType(pub i32);
 impl WiFiDirectDeviceSelectorType {
     pub const DeviceInterface: Self = Self(0i32);
@@ -1467,12 +1448,6 @@ impl ::core::clone::Clone for WiFiDirectDeviceSelectorType {
 unsafe impl ::windows::core::Abi for WiFiDirectDeviceSelectorType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WiFiDirectDeviceSelectorType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WiFiDirectDeviceSelectorType {}
 impl ::core::fmt::Debug for WiFiDirectDeviceSelectorType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WiFiDirectDeviceSelectorType").field(&self.0).finish()
@@ -1486,6 +1461,7 @@ impl ::windows::core::DefaultType for WiFiDirectDeviceSelectorType {
 }
 #[doc = "*Required features: 'Devices_WiFiDirect'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WiFiDirectError(pub i32);
 impl WiFiDirectError {
     pub const Success: Self = Self(0i32);
@@ -1501,12 +1477,6 @@ impl ::core::clone::Clone for WiFiDirectError {
 unsafe impl ::windows::core::Abi for WiFiDirectError {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WiFiDirectError {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WiFiDirectError {}
 impl ::core::fmt::Debug for WiFiDirectError {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WiFiDirectError").field(&self.0).finish()
@@ -1778,6 +1748,7 @@ unsafe impl ::core::marker::Send for WiFiDirectLegacySettings {}
 unsafe impl ::core::marker::Sync for WiFiDirectLegacySettings {}
 #[doc = "*Required features: 'Devices_WiFiDirect'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WiFiDirectPairingProcedure(pub i32);
 impl WiFiDirectPairingProcedure {
     pub const GroupOwnerNegotiation: Self = Self(0i32);
@@ -1792,12 +1763,6 @@ impl ::core::clone::Clone for WiFiDirectPairingProcedure {
 unsafe impl ::windows::core::Abi for WiFiDirectPairingProcedure {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WiFiDirectPairingProcedure {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WiFiDirectPairingProcedure {}
 impl ::core::fmt::Debug for WiFiDirectPairingProcedure {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WiFiDirectPairingProcedure").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Foundation/Collections/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/Collections/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'Foundation_Collections'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CollectionChange(pub i32);
 impl CollectionChange {
     pub const Reset: Self = Self(0i32);
@@ -17,12 +18,6 @@ impl ::core::clone::Clone for CollectionChange {
 unsafe impl ::windows::core::Abi for CollectionChange {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CollectionChange {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CollectionChange {}
 impl ::core::fmt::Debug for CollectionChange {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CollectionChange").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Foundation/Diagnostics/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/Diagnostics/mod.rs
@@ -44,6 +44,7 @@ impl ::windows::core::RuntimeName for AsyncCausalityTracer {
 }
 #[doc = "*Required features: 'Foundation_Diagnostics'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CausalityRelation(pub i32);
 impl CausalityRelation {
     pub const AssignDelegate: Self = Self(0i32);
@@ -61,12 +62,6 @@ impl ::core::clone::Clone for CausalityRelation {
 unsafe impl ::windows::core::Abi for CausalityRelation {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CausalityRelation {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CausalityRelation {}
 impl ::core::fmt::Debug for CausalityRelation {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CausalityRelation").field(&self.0).finish()
@@ -80,6 +75,7 @@ impl ::windows::core::DefaultType for CausalityRelation {
 }
 #[doc = "*Required features: 'Foundation_Diagnostics'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CausalitySource(pub i32);
 impl CausalitySource {
     pub const Application: Self = Self(0i32);
@@ -95,12 +91,6 @@ impl ::core::clone::Clone for CausalitySource {
 unsafe impl ::windows::core::Abi for CausalitySource {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CausalitySource {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CausalitySource {}
 impl ::core::fmt::Debug for CausalitySource {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CausalitySource").field(&self.0).finish()
@@ -114,6 +104,7 @@ impl ::windows::core::DefaultType for CausalitySource {
 }
 #[doc = "*Required features: 'Foundation_Diagnostics'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CausalitySynchronousWork(pub i32);
 impl CausalitySynchronousWork {
     pub const CompletionNotification: Self = Self(0i32);
@@ -129,12 +120,6 @@ impl ::core::clone::Clone for CausalitySynchronousWork {
 unsafe impl ::windows::core::Abi for CausalitySynchronousWork {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CausalitySynchronousWork {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CausalitySynchronousWork {}
 impl ::core::fmt::Debug for CausalitySynchronousWork {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CausalitySynchronousWork").field(&self.0).finish()
@@ -148,6 +133,7 @@ impl ::windows::core::DefaultType for CausalitySynchronousWork {
 }
 #[doc = "*Required features: 'Foundation_Diagnostics'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CausalityTraceLevel(pub i32);
 impl CausalityTraceLevel {
     pub const Required: Self = Self(0i32);
@@ -163,12 +149,6 @@ impl ::core::clone::Clone for CausalityTraceLevel {
 unsafe impl ::windows::core::Abi for CausalityTraceLevel {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CausalityTraceLevel {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CausalityTraceLevel {}
 impl ::core::fmt::Debug for CausalityTraceLevel {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CausalityTraceLevel").field(&self.0).finish()
@@ -291,6 +271,7 @@ unsafe impl ::core::marker::Send for ErrorDetails {}
 unsafe impl ::core::marker::Sync for ErrorDetails {}
 #[doc = "*Required features: 'Foundation_Diagnostics'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ErrorOptions(pub u32);
 impl ErrorOptions {
     pub const None: Self = Self(0u32);
@@ -308,12 +289,6 @@ impl ::core::clone::Clone for ErrorOptions {
 unsafe impl ::windows::core::Abi for ErrorOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ErrorOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ErrorOptions {}
 impl ::core::fmt::Debug for ErrorOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ErrorOptions").field(&self.0).finish()
@@ -2491,6 +2466,7 @@ unsafe impl ::core::marker::Send for LoggingChannelOptions {}
 unsafe impl ::core::marker::Sync for LoggingChannelOptions {}
 #[doc = "*Required features: 'Foundation_Diagnostics'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LoggingFieldFormat(pub i32);
 impl LoggingFieldFormat {
     pub const Default: Self = Self(0i32);
@@ -2522,12 +2498,6 @@ impl ::core::clone::Clone for LoggingFieldFormat {
 unsafe impl ::windows::core::Abi for LoggingFieldFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LoggingFieldFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LoggingFieldFormat {}
 impl ::core::fmt::Debug for LoggingFieldFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LoggingFieldFormat").field(&self.0).finish()
@@ -3196,6 +3166,7 @@ unsafe impl ::core::marker::Send for LoggingFields {}
 unsafe impl ::core::marker::Sync for LoggingFields {}
 #[doc = "*Required features: 'Foundation_Diagnostics'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LoggingLevel(pub i32);
 impl LoggingLevel {
     pub const Verbose: Self = Self(0i32);
@@ -3213,12 +3184,6 @@ impl ::core::clone::Clone for LoggingLevel {
 unsafe impl ::windows::core::Abi for LoggingLevel {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LoggingLevel {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LoggingLevel {}
 impl ::core::fmt::Debug for LoggingLevel {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LoggingLevel").field(&self.0).finish()
@@ -3232,6 +3197,7 @@ impl ::windows::core::DefaultType for LoggingLevel {
 }
 #[doc = "*Required features: 'Foundation_Diagnostics'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LoggingOpcode(pub i32);
 impl LoggingOpcode {
     pub const Info: Self = Self(0i32);
@@ -3251,12 +3217,6 @@ impl ::core::clone::Clone for LoggingOpcode {
 unsafe impl ::windows::core::Abi for LoggingOpcode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LoggingOpcode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LoggingOpcode {}
 impl ::core::fmt::Debug for LoggingOpcode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LoggingOpcode").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Foundation/Metadata/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/Metadata/mod.rs
@@ -83,6 +83,7 @@ impl ::windows::core::RuntimeName for ApiInformation {
 }
 #[doc = "*Required features: 'Foundation_Metadata'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AttributeTargets(pub u32);
 impl AttributeTargets {
     pub const All: Self = Self(4294967295u32);
@@ -108,12 +109,6 @@ impl ::core::clone::Clone for AttributeTargets {
 unsafe impl ::windows::core::Abi for AttributeTargets {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AttributeTargets {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AttributeTargets {}
 impl ::core::fmt::Debug for AttributeTargets {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AttributeTargets").field(&self.0).finish()
@@ -155,6 +150,7 @@ impl ::windows::core::DefaultType for AttributeTargets {
 }
 #[doc = "*Required features: 'Foundation_Metadata'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CompositionType(pub i32);
 impl CompositionType {
     pub const Protected: Self = Self(1i32);
@@ -169,12 +165,6 @@ impl ::core::clone::Clone for CompositionType {
 unsafe impl ::windows::core::Abi for CompositionType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CompositionType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CompositionType {}
 impl ::core::fmt::Debug for CompositionType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CompositionType").field(&self.0).finish()
@@ -188,6 +178,7 @@ impl ::windows::core::DefaultType for CompositionType {
 }
 #[doc = "*Required features: 'Foundation_Metadata'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DeprecationType(pub i32);
 impl DeprecationType {
     pub const Deprecate: Self = Self(0i32);
@@ -202,12 +193,6 @@ impl ::core::clone::Clone for DeprecationType {
 unsafe impl ::windows::core::Abi for DeprecationType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DeprecationType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DeprecationType {}
 impl ::core::fmt::Debug for DeprecationType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DeprecationType").field(&self.0).finish()
@@ -221,6 +206,7 @@ impl ::windows::core::DefaultType for DeprecationType {
 }
 #[doc = "*Required features: 'Foundation_Metadata'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FeatureStage(pub i32);
 impl FeatureStage {
     pub const AlwaysDisabled: Self = Self(0i32);
@@ -237,12 +223,6 @@ impl ::core::clone::Clone for FeatureStage {
 unsafe impl ::windows::core::Abi for FeatureStage {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FeatureStage {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FeatureStage {}
 impl ::core::fmt::Debug for FeatureStage {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FeatureStage").field(&self.0).finish()
@@ -256,6 +236,7 @@ impl ::windows::core::DefaultType for FeatureStage {
 }
 #[doc = "*Required features: 'Foundation_Metadata'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GCPressureAmount(pub i32);
 impl GCPressureAmount {
     pub const Low: Self = Self(0i32);
@@ -271,12 +252,6 @@ impl ::core::clone::Clone for GCPressureAmount {
 unsafe impl ::windows::core::Abi for GCPressureAmount {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GCPressureAmount {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GCPressureAmount {}
 impl ::core::fmt::Debug for GCPressureAmount {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GCPressureAmount").field(&self.0).finish()
@@ -317,6 +292,7 @@ pub struct IApiInformationStaticsVtbl(
 );
 #[doc = "*Required features: 'Foundation_Metadata'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MarshalingType(pub i32);
 impl MarshalingType {
     pub const None: Self = Self(1i32);
@@ -333,12 +309,6 @@ impl ::core::clone::Clone for MarshalingType {
 unsafe impl ::windows::core::Abi for MarshalingType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MarshalingType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MarshalingType {}
 impl ::core::fmt::Debug for MarshalingType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MarshalingType").field(&self.0).finish()
@@ -352,6 +322,7 @@ impl ::windows::core::DefaultType for MarshalingType {
 }
 #[doc = "*Required features: 'Foundation_Metadata'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct Platform(pub i32);
 impl Platform {
     pub const Windows: Self = Self(0i32);
@@ -366,12 +337,6 @@ impl ::core::clone::Clone for Platform {
 unsafe impl ::windows::core::Abi for Platform {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for Platform {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for Platform {}
 impl ::core::fmt::Debug for Platform {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("Platform").field(&self.0).finish()
@@ -385,6 +350,7 @@ impl ::windows::core::DefaultType for Platform {
 }
 #[doc = "*Required features: 'Foundation_Metadata'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ThreadingModel(pub i32);
 impl ThreadingModel {
     pub const STA: Self = Self(1i32);
@@ -401,12 +367,6 @@ impl ::core::clone::Clone for ThreadingModel {
 unsafe impl ::windows::core::Abi for ThreadingModel {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ThreadingModel {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ThreadingModel {}
 impl ::core::fmt::Debug for ThreadingModel {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ThreadingModel").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/mod.rs
@@ -532,6 +532,7 @@ where
     TProgress: ::windows::core::RuntimeType + 'static;
 #[doc = "*Required features: 'Foundation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AsyncStatus(pub i32);
 impl AsyncStatus {
     pub const Canceled: Self = Self(2i32);
@@ -548,12 +549,6 @@ impl ::core::clone::Clone for AsyncStatus {
 unsafe impl ::windows::core::Abi for AsyncStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AsyncStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AsyncStatus {}
 impl ::core::fmt::Debug for AsyncStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AsyncStatus").field(&self.0).finish()
@@ -4018,6 +4013,7 @@ impl ::core::default::Default for Point {
 }
 #[doc = "*Required features: 'Foundation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PropertyType(pub i32);
 impl PropertyType {
     pub const Empty: Self = Self(0i32);
@@ -4071,12 +4067,6 @@ impl ::core::clone::Clone for PropertyType {
 unsafe impl ::windows::core::Abi for PropertyType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PropertyType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PropertyType {}
 impl ::core::fmt::Debug for PropertyType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PropertyType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Gaming/Input/Custom/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Input/Custom/mod.rs
@@ -210,6 +210,7 @@ unsafe impl ::core::marker::Send for GipFirmwareUpdateResult {}
 unsafe impl ::core::marker::Sync for GipFirmwareUpdateResult {}
 #[doc = "*Required features: 'Gaming_Input_Custom'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GipFirmwareUpdateStatus(pub i32);
 impl GipFirmwareUpdateStatus {
     pub const Completed: Self = Self(0i32);
@@ -225,12 +226,6 @@ impl ::core::clone::Clone for GipFirmwareUpdateStatus {
 unsafe impl ::windows::core::Abi for GipFirmwareUpdateStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GipFirmwareUpdateStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GipFirmwareUpdateStatus {}
 impl ::core::fmt::Debug for GipFirmwareUpdateStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GipFirmwareUpdateStatus").field(&self.0).finish()
@@ -398,6 +393,7 @@ unsafe impl ::core::marker::Send for GipGameControllerProvider {}
 unsafe impl ::core::marker::Sync for GipGameControllerProvider {}
 #[doc = "*Required features: 'Gaming_Input_Custom'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GipMessageClass(pub i32);
 impl GipMessageClass {
     pub const Command: Self = Self(0i32);
@@ -413,12 +409,6 @@ impl ::core::clone::Clone for GipMessageClass {
 unsafe impl ::windows::core::Abi for GipMessageClass {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GipMessageClass {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GipMessageClass {}
 impl ::core::fmt::Debug for GipMessageClass {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GipMessageClass").field(&self.0).finish()
@@ -1383,6 +1373,7 @@ pub struct IXusbGameControllerProviderVtbl(
 );
 #[doc = "*Required features: 'Gaming_Input_Custom'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct XusbDeviceSubtype(pub i32);
 impl XusbDeviceSubtype {
     pub const Unknown: Self = Self(0i32);
@@ -1406,12 +1397,6 @@ impl ::core::clone::Clone for XusbDeviceSubtype {
 unsafe impl ::windows::core::Abi for XusbDeviceSubtype {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XusbDeviceSubtype {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for XusbDeviceSubtype {}
 impl ::core::fmt::Debug for XusbDeviceSubtype {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("XusbDeviceSubtype").field(&self.0).finish()
@@ -1425,6 +1410,7 @@ impl ::windows::core::DefaultType for XusbDeviceSubtype {
 }
 #[doc = "*Required features: 'Gaming_Input_Custom'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct XusbDeviceType(pub i32);
 impl XusbDeviceType {
     pub const Unknown: Self = Self(0i32);
@@ -1439,12 +1425,6 @@ impl ::core::clone::Clone for XusbDeviceType {
 unsafe impl ::windows::core::Abi for XusbDeviceType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XusbDeviceType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for XusbDeviceType {}
 impl ::core::fmt::Debug for XusbDeviceType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("XusbDeviceType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Gaming/Input/ForceFeedback/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Input/ForceFeedback/mod.rs
@@ -153,6 +153,7 @@ unsafe impl ::core::marker::Send for ConditionForceEffect {}
 unsafe impl ::core::marker::Sync for ConditionForceEffect {}
 #[doc = "*Required features: 'Gaming_Input_ForceFeedback'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ConditionForceEffectKind(pub i32);
 impl ConditionForceEffectKind {
     pub const Spring: Self = Self(0i32);
@@ -169,12 +170,6 @@ impl ::core::clone::Clone for ConditionForceEffectKind {
 unsafe impl ::windows::core::Abi for ConditionForceEffectKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ConditionForceEffectKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ConditionForceEffectKind {}
 impl ::core::fmt::Debug for ConditionForceEffectKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ConditionForceEffectKind").field(&self.0).finish()
@@ -333,6 +328,7 @@ unsafe impl ::core::marker::Send for ConstantForceEffect {}
 unsafe impl ::core::marker::Sync for ConstantForceEffect {}
 #[doc = "*Required features: 'Gaming_Input_ForceFeedback'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ForceFeedbackEffectAxes(pub u32);
 impl ForceFeedbackEffectAxes {
     pub const None: Self = Self(0u32);
@@ -349,12 +345,6 @@ impl ::core::clone::Clone for ForceFeedbackEffectAxes {
 unsafe impl ::windows::core::Abi for ForceFeedbackEffectAxes {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ForceFeedbackEffectAxes {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ForceFeedbackEffectAxes {}
 impl ::core::fmt::Debug for ForceFeedbackEffectAxes {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ForceFeedbackEffectAxes").field(&self.0).finish()
@@ -396,6 +386,7 @@ impl ::windows::core::DefaultType for ForceFeedbackEffectAxes {
 }
 #[doc = "*Required features: 'Gaming_Input_ForceFeedback'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ForceFeedbackEffectState(pub i32);
 impl ForceFeedbackEffectState {
     pub const Stopped: Self = Self(0i32);
@@ -412,12 +403,6 @@ impl ::core::clone::Clone for ForceFeedbackEffectState {
 unsafe impl ::windows::core::Abi for ForceFeedbackEffectState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ForceFeedbackEffectState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ForceFeedbackEffectState {}
 impl ::core::fmt::Debug for ForceFeedbackEffectState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ForceFeedbackEffectState").field(&self.0).finish()
@@ -431,6 +416,7 @@ impl ::windows::core::DefaultType for ForceFeedbackEffectState {
 }
 #[doc = "*Required features: 'Gaming_Input_ForceFeedback'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ForceFeedbackLoadEffectResult(pub i32);
 impl ForceFeedbackLoadEffectResult {
     pub const Succeeded: Self = Self(0i32);
@@ -446,12 +432,6 @@ impl ::core::clone::Clone for ForceFeedbackLoadEffectResult {
 unsafe impl ::windows::core::Abi for ForceFeedbackLoadEffectResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ForceFeedbackLoadEffectResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ForceFeedbackLoadEffectResult {}
 impl ::core::fmt::Debug for ForceFeedbackLoadEffectResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ForceFeedbackLoadEffectResult").field(&self.0).finish()
@@ -1062,6 +1042,7 @@ unsafe impl ::core::marker::Send for PeriodicForceEffect {}
 unsafe impl ::core::marker::Sync for PeriodicForceEffect {}
 #[doc = "*Required features: 'Gaming_Input_ForceFeedback'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PeriodicForceEffectKind(pub i32);
 impl PeriodicForceEffectKind {
     pub const SquareWave: Self = Self(0i32);
@@ -1079,12 +1060,6 @@ impl ::core::clone::Clone for PeriodicForceEffectKind {
 unsafe impl ::windows::core::Abi for PeriodicForceEffectKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PeriodicForceEffectKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PeriodicForceEffectKind {}
 impl ::core::fmt::Debug for PeriodicForceEffectKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PeriodicForceEffectKind").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Gaming/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Input/mod.rs
@@ -270,6 +270,7 @@ unsafe impl ::core::marker::Send for ArcadeStick {}
 unsafe impl ::core::marker::Sync for ArcadeStick {}
 #[doc = "*Required features: 'Gaming_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ArcadeStickButtons(pub u32);
 impl ArcadeStickButtons {
     pub const None: Self = Self(0u32);
@@ -295,12 +296,6 @@ impl ::core::clone::Clone for ArcadeStickButtons {
 unsafe impl ::windows::core::Abi for ArcadeStickButtons {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ArcadeStickButtons {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ArcadeStickButtons {}
 impl ::core::fmt::Debug for ArcadeStickButtons {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ArcadeStickButtons").field(&self.0).finish()
@@ -645,6 +640,7 @@ unsafe impl ::core::marker::Send for FlightStick {}
 unsafe impl ::core::marker::Sync for FlightStick {}
 #[doc = "*Required features: 'Gaming_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FlightStickButtons(pub u32);
 impl FlightStickButtons {
     pub const None: Self = Self(0u32);
@@ -660,12 +656,6 @@ impl ::core::clone::Clone for FlightStickButtons {
 unsafe impl ::windows::core::Abi for FlightStickButtons {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FlightStickButtons {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FlightStickButtons {}
 impl ::core::fmt::Debug for FlightStickButtons {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FlightStickButtons").field(&self.0).finish()
@@ -749,6 +739,7 @@ impl ::core::default::Default for FlightStickReading {
 }
 #[doc = "*Required features: 'Gaming_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GameControllerButtonLabel(pub i32);
 impl GameControllerButtonLabel {
     pub const None: Self = Self(0i32);
@@ -830,12 +821,6 @@ impl ::core::clone::Clone for GameControllerButtonLabel {
 unsafe impl ::windows::core::Abi for GameControllerButtonLabel {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GameControllerButtonLabel {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GameControllerButtonLabel {}
 impl ::core::fmt::Debug for GameControllerButtonLabel {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GameControllerButtonLabel").field(&self.0).finish()
@@ -849,6 +834,7 @@ impl ::windows::core::DefaultType for GameControllerButtonLabel {
 }
 #[doc = "*Required features: 'Gaming_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GameControllerSwitchKind(pub i32);
 impl GameControllerSwitchKind {
     pub const TwoWay: Self = Self(0i32);
@@ -864,12 +850,6 @@ impl ::core::clone::Clone for GameControllerSwitchKind {
 unsafe impl ::windows::core::Abi for GameControllerSwitchKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GameControllerSwitchKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GameControllerSwitchKind {}
 impl ::core::fmt::Debug for GameControllerSwitchKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GameControllerSwitchKind").field(&self.0).finish()
@@ -883,6 +863,7 @@ impl ::windows::core::DefaultType for GameControllerSwitchKind {
 }
 #[doc = "*Required features: 'Gaming_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GameControllerSwitchPosition(pub i32);
 impl GameControllerSwitchPosition {
     pub const Center: Self = Self(0i32);
@@ -904,12 +885,6 @@ impl ::core::clone::Clone for GameControllerSwitchPosition {
 unsafe impl ::windows::core::Abi for GameControllerSwitchPosition {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GameControllerSwitchPosition {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GameControllerSwitchPosition {}
 impl ::core::fmt::Debug for GameControllerSwitchPosition {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GameControllerSwitchPosition").field(&self.0).finish()
@@ -1199,6 +1174,7 @@ unsafe impl ::core::marker::Send for Gamepad {}
 unsafe impl ::core::marker::Sync for Gamepad {}
 #[doc = "*Required features: 'Gaming_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GamepadButtons(pub u32);
 impl GamepadButtons {
     pub const None: Self = Self(0u32);
@@ -1230,12 +1206,6 @@ impl ::core::clone::Clone for GamepadButtons {
 unsafe impl ::windows::core::Abi for GamepadButtons {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GamepadButtons {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GamepadButtons {}
 impl ::core::fmt::Debug for GamepadButtons {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GamepadButtons").field(&self.0).finish()
@@ -2158,6 +2128,7 @@ pub struct IUINavigationControllerStatics2Vtbl(
 );
 #[doc = "*Required features: 'Gaming_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct OptionalUINavigationButtons(pub u32);
 impl OptionalUINavigationButtons {
     pub const None: Self = Self(0u32);
@@ -2183,12 +2154,6 @@ impl ::core::clone::Clone for OptionalUINavigationButtons {
 unsafe impl ::windows::core::Abi for OptionalUINavigationButtons {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for OptionalUINavigationButtons {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for OptionalUINavigationButtons {}
 impl ::core::fmt::Debug for OptionalUINavigationButtons {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("OptionalUINavigationButtons").field(&self.0).finish()
@@ -2542,6 +2507,7 @@ unsafe impl ::core::marker::Send for RacingWheel {}
 unsafe impl ::core::marker::Sync for RacingWheel {}
 #[doc = "*Required features: 'Gaming_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RacingWheelButtons(pub u32);
 impl RacingWheelButtons {
     pub const None: Self = Self(0u32);
@@ -2577,12 +2543,6 @@ impl ::core::clone::Clone for RacingWheelButtons {
 unsafe impl ::windows::core::Abi for RacingWheelButtons {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RacingWheelButtons {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RacingWheelButtons {}
 impl ::core::fmt::Debug for RacingWheelButtons {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RacingWheelButtons").field(&self.0).finish()
@@ -3007,6 +2967,7 @@ unsafe impl ::core::marker::Send for RawGameController {}
 unsafe impl ::core::marker::Sync for RawGameController {}
 #[doc = "*Required features: 'Gaming_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RequiredUINavigationButtons(pub u32);
 impl RequiredUINavigationButtons {
     pub const None: Self = Self(0u32);
@@ -3028,12 +2989,6 @@ impl ::core::clone::Clone for RequiredUINavigationButtons {
 unsafe impl ::windows::core::Abi for RequiredUINavigationButtons {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RequiredUINavigationButtons {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RequiredUINavigationButtons {}
 impl ::core::fmt::Debug for RequiredUINavigationButtons {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RequiredUINavigationButtons").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Gaming/Preview/GamesEnumeration/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/Preview/GamesEnumeration/mod.rs
@@ -89,6 +89,7 @@ impl ::windows::core::RuntimeName for GameList {
 }
 #[doc = "*Required features: 'Gaming_Preview_GamesEnumeration'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GameListCategory(pub i32);
 impl GameListCategory {
     pub const Candidate: Self = Self(0i32);
@@ -104,12 +105,6 @@ impl ::core::clone::Clone for GameListCategory {
 unsafe impl ::windows::core::Abi for GameListCategory {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GameListCategory {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GameListCategory {}
 impl ::core::fmt::Debug for GameListCategory {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GameListCategory").field(&self.0).finish()
@@ -405,6 +400,7 @@ unsafe impl ::core::marker::Send for GameListEntry {}
 unsafe impl ::core::marker::Sync for GameListEntry {}
 #[doc = "*Required features: 'Gaming_Preview_GamesEnumeration'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GameListEntryLaunchableState(pub i32);
 impl GameListEntryLaunchableState {
     pub const NotLaunchable: Self = Self(0i32);
@@ -421,12 +417,6 @@ impl ::core::clone::Clone for GameListEntryLaunchableState {
 unsafe impl ::windows::core::Abi for GameListEntryLaunchableState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GameListEntryLaunchableState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GameListEntryLaunchableState {}
 impl ::core::fmt::Debug for GameListEntryLaunchableState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GameListEntryLaunchableState").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Gaming/UI/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/UI/mod.rs
@@ -53,6 +53,7 @@ impl ::windows::core::RuntimeName for GameBar {
 }
 #[doc = "*Required features: 'Gaming_UI'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GameChatMessageOrigin(pub i32);
 impl GameChatMessageOrigin {
     pub const Voice: Self = Self(0i32);
@@ -67,12 +68,6 @@ impl ::core::clone::Clone for GameChatMessageOrigin {
 unsafe impl ::windows::core::Abi for GameChatMessageOrigin {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GameChatMessageOrigin {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GameChatMessageOrigin {}
 impl ::core::fmt::Debug for GameChatMessageOrigin {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GameChatMessageOrigin").field(&self.0).finish()
@@ -403,6 +398,7 @@ unsafe impl ::core::marker::Send for GameChatOverlayMessageSource {}
 unsafe impl ::core::marker::Sync for GameChatOverlayMessageSource {}
 #[doc = "*Required features: 'Gaming_UI'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GameChatOverlayPosition(pub i32);
 impl GameChatOverlayPosition {
     pub const BottomCenter: Self = Self(0i32);
@@ -423,12 +419,6 @@ impl ::core::clone::Clone for GameChatOverlayPosition {
 unsafe impl ::windows::core::Abi for GameChatOverlayPosition {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GameChatOverlayPosition {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GameChatOverlayPosition {}
 impl ::core::fmt::Debug for GameChatOverlayPosition {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GameChatOverlayPosition").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Gaming/XboxLive/Storage/mod.rs
+++ b/crates/libs/windows/src/Windows/Gaming/XboxLive/Storage/mod.rs
@@ -807,6 +807,7 @@ unsafe impl ::core::marker::Send for GameSaveContainerInfoQuery {}
 unsafe impl ::core::marker::Sync for GameSaveContainerInfoQuery {}
 #[doc = "*Required features: 'Gaming_XboxLive_Storage'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GameSaveErrorStatus(pub i32);
 impl GameSaveErrorStatus {
     pub const Ok: Self = Self(0i32);
@@ -834,12 +835,6 @@ impl ::core::clone::Clone for GameSaveErrorStatus {
 unsafe impl ::windows::core::Abi for GameSaveErrorStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GameSaveErrorStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GameSaveErrorStatus {}
 impl ::core::fmt::Debug for GameSaveErrorStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GameSaveErrorStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Globalization/DateTimeFormatting/mod.rs
+++ b/crates/libs/windows/src/Windows/Globalization/DateTimeFormatting/mod.rs
@@ -318,6 +318,7 @@ unsafe impl ::core::marker::Send for DateTimeFormatter {}
 unsafe impl ::core::marker::Sync for DateTimeFormatter {}
 #[doc = "*Required features: 'Globalization_DateTimeFormatting'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DayFormat(pub i32);
 impl DayFormat {
     pub const None: Self = Self(0i32);
@@ -332,12 +333,6 @@ impl ::core::clone::Clone for DayFormat {
 unsafe impl ::windows::core::Abi for DayFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DayFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DayFormat {}
 impl ::core::fmt::Debug for DayFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DayFormat").field(&self.0).finish()
@@ -351,6 +346,7 @@ impl ::windows::core::DefaultType for DayFormat {
 }
 #[doc = "*Required features: 'Globalization_DateTimeFormatting'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DayOfWeekFormat(pub i32);
 impl DayOfWeekFormat {
     pub const None: Self = Self(0i32);
@@ -367,12 +363,6 @@ impl ::core::clone::Clone for DayOfWeekFormat {
 unsafe impl ::windows::core::Abi for DayOfWeekFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DayOfWeekFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DayOfWeekFormat {}
 impl ::core::fmt::Debug for DayOfWeekFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DayOfWeekFormat").field(&self.0).finish()
@@ -386,6 +376,7 @@ impl ::windows::core::DefaultType for DayOfWeekFormat {
 }
 #[doc = "*Required features: 'Globalization_DateTimeFormatting'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HourFormat(pub i32);
 impl HourFormat {
     pub const None: Self = Self(0i32);
@@ -400,12 +391,6 @@ impl ::core::clone::Clone for HourFormat {
 unsafe impl ::windows::core::Abi for HourFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HourFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HourFormat {}
 impl ::core::fmt::Debug for HourFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HourFormat").field(&self.0).finish()
@@ -525,6 +510,7 @@ pub struct IDateTimeFormatterStaticsVtbl(
 );
 #[doc = "*Required features: 'Globalization_DateTimeFormatting'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MinuteFormat(pub i32);
 impl MinuteFormat {
     pub const None: Self = Self(0i32);
@@ -539,12 +525,6 @@ impl ::core::clone::Clone for MinuteFormat {
 unsafe impl ::windows::core::Abi for MinuteFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MinuteFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MinuteFormat {}
 impl ::core::fmt::Debug for MinuteFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MinuteFormat").field(&self.0).finish()
@@ -558,6 +538,7 @@ impl ::windows::core::DefaultType for MinuteFormat {
 }
 #[doc = "*Required features: 'Globalization_DateTimeFormatting'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MonthFormat(pub i32);
 impl MonthFormat {
     pub const None: Self = Self(0i32);
@@ -575,12 +556,6 @@ impl ::core::clone::Clone for MonthFormat {
 unsafe impl ::windows::core::Abi for MonthFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MonthFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MonthFormat {}
 impl ::core::fmt::Debug for MonthFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MonthFormat").field(&self.0).finish()
@@ -594,6 +569,7 @@ impl ::windows::core::DefaultType for MonthFormat {
 }
 #[doc = "*Required features: 'Globalization_DateTimeFormatting'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SecondFormat(pub i32);
 impl SecondFormat {
     pub const None: Self = Self(0i32);
@@ -608,12 +584,6 @@ impl ::core::clone::Clone for SecondFormat {
 unsafe impl ::windows::core::Abi for SecondFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SecondFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SecondFormat {}
 impl ::core::fmt::Debug for SecondFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SecondFormat").field(&self.0).finish()
@@ -627,6 +597,7 @@ impl ::windows::core::DefaultType for SecondFormat {
 }
 #[doc = "*Required features: 'Globalization_DateTimeFormatting'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct YearFormat(pub i32);
 impl YearFormat {
     pub const None: Self = Self(0i32);
@@ -643,12 +614,6 @@ impl ::core::clone::Clone for YearFormat {
 unsafe impl ::windows::core::Abi for YearFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for YearFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for YearFormat {}
 impl ::core::fmt::Debug for YearFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("YearFormat").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Globalization/NumberFormatting/mod.rs
+++ b/crates/libs/windows/src/Windows/Globalization/NumberFormatting/mod.rs
@@ -492,6 +492,7 @@ unsafe impl ::core::marker::Send for CurrencyFormatter {}
 unsafe impl ::core::marker::Sync for CurrencyFormatter {}
 #[doc = "*Required features: 'Globalization_NumberFormatting'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CurrencyFormatterMode(pub i32);
 impl CurrencyFormatterMode {
     pub const UseSymbol: Self = Self(0i32);
@@ -506,12 +507,6 @@ impl ::core::clone::Clone for CurrencyFormatterMode {
 unsafe impl ::windows::core::Abi for CurrencyFormatterMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CurrencyFormatterMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CurrencyFormatterMode {}
 impl ::core::fmt::Debug for CurrencyFormatterMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CurrencyFormatterMode").field(&self.0).finish()
@@ -3333,6 +3328,7 @@ unsafe impl ::core::marker::Send for PermilleFormatter {}
 unsafe impl ::core::marker::Sync for PermilleFormatter {}
 #[doc = "*Required features: 'Globalization_NumberFormatting'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RoundingAlgorithm(pub i32);
 impl RoundingAlgorithm {
     pub const None: Self = Self(0i32);
@@ -3356,12 +3352,6 @@ impl ::core::clone::Clone for RoundingAlgorithm {
 unsafe impl ::windows::core::Abi for RoundingAlgorithm {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RoundingAlgorithm {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RoundingAlgorithm {}
 impl ::core::fmt::Debug for RoundingAlgorithm {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RoundingAlgorithm").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Globalization/PhoneNumberFormatting/mod.rs
+++ b/crates/libs/windows/src/Windows/Globalization/PhoneNumberFormatting/mod.rs
@@ -106,6 +106,7 @@ pub struct IPhoneNumberInfoStaticsVtbl(
 );
 #[doc = "*Required features: 'Globalization_PhoneNumberFormatting'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneNumberFormat(pub i32);
 impl PhoneNumberFormat {
     pub const E164: Self = Self(0i32);
@@ -122,12 +123,6 @@ impl ::core::clone::Clone for PhoneNumberFormat {
 unsafe impl ::windows::core::Abi for PhoneNumberFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneNumberFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneNumberFormat {}
 impl ::core::fmt::Debug for PhoneNumberFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneNumberFormat").field(&self.0).finish()
@@ -494,6 +489,7 @@ unsafe impl ::core::marker::Send for PhoneNumberInfo {}
 unsafe impl ::core::marker::Sync for PhoneNumberInfo {}
 #[doc = "*Required features: 'Globalization_PhoneNumberFormatting'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneNumberMatchResult(pub i32);
 impl PhoneNumberMatchResult {
     pub const NoMatch: Self = Self(0i32);
@@ -510,12 +506,6 @@ impl ::core::clone::Clone for PhoneNumberMatchResult {
 unsafe impl ::windows::core::Abi for PhoneNumberMatchResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneNumberMatchResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneNumberMatchResult {}
 impl ::core::fmt::Debug for PhoneNumberMatchResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneNumberMatchResult").field(&self.0).finish()
@@ -529,6 +519,7 @@ impl ::windows::core::DefaultType for PhoneNumberMatchResult {
 }
 #[doc = "*Required features: 'Globalization_PhoneNumberFormatting'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneNumberParseResult(pub i32);
 impl PhoneNumberParseResult {
     pub const Valid: Self = Self(0i32);
@@ -546,12 +537,6 @@ impl ::core::clone::Clone for PhoneNumberParseResult {
 unsafe impl ::windows::core::Abi for PhoneNumberParseResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneNumberParseResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneNumberParseResult {}
 impl ::core::fmt::Debug for PhoneNumberParseResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneNumberParseResult").field(&self.0).finish()
@@ -565,6 +550,7 @@ impl ::windows::core::DefaultType for PhoneNumberParseResult {
 }
 #[doc = "*Required features: 'Globalization_PhoneNumberFormatting'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PredictedPhoneNumberKind(pub i32);
 impl PredictedPhoneNumberKind {
     pub const FixedLine: Self = Self(0i32);
@@ -589,12 +575,6 @@ impl ::core::clone::Clone for PredictedPhoneNumberKind {
 unsafe impl ::windows::core::Abi for PredictedPhoneNumberKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PredictedPhoneNumberKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PredictedPhoneNumberKind {}
 impl ::core::fmt::Debug for PredictedPhoneNumberKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PredictedPhoneNumberKind").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Globalization/mod.rs
+++ b/crates/libs/windows/src/Windows/Globalization/mod.rs
@@ -2323,6 +2323,7 @@ impl ::windows::core::RuntimeName for CurrencyIdentifiers {
 }
 #[doc = "*Required features: 'Globalization'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DayOfWeek(pub i32);
 impl DayOfWeek {
     pub const Sunday: Self = Self(0i32);
@@ -2342,12 +2343,6 @@ impl ::core::clone::Clone for DayOfWeek {
 unsafe impl ::windows::core::Abi for DayOfWeek {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DayOfWeek {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DayOfWeek {}
 impl ::core::fmt::Debug for DayOfWeek {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DayOfWeek").field(&self.0).finish()
@@ -3722,6 +3717,7 @@ unsafe impl ::core::marker::Send for Language {}
 unsafe impl ::core::marker::Sync for Language {}
 #[doc = "*Required features: 'Globalization'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LanguageLayoutDirection(pub i32);
 impl LanguageLayoutDirection {
     pub const Ltr: Self = Self(0i32);
@@ -3738,12 +3734,6 @@ impl ::core::clone::Clone for LanguageLayoutDirection {
 unsafe impl ::windows::core::Abi for LanguageLayoutDirection {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LanguageLayoutDirection {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LanguageLayoutDirection {}
 impl ::core::fmt::Debug for LanguageLayoutDirection {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LanguageLayoutDirection").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Graphics/Capture/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Capture/mod.rs
@@ -329,6 +329,7 @@ impl ::windows::core::RuntimeName for GraphicsCaptureAccess {
 }
 #[doc = "*Required features: 'Graphics_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GraphicsCaptureAccessKind(pub i32);
 impl GraphicsCaptureAccessKind {
     pub const Borderless: Self = Self(0i32);
@@ -343,12 +344,6 @@ impl ::core::clone::Clone for GraphicsCaptureAccessKind {
 unsafe impl ::windows::core::Abi for GraphicsCaptureAccessKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GraphicsCaptureAccessKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GraphicsCaptureAccessKind {}
 impl ::core::fmt::Debug for GraphicsCaptureAccessKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GraphicsCaptureAccessKind").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Graphics/DirectX/Direct3D11/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/DirectX/Direct3D11/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'Graphics_DirectX_Direct3D11'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct Direct3DBindings(pub u32);
 impl Direct3DBindings {
     pub const VertexBuffer: Self = Self(1u32);
@@ -23,12 +24,6 @@ impl ::core::clone::Clone for Direct3DBindings {
 unsafe impl ::windows::core::Abi for Direct3DBindings {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for Direct3DBindings {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for Direct3DBindings {}
 impl ::core::fmt::Debug for Direct3DBindings {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("Direct3DBindings").field(&self.0).finish()
@@ -146,6 +141,7 @@ impl ::core::default::Default for Direct3DSurfaceDescription {
 }
 #[doc = "*Required features: 'Graphics_DirectX_Direct3D11'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct Direct3DUsage(pub i32);
 impl Direct3DUsage {
     pub const Default: Self = Self(0i32);
@@ -162,12 +158,6 @@ impl ::core::clone::Clone for Direct3DUsage {
 unsafe impl ::windows::core::Abi for Direct3DUsage {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for Direct3DUsage {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for Direct3DUsage {}
 impl ::core::fmt::Debug for Direct3DUsage {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("Direct3DUsage").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Graphics/DirectX/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/DirectX/mod.rs
@@ -3,6 +3,7 @@
 pub mod Direct3D11;
 #[doc = "*Required features: 'Graphics_DirectX'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DirectXAlphaMode(pub i32);
 impl DirectXAlphaMode {
     pub const Unspecified: Self = Self(0i32);
@@ -19,12 +20,6 @@ impl ::core::clone::Clone for DirectXAlphaMode {
 unsafe impl ::windows::core::Abi for DirectXAlphaMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DirectXAlphaMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DirectXAlphaMode {}
 impl ::core::fmt::Debug for DirectXAlphaMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DirectXAlphaMode").field(&self.0).finish()
@@ -38,6 +33,7 @@ impl ::windows::core::DefaultType for DirectXAlphaMode {
 }
 #[doc = "*Required features: 'Graphics_DirectX'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DirectXColorSpace(pub i32);
 impl DirectXColorSpace {
     pub const RgbFullG22NoneP709: Self = Self(0i32);
@@ -75,12 +71,6 @@ impl ::core::clone::Clone for DirectXColorSpace {
 unsafe impl ::windows::core::Abi for DirectXColorSpace {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DirectXColorSpace {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DirectXColorSpace {}
 impl ::core::fmt::Debug for DirectXColorSpace {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DirectXColorSpace").field(&self.0).finish()
@@ -94,6 +84,7 @@ impl ::windows::core::DefaultType for DirectXColorSpace {
 }
 #[doc = "*Required features: 'Graphics_DirectX'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DirectXPixelFormat(pub i32);
 impl DirectXPixelFormat {
     pub const Unknown: Self = Self(0i32);
@@ -227,12 +218,6 @@ impl ::core::clone::Clone for DirectXPixelFormat {
 unsafe impl ::windows::core::Abi for DirectXPixelFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DirectXPixelFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DirectXPixelFormat {}
 impl ::core::fmt::Debug for DirectXPixelFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DirectXPixelFormat").field(&self.0).finish()
@@ -246,6 +231,7 @@ impl ::windows::core::DefaultType for DirectXPixelFormat {
 }
 #[doc = "*Required features: 'Graphics_DirectX'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DirectXPrimitiveTopology(pub i32);
 impl DirectXPrimitiveTopology {
     pub const Undefined: Self = Self(0i32);
@@ -264,12 +250,6 @@ impl ::core::clone::Clone for DirectXPrimitiveTopology {
 unsafe impl ::windows::core::Abi for DirectXPrimitiveTopology {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DirectXPrimitiveTopology {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DirectXPrimitiveTopology {}
 impl ::core::fmt::Debug for DirectXPrimitiveTopology {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DirectXPrimitiveTopology").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Graphics/Display/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Display/Core/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'Graphics_Display_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HdmiDisplayColorSpace(pub i32);
 impl HdmiDisplayColorSpace {
     pub const RgbLimited: Self = Self(0i32);
@@ -17,12 +18,6 @@ impl ::core::clone::Clone for HdmiDisplayColorSpace {
 unsafe impl ::windows::core::Abi for HdmiDisplayColorSpace {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HdmiDisplayColorSpace {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HdmiDisplayColorSpace {}
 impl ::core::fmt::Debug for HdmiDisplayColorSpace {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HdmiDisplayColorSpace").field(&self.0).finish()
@@ -96,6 +91,7 @@ impl ::core::default::Default for HdmiDisplayHdr2086Metadata {
 }
 #[doc = "*Required features: 'Graphics_Display_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HdmiDisplayHdrOption(pub i32);
 impl HdmiDisplayHdrOption {
     pub const None: Self = Self(0i32);
@@ -112,12 +108,6 @@ impl ::core::clone::Clone for HdmiDisplayHdrOption {
 unsafe impl ::windows::core::Abi for HdmiDisplayHdrOption {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HdmiDisplayHdrOption {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HdmiDisplayHdrOption {}
 impl ::core::fmt::Debug for HdmiDisplayHdrOption {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HdmiDisplayHdrOption").field(&self.0).finish()
@@ -453,6 +443,7 @@ unsafe impl ::core::marker::Send for HdmiDisplayMode {}
 unsafe impl ::core::marker::Sync for HdmiDisplayMode {}
 #[doc = "*Required features: 'Graphics_Display_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HdmiDisplayPixelEncoding(pub i32);
 impl HdmiDisplayPixelEncoding {
     pub const Rgb444: Self = Self(0i32);
@@ -469,12 +460,6 @@ impl ::core::clone::Clone for HdmiDisplayPixelEncoding {
 unsafe impl ::windows::core::Abi for HdmiDisplayPixelEncoding {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HdmiDisplayPixelEncoding {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HdmiDisplayPixelEncoding {}
 impl ::core::fmt::Debug for HdmiDisplayPixelEncoding {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HdmiDisplayPixelEncoding").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Graphics/Display/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Display/mod.rs
@@ -168,6 +168,7 @@ unsafe impl ::core::marker::Send for AdvancedColorInfo {}
 unsafe impl ::core::marker::Sync for AdvancedColorInfo {}
 #[doc = "*Required features: 'Graphics_Display'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AdvancedColorKind(pub i32);
 impl AdvancedColorKind {
     pub const StandardDynamicRange: Self = Self(0i32);
@@ -183,12 +184,6 @@ impl ::core::clone::Clone for AdvancedColorKind {
 unsafe impl ::windows::core::Abi for AdvancedColorKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AdvancedColorKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AdvancedColorKind {}
 impl ::core::fmt::Debug for AdvancedColorKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AdvancedColorKind").field(&self.0).finish()
@@ -607,6 +602,7 @@ unsafe impl ::core::marker::Send for ColorOverrideSettings {}
 unsafe impl ::core::marker::Sync for ColorOverrideSettings {}
 #[doc = "*Required features: 'Graphics_Display'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DisplayBrightnessOverrideOptions(pub u32);
 impl DisplayBrightnessOverrideOptions {
     pub const None: Self = Self(0u32);
@@ -621,12 +617,6 @@ impl ::core::clone::Clone for DisplayBrightnessOverrideOptions {
 unsafe impl ::windows::core::Abi for DisplayBrightnessOverrideOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DisplayBrightnessOverrideOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DisplayBrightnessOverrideOptions {}
 impl ::core::fmt::Debug for DisplayBrightnessOverrideOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayBrightnessOverrideOptions").field(&self.0).finish()
@@ -668,6 +658,7 @@ impl ::windows::core::DefaultType for DisplayBrightnessOverrideOptions {
 }
 #[doc = "*Required features: 'Graphics_Display'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DisplayBrightnessOverrideScenario(pub i32);
 impl DisplayBrightnessOverrideScenario {
     pub const IdleBrightness: Self = Self(0i32);
@@ -683,12 +674,6 @@ impl ::core::clone::Clone for DisplayBrightnessOverrideScenario {
 unsafe impl ::windows::core::Abi for DisplayBrightnessOverrideScenario {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DisplayBrightnessOverrideScenario {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DisplayBrightnessOverrideScenario {}
 impl ::core::fmt::Debug for DisplayBrightnessOverrideScenario {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayBrightnessOverrideScenario").field(&self.0).finish()
@@ -702,6 +687,7 @@ impl ::windows::core::DefaultType for DisplayBrightnessOverrideScenario {
 }
 #[doc = "*Required features: 'Graphics_Display'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DisplayBrightnessScenario(pub i32);
 impl DisplayBrightnessScenario {
     pub const DefaultBrightness: Self = Self(0i32);
@@ -718,12 +704,6 @@ impl ::core::clone::Clone for DisplayBrightnessScenario {
 unsafe impl ::windows::core::Abi for DisplayBrightnessScenario {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DisplayBrightnessScenario {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DisplayBrightnessScenario {}
 impl ::core::fmt::Debug for DisplayBrightnessScenario {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayBrightnessScenario").field(&self.0).finish()
@@ -737,6 +717,7 @@ impl ::windows::core::DefaultType for DisplayBrightnessScenario {
 }
 #[doc = "*Required features: 'Graphics_Display'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DisplayColorOverrideScenario(pub i32);
 impl DisplayColorOverrideScenario {
     pub const Accurate: Self = Self(0i32);
@@ -750,12 +731,6 @@ impl ::core::clone::Clone for DisplayColorOverrideScenario {
 unsafe impl ::windows::core::Abi for DisplayColorOverrideScenario {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DisplayColorOverrideScenario {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DisplayColorOverrideScenario {}
 impl ::core::fmt::Debug for DisplayColorOverrideScenario {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayColorOverrideScenario").field(&self.0).finish()
@@ -1428,6 +1403,7 @@ unsafe impl ::core::marker::Send for DisplayInformation {}
 unsafe impl ::core::marker::Sync for DisplayInformation {}
 #[doc = "*Required features: 'Graphics_Display'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DisplayOrientations(pub u32);
 impl DisplayOrientations {
     pub const None: Self = Self(0u32);
@@ -1445,12 +1421,6 @@ impl ::core::clone::Clone for DisplayOrientations {
 unsafe impl ::windows::core::Abi for DisplayOrientations {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DisplayOrientations {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DisplayOrientations {}
 impl ::core::fmt::Debug for DisplayOrientations {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DisplayOrientations").field(&self.0).finish()
@@ -1812,6 +1782,7 @@ unsafe impl ::core::marker::Send for DisplayServices {}
 unsafe impl ::core::marker::Sync for DisplayServices {}
 #[doc = "*Required features: 'Graphics_Display'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HdrMetadataFormat(pub i32);
 impl HdrMetadataFormat {
     pub const Hdr10: Self = Self(0i32);
@@ -1826,12 +1797,6 @@ impl ::core::clone::Clone for HdrMetadataFormat {
 unsafe impl ::windows::core::Abi for HdrMetadataFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HdrMetadataFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HdrMetadataFormat {}
 impl ::core::fmt::Debug for HdrMetadataFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HdrMetadataFormat").field(&self.0).finish()
@@ -2378,6 +2343,7 @@ impl ::core::default::Default for NitRange {
 }
 #[doc = "*Required features: 'Graphics_Display'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ResolutionScale(pub i32);
 impl ResolutionScale {
     pub const Invalid: Self = Self(0i32);
@@ -2407,12 +2373,6 @@ impl ::core::clone::Clone for ResolutionScale {
 unsafe impl ::windows::core::Abi for ResolutionScale {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ResolutionScale {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ResolutionScale {}
 impl ::core::fmt::Debug for ResolutionScale {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ResolutionScale").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Graphics/Holographic/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Holographic/mod.rs
@@ -655,6 +655,7 @@ unsafe impl ::core::marker::Send for HolographicCameraViewportParameters {}
 unsafe impl ::core::marker::Sync for HolographicCameraViewportParameters {}
 #[doc = "*Required features: 'Graphics_Holographic'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HolographicDepthReprojectionMethod(pub i32);
 impl HolographicDepthReprojectionMethod {
     pub const DepthReprojection: Self = Self(0i32);
@@ -669,12 +670,6 @@ impl ::core::clone::Clone for HolographicDepthReprojectionMethod {
 unsafe impl ::windows::core::Abi for HolographicDepthReprojectionMethod {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HolographicDepthReprojectionMethod {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HolographicDepthReprojectionMethod {}
 impl ::core::fmt::Debug for HolographicDepthReprojectionMethod {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HolographicDepthReprojectionMethod").field(&self.0).finish()
@@ -1124,6 +1119,7 @@ unsafe impl ::core::marker::Send for HolographicFramePrediction {}
 unsafe impl ::core::marker::Sync for HolographicFramePrediction {}
 #[doc = "*Required features: 'Graphics_Holographic'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HolographicFramePresentResult(pub i32);
 impl HolographicFramePresentResult {
     pub const Success: Self = Self(0i32);
@@ -1138,12 +1134,6 @@ impl ::core::clone::Clone for HolographicFramePresentResult {
 unsafe impl ::windows::core::Abi for HolographicFramePresentResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HolographicFramePresentResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HolographicFramePresentResult {}
 impl ::core::fmt::Debug for HolographicFramePresentResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HolographicFramePresentResult").field(&self.0).finish()
@@ -1157,6 +1147,7 @@ impl ::windows::core::DefaultType for HolographicFramePresentResult {
 }
 #[doc = "*Required features: 'Graphics_Holographic'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HolographicFramePresentWaitBehavior(pub i32);
 impl HolographicFramePresentWaitBehavior {
     pub const WaitForFrameToFinish: Self = Self(0i32);
@@ -1171,12 +1162,6 @@ impl ::core::clone::Clone for HolographicFramePresentWaitBehavior {
 unsafe impl ::windows::core::Abi for HolographicFramePresentWaitBehavior {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HolographicFramePresentWaitBehavior {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HolographicFramePresentWaitBehavior {}
 impl ::core::fmt::Debug for HolographicFramePresentWaitBehavior {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HolographicFramePresentWaitBehavior").field(&self.0).finish()
@@ -2078,6 +2063,7 @@ unsafe impl ::core::marker::Send for HolographicQuadLayerUpdateParameters {}
 unsafe impl ::core::marker::Sync for HolographicQuadLayerUpdateParameters {}
 #[doc = "*Required features: 'Graphics_Holographic'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HolographicReprojectionMode(pub i32);
 impl HolographicReprojectionMode {
     pub const PositionAndOrientation: Self = Self(0i32);
@@ -2093,12 +2079,6 @@ impl ::core::clone::Clone for HolographicReprojectionMode {
 unsafe impl ::windows::core::Abi for HolographicReprojectionMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HolographicReprojectionMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HolographicReprojectionMode {}
 impl ::core::fmt::Debug for HolographicReprojectionMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HolographicReprojectionMode").field(&self.0).finish()
@@ -2516,6 +2496,7 @@ unsafe impl ::core::marker::Send for HolographicSpaceCameraRemovedEventArgs {}
 unsafe impl ::core::marker::Sync for HolographicSpaceCameraRemovedEventArgs {}
 #[doc = "*Required features: 'Graphics_Holographic'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HolographicSpaceUserPresence(pub i32);
 impl HolographicSpaceUserPresence {
     pub const Absent: Self = Self(0i32);
@@ -2531,12 +2512,6 @@ impl ::core::clone::Clone for HolographicSpaceUserPresence {
 unsafe impl ::windows::core::Abi for HolographicSpaceUserPresence {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HolographicSpaceUserPresence {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HolographicSpaceUserPresence {}
 impl ::core::fmt::Debug for HolographicSpaceUserPresence {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HolographicSpaceUserPresence").field(&self.0).finish()
@@ -2775,6 +2750,7 @@ unsafe impl ::core::marker::Send for HolographicViewConfiguration {}
 unsafe impl ::core::marker::Sync for HolographicViewConfiguration {}
 #[doc = "*Required features: 'Graphics_Holographic'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HolographicViewConfigurationKind(pub i32);
 impl HolographicViewConfigurationKind {
     pub const Display: Self = Self(0i32);
@@ -2789,12 +2765,6 @@ impl ::core::clone::Clone for HolographicViewConfigurationKind {
 unsafe impl ::windows::core::Abi for HolographicViewConfigurationKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HolographicViewConfigurationKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HolographicViewConfigurationKind {}
 impl ::core::fmt::Debug for HolographicViewConfigurationKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HolographicViewConfigurationKind").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Graphics/Imaging/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Imaging/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'Graphics_Imaging'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BitmapAlphaMode(pub i32);
 impl BitmapAlphaMode {
     pub const Premultiplied: Self = Self(0i32);
@@ -16,12 +17,6 @@ impl ::core::clone::Clone for BitmapAlphaMode {
 unsafe impl ::windows::core::Abi for BitmapAlphaMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BitmapAlphaMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BitmapAlphaMode {}
 impl ::core::fmt::Debug for BitmapAlphaMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BitmapAlphaMode").field(&self.0).finish()
@@ -230,6 +225,7 @@ unsafe impl ::core::marker::Send for BitmapBuffer {}
 unsafe impl ::core::marker::Sync for BitmapBuffer {}
 #[doc = "*Required features: 'Graphics_Imaging'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BitmapBufferAccessMode(pub i32);
 impl BitmapBufferAccessMode {
     pub const Read: Self = Self(0i32);
@@ -245,12 +241,6 @@ impl ::core::clone::Clone for BitmapBufferAccessMode {
 unsafe impl ::windows::core::Abi for BitmapBufferAccessMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BitmapBufferAccessMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BitmapBufferAccessMode {}
 impl ::core::fmt::Debug for BitmapBufferAccessMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BitmapBufferAccessMode").field(&self.0).finish()
@@ -1033,6 +1023,7 @@ unsafe impl ::core::marker::Send for BitmapEncoder {}
 unsafe impl ::core::marker::Sync for BitmapEncoder {}
 #[doc = "*Required features: 'Graphics_Imaging'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BitmapFlip(pub i32);
 impl BitmapFlip {
     pub const None: Self = Self(0i32);
@@ -1048,12 +1039,6 @@ impl ::core::clone::Clone for BitmapFlip {
 unsafe impl ::windows::core::Abi for BitmapFlip {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BitmapFlip {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BitmapFlip {}
 impl ::core::fmt::Debug for BitmapFlip {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BitmapFlip").field(&self.0).finish()
@@ -1310,6 +1295,7 @@ unsafe impl ::core::marker::Send for BitmapFrame {}
 unsafe impl ::core::marker::Sync for BitmapFrame {}
 #[doc = "*Required features: 'Graphics_Imaging'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BitmapInterpolationMode(pub i32);
 impl BitmapInterpolationMode {
     pub const NearestNeighbor: Self = Self(0i32);
@@ -1326,12 +1312,6 @@ impl ::core::clone::Clone for BitmapInterpolationMode {
 unsafe impl ::windows::core::Abi for BitmapInterpolationMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BitmapInterpolationMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BitmapInterpolationMode {}
 impl ::core::fmt::Debug for BitmapInterpolationMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BitmapInterpolationMode").field(&self.0).finish()
@@ -1345,6 +1325,7 @@ impl ::windows::core::DefaultType for BitmapInterpolationMode {
 }
 #[doc = "*Required features: 'Graphics_Imaging'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BitmapPixelFormat(pub i32);
 impl BitmapPixelFormat {
     pub const Unknown: Self = Self(0i32);
@@ -1366,12 +1347,6 @@ impl ::core::clone::Clone for BitmapPixelFormat {
 unsafe impl ::windows::core::Abi for BitmapPixelFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BitmapPixelFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BitmapPixelFormat {}
 impl ::core::fmt::Debug for BitmapPixelFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BitmapPixelFormat").field(&self.0).finish()
@@ -1874,6 +1849,7 @@ unsafe impl ::core::marker::Send for BitmapPropertySet {}
 unsafe impl ::core::marker::Sync for BitmapPropertySet {}
 #[doc = "*Required features: 'Graphics_Imaging'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BitmapRotation(pub i32);
 impl BitmapRotation {
     pub const None: Self = Self(0i32);
@@ -1890,12 +1866,6 @@ impl ::core::clone::Clone for BitmapRotation {
 unsafe impl ::windows::core::Abi for BitmapRotation {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BitmapRotation {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BitmapRotation {}
 impl ::core::fmt::Debug for BitmapRotation {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BitmapRotation").field(&self.0).finish()
@@ -2207,6 +2177,7 @@ unsafe impl ::core::marker::Send for BitmapTypedValue {}
 unsafe impl ::core::marker::Sync for BitmapTypedValue {}
 #[doc = "*Required features: 'Graphics_Imaging'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ColorManagementMode(pub i32);
 impl ColorManagementMode {
     pub const DoNotColorManage: Self = Self(0i32);
@@ -2221,12 +2192,6 @@ impl ::core::clone::Clone for ColorManagementMode {
 unsafe impl ::windows::core::Abi for ColorManagementMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ColorManagementMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ColorManagementMode {}
 impl ::core::fmt::Debug for ColorManagementMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ColorManagementMode").field(&self.0).finish()
@@ -2240,6 +2205,7 @@ impl ::windows::core::DefaultType for ColorManagementMode {
 }
 #[doc = "*Required features: 'Graphics_Imaging'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ExifOrientationMode(pub i32);
 impl ExifOrientationMode {
     pub const IgnoreExifOrientation: Self = Self(0i32);
@@ -2254,12 +2220,6 @@ impl ::core::clone::Clone for ExifOrientationMode {
 unsafe impl ::windows::core::Abi for ExifOrientationMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ExifOrientationMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ExifOrientationMode {}
 impl ::core::fmt::Debug for ExifOrientationMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ExifOrientationMode").field(&self.0).finish()
@@ -3554,6 +3514,7 @@ unsafe impl ::core::marker::Send for ImageStream {}
 unsafe impl ::core::marker::Sync for ImageStream {}
 #[doc = "*Required features: 'Graphics_Imaging'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct JpegSubsamplingMode(pub i32);
 impl JpegSubsamplingMode {
     pub const Default: Self = Self(0i32);
@@ -3570,12 +3531,6 @@ impl ::core::clone::Clone for JpegSubsamplingMode {
 unsafe impl ::windows::core::Abi for JpegSubsamplingMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JpegSubsamplingMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for JpegSubsamplingMode {}
 impl ::core::fmt::Debug for JpegSubsamplingMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("JpegSubsamplingMode").field(&self.0).finish()
@@ -3670,6 +3625,7 @@ unsafe impl ::core::marker::Send for PixelDataProvider {}
 unsafe impl ::core::marker::Sync for PixelDataProvider {}
 #[doc = "*Required features: 'Graphics_Imaging'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PngFilterMode(pub i32);
 impl PngFilterMode {
     pub const Automatic: Self = Self(0i32);
@@ -3689,12 +3645,6 @@ impl ::core::clone::Clone for PngFilterMode {
 unsafe impl ::windows::core::Abi for PngFilterMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PngFilterMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PngFilterMode {}
 impl ::core::fmt::Debug for PngFilterMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PngFilterMode").field(&self.0).finish()
@@ -3989,6 +3939,7 @@ unsafe impl ::core::marker::Send for SoftwareBitmap {}
 unsafe impl ::core::marker::Sync for SoftwareBitmap {}
 #[doc = "*Required features: 'Graphics_Imaging'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TiffCompressionMode(pub i32);
 impl TiffCompressionMode {
     pub const Automatic: Self = Self(0i32);
@@ -4009,12 +3960,6 @@ impl ::core::clone::Clone for TiffCompressionMode {
 unsafe impl ::windows::core::Abi for TiffCompressionMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TiffCompressionMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TiffCompressionMode {}
 impl ::core::fmt::Debug for TiffCompressionMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TiffCompressionMode").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Graphics/Printing/OptionDetails/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/OptionDetails/mod.rs
@@ -4013,6 +4013,7 @@ unsafe impl ::core::marker::Send for PrintMediaTypeOptionDetails {}
 unsafe impl ::core::marker::Sync for PrintMediaTypeOptionDetails {}
 #[doc = "*Required features: 'Graphics_Printing_OptionDetails'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PrintOptionStates(pub u32);
 impl PrintOptionStates {
     pub const None: Self = Self(0u32);
@@ -4028,12 +4029,6 @@ impl ::core::clone::Clone for PrintOptionStates {
 unsafe impl ::windows::core::Abi for PrintOptionStates {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PrintOptionStates {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PrintOptionStates {}
 impl ::core::fmt::Debug for PrintOptionStates {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PrintOptionStates").field(&self.0).finish()
@@ -4075,6 +4070,7 @@ impl ::windows::core::DefaultType for PrintOptionStates {
 }
 #[doc = "*Required features: 'Graphics_Printing_OptionDetails'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PrintOptionType(pub i32);
 impl PrintOptionType {
     pub const Unknown: Self = Self(0i32);
@@ -4092,12 +4088,6 @@ impl ::core::clone::Clone for PrintOptionType {
 unsafe impl ::windows::core::Abi for PrintOptionType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PrintOptionType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PrintOptionType {}
 impl ::core::fmt::Debug for PrintOptionType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PrintOptionType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Graphics/Printing/PrintSupport/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/PrintSupport/mod.rs
@@ -929,6 +929,7 @@ unsafe impl ::core::marker::Send for PrintSupportSettingsUISession {}
 unsafe impl ::core::marker::Sync for PrintSupportSettingsUISession {}
 #[doc = "*Required features: 'Graphics_Printing_PrintSupport'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SettingsLaunchKind(pub i32);
 impl SettingsLaunchKind {
     pub const JobPrintTicket: Self = Self(0i32);
@@ -943,12 +944,6 @@ impl ::core::clone::Clone for SettingsLaunchKind {
 unsafe impl ::windows::core::Abi for SettingsLaunchKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SettingsLaunchKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SettingsLaunchKind {}
 impl ::core::fmt::Debug for SettingsLaunchKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SettingsLaunchKind").field(&self.0).finish()
@@ -962,6 +957,7 @@ impl ::windows::core::DefaultType for SettingsLaunchKind {
 }
 #[doc = "*Required features: 'Graphics_Printing_PrintSupport'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WorkflowPrintTicketValidationStatus(pub i32);
 impl WorkflowPrintTicketValidationStatus {
     pub const Resolved: Self = Self(0i32);
@@ -977,12 +973,6 @@ impl ::core::clone::Clone for WorkflowPrintTicketValidationStatus {
 unsafe impl ::windows::core::Abi for WorkflowPrintTicketValidationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WorkflowPrintTicketValidationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WorkflowPrintTicketValidationStatus {}
 impl ::core::fmt::Debug for WorkflowPrintTicketValidationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WorkflowPrintTicketValidationStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Graphics/Printing/PrintTicket/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/PrintTicket/mod.rs
@@ -606,6 +606,7 @@ unsafe impl ::core::marker::Send for PrintTicketFeature {}
 unsafe impl ::core::marker::Sync for PrintTicketFeature {}
 #[doc = "*Required features: 'Graphics_Printing_PrintTicket'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PrintTicketFeatureSelectionType(pub i32);
 impl PrintTicketFeatureSelectionType {
     pub const PickOne: Self = Self(0i32);
@@ -620,12 +621,6 @@ impl ::core::clone::Clone for PrintTicketFeatureSelectionType {
 unsafe impl ::windows::core::Abi for PrintTicketFeatureSelectionType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PrintTicketFeatureSelectionType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PrintTicketFeatureSelectionType {}
 impl ::core::fmt::Debug for PrintTicketFeatureSelectionType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PrintTicketFeatureSelectionType").field(&self.0).finish()
@@ -779,6 +774,7 @@ unsafe impl ::core::marker::Send for PrintTicketOption {}
 unsafe impl ::core::marker::Sync for PrintTicketOption {}
 #[doc = "*Required features: 'Graphics_Printing_PrintTicket'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PrintTicketParameterDataType(pub i32);
 impl PrintTicketParameterDataType {
     pub const Integer: Self = Self(0i32);
@@ -794,12 +790,6 @@ impl ::core::clone::Clone for PrintTicketParameterDataType {
 unsafe impl ::windows::core::Abi for PrintTicketParameterDataType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PrintTicketParameterDataType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PrintTicketParameterDataType {}
 impl ::core::fmt::Debug for PrintTicketParameterDataType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PrintTicketParameterDataType").field(&self.0).finish()
@@ -1151,6 +1141,7 @@ unsafe impl ::core::marker::Send for PrintTicketValue {}
 unsafe impl ::core::marker::Sync for PrintTicketValue {}
 #[doc = "*Required features: 'Graphics_Printing_PrintTicket'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PrintTicketValueType(pub i32);
 impl PrintTicketValueType {
     pub const Integer: Self = Self(0i32);
@@ -1166,12 +1157,6 @@ impl ::core::clone::Clone for PrintTicketValueType {
 unsafe impl ::windows::core::Abi for PrintTicketValueType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PrintTicketValueType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PrintTicketValueType {}
 impl ::core::fmt::Debug for PrintTicketValueType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PrintTicketValueType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Graphics/Printing/Workflow/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/Workflow/mod.rs
@@ -1201,6 +1201,7 @@ unsafe impl ::core::marker::Send for PrintWorkflowForegroundSetupRequestedEventA
 unsafe impl ::core::marker::Sync for PrintWorkflowForegroundSetupRequestedEventArgs {}
 #[doc = "*Required features: 'Graphics_Printing_Workflow'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PrintWorkflowJobAbortReason(pub i32);
 impl PrintWorkflowJobAbortReason {
     pub const JobFailed: Self = Self(0i32);
@@ -1215,12 +1216,6 @@ impl ::core::clone::Clone for PrintWorkflowJobAbortReason {
 unsafe impl ::windows::core::Abi for PrintWorkflowJobAbortReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PrintWorkflowJobAbortReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PrintWorkflowJobAbortReason {}
 impl ::core::fmt::Debug for PrintWorkflowJobAbortReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PrintWorkflowJobAbortReason").field(&self.0).finish()
@@ -2076,6 +2071,7 @@ unsafe impl ::core::marker::Send for PrintWorkflowObjectModelTargetPackage {}
 unsafe impl ::core::marker::Sync for PrintWorkflowObjectModelTargetPackage {}
 #[doc = "*Required features: 'Graphics_Printing_Workflow'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PrintWorkflowPdlConversionType(pub i32);
 impl PrintWorkflowPdlConversionType {
     pub const XpsToPdf: Self = Self(0i32);
@@ -2091,12 +2087,6 @@ impl ::core::clone::Clone for PrintWorkflowPdlConversionType {
 unsafe impl ::windows::core::Abi for PrintWorkflowPdlConversionType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PrintWorkflowPdlConversionType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PrintWorkflowPdlConversionType {}
 impl ::core::fmt::Debug for PrintWorkflowPdlConversionType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PrintWorkflowPdlConversionType").field(&self.0).finish()
@@ -2775,6 +2765,7 @@ unsafe impl ::core::marker::Send for PrintWorkflowPrinterJob {}
 unsafe impl ::core::marker::Sync for PrintWorkflowPrinterJob {}
 #[doc = "*Required features: 'Graphics_Printing_Workflow'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PrintWorkflowPrinterJobStatus(pub i32);
 impl PrintWorkflowPrinterJobStatus {
     pub const Error: Self = Self(0i32);
@@ -2791,12 +2782,6 @@ impl ::core::clone::Clone for PrintWorkflowPrinterJobStatus {
 unsafe impl ::windows::core::Abi for PrintWorkflowPrinterJobStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PrintWorkflowPrinterJobStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PrintWorkflowPrinterJobStatus {}
 impl ::core::fmt::Debug for PrintWorkflowPrinterJobStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PrintWorkflowPrinterJobStatus").field(&self.0).finish()
@@ -2810,6 +2795,7 @@ impl ::windows::core::DefaultType for PrintWorkflowPrinterJobStatus {
 }
 #[doc = "*Required features: 'Graphics_Printing_Workflow'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PrintWorkflowSessionStatus(pub i32);
 impl PrintWorkflowSessionStatus {
     pub const Started: Self = Self(0i32);
@@ -2827,12 +2813,6 @@ impl ::core::clone::Clone for PrintWorkflowSessionStatus {
 unsafe impl ::windows::core::Abi for PrintWorkflowSessionStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PrintWorkflowSessionStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PrintWorkflowSessionStatus {}
 impl ::core::fmt::Debug for PrintWorkflowSessionStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PrintWorkflowSessionStatus").field(&self.0).finish()
@@ -3301,6 +3281,7 @@ unsafe impl ::core::marker::Send for PrintWorkflowSubmittedOperation {}
 unsafe impl ::core::marker::Sync for PrintWorkflowSubmittedOperation {}
 #[doc = "*Required features: 'Graphics_Printing_Workflow'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PrintWorkflowSubmittedStatus(pub i32);
 impl PrintWorkflowSubmittedStatus {
     pub const Succeeded: Self = Self(0i32);
@@ -3316,12 +3297,6 @@ impl ::core::clone::Clone for PrintWorkflowSubmittedStatus {
 unsafe impl ::windows::core::Abi for PrintWorkflowSubmittedStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PrintWorkflowSubmittedStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PrintWorkflowSubmittedStatus {}
 impl ::core::fmt::Debug for PrintWorkflowSubmittedStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PrintWorkflowSubmittedStatus").field(&self.0).finish()
@@ -3674,6 +3649,7 @@ unsafe impl ::core::marker::Send for PrintWorkflowUIActivatedEventArgs {}
 unsafe impl ::core::marker::Sync for PrintWorkflowUIActivatedEventArgs {}
 #[doc = "*Required features: 'Graphics_Printing_Workflow'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PrintWorkflowUICompletionStatus(pub i32);
 impl PrintWorkflowUICompletionStatus {
     pub const Completed: Self = Self(0i32);
@@ -3690,12 +3666,6 @@ impl ::core::clone::Clone for PrintWorkflowUICompletionStatus {
 unsafe impl ::windows::core::Abi for PrintWorkflowUICompletionStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PrintWorkflowUICompletionStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PrintWorkflowUICompletionStatus {}
 impl ::core::fmt::Debug for PrintWorkflowUICompletionStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PrintWorkflowUICompletionStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Graphics/Printing/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing/mod.rs
@@ -990,6 +990,7 @@ pub struct IStandardPrintTaskOptionsStatic3Vtbl(
 );
 #[doc = "*Required features: 'Graphics_Printing'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PrintBinding(pub i32);
 impl PrintBinding {
     pub const Default: Self = Self(0i32);
@@ -1019,12 +1020,6 @@ impl ::core::clone::Clone for PrintBinding {
 unsafe impl ::windows::core::Abi for PrintBinding {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PrintBinding {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PrintBinding {}
 impl ::core::fmt::Debug for PrintBinding {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PrintBinding").field(&self.0).finish()
@@ -1038,6 +1033,7 @@ impl ::windows::core::DefaultType for PrintBinding {
 }
 #[doc = "*Required features: 'Graphics_Printing'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PrintBordering(pub i32);
 impl PrintBordering {
     pub const Default: Self = Self(0i32);
@@ -1055,12 +1051,6 @@ impl ::core::clone::Clone for PrintBordering {
 unsafe impl ::windows::core::Abi for PrintBordering {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PrintBordering {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PrintBordering {}
 impl ::core::fmt::Debug for PrintBordering {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PrintBordering").field(&self.0).finish()
@@ -1074,6 +1064,7 @@ impl ::windows::core::DefaultType for PrintBordering {
 }
 #[doc = "*Required features: 'Graphics_Printing'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PrintCollation(pub i32);
 impl PrintCollation {
     pub const Default: Self = Self(0i32);
@@ -1091,12 +1082,6 @@ impl ::core::clone::Clone for PrintCollation {
 unsafe impl ::windows::core::Abi for PrintCollation {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PrintCollation {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PrintCollation {}
 impl ::core::fmt::Debug for PrintCollation {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PrintCollation").field(&self.0).finish()
@@ -1110,6 +1095,7 @@ impl ::windows::core::DefaultType for PrintCollation {
 }
 #[doc = "*Required features: 'Graphics_Printing'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PrintColorMode(pub i32);
 impl PrintColorMode {
     pub const Default: Self = Self(0i32);
@@ -1128,12 +1114,6 @@ impl ::core::clone::Clone for PrintColorMode {
 unsafe impl ::windows::core::Abi for PrintColorMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PrintColorMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PrintColorMode {}
 impl ::core::fmt::Debug for PrintColorMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PrintColorMode").field(&self.0).finish()
@@ -1147,6 +1127,7 @@ impl ::windows::core::DefaultType for PrintColorMode {
 }
 #[doc = "*Required features: 'Graphics_Printing'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PrintDuplex(pub i32);
 impl PrintDuplex {
     pub const Default: Self = Self(0i32);
@@ -1165,12 +1146,6 @@ impl ::core::clone::Clone for PrintDuplex {
 unsafe impl ::windows::core::Abi for PrintDuplex {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PrintDuplex {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PrintDuplex {}
 impl ::core::fmt::Debug for PrintDuplex {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PrintDuplex").field(&self.0).finish()
@@ -1184,6 +1159,7 @@ impl ::windows::core::DefaultType for PrintDuplex {
 }
 #[doc = "*Required features: 'Graphics_Printing'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PrintHolePunch(pub i32);
 impl PrintHolePunch {
     pub const Default: Self = Self(0i32);
@@ -1204,12 +1180,6 @@ impl ::core::clone::Clone for PrintHolePunch {
 unsafe impl ::windows::core::Abi for PrintHolePunch {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PrintHolePunch {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PrintHolePunch {}
 impl ::core::fmt::Debug for PrintHolePunch {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PrintHolePunch").field(&self.0).finish()
@@ -1343,6 +1313,7 @@ unsafe impl ::core::marker::Send for PrintManager {}
 unsafe impl ::core::marker::Sync for PrintManager {}
 #[doc = "*Required features: 'Graphics_Printing'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PrintMediaSize(pub i32);
 impl PrintMediaSize {
     pub const Default: Self = Self(0i32);
@@ -1528,12 +1499,6 @@ impl ::core::clone::Clone for PrintMediaSize {
 unsafe impl ::windows::core::Abi for PrintMediaSize {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PrintMediaSize {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PrintMediaSize {}
 impl ::core::fmt::Debug for PrintMediaSize {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PrintMediaSize").field(&self.0).finish()
@@ -1547,6 +1512,7 @@ impl ::windows::core::DefaultType for PrintMediaSize {
 }
 #[doc = "*Required features: 'Graphics_Printing'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PrintMediaType(pub i32);
 impl PrintMediaType {
     pub const Default: Self = Self(0i32);
@@ -1591,12 +1557,6 @@ impl ::core::clone::Clone for PrintMediaType {
 unsafe impl ::windows::core::Abi for PrintMediaType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PrintMediaType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PrintMediaType {}
 impl ::core::fmt::Debug for PrintMediaType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PrintMediaType").field(&self.0).finish()
@@ -1610,6 +1570,7 @@ impl ::windows::core::DefaultType for PrintMediaType {
 }
 #[doc = "*Required features: 'Graphics_Printing'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PrintOrientation(pub i32);
 impl PrintOrientation {
     pub const Default: Self = Self(0i32);
@@ -1629,12 +1590,6 @@ impl ::core::clone::Clone for PrintOrientation {
 unsafe impl ::windows::core::Abi for PrintOrientation {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PrintOrientation {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PrintOrientation {}
 impl ::core::fmt::Debug for PrintOrientation {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PrintOrientation").field(&self.0).finish()
@@ -2064,6 +2019,7 @@ unsafe impl ::core::marker::Send for PrintPageRangeOptions {}
 unsafe impl ::core::marker::Sync for PrintPageRangeOptions {}
 #[doc = "*Required features: 'Graphics_Printing'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PrintQuality(pub i32);
 impl PrintQuality {
     pub const Default: Self = Self(0i32);
@@ -2086,12 +2042,6 @@ impl ::core::clone::Clone for PrintQuality {
 unsafe impl ::windows::core::Abi for PrintQuality {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PrintQuality {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PrintQuality {}
 impl ::core::fmt::Debug for PrintQuality {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PrintQuality").field(&self.0).finish()
@@ -2105,6 +2055,7 @@ impl ::windows::core::DefaultType for PrintQuality {
 }
 #[doc = "*Required features: 'Graphics_Printing'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PrintStaple(pub i32);
 impl PrintStaple {
     pub const Default: Self = Self(0i32);
@@ -2130,12 +2081,6 @@ impl ::core::clone::Clone for PrintStaple {
 unsafe impl ::windows::core::Abi for PrintStaple {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PrintStaple {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PrintStaple {}
 impl ::core::fmt::Debug for PrintStaple {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PrintStaple").field(&self.0).finish()
@@ -2427,6 +2372,7 @@ unsafe impl ::core::marker::Send for PrintTaskCompletedEventArgs {}
 unsafe impl ::core::marker::Sync for PrintTaskCompletedEventArgs {}
 #[doc = "*Required features: 'Graphics_Printing'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PrintTaskCompletion(pub i32);
 impl PrintTaskCompletion {
     pub const Abandoned: Self = Self(0i32);
@@ -2443,12 +2389,6 @@ impl ::core::clone::Clone for PrintTaskCompletion {
 unsafe impl ::windows::core::Abi for PrintTaskCompletion {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PrintTaskCompletion {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PrintTaskCompletion {}
 impl ::core::fmt::Debug for PrintTaskCompletion {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PrintTaskCompletion").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Graphics/Printing3D/mod.rs
+++ b/crates/libs/windows/src/Windows/Graphics/Printing3D/mod.rs
@@ -1216,6 +1216,7 @@ unsafe impl ::core::marker::Send for Print3DTaskCompletedEventArgs {}
 unsafe impl ::core::marker::Sync for Print3DTaskCompletedEventArgs {}
 #[doc = "*Required features: 'Graphics_Printing3D'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct Print3DTaskCompletion(pub i32);
 impl Print3DTaskCompletion {
     pub const Abandoned: Self = Self(0i32);
@@ -1233,12 +1234,6 @@ impl ::core::clone::Clone for Print3DTaskCompletion {
 unsafe impl ::windows::core::Abi for Print3DTaskCompletion {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for Print3DTaskCompletion {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for Print3DTaskCompletion {}
 impl ::core::fmt::Debug for Print3DTaskCompletion {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("Print3DTaskCompletion").field(&self.0).finish()
@@ -1252,6 +1247,7 @@ impl ::windows::core::DefaultType for Print3DTaskCompletion {
 }
 #[doc = "*Required features: 'Graphics_Printing3D'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct Print3DTaskDetail(pub i32);
 impl Print3DTaskDetail {
     pub const Unknown: Self = Self(0i32);
@@ -1271,12 +1267,6 @@ impl ::core::clone::Clone for Print3DTaskDetail {
 unsafe impl ::windows::core::Abi for Print3DTaskDetail {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for Print3DTaskDetail {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for Print3DTaskDetail {}
 impl ::core::fmt::Debug for Print3DTaskDetail {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("Print3DTaskDetail").field(&self.0).finish()
@@ -2135,6 +2125,7 @@ impl ::core::default::Default for Printing3DBufferDescription {
 }
 #[doc = "*Required features: 'Graphics_Printing3D'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct Printing3DBufferFormat(pub i32);
 impl Printing3DBufferFormat {
     pub const Unknown: Self = Self(0i32);
@@ -2154,12 +2145,6 @@ impl ::core::clone::Clone for Printing3DBufferFormat {
 unsafe impl ::windows::core::Abi for Printing3DBufferFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for Printing3DBufferFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for Printing3DBufferFormat {}
 impl ::core::fmt::Debug for Printing3DBufferFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("Printing3DBufferFormat").field(&self.0).finish()
@@ -3343,6 +3328,7 @@ unsafe impl ::core::marker::Send for Printing3DMesh {}
 unsafe impl ::core::marker::Sync for Printing3DMesh {}
 #[doc = "*Required features: 'Graphics_Printing3D'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct Printing3DMeshVerificationMode(pub i32);
 impl Printing3DMeshVerificationMode {
     pub const FindFirstError: Self = Self(0i32);
@@ -3357,12 +3343,6 @@ impl ::core::clone::Clone for Printing3DMeshVerificationMode {
 unsafe impl ::windows::core::Abi for Printing3DMeshVerificationMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for Printing3DMeshVerificationMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for Printing3DMeshVerificationMode {}
 impl ::core::fmt::Debug for Printing3DMeshVerificationMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("Printing3DMeshVerificationMode").field(&self.0).finish()
@@ -3842,6 +3822,7 @@ unsafe impl ::core::marker::Send for Printing3DModelTexture {}
 unsafe impl ::core::marker::Sync for Printing3DModelTexture {}
 #[doc = "*Required features: 'Graphics_Printing3D'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct Printing3DModelUnit(pub i32);
 impl Printing3DModelUnit {
     pub const Meter: Self = Self(0i32);
@@ -3860,12 +3841,6 @@ impl ::core::clone::Clone for Printing3DModelUnit {
 unsafe impl ::windows::core::Abi for Printing3DModelUnit {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for Printing3DModelUnit {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for Printing3DModelUnit {}
 impl ::core::fmt::Debug for Printing3DModelUnit {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("Printing3DModelUnit").field(&self.0).finish()
@@ -4079,6 +4054,7 @@ unsafe impl ::core::marker::Send for Printing3DMultiplePropertyMaterialGroup {}
 unsafe impl ::core::marker::Sync for Printing3DMultiplePropertyMaterialGroup {}
 #[doc = "*Required features: 'Graphics_Printing3D'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct Printing3DObjectType(pub i32);
 impl Printing3DObjectType {
     pub const Model: Self = Self(0i32);
@@ -4094,12 +4070,6 @@ impl ::core::clone::Clone for Printing3DObjectType {
 unsafe impl ::windows::core::Abi for Printing3DObjectType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for Printing3DObjectType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for Printing3DObjectType {}
 impl ::core::fmt::Debug for Printing3DObjectType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("Printing3DObjectType").field(&self.0).finish()
@@ -4113,6 +4083,7 @@ impl ::windows::core::DefaultType for Printing3DObjectType {
 }
 #[doc = "*Required features: 'Graphics_Printing3D'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct Printing3DPackageCompression(pub i32);
 impl Printing3DPackageCompression {
     pub const Low: Self = Self(0i32);
@@ -4128,12 +4099,6 @@ impl ::core::clone::Clone for Printing3DPackageCompression {
 unsafe impl ::windows::core::Abi for Printing3DPackageCompression {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for Printing3DPackageCompression {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for Printing3DPackageCompression {}
 impl ::core::fmt::Debug for Printing3DPackageCompression {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("Printing3DPackageCompression").field(&self.0).finish()
@@ -4381,6 +4346,7 @@ unsafe impl ::core::marker::Send for Printing3DTexture2CoordMaterialGroup {}
 unsafe impl ::core::marker::Sync for Printing3DTexture2CoordMaterialGroup {}
 #[doc = "*Required features: 'Graphics_Printing3D'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct Printing3DTextureEdgeBehavior(pub i32);
 impl Printing3DTextureEdgeBehavior {
     pub const None: Self = Self(0i32);
@@ -4397,12 +4363,6 @@ impl ::core::clone::Clone for Printing3DTextureEdgeBehavior {
 unsafe impl ::windows::core::Abi for Printing3DTextureEdgeBehavior {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for Printing3DTextureEdgeBehavior {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for Printing3DTextureEdgeBehavior {}
 impl ::core::fmt::Debug for Printing3DTextureEdgeBehavior {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("Printing3DTextureEdgeBehavior").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Management/Deployment/mod.rs
+++ b/crates/libs/windows/src/Windows/Management/Deployment/mod.rs
@@ -3,6 +3,7 @@
 pub mod Preview;
 #[doc = "*Required features: 'Management_Deployment'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AddPackageByAppInstallerOptions(pub u32);
 impl AddPackageByAppInstallerOptions {
     pub const None: Self = Self(0u32);
@@ -20,12 +21,6 @@ impl ::core::clone::Clone for AddPackageByAppInstallerOptions {
 unsafe impl ::windows::core::Abi for AddPackageByAppInstallerOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AddPackageByAppInstallerOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AddPackageByAppInstallerOptions {}
 impl ::core::fmt::Debug for AddPackageByAppInstallerOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AddPackageByAppInstallerOptions").field(&self.0).finish()
@@ -1119,6 +1114,7 @@ unsafe impl ::core::marker::Send for DeleteSharedPackageContainerResult {}
 unsafe impl ::core::marker::Sync for DeleteSharedPackageContainerResult {}
 #[doc = "*Required features: 'Management_Deployment'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DeploymentOptions(pub u32);
 impl DeploymentOptions {
     pub const None: Self = Self(0u32);
@@ -1140,12 +1136,6 @@ impl ::core::clone::Clone for DeploymentOptions {
 unsafe impl ::windows::core::Abi for DeploymentOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DeploymentOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DeploymentOptions {}
 impl ::core::fmt::Debug for DeploymentOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DeploymentOptions").field(&self.0).finish()
@@ -1224,6 +1214,7 @@ impl ::core::default::Default for DeploymentProgress {
 }
 #[doc = "*Required features: 'Management_Deployment'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DeploymentProgressState(pub i32);
 impl DeploymentProgressState {
     pub const Queued: Self = Self(0i32);
@@ -1238,12 +1229,6 @@ impl ::core::clone::Clone for DeploymentProgressState {
 unsafe impl ::windows::core::Abi for DeploymentProgressState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DeploymentProgressState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DeploymentProgressState {}
 impl ::core::fmt::Debug for DeploymentProgressState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DeploymentProgressState").field(&self.0).finish()
@@ -2516,6 +2501,7 @@ unsafe impl ::core::marker::Send for PackageAllUserProvisioningOptions {}
 unsafe impl ::core::marker::Sync for PackageAllUserProvisioningOptions {}
 #[doc = "*Required features: 'Management_Deployment'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PackageInstallState(pub i32);
 impl PackageInstallState {
     pub const NotInstalled: Self = Self(0i32);
@@ -2532,12 +2518,6 @@ impl ::core::clone::Clone for PackageInstallState {
 unsafe impl ::windows::core::Abi for PackageInstallState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PackageInstallState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PackageInstallState {}
 impl ::core::fmt::Debug for PackageInstallState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PackageInstallState").field(&self.0).finish()
@@ -3307,6 +3287,7 @@ unsafe impl ::core::marker::Send for PackageManagerDebugSettings {}
 unsafe impl ::core::marker::Sync for PackageManagerDebugSettings {}
 #[doc = "*Required features: 'Management_Deployment'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PackageState(pub i32);
 impl PackageState {
     pub const Normal: Self = Self(0i32);
@@ -3323,12 +3304,6 @@ impl ::core::clone::Clone for PackageState {
 unsafe impl ::windows::core::Abi for PackageState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PackageState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PackageState {}
 impl ::core::fmt::Debug for PackageState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PackageState").field(&self.0).finish()
@@ -3342,6 +3317,7 @@ impl ::windows::core::DefaultType for PackageState {
 }
 #[doc = "*Required features: 'Management_Deployment'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PackageStatus(pub u32);
 impl PackageStatus {
     pub const OK: Self = Self(0u32);
@@ -3359,12 +3335,6 @@ impl ::core::clone::Clone for PackageStatus {
 unsafe impl ::windows::core::Abi for PackageStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PackageStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PackageStatus {}
 impl ::core::fmt::Debug for PackageStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PackageStatus").field(&self.0).finish()
@@ -3406,6 +3376,7 @@ impl ::windows::core::DefaultType for PackageStatus {
 }
 #[doc = "*Required features: 'Management_Deployment'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PackageStubPreference(pub i32);
 impl PackageStubPreference {
     pub const Full: Self = Self(0i32);
@@ -3420,12 +3391,6 @@ impl ::core::clone::Clone for PackageStubPreference {
 unsafe impl ::windows::core::Abi for PackageStubPreference {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PackageStubPreference {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PackageStubPreference {}
 impl ::core::fmt::Debug for PackageStubPreference {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PackageStubPreference").field(&self.0).finish()
@@ -3439,6 +3404,7 @@ impl ::windows::core::DefaultType for PackageStubPreference {
 }
 #[doc = "*Required features: 'Management_Deployment'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PackageTypes(pub u32);
 impl PackageTypes {
     pub const None: Self = Self(0u32);
@@ -3459,12 +3425,6 @@ impl ::core::clone::Clone for PackageTypes {
 unsafe impl ::windows::core::Abi for PackageTypes {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PackageTypes {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PackageTypes {}
 impl ::core::fmt::Debug for PackageTypes {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PackageTypes").field(&self.0).finish()
@@ -4097,6 +4057,7 @@ unsafe impl ::core::marker::Send for RegisterPackageOptions {}
 unsafe impl ::core::marker::Sync for RegisterPackageOptions {}
 #[doc = "*Required features: 'Management_Deployment'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RemovalOptions(pub u32);
 impl RemovalOptions {
     pub const None: Self = Self(0u32);
@@ -4113,12 +4074,6 @@ impl ::core::clone::Clone for RemovalOptions {
 unsafe impl ::windows::core::Abi for RemovalOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RemovalOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RemovalOptions {}
 impl ::core::fmt::Debug for RemovalOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RemovalOptions").field(&self.0).finish()
@@ -4274,6 +4229,7 @@ unsafe impl ::core::marker::Send for SharedPackageContainer {}
 unsafe impl ::core::marker::Sync for SharedPackageContainer {}
 #[doc = "*Required features: 'Management_Deployment'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SharedPackageContainerCreationCollisionOptions(pub i32);
 impl SharedPackageContainerCreationCollisionOptions {
     pub const FailIfExists: Self = Self(0i32);
@@ -4289,12 +4245,6 @@ impl ::core::clone::Clone for SharedPackageContainerCreationCollisionOptions {
 unsafe impl ::windows::core::Abi for SharedPackageContainerCreationCollisionOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SharedPackageContainerCreationCollisionOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SharedPackageContainerCreationCollisionOptions {}
 impl ::core::fmt::Debug for SharedPackageContainerCreationCollisionOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SharedPackageContainerCreationCollisionOptions").field(&self.0).finish()
@@ -4542,6 +4492,7 @@ unsafe impl ::core::marker::Send for SharedPackageContainerMember {}
 unsafe impl ::core::marker::Sync for SharedPackageContainerMember {}
 #[doc = "*Required features: 'Management_Deployment'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SharedPackageContainerOperationStatus(pub i32);
 impl SharedPackageContainerOperationStatus {
     pub const Success: Self = Self(0i32);
@@ -4560,12 +4511,6 @@ impl ::core::clone::Clone for SharedPackageContainerOperationStatus {
 unsafe impl ::windows::core::Abi for SharedPackageContainerOperationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SharedPackageContainerOperationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SharedPackageContainerOperationStatus {}
 impl ::core::fmt::Debug for SharedPackageContainerOperationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SharedPackageContainerOperationStatus").field(&self.0).finish()
@@ -4814,6 +4759,7 @@ unsafe impl ::core::marker::Send for StagePackageOptions {}
 unsafe impl ::core::marker::Sync for StagePackageOptions {}
 #[doc = "*Required features: 'Management_Deployment'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StubPackageOption(pub i32);
 impl StubPackageOption {
     pub const Default: Self = Self(0i32);
@@ -4830,12 +4776,6 @@ impl ::core::clone::Clone for StubPackageOption {
 unsafe impl ::windows::core::Abi for StubPackageOption {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StubPackageOption {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StubPackageOption {}
 impl ::core::fmt::Debug for StubPackageOption {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StubPackageOption").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Management/Policies/mod.rs
+++ b/crates/libs/windows/src/Windows/Management/Policies/mod.rs
@@ -260,6 +260,7 @@ unsafe impl ::core::marker::Send for NamedPolicyData {}
 unsafe impl ::core::marker::Sync for NamedPolicyData {}
 #[doc = "*Required features: 'Management_Policies'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct NamedPolicyKind(pub i32);
 impl NamedPolicyKind {
     pub const Invalid: Self = Self(0i32);
@@ -278,12 +279,6 @@ impl ::core::clone::Clone for NamedPolicyKind {
 unsafe impl ::windows::core::Abi for NamedPolicyKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NamedPolicyKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for NamedPolicyKind {}
 impl ::core::fmt::Debug for NamedPolicyKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NamedPolicyKind").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Management/Workplace/mod.rs
+++ b/crates/libs/windows/src/Windows/Management/Workplace/mod.rs
@@ -110,6 +110,7 @@ impl ::windows::core::RuntimeName for MdmPolicy {
 }
 #[doc = "*Required features: 'Management_Workplace'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MessagingSyncPolicy(pub i32);
 impl MessagingSyncPolicy {
     pub const Disallowed: Self = Self(0i32);
@@ -125,12 +126,6 @@ impl ::core::clone::Clone for MessagingSyncPolicy {
 unsafe impl ::windows::core::Abi for MessagingSyncPolicy {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MessagingSyncPolicy {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MessagingSyncPolicy {}
 impl ::core::fmt::Debug for MessagingSyncPolicy {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MessagingSyncPolicy").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Management/mod.rs
+++ b/crates/libs/windows/src/Windows/Management/mod.rs
@@ -256,6 +256,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &MdmA
 }
 #[doc = "*Required features: 'Management'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MdmAlertDataType(pub i32);
 impl MdmAlertDataType {
     pub const String: Self = Self(0i32);
@@ -272,12 +273,6 @@ impl ::core::clone::Clone for MdmAlertDataType {
 unsafe impl ::windows::core::Abi for MdmAlertDataType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MdmAlertDataType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MdmAlertDataType {}
 impl ::core::fmt::Debug for MdmAlertDataType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MdmAlertDataType").field(&self.0).finish()
@@ -291,6 +286,7 @@ impl ::windows::core::DefaultType for MdmAlertDataType {
 }
 #[doc = "*Required features: 'Management'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MdmAlertMark(pub i32);
 impl MdmAlertMark {
     pub const None: Self = Self(0i32);
@@ -308,12 +304,6 @@ impl ::core::clone::Clone for MdmAlertMark {
 unsafe impl ::windows::core::Abi for MdmAlertMark {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MdmAlertMark {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MdmAlertMark {}
 impl ::core::fmt::Debug for MdmAlertMark {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MdmAlertMark").field(&self.0).finish()
@@ -501,6 +491,7 @@ impl ::windows::core::RuntimeName for MdmSessionManager {
 }
 #[doc = "*Required features: 'Management'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MdmSessionState(pub i32);
 impl MdmSessionState {
     pub const NotStarted: Self = Self(0i32);
@@ -520,12 +511,6 @@ impl ::core::clone::Clone for MdmSessionState {
 unsafe impl ::windows::core::Abi for MdmSessionState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MdmSessionState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MdmSessionState {}
 impl ::core::fmt::Debug for MdmSessionState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MdmSessionState").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Media/AppRecording/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/AppRecording/mod.rs
@@ -236,6 +236,7 @@ unsafe impl ::core::marker::Send for AppRecordingResult {}
 unsafe impl ::core::marker::Sync for AppRecordingResult {}
 #[doc = "*Required features: 'Media_AppRecording'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppRecordingSaveScreenshotOption(pub i32);
 impl AppRecordingSaveScreenshotOption {
     pub const None: Self = Self(0i32);
@@ -250,12 +251,6 @@ impl ::core::clone::Clone for AppRecordingSaveScreenshotOption {
 unsafe impl ::windows::core::Abi for AppRecordingSaveScreenshotOption {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppRecordingSaveScreenshotOption {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppRecordingSaveScreenshotOption {}
 impl ::core::fmt::Debug for AppRecordingSaveScreenshotOption {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppRecordingSaveScreenshotOption").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Media/Audio/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Audio/mod.rs
@@ -284,6 +284,7 @@ unsafe impl ::core::marker::Send for AudioDeviceInputNode {}
 unsafe impl ::core::marker::Sync for AudioDeviceInputNode {}
 #[doc = "*Required features: 'Media_Audio'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AudioDeviceNodeCreationStatus(pub i32);
 impl AudioDeviceNodeCreationStatus {
     pub const Success: Self = Self(0i32);
@@ -301,12 +302,6 @@ impl ::core::clone::Clone for AudioDeviceNodeCreationStatus {
 unsafe impl ::windows::core::Abi for AudioDeviceNodeCreationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AudioDeviceNodeCreationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AudioDeviceNodeCreationStatus {}
 impl ::core::fmt::Debug for AudioDeviceNodeCreationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AudioDeviceNodeCreationStatus").field(&self.0).finish()
@@ -942,6 +937,7 @@ unsafe impl ::core::marker::Send for AudioFileInputNode {}
 unsafe impl ::core::marker::Sync for AudioFileInputNode {}
 #[doc = "*Required features: 'Media_Audio'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AudioFileNodeCreationStatus(pub i32);
 impl AudioFileNodeCreationStatus {
     pub const Success: Self = Self(0i32);
@@ -959,12 +955,6 @@ impl ::core::clone::Clone for AudioFileNodeCreationStatus {
 unsafe impl ::windows::core::Abi for AudioFileNodeCreationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AudioFileNodeCreationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AudioFileNodeCreationStatus {}
 impl ::core::fmt::Debug for AudioFileNodeCreationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AudioFileNodeCreationStatus").field(&self.0).finish()
@@ -2448,6 +2438,7 @@ unsafe impl ::core::marker::Send for AudioGraphConnection {}
 unsafe impl ::core::marker::Sync for AudioGraphConnection {}
 #[doc = "*Required features: 'Media_Audio'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AudioGraphCreationStatus(pub i32);
 impl AudioGraphCreationStatus {
     pub const Success: Self = Self(0i32);
@@ -2464,12 +2455,6 @@ impl ::core::clone::Clone for AudioGraphCreationStatus {
 unsafe impl ::windows::core::Abi for AudioGraphCreationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AudioGraphCreationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AudioGraphCreationStatus {}
 impl ::core::fmt::Debug for AudioGraphCreationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AudioGraphCreationStatus").field(&self.0).finish()
@@ -2666,6 +2651,7 @@ unsafe impl ::core::marker::Send for AudioGraphSettings {}
 unsafe impl ::core::marker::Sync for AudioGraphSettings {}
 #[doc = "*Required features: 'Media_Audio'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AudioGraphUnrecoverableError(pub i32);
 impl AudioGraphUnrecoverableError {
     pub const None: Self = Self(0i32);
@@ -2682,12 +2668,6 @@ impl ::core::clone::Clone for AudioGraphUnrecoverableError {
 unsafe impl ::windows::core::Abi for AudioGraphUnrecoverableError {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AudioGraphUnrecoverableError {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AudioGraphUnrecoverableError {}
 impl ::core::fmt::Debug for AudioGraphUnrecoverableError {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AudioGraphUnrecoverableError").field(&self.0).finish()
@@ -3092,6 +3072,7 @@ unsafe impl ::core::marker::Send for AudioNodeEmitterConeProperties {}
 unsafe impl ::core::marker::Sync for AudioNodeEmitterConeProperties {}
 #[doc = "*Required features: 'Media_Audio'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AudioNodeEmitterDecayKind(pub i32);
 impl AudioNodeEmitterDecayKind {
     pub const Natural: Self = Self(0i32);
@@ -3106,12 +3087,6 @@ impl ::core::clone::Clone for AudioNodeEmitterDecayKind {
 unsafe impl ::windows::core::Abi for AudioNodeEmitterDecayKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AudioNodeEmitterDecayKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AudioNodeEmitterDecayKind {}
 impl ::core::fmt::Debug for AudioNodeEmitterDecayKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AudioNodeEmitterDecayKind").field(&self.0).finish()
@@ -3338,6 +3313,7 @@ unsafe impl ::core::marker::Send for AudioNodeEmitterNaturalDecayModelProperties
 unsafe impl ::core::marker::Sync for AudioNodeEmitterNaturalDecayModelProperties {}
 #[doc = "*Required features: 'Media_Audio'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AudioNodeEmitterSettings(pub u32);
 impl AudioNodeEmitterSettings {
     pub const None: Self = Self(0u32);
@@ -3352,12 +3328,6 @@ impl ::core::clone::Clone for AudioNodeEmitterSettings {
 unsafe impl ::windows::core::Abi for AudioNodeEmitterSettings {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AudioNodeEmitterSettings {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AudioNodeEmitterSettings {}
 impl ::core::fmt::Debug for AudioNodeEmitterSettings {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AudioNodeEmitterSettings").field(&self.0).finish()
@@ -3507,6 +3477,7 @@ unsafe impl ::core::marker::Send for AudioNodeEmitterShape {}
 unsafe impl ::core::marker::Sync for AudioNodeEmitterShape {}
 #[doc = "*Required features: 'Media_Audio'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AudioNodeEmitterShapeKind(pub i32);
 impl AudioNodeEmitterShapeKind {
     pub const Omnidirectional: Self = Self(0i32);
@@ -3521,12 +3492,6 @@ impl ::core::clone::Clone for AudioNodeEmitterShapeKind {
 unsafe impl ::windows::core::Abi for AudioNodeEmitterShapeKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AudioNodeEmitterShapeKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AudioNodeEmitterShapeKind {}
 impl ::core::fmt::Debug for AudioNodeEmitterShapeKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AudioNodeEmitterShapeKind").field(&self.0).finish()
@@ -3953,6 +3918,7 @@ unsafe impl ::core::marker::Send for AudioPlaybackConnectionOpenResult {}
 unsafe impl ::core::marker::Sync for AudioPlaybackConnectionOpenResult {}
 #[doc = "*Required features: 'Media_Audio'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AudioPlaybackConnectionOpenResultStatus(pub i32);
 impl AudioPlaybackConnectionOpenResultStatus {
     pub const Success: Self = Self(0i32);
@@ -3969,12 +3935,6 @@ impl ::core::clone::Clone for AudioPlaybackConnectionOpenResultStatus {
 unsafe impl ::windows::core::Abi for AudioPlaybackConnectionOpenResultStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AudioPlaybackConnectionOpenResultStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AudioPlaybackConnectionOpenResultStatus {}
 impl ::core::fmt::Debug for AudioPlaybackConnectionOpenResultStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AudioPlaybackConnectionOpenResultStatus").field(&self.0).finish()
@@ -3988,6 +3948,7 @@ impl ::windows::core::DefaultType for AudioPlaybackConnectionOpenResultStatus {
 }
 #[doc = "*Required features: 'Media_Audio'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AudioPlaybackConnectionState(pub i32);
 impl AudioPlaybackConnectionState {
     pub const Closed: Self = Self(0i32);
@@ -4002,12 +3963,6 @@ impl ::core::clone::Clone for AudioPlaybackConnectionState {
 unsafe impl ::windows::core::Abi for AudioPlaybackConnectionState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AudioPlaybackConnectionState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AudioPlaybackConnectionState {}
 impl ::core::fmt::Debug for AudioPlaybackConnectionState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AudioPlaybackConnectionState").field(&self.0).finish()
@@ -8382,6 +8337,7 @@ unsafe impl ::core::marker::Send for MediaSourceAudioInputNode {}
 unsafe impl ::core::marker::Sync for MediaSourceAudioInputNode {}
 #[doc = "*Required features: 'Media_Audio'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaSourceAudioInputNodeCreationStatus(pub i32);
 impl MediaSourceAudioInputNodeCreationStatus {
     pub const Success: Self = Self(0i32);
@@ -8398,12 +8354,6 @@ impl ::core::clone::Clone for MediaSourceAudioInputNodeCreationStatus {
 unsafe impl ::windows::core::Abi for MediaSourceAudioInputNodeCreationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaSourceAudioInputNodeCreationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaSourceAudioInputNodeCreationStatus {}
 impl ::core::fmt::Debug for MediaSourceAudioInputNodeCreationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaSourceAudioInputNodeCreationStatus").field(&self.0).finish()
@@ -8417,6 +8367,7 @@ impl ::windows::core::DefaultType for MediaSourceAudioInputNodeCreationStatus {
 }
 #[doc = "*Required features: 'Media_Audio'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MixedRealitySpatialAudioFormatPolicy(pub i32);
 impl MixedRealitySpatialAudioFormatPolicy {
     pub const UseMixedRealityDefaultSpatialAudioFormat: Self = Self(0i32);
@@ -8431,12 +8382,6 @@ impl ::core::clone::Clone for MixedRealitySpatialAudioFormatPolicy {
 unsafe impl ::windows::core::Abi for MixedRealitySpatialAudioFormatPolicy {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MixedRealitySpatialAudioFormatPolicy {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MixedRealitySpatialAudioFormatPolicy {}
 impl ::core::fmt::Debug for MixedRealitySpatialAudioFormatPolicy {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MixedRealitySpatialAudioFormatPolicy").field(&self.0).finish()
@@ -8450,6 +8395,7 @@ impl ::windows::core::DefaultType for MixedRealitySpatialAudioFormatPolicy {
 }
 #[doc = "*Required features: 'Media_Audio'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct QuantumSizeSelectionMode(pub i32);
 impl QuantumSizeSelectionMode {
     pub const SystemDefault: Self = Self(0i32);
@@ -8465,12 +8411,6 @@ impl ::core::clone::Clone for QuantumSizeSelectionMode {
 unsafe impl ::windows::core::Abi for QuantumSizeSelectionMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for QuantumSizeSelectionMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for QuantumSizeSelectionMode {}
 impl ::core::fmt::Debug for QuantumSizeSelectionMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("QuantumSizeSelectionMode").field(&self.0).finish()
@@ -8993,6 +8933,7 @@ unsafe impl ::core::marker::Send for SetDefaultSpatialAudioFormatResult {}
 unsafe impl ::core::marker::Sync for SetDefaultSpatialAudioFormatResult {}
 #[doc = "*Required features: 'Media_Audio'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SetDefaultSpatialAudioFormatStatus(pub i32);
 impl SetDefaultSpatialAudioFormatStatus {
     pub const Succeeded: Self = Self(0i32);
@@ -9011,12 +8952,6 @@ impl ::core::clone::Clone for SetDefaultSpatialAudioFormatStatus {
 unsafe impl ::windows::core::Abi for SetDefaultSpatialAudioFormatStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SetDefaultSpatialAudioFormatStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SetDefaultSpatialAudioFormatStatus {}
 impl ::core::fmt::Debug for SetDefaultSpatialAudioFormatStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SetDefaultSpatialAudioFormatStatus").field(&self.0).finish()
@@ -9361,6 +9296,7 @@ impl ::windows::core::RuntimeName for SpatialAudioFormatSubtype {
 }
 #[doc = "*Required features: 'Media_Audio'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SpatialAudioModel(pub i32);
 impl SpatialAudioModel {
     pub const ObjectBased: Self = Self(0i32);
@@ -9375,12 +9311,6 @@ impl ::core::clone::Clone for SpatialAudioModel {
 unsafe impl ::windows::core::Abi for SpatialAudioModel {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpatialAudioModel {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SpatialAudioModel {}
 impl ::core::fmt::Debug for SpatialAudioModel {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SpatialAudioModel").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Media/Capture/Frames/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Capture/Frames/mod.rs
@@ -1475,6 +1475,7 @@ unsafe impl ::core::marker::Send for MediaFrameReader {}
 unsafe impl ::core::marker::Sync for MediaFrameReader {}
 #[doc = "*Required features: 'Media_Capture_Frames'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaFrameReaderAcquisitionMode(pub i32);
 impl MediaFrameReaderAcquisitionMode {
     pub const Realtime: Self = Self(0i32);
@@ -1489,12 +1490,6 @@ impl ::core::clone::Clone for MediaFrameReaderAcquisitionMode {
 unsafe impl ::windows::core::Abi for MediaFrameReaderAcquisitionMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaFrameReaderAcquisitionMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaFrameReaderAcquisitionMode {}
 impl ::core::fmt::Debug for MediaFrameReaderAcquisitionMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaFrameReaderAcquisitionMode").field(&self.0).finish()
@@ -1508,6 +1503,7 @@ impl ::windows::core::DefaultType for MediaFrameReaderAcquisitionMode {
 }
 #[doc = "*Required features: 'Media_Capture_Frames'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaFrameReaderStartStatus(pub i32);
 impl MediaFrameReaderStartStatus {
     pub const Success: Self = Self(0i32);
@@ -1525,12 +1521,6 @@ impl ::core::clone::Clone for MediaFrameReaderStartStatus {
 unsafe impl ::windows::core::Abi for MediaFrameReaderStartStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaFrameReaderStartStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaFrameReaderStartStatus {}
 impl ::core::fmt::Debug for MediaFrameReaderStartStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaFrameReaderStartStatus").field(&self.0).finish()
@@ -2080,6 +2070,7 @@ unsafe impl ::core::marker::Send for MediaFrameSourceGetPropertyResult {}
 unsafe impl ::core::marker::Sync for MediaFrameSourceGetPropertyResult {}
 #[doc = "*Required features: 'Media_Capture_Frames'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaFrameSourceGetPropertyStatus(pub i32);
 impl MediaFrameSourceGetPropertyStatus {
     pub const Success: Self = Self(0i32);
@@ -2098,12 +2089,6 @@ impl ::core::clone::Clone for MediaFrameSourceGetPropertyStatus {
 unsafe impl ::windows::core::Abi for MediaFrameSourceGetPropertyStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaFrameSourceGetPropertyStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaFrameSourceGetPropertyStatus {}
 impl ::core::fmt::Debug for MediaFrameSourceGetPropertyStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaFrameSourceGetPropertyStatus").field(&self.0).finish()
@@ -2401,6 +2386,7 @@ unsafe impl ::core::marker::Send for MediaFrameSourceInfo {}
 unsafe impl ::core::marker::Sync for MediaFrameSourceInfo {}
 #[doc = "*Required features: 'Media_Capture_Frames'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaFrameSourceKind(pub i32);
 impl MediaFrameSourceKind {
     pub const Custom: Self = Self(0i32);
@@ -2420,12 +2406,6 @@ impl ::core::clone::Clone for MediaFrameSourceKind {
 unsafe impl ::windows::core::Abi for MediaFrameSourceKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaFrameSourceKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaFrameSourceKind {}
 impl ::core::fmt::Debug for MediaFrameSourceKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaFrameSourceKind").field(&self.0).finish()
@@ -2439,6 +2419,7 @@ impl ::windows::core::DefaultType for MediaFrameSourceKind {
 }
 #[doc = "*Required features: 'Media_Capture_Frames'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaFrameSourceSetPropertyStatus(pub i32);
 impl MediaFrameSourceSetPropertyStatus {
     pub const Success: Self = Self(0i32);
@@ -2457,12 +2438,6 @@ impl ::core::clone::Clone for MediaFrameSourceSetPropertyStatus {
 unsafe impl ::windows::core::Abi for MediaFrameSourceSetPropertyStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaFrameSourceSetPropertyStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaFrameSourceSetPropertyStatus {}
 impl ::core::fmt::Debug for MediaFrameSourceSetPropertyStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaFrameSourceSetPropertyStatus").field(&self.0).finish()
@@ -2707,6 +2682,7 @@ unsafe impl ::core::marker::Send for MultiSourceMediaFrameReader {}
 unsafe impl ::core::marker::Sync for MultiSourceMediaFrameReader {}
 #[doc = "*Required features: 'Media_Capture_Frames'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MultiSourceMediaFrameReaderStartStatus(pub i32);
 impl MultiSourceMediaFrameReaderStartStatus {
     pub const Success: Self = Self(0i32);
@@ -2724,12 +2700,6 @@ impl ::core::clone::Clone for MultiSourceMediaFrameReaderStartStatus {
 unsafe impl ::windows::core::Abi for MultiSourceMediaFrameReaderStartStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MultiSourceMediaFrameReaderStartStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MultiSourceMediaFrameReaderStartStatus {}
 impl ::core::fmt::Debug for MultiSourceMediaFrameReaderStartStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MultiSourceMediaFrameReaderStartStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Media/Capture/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Capture/mod.rs
@@ -822,6 +822,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &AppB
 }
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppBroadcastCameraCaptureState(pub i32);
 impl AppBroadcastCameraCaptureState {
     pub const Stopped: Self = Self(0i32);
@@ -837,12 +838,6 @@ impl ::core::clone::Clone for AppBroadcastCameraCaptureState {
 unsafe impl ::windows::core::Abi for AppBroadcastCameraCaptureState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppBroadcastCameraCaptureState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppBroadcastCameraCaptureState {}
 impl ::core::fmt::Debug for AppBroadcastCameraCaptureState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppBroadcastCameraCaptureState").field(&self.0).finish()
@@ -945,6 +940,7 @@ unsafe impl ::core::marker::Send for AppBroadcastCameraCaptureStateChangedEventA
 unsafe impl ::core::marker::Sync for AppBroadcastCameraCaptureStateChangedEventArgs {}
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppBroadcastCameraOverlayLocation(pub i32);
 impl AppBroadcastCameraOverlayLocation {
     pub const TopLeft: Self = Self(0i32);
@@ -966,12 +962,6 @@ impl ::core::clone::Clone for AppBroadcastCameraOverlayLocation {
 unsafe impl ::windows::core::Abi for AppBroadcastCameraOverlayLocation {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppBroadcastCameraOverlayLocation {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppBroadcastCameraOverlayLocation {}
 impl ::core::fmt::Debug for AppBroadcastCameraOverlayLocation {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppBroadcastCameraOverlayLocation").field(&self.0).finish()
@@ -985,6 +975,7 @@ impl ::windows::core::DefaultType for AppBroadcastCameraOverlayLocation {
 }
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppBroadcastCameraOverlaySize(pub i32);
 impl AppBroadcastCameraOverlaySize {
     pub const Small: Self = Self(0i32);
@@ -1000,12 +991,6 @@ impl ::core::clone::Clone for AppBroadcastCameraOverlaySize {
 unsafe impl ::windows::core::Abi for AppBroadcastCameraOverlaySize {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppBroadcastCameraOverlaySize {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppBroadcastCameraOverlaySize {}
 impl ::core::fmt::Debug for AppBroadcastCameraOverlaySize {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppBroadcastCameraOverlaySize").field(&self.0).finish()
@@ -1019,6 +1004,7 @@ impl ::windows::core::DefaultType for AppBroadcastCameraOverlaySize {
 }
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppBroadcastCaptureTargetType(pub i32);
 impl AppBroadcastCaptureTargetType {
     pub const AppView: Self = Self(0i32);
@@ -1033,12 +1019,6 @@ impl ::core::clone::Clone for AppBroadcastCaptureTargetType {
 unsafe impl ::windows::core::Abi for AppBroadcastCaptureTargetType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppBroadcastCaptureTargetType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppBroadcastCaptureTargetType {}
 impl ::core::fmt::Debug for AppBroadcastCaptureTargetType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppBroadcastCaptureTargetType").field(&self.0).finish()
@@ -1052,6 +1032,7 @@ impl ::windows::core::DefaultType for AppBroadcastCaptureTargetType {
 }
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppBroadcastExitBroadcastModeReason(pub i32);
 impl AppBroadcastExitBroadcastModeReason {
     pub const NormalExit: Self = Self(0i32);
@@ -1068,12 +1049,6 @@ impl ::core::clone::Clone for AppBroadcastExitBroadcastModeReason {
 unsafe impl ::windows::core::Abi for AppBroadcastExitBroadcastModeReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppBroadcastExitBroadcastModeReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppBroadcastExitBroadcastModeReason {}
 impl ::core::fmt::Debug for AppBroadcastExitBroadcastModeReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppBroadcastExitBroadcastModeReason").field(&self.0).finish()
@@ -1438,6 +1413,7 @@ impl ::windows::core::RuntimeName for AppBroadcastManager {
 }
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppBroadcastMicrophoneCaptureState(pub i32);
 impl AppBroadcastMicrophoneCaptureState {
     pub const Stopped: Self = Self(0i32);
@@ -1453,12 +1429,6 @@ impl ::core::clone::Clone for AppBroadcastMicrophoneCaptureState {
 unsafe impl ::windows::core::Abi for AppBroadcastMicrophoneCaptureState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppBroadcastMicrophoneCaptureState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppBroadcastMicrophoneCaptureState {}
 impl ::core::fmt::Debug for AppBroadcastMicrophoneCaptureState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppBroadcastMicrophoneCaptureState").field(&self.0).finish()
@@ -1790,6 +1760,7 @@ unsafe impl ::core::marker::Send for AppBroadcastPlugInManager {}
 unsafe impl ::core::marker::Sync for AppBroadcastPlugInManager {}
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppBroadcastPlugInState(pub i32);
 impl AppBroadcastPlugInState {
     pub const Unknown: Self = Self(0i32);
@@ -1809,12 +1780,6 @@ impl ::core::clone::Clone for AppBroadcastPlugInState {
 unsafe impl ::windows::core::Abi for AppBroadcastPlugInState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppBroadcastPlugInState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppBroadcastPlugInState {}
 impl ::core::fmt::Debug for AppBroadcastPlugInState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppBroadcastPlugInState").field(&self.0).finish()
@@ -2027,6 +1992,7 @@ unsafe impl ::core::marker::Send for AppBroadcastPreview {}
 unsafe impl ::core::marker::Sync for AppBroadcastPreview {}
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppBroadcastPreviewState(pub i32);
 impl AppBroadcastPreviewState {
     pub const Started: Self = Self(0i32);
@@ -2042,12 +2008,6 @@ impl ::core::clone::Clone for AppBroadcastPreviewState {
 unsafe impl ::windows::core::Abi for AppBroadcastPreviewState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppBroadcastPreviewState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppBroadcastPreviewState {}
 impl ::core::fmt::Debug for AppBroadcastPreviewState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppBroadcastPreviewState").field(&self.0).finish()
@@ -2822,6 +2782,7 @@ unsafe impl ::core::marker::Send for AppBroadcastServices {}
 unsafe impl ::core::marker::Sync for AppBroadcastServices {}
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppBroadcastSignInResult(pub i32);
 impl AppBroadcastSignInResult {
     pub const Success: Self = Self(0i32);
@@ -2839,12 +2800,6 @@ impl ::core::clone::Clone for AppBroadcastSignInResult {
 unsafe impl ::windows::core::Abi for AppBroadcastSignInResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppBroadcastSignInResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppBroadcastSignInResult {}
 impl ::core::fmt::Debug for AppBroadcastSignInResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppBroadcastSignInResult").field(&self.0).finish()
@@ -2858,6 +2813,7 @@ impl ::windows::core::DefaultType for AppBroadcastSignInResult {
 }
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppBroadcastSignInState(pub i32);
 impl AppBroadcastSignInState {
     pub const NotSignedIn: Self = Self(0i32);
@@ -2875,12 +2831,6 @@ impl ::core::clone::Clone for AppBroadcastSignInState {
 unsafe impl ::windows::core::Abi for AppBroadcastSignInState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppBroadcastSignInState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppBroadcastSignInState {}
 impl ::core::fmt::Debug for AppBroadcastSignInState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppBroadcastSignInState").field(&self.0).finish()
@@ -3691,6 +3641,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &AppB
 }
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppBroadcastStreamState(pub i32);
 impl AppBroadcastStreamState {
     pub const Initializing: Self = Self(0i32);
@@ -3708,12 +3659,6 @@ impl ::core::clone::Clone for AppBroadcastStreamState {
 unsafe impl ::windows::core::Abi for AppBroadcastStreamState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppBroadcastStreamState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppBroadcastStreamState {}
 impl ::core::fmt::Debug for AppBroadcastStreamState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppBroadcastStreamState").field(&self.0).finish()
@@ -4016,6 +3961,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &AppB
 }
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppBroadcastTerminationReason(pub i32);
 impl AppBroadcastTerminationReason {
     pub const NormalTermination: Self = Self(0i32);
@@ -4038,12 +3984,6 @@ impl ::core::clone::Clone for AppBroadcastTerminationReason {
 unsafe impl ::windows::core::Abi for AppBroadcastTerminationReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppBroadcastTerminationReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppBroadcastTerminationReason {}
 impl ::core::fmt::Debug for AppBroadcastTerminationReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppBroadcastTerminationReason").field(&self.0).finish()
@@ -4136,6 +4076,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &AppB
 }
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppBroadcastVideoEncodingBitrateMode(pub i32);
 impl AppBroadcastVideoEncodingBitrateMode {
     pub const Custom: Self = Self(0i32);
@@ -4150,12 +4091,6 @@ impl ::core::clone::Clone for AppBroadcastVideoEncodingBitrateMode {
 unsafe impl ::windows::core::Abi for AppBroadcastVideoEncodingBitrateMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppBroadcastVideoEncodingBitrateMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppBroadcastVideoEncodingBitrateMode {}
 impl ::core::fmt::Debug for AppBroadcastVideoEncodingBitrateMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppBroadcastVideoEncodingBitrateMode").field(&self.0).finish()
@@ -4169,6 +4104,7 @@ impl ::windows::core::DefaultType for AppBroadcastVideoEncodingBitrateMode {
 }
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppBroadcastVideoEncodingResolutionMode(pub i32);
 impl AppBroadcastVideoEncodingResolutionMode {
     pub const Custom: Self = Self(0i32);
@@ -4183,12 +4119,6 @@ impl ::core::clone::Clone for AppBroadcastVideoEncodingResolutionMode {
 unsafe impl ::windows::core::Abi for AppBroadcastVideoEncodingResolutionMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppBroadcastVideoEncodingResolutionMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppBroadcastVideoEncodingResolutionMode {}
 impl ::core::fmt::Debug for AppBroadcastVideoEncodingResolutionMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppBroadcastVideoEncodingResolutionMode").field(&self.0).finish()
@@ -4885,6 +4815,7 @@ unsafe impl ::core::marker::Send for AppCaptureFileGeneratedEventArgs {}
 unsafe impl ::core::marker::Sync for AppCaptureFileGeneratedEventArgs {}
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppCaptureHistoricalBufferLengthUnit(pub i32);
 impl AppCaptureHistoricalBufferLengthUnit {
     pub const Megabytes: Self = Self(0i32);
@@ -4899,12 +4830,6 @@ impl ::core::clone::Clone for AppCaptureHistoricalBufferLengthUnit {
 unsafe impl ::windows::core::Abi for AppCaptureHistoricalBufferLengthUnit {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppCaptureHistoricalBufferLengthUnit {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppCaptureHistoricalBufferLengthUnit {}
 impl ::core::fmt::Debug for AppCaptureHistoricalBufferLengthUnit {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppCaptureHistoricalBufferLengthUnit").field(&self.0).finish()
@@ -4941,6 +4866,7 @@ impl ::windows::core::RuntimeName for AppCaptureManager {
 }
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppCaptureMetadataPriority(pub i32);
 impl AppCaptureMetadataPriority {
     pub const Informational: Self = Self(0i32);
@@ -4955,12 +4881,6 @@ impl ::core::clone::Clone for AppCaptureMetadataPriority {
 unsafe impl ::windows::core::Abi for AppCaptureMetadataPriority {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppCaptureMetadataPriority {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppCaptureMetadataPriority {}
 impl ::core::fmt::Debug for AppCaptureMetadataPriority {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppCaptureMetadataPriority").field(&self.0).finish()
@@ -5149,6 +5069,7 @@ unsafe impl ::core::marker::Send for AppCaptureMetadataWriter {}
 unsafe impl ::core::marker::Sync for AppCaptureMetadataWriter {}
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppCaptureMicrophoneCaptureState(pub i32);
 impl AppCaptureMicrophoneCaptureState {
     pub const Stopped: Self = Self(0i32);
@@ -5164,12 +5085,6 @@ impl ::core::clone::Clone for AppCaptureMicrophoneCaptureState {
 unsafe impl ::windows::core::Abi for AppCaptureMicrophoneCaptureState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppCaptureMicrophoneCaptureState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppCaptureMicrophoneCaptureState {}
 impl ::core::fmt::Debug for AppCaptureMicrophoneCaptureState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppCaptureMicrophoneCaptureState").field(&self.0).finish()
@@ -5439,6 +5354,7 @@ unsafe impl ::core::marker::Send for AppCaptureRecordOperation {}
 unsafe impl ::core::marker::Sync for AppCaptureRecordOperation {}
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppCaptureRecordingState(pub i32);
 impl AppCaptureRecordingState {
     pub const InProgress: Self = Self(0i32);
@@ -5454,12 +5370,6 @@ impl ::core::clone::Clone for AppCaptureRecordingState {
 unsafe impl ::windows::core::Abi for AppCaptureRecordingState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppCaptureRecordingState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppCaptureRecordingState {}
 impl ::core::fmt::Debug for AppCaptureRecordingState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppCaptureRecordingState").field(&self.0).finish()
@@ -6245,6 +6155,7 @@ unsafe impl ::core::marker::Send for AppCaptureState {}
 unsafe impl ::core::marker::Sync for AppCaptureState {}
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppCaptureVideoEncodingBitrateMode(pub i32);
 impl AppCaptureVideoEncodingBitrateMode {
     pub const Custom: Self = Self(0i32);
@@ -6260,12 +6171,6 @@ impl ::core::clone::Clone for AppCaptureVideoEncodingBitrateMode {
 unsafe impl ::windows::core::Abi for AppCaptureVideoEncodingBitrateMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppCaptureVideoEncodingBitrateMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppCaptureVideoEncodingBitrateMode {}
 impl ::core::fmt::Debug for AppCaptureVideoEncodingBitrateMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppCaptureVideoEncodingBitrateMode").field(&self.0).finish()
@@ -6279,6 +6184,7 @@ impl ::windows::core::DefaultType for AppCaptureVideoEncodingBitrateMode {
 }
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppCaptureVideoEncodingFrameRateMode(pub i32);
 impl AppCaptureVideoEncodingFrameRateMode {
     pub const Standard: Self = Self(0i32);
@@ -6293,12 +6199,6 @@ impl ::core::clone::Clone for AppCaptureVideoEncodingFrameRateMode {
 unsafe impl ::windows::core::Abi for AppCaptureVideoEncodingFrameRateMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppCaptureVideoEncodingFrameRateMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppCaptureVideoEncodingFrameRateMode {}
 impl ::core::fmt::Debug for AppCaptureVideoEncodingFrameRateMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppCaptureVideoEncodingFrameRateMode").field(&self.0).finish()
@@ -6312,6 +6212,7 @@ impl ::windows::core::DefaultType for AppCaptureVideoEncodingFrameRateMode {
 }
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppCaptureVideoEncodingResolutionMode(pub i32);
 impl AppCaptureVideoEncodingResolutionMode {
     pub const Custom: Self = Self(0i32);
@@ -6327,12 +6228,6 @@ impl ::core::clone::Clone for AppCaptureVideoEncodingResolutionMode {
 unsafe impl ::windows::core::Abi for AppCaptureVideoEncodingResolutionMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppCaptureVideoEncodingResolutionMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppCaptureVideoEncodingResolutionMode {}
 impl ::core::fmt::Debug for AppCaptureVideoEncodingResolutionMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppCaptureVideoEncodingResolutionMode").field(&self.0).finish()
@@ -6449,6 +6344,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Came
 }
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CameraCaptureUIMaxPhotoResolution(pub i32);
 impl CameraCaptureUIMaxPhotoResolution {
     pub const HighestAvailable: Self = Self(0i32);
@@ -6467,12 +6363,6 @@ impl ::core::clone::Clone for CameraCaptureUIMaxPhotoResolution {
 unsafe impl ::windows::core::Abi for CameraCaptureUIMaxPhotoResolution {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CameraCaptureUIMaxPhotoResolution {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CameraCaptureUIMaxPhotoResolution {}
 impl ::core::fmt::Debug for CameraCaptureUIMaxPhotoResolution {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CameraCaptureUIMaxPhotoResolution").field(&self.0).finish()
@@ -6486,6 +6376,7 @@ impl ::windows::core::DefaultType for CameraCaptureUIMaxPhotoResolution {
 }
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CameraCaptureUIMaxVideoResolution(pub i32);
 impl CameraCaptureUIMaxVideoResolution {
     pub const HighestAvailable: Self = Self(0i32);
@@ -6502,12 +6393,6 @@ impl ::core::clone::Clone for CameraCaptureUIMaxVideoResolution {
 unsafe impl ::windows::core::Abi for CameraCaptureUIMaxVideoResolution {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CameraCaptureUIMaxVideoResolution {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CameraCaptureUIMaxVideoResolution {}
 impl ::core::fmt::Debug for CameraCaptureUIMaxVideoResolution {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CameraCaptureUIMaxVideoResolution").field(&self.0).finish()
@@ -6521,6 +6406,7 @@ impl ::windows::core::DefaultType for CameraCaptureUIMaxVideoResolution {
 }
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CameraCaptureUIMode(pub i32);
 impl CameraCaptureUIMode {
     pub const PhotoOrVideo: Self = Self(0i32);
@@ -6536,12 +6422,6 @@ impl ::core::clone::Clone for CameraCaptureUIMode {
 unsafe impl ::windows::core::Abi for CameraCaptureUIMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CameraCaptureUIMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CameraCaptureUIMode {}
 impl ::core::fmt::Debug for CameraCaptureUIMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CameraCaptureUIMode").field(&self.0).finish()
@@ -6697,6 +6577,7 @@ unsafe impl ::core::marker::Send for CameraCaptureUIPhotoCaptureSettings {}
 unsafe impl ::core::marker::Sync for CameraCaptureUIPhotoCaptureSettings {}
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CameraCaptureUIPhotoFormat(pub i32);
 impl CameraCaptureUIPhotoFormat {
     pub const Jpeg: Self = Self(0i32);
@@ -6712,12 +6593,6 @@ impl ::core::clone::Clone for CameraCaptureUIPhotoFormat {
 unsafe impl ::windows::core::Abi for CameraCaptureUIPhotoFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CameraCaptureUIPhotoFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CameraCaptureUIPhotoFormat {}
 impl ::core::fmt::Debug for CameraCaptureUIPhotoFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CameraCaptureUIPhotoFormat").field(&self.0).finish()
@@ -6856,6 +6731,7 @@ unsafe impl ::core::marker::Send for CameraCaptureUIVideoCaptureSettings {}
 unsafe impl ::core::marker::Sync for CameraCaptureUIVideoCaptureSettings {}
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CameraCaptureUIVideoFormat(pub i32);
 impl CameraCaptureUIVideoFormat {
     pub const Mp4: Self = Self(0i32);
@@ -6870,12 +6746,6 @@ impl ::core::clone::Clone for CameraCaptureUIVideoFormat {
 unsafe impl ::windows::core::Abi for CameraCaptureUIVideoFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CameraCaptureUIVideoFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CameraCaptureUIVideoFormat {}
 impl ::core::fmt::Debug for CameraCaptureUIVideoFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CameraCaptureUIVideoFormat").field(&self.0).finish()
@@ -7581,6 +7451,7 @@ unsafe impl ::core::marker::Send for CapturedPhoto {}
 unsafe impl ::core::marker::Sync for CapturedPhoto {}
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ForegroundActivationArgument(pub i32);
 impl ForegroundActivationArgument {
     pub const SignInRequired: Self = Self(0i32);
@@ -7595,12 +7466,6 @@ impl ::core::clone::Clone for ForegroundActivationArgument {
 unsafe impl ::windows::core::Abi for ForegroundActivationArgument {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ForegroundActivationArgument {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ForegroundActivationArgument {}
 impl ::core::fmt::Debug for ForegroundActivationArgument {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ForegroundActivationArgument").field(&self.0).finish()
@@ -7614,6 +7479,7 @@ impl ::windows::core::DefaultType for ForegroundActivationArgument {
 }
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GameBarCommand(pub i32);
 impl GameBarCommand {
     pub const OpenGameBar: Self = Self(0i32);
@@ -7640,12 +7506,6 @@ impl ::core::clone::Clone for GameBarCommand {
 unsafe impl ::windows::core::Abi for GameBarCommand {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GameBarCommand {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GameBarCommand {}
 impl ::core::fmt::Debug for GameBarCommand {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GameBarCommand").field(&self.0).finish()
@@ -7659,6 +7519,7 @@ impl ::windows::core::DefaultType for GameBarCommand {
 }
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GameBarCommandOrigin(pub i32);
 impl GameBarCommandOrigin {
     pub const ShortcutKey: Self = Self(0i32);
@@ -7674,12 +7535,6 @@ impl ::core::clone::Clone for GameBarCommandOrigin {
 unsafe impl ::windows::core::Abi for GameBarCommandOrigin {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GameBarCommandOrigin {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GameBarCommandOrigin {}
 impl ::core::fmt::Debug for GameBarCommandOrigin {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GameBarCommandOrigin").field(&self.0).finish()
@@ -7920,6 +7775,7 @@ unsafe impl ::core::marker::Send for GameBarServicesCommandEventArgs {}
 unsafe impl ::core::marker::Sync for GameBarServicesCommandEventArgs {}
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GameBarServicesDisplayMode(pub i32);
 impl GameBarServicesDisplayMode {
     pub const Windowed: Self = Self(0i32);
@@ -7934,12 +7790,6 @@ impl ::core::clone::Clone for GameBarServicesDisplayMode {
 unsafe impl ::windows::core::Abi for GameBarServicesDisplayMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GameBarServicesDisplayMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GameBarServicesDisplayMode {}
 impl ::core::fmt::Debug for GameBarServicesDisplayMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GameBarServicesDisplayMode").field(&self.0).finish()
@@ -8239,6 +8089,7 @@ unsafe impl ::core::marker::Send for GameBarServicesTargetInfo {}
 unsafe impl ::core::marker::Sync for GameBarServicesTargetInfo {}
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GameBarTargetCapturePolicy(pub i32);
 impl GameBarTargetCapturePolicy {
     pub const EnabledBySystem: Self = Self(0i32);
@@ -8256,12 +8107,6 @@ impl ::core::clone::Clone for GameBarTargetCapturePolicy {
 unsafe impl ::windows::core::Abi for GameBarTargetCapturePolicy {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GameBarTargetCapturePolicy {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GameBarTargetCapturePolicy {}
 impl ::core::fmt::Debug for GameBarTargetCapturePolicy {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GameBarTargetCapturePolicy").field(&self.0).finish()
@@ -11058,6 +10903,7 @@ pub struct IVideoStreamConfigurationVtbl(
 );
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct KnownVideoProfile(pub i32);
 impl KnownVideoProfile {
     pub const VideoRecording: Self = Self(0i32);
@@ -11081,12 +10927,6 @@ impl ::core::clone::Clone for KnownVideoProfile {
 unsafe impl ::windows::core::Abi for KnownVideoProfile {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KnownVideoProfile {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for KnownVideoProfile {}
 impl ::core::fmt::Debug for KnownVideoProfile {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("KnownVideoProfile").field(&self.0).finish()
@@ -12133,6 +11973,7 @@ impl<'a> ::windows::core::IntoParam<'a, super::super::Foundation::IClosable> for
 }
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaCaptureDeviceExclusiveControlStatus(pub i32);
 impl MediaCaptureDeviceExclusiveControlStatus {
     pub const ExclusiveControlAvailable: Self = Self(0i32);
@@ -12147,12 +11988,6 @@ impl ::core::clone::Clone for MediaCaptureDeviceExclusiveControlStatus {
 unsafe impl ::windows::core::Abi for MediaCaptureDeviceExclusiveControlStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaCaptureDeviceExclusiveControlStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaCaptureDeviceExclusiveControlStatus {}
 impl ::core::fmt::Debug for MediaCaptureDeviceExclusiveControlStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaCaptureDeviceExclusiveControlStatus").field(&self.0).finish()
@@ -12823,6 +12658,7 @@ unsafe impl ::core::marker::Send for MediaCaptureInitializationSettings {}
 unsafe impl ::core::marker::Sync for MediaCaptureInitializationSettings {}
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaCaptureMemoryPreference(pub i32);
 impl MediaCaptureMemoryPreference {
     pub const Auto: Self = Self(0i32);
@@ -12837,12 +12673,6 @@ impl ::core::clone::Clone for MediaCaptureMemoryPreference {
 unsafe impl ::windows::core::Abi for MediaCaptureMemoryPreference {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaCaptureMemoryPreference {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaCaptureMemoryPreference {}
 impl ::core::fmt::Debug for MediaCaptureMemoryPreference {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaCaptureMemoryPreference").field(&self.0).finish()
@@ -13302,6 +13132,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Medi
 }
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaCaptureSharingMode(pub i32);
 impl MediaCaptureSharingMode {
     pub const ExclusiveControl: Self = Self(0i32);
@@ -13316,12 +13147,6 @@ impl ::core::clone::Clone for MediaCaptureSharingMode {
 unsafe impl ::windows::core::Abi for MediaCaptureSharingMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaCaptureSharingMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaCaptureSharingMode {}
 impl ::core::fmt::Debug for MediaCaptureSharingMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaCaptureSharingMode").field(&self.0).finish()
@@ -13455,6 +13280,7 @@ impl<'a> ::windows::core::IntoParam<'a, super::super::Foundation::IClosable> for
 }
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaCaptureThermalStatus(pub i32);
 impl MediaCaptureThermalStatus {
     pub const Normal: Self = Self(0i32);
@@ -13469,12 +13295,6 @@ impl ::core::clone::Clone for MediaCaptureThermalStatus {
 unsafe impl ::windows::core::Abi for MediaCaptureThermalStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaCaptureThermalStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaCaptureThermalStatus {}
 impl ::core::fmt::Debug for MediaCaptureThermalStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaCaptureThermalStatus").field(&self.0).finish()
@@ -13763,6 +13583,7 @@ unsafe impl ::core::marker::Send for MediaCaptureVideoProfileMediaDescription {}
 unsafe impl ::core::marker::Sync for MediaCaptureVideoProfileMediaDescription {}
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaCategory(pub i32);
 impl MediaCategory {
     pub const Other: Self = Self(0i32);
@@ -13783,12 +13604,6 @@ impl ::core::clone::Clone for MediaCategory {
 unsafe impl ::windows::core::Abi for MediaCategory {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaCategory {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaCategory {}
 impl ::core::fmt::Debug for MediaCategory {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaCategory").field(&self.0).finish()
@@ -13802,6 +13617,7 @@ impl ::windows::core::DefaultType for MediaCategory {
 }
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaStreamType(pub i32);
 impl MediaStreamType {
     pub const VideoPreview: Self = Self(0i32);
@@ -13819,12 +13635,6 @@ impl ::core::clone::Clone for MediaStreamType {
 unsafe impl ::windows::core::Abi for MediaStreamType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaStreamType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaStreamType {}
 impl ::core::fmt::Debug for MediaStreamType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaStreamType").field(&self.0).finish()
@@ -13927,6 +13737,7 @@ unsafe impl ::core::marker::Send for OptionalReferencePhotoCapturedEventArgs {}
 unsafe impl ::core::marker::Sync for OptionalReferencePhotoCapturedEventArgs {}
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhotoCaptureSource(pub i32);
 impl PhotoCaptureSource {
     pub const Auto: Self = Self(0i32);
@@ -13942,12 +13753,6 @@ impl ::core::clone::Clone for PhotoCaptureSource {
 unsafe impl ::windows::core::Abi for PhotoCaptureSource {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhotoCaptureSource {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhotoCaptureSource {}
 impl ::core::fmt::Debug for PhotoCaptureSource {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhotoCaptureSource").field(&self.0).finish()
@@ -14149,6 +13954,7 @@ unsafe impl ::core::marker::Send for PhotoConfirmationCapturedEventArgs {}
 unsafe impl ::core::marker::Sync for PhotoConfirmationCapturedEventArgs {}
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PowerlineFrequency(pub i32);
 impl PowerlineFrequency {
     pub const Disabled: Self = Self(0i32);
@@ -14165,12 +13971,6 @@ impl ::core::clone::Clone for PowerlineFrequency {
 unsafe impl ::windows::core::Abi for PowerlineFrequency {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PowerlineFrequency {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PowerlineFrequency {}
 impl ::core::fmt::Debug for PowerlineFrequency {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PowerlineFrequency").field(&self.0).finish()
@@ -14482,6 +14282,7 @@ unsafe impl ::core::marker::Send for SourceSuspensionChangedEventArgs {}
 unsafe impl ::core::marker::Sync for SourceSuspensionChangedEventArgs {}
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StreamingCaptureMode(pub i32);
 impl StreamingCaptureMode {
     pub const AudioAndVideo: Self = Self(0i32);
@@ -14497,12 +14298,6 @@ impl ::core::clone::Clone for StreamingCaptureMode {
 unsafe impl ::windows::core::Abi for StreamingCaptureMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StreamingCaptureMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StreamingCaptureMode {}
 impl ::core::fmt::Debug for StreamingCaptureMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StreamingCaptureMode").field(&self.0).finish()
@@ -14516,6 +14311,7 @@ impl ::windows::core::DefaultType for StreamingCaptureMode {
 }
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VideoDeviceCharacteristic(pub i32);
 impl VideoDeviceCharacteristic {
     pub const AllStreamsIndependent: Self = Self(0i32);
@@ -14533,12 +14329,6 @@ impl ::core::clone::Clone for VideoDeviceCharacteristic {
 unsafe impl ::windows::core::Abi for VideoDeviceCharacteristic {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VideoDeviceCharacteristic {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VideoDeviceCharacteristic {}
 impl ::core::fmt::Debug for VideoDeviceCharacteristic {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VideoDeviceCharacteristic").field(&self.0).finish()
@@ -14552,6 +14342,7 @@ impl ::windows::core::DefaultType for VideoDeviceCharacteristic {
 }
 #[doc = "*Required features: 'Media_Capture'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VideoRotation(pub i32);
 impl VideoRotation {
     pub const None: Self = Self(0i32);
@@ -14568,12 +14359,6 @@ impl ::core::clone::Clone for VideoRotation {
 unsafe impl ::windows::core::Abi for VideoRotation {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VideoRotation {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VideoRotation {}
 impl ::core::fmt::Debug for VideoRotation {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VideoRotation").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Media/Casting/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Casting/mod.rs
@@ -272,6 +272,7 @@ unsafe impl ::core::marker::Send for CastingConnectionErrorOccurredEventArgs {}
 unsafe impl ::core::marker::Sync for CastingConnectionErrorOccurredEventArgs {}
 #[doc = "*Required features: 'Media_Casting'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CastingConnectionErrorStatus(pub i32);
 impl CastingConnectionErrorStatus {
     pub const Succeeded: Self = Self(0i32);
@@ -291,12 +292,6 @@ impl ::core::clone::Clone for CastingConnectionErrorStatus {
 unsafe impl ::windows::core::Abi for CastingConnectionErrorStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CastingConnectionErrorStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CastingConnectionErrorStatus {}
 impl ::core::fmt::Debug for CastingConnectionErrorStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CastingConnectionErrorStatus").field(&self.0).finish()
@@ -310,6 +305,7 @@ impl ::windows::core::DefaultType for CastingConnectionErrorStatus {
 }
 #[doc = "*Required features: 'Media_Casting'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CastingConnectionState(pub i32);
 impl CastingConnectionState {
     pub const Disconnected: Self = Self(0i32);
@@ -327,12 +323,6 @@ impl ::core::clone::Clone for CastingConnectionState {
 unsafe impl ::windows::core::Abi for CastingConnectionState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CastingConnectionState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CastingConnectionState {}
 impl ::core::fmt::Debug for CastingConnectionState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CastingConnectionState").field(&self.0).finish()
@@ -843,6 +833,7 @@ unsafe impl ::core::marker::Send for CastingDeviceSelectedEventArgs {}
 unsafe impl ::core::marker::Sync for CastingDeviceSelectedEventArgs {}
 #[doc = "*Required features: 'Media_Casting'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CastingPlaybackTypes(pub u32);
 impl CastingPlaybackTypes {
     pub const None: Self = Self(0u32);
@@ -859,12 +850,6 @@ impl ::core::clone::Clone for CastingPlaybackTypes {
 unsafe impl ::windows::core::Abi for CastingPlaybackTypes {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CastingPlaybackTypes {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CastingPlaybackTypes {}
 impl ::core::fmt::Debug for CastingPlaybackTypes {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CastingPlaybackTypes").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Media/ClosedCaptioning/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/ClosedCaptioning/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'Media_ClosedCaptioning'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ClosedCaptionColor(pub i32);
 impl ClosedCaptionColor {
     pub const Default: Self = Self(0i32);
@@ -22,12 +23,6 @@ impl ::core::clone::Clone for ClosedCaptionColor {
 unsafe impl ::windows::core::Abi for ClosedCaptionColor {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ClosedCaptionColor {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ClosedCaptionColor {}
 impl ::core::fmt::Debug for ClosedCaptionColor {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ClosedCaptionColor").field(&self.0).finish()
@@ -41,6 +36,7 @@ impl ::windows::core::DefaultType for ClosedCaptionColor {
 }
 #[doc = "*Required features: 'Media_ClosedCaptioning'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ClosedCaptionEdgeEffect(pub i32);
 impl ClosedCaptionEdgeEffect {
     pub const Default: Self = Self(0i32);
@@ -59,12 +55,6 @@ impl ::core::clone::Clone for ClosedCaptionEdgeEffect {
 unsafe impl ::windows::core::Abi for ClosedCaptionEdgeEffect {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ClosedCaptionEdgeEffect {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ClosedCaptionEdgeEffect {}
 impl ::core::fmt::Debug for ClosedCaptionEdgeEffect {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ClosedCaptionEdgeEffect").field(&self.0).finish()
@@ -78,6 +68,7 @@ impl ::windows::core::DefaultType for ClosedCaptionEdgeEffect {
 }
 #[doc = "*Required features: 'Media_ClosedCaptioning'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ClosedCaptionOpacity(pub i32);
 impl ClosedCaptionOpacity {
     pub const Default: Self = Self(0i32);
@@ -95,12 +86,6 @@ impl ::core::clone::Clone for ClosedCaptionOpacity {
 unsafe impl ::windows::core::Abi for ClosedCaptionOpacity {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ClosedCaptionOpacity {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ClosedCaptionOpacity {}
 impl ::core::fmt::Debug for ClosedCaptionOpacity {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ClosedCaptionOpacity").field(&self.0).finish()
@@ -213,6 +198,7 @@ impl ::windows::core::RuntimeName for ClosedCaptionProperties {
 }
 #[doc = "*Required features: 'Media_ClosedCaptioning'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ClosedCaptionSize(pub i32);
 impl ClosedCaptionSize {
     pub const Default: Self = Self(0i32);
@@ -230,12 +216,6 @@ impl ::core::clone::Clone for ClosedCaptionSize {
 unsafe impl ::windows::core::Abi for ClosedCaptionSize {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ClosedCaptionSize {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ClosedCaptionSize {}
 impl ::core::fmt::Debug for ClosedCaptionSize {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ClosedCaptionSize").field(&self.0).finish()
@@ -249,6 +229,7 @@ impl ::windows::core::DefaultType for ClosedCaptionSize {
 }
 #[doc = "*Required features: 'Media_ClosedCaptioning'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ClosedCaptionStyle(pub i32);
 impl ClosedCaptionStyle {
     pub const Default: Self = Self(0i32);
@@ -269,12 +250,6 @@ impl ::core::clone::Clone for ClosedCaptionStyle {
 unsafe impl ::windows::core::Abi for ClosedCaptionStyle {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ClosedCaptionStyle {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ClosedCaptionStyle {}
 impl ::core::fmt::Debug for ClosedCaptionStyle {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ClosedCaptionStyle").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Media/ContentRestrictions/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/ContentRestrictions/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'Media_ContentRestrictions'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ContentAccessRestrictionLevel(pub i32);
 impl ContentAccessRestrictionLevel {
     pub const Allow: Self = Self(0i32);
@@ -17,12 +18,6 @@ impl ::core::clone::Clone for ContentAccessRestrictionLevel {
 unsafe impl ::windows::core::Abi for ContentAccessRestrictionLevel {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ContentAccessRestrictionLevel {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ContentAccessRestrictionLevel {}
 impl ::core::fmt::Debug for ContentAccessRestrictionLevel {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ContentAccessRestrictionLevel").field(&self.0).finish()
@@ -251,6 +246,7 @@ pub struct IRatedContentRestrictionsFactoryVtbl(
 );
 #[doc = "*Required features: 'Media_ContentRestrictions'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RatedContentCategory(pub i32);
 impl RatedContentCategory {
     pub const General: Self = Self(0i32);
@@ -269,12 +265,6 @@ impl ::core::clone::Clone for RatedContentCategory {
 unsafe impl ::windows::core::Abi for RatedContentCategory {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RatedContentCategory {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RatedContentCategory {}
 impl ::core::fmt::Debug for RatedContentCategory {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RatedContentCategory").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Media/Control/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Control/mod.rs
@@ -966,6 +966,7 @@ unsafe impl ::core::marker::Send for GlobalSystemMediaTransportControlsSessionPl
 unsafe impl ::core::marker::Sync for GlobalSystemMediaTransportControlsSessionPlaybackInfo {}
 #[doc = "*Required features: 'Media_Control'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GlobalSystemMediaTransportControlsSessionPlaybackStatus(pub i32);
 impl GlobalSystemMediaTransportControlsSessionPlaybackStatus {
     pub const Closed: Self = Self(0i32);
@@ -984,12 +985,6 @@ impl ::core::clone::Clone for GlobalSystemMediaTransportControlsSessionPlaybackS
 unsafe impl ::windows::core::Abi for GlobalSystemMediaTransportControlsSessionPlaybackStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GlobalSystemMediaTransportControlsSessionPlaybackStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GlobalSystemMediaTransportControlsSessionPlaybackStatus {}
 impl ::core::fmt::Debug for GlobalSystemMediaTransportControlsSessionPlaybackStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GlobalSystemMediaTransportControlsSessionPlaybackStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Media/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Core/mod.rs
@@ -3,6 +3,7 @@
 pub mod Preview;
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AudioDecoderDegradation(pub i32);
 impl AudioDecoderDegradation {
     pub const None: Self = Self(0i32);
@@ -19,12 +20,6 @@ impl ::core::clone::Clone for AudioDecoderDegradation {
 unsafe impl ::windows::core::Abi for AudioDecoderDegradation {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AudioDecoderDegradation {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AudioDecoderDegradation {}
 impl ::core::fmt::Debug for AudioDecoderDegradation {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AudioDecoderDegradation").field(&self.0).finish()
@@ -38,6 +33,7 @@ impl ::windows::core::DefaultType for AudioDecoderDegradation {
 }
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AudioDecoderDegradationReason(pub i32);
 impl AudioDecoderDegradationReason {
     pub const None: Self = Self(0i32);
@@ -53,12 +49,6 @@ impl ::core::clone::Clone for AudioDecoderDegradationReason {
 unsafe impl ::windows::core::Abi for AudioDecoderDegradationReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AudioDecoderDegradationReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AudioDecoderDegradationReason {}
 impl ::core::fmt::Debug for AudioDecoderDegradationReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AudioDecoderDegradationReason").field(&self.0).finish()
@@ -821,6 +811,7 @@ unsafe impl ::core::marker::Send for ChapterCue {}
 unsafe impl ::core::marker::Sync for ChapterCue {}
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CodecCategory(pub i32);
 impl CodecCategory {
     pub const Encoder: Self = Self(0i32);
@@ -835,12 +826,6 @@ impl ::core::clone::Clone for CodecCategory {
 unsafe impl ::windows::core::Abi for CodecCategory {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CodecCategory {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CodecCategory {}
 impl ::core::fmt::Debug for CodecCategory {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CodecCategory").field(&self.0).finish()
@@ -968,6 +953,7 @@ unsafe impl ::core::marker::Send for CodecInfo {}
 unsafe impl ::core::marker::Sync for CodecInfo {}
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CodecKind(pub i32);
 impl CodecKind {
     pub const Audio: Self = Self(0i32);
@@ -982,12 +968,6 @@ impl ::core::clone::Clone for CodecKind {
 unsafe impl ::windows::core::Abi for CodecKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CodecKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CodecKind {}
 impl ::core::fmt::Debug for CodecKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CodecKind").field(&self.0).finish()
@@ -2241,6 +2221,7 @@ unsafe impl ::core::marker::Send for FaceDetectionEffectFrame {}
 unsafe impl ::core::marker::Sync for FaceDetectionEffectFrame {}
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FaceDetectionMode(pub i32);
 impl FaceDetectionMode {
     pub const HighPerformance: Self = Self(0i32);
@@ -2256,12 +2237,6 @@ impl ::core::clone::Clone for FaceDetectionMode {
 unsafe impl ::windows::core::Abi for FaceDetectionMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FaceDetectionMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FaceDetectionMode {}
 impl ::core::fmt::Debug for FaceDetectionMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FaceDetectionMode").field(&self.0).finish()
@@ -6367,6 +6342,7 @@ unsafe impl ::core::marker::Send for MediaCueEventArgs {}
 unsafe impl ::core::marker::Sync for MediaCueEventArgs {}
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaDecoderStatus(pub i32);
 impl MediaDecoderStatus {
     pub const FullySupported: Self = Self(0i32);
@@ -6383,12 +6359,6 @@ impl ::core::clone::Clone for MediaDecoderStatus {
 unsafe impl ::windows::core::Abi for MediaDecoderStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaDecoderStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaDecoderStatus {}
 impl ::core::fmt::Debug for MediaDecoderStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaDecoderStatus").field(&self.0).finish()
@@ -7042,6 +7012,7 @@ unsafe impl ::core::marker::Send for MediaSourceOpenOperationCompletedEventArgs 
 unsafe impl ::core::marker::Sync for MediaSourceOpenOperationCompletedEventArgs {}
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaSourceState(pub i32);
 impl MediaSourceState {
     pub const Initial: Self = Self(0i32);
@@ -7059,12 +7030,6 @@ impl ::core::clone::Clone for MediaSourceState {
 unsafe impl ::windows::core::Abi for MediaSourceState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaSourceState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaSourceState {}
 impl ::core::fmt::Debug for MediaSourceState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaSourceState").field(&self.0).finish()
@@ -7167,6 +7132,7 @@ unsafe impl ::core::marker::Send for MediaSourceStateChangedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaSourceStateChangedEventArgs {}
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaSourceStatus(pub i32);
 impl MediaSourceStatus {
     pub const FullySupported: Self = Self(0i32);
@@ -7181,12 +7147,6 @@ impl ::core::clone::Clone for MediaSourceStatus {
 unsafe impl ::windows::core::Abi for MediaSourceStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaSourceStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaSourceStatus {}
 impl ::core::fmt::Debug for MediaSourceStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaSourceStatus").field(&self.0).finish()
@@ -8176,6 +8136,7 @@ unsafe impl ::core::marker::Send for MediaStreamSourceClosedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaStreamSourceClosedEventArgs {}
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaStreamSourceClosedReason(pub i32);
 impl MediaStreamSourceClosedReason {
     pub const Done: Self = Self(0i32);
@@ -8195,12 +8156,6 @@ impl ::core::clone::Clone for MediaStreamSourceClosedReason {
 unsafe impl ::windows::core::Abi for MediaStreamSourceClosedReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaStreamSourceClosedReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaStreamSourceClosedReason {}
 impl ::core::fmt::Debug for MediaStreamSourceClosedReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaStreamSourceClosedReason").field(&self.0).finish()
@@ -8295,6 +8250,7 @@ unsafe impl ::core::marker::Send for MediaStreamSourceClosedRequest {}
 unsafe impl ::core::marker::Sync for MediaStreamSourceClosedRequest {}
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaStreamSourceErrorStatus(pub i32);
 impl MediaStreamSourceErrorStatus {
     pub const Other: Self = Self(0i32);
@@ -8315,12 +8271,6 @@ impl ::core::clone::Clone for MediaStreamSourceErrorStatus {
 unsafe impl ::windows::core::Abi for MediaStreamSourceErrorStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaStreamSourceErrorStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaStreamSourceErrorStatus {}
 impl ::core::fmt::Debug for MediaStreamSourceErrorStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaStreamSourceErrorStatus").field(&self.0).finish()
@@ -9193,6 +9143,7 @@ unsafe impl ::core::marker::Send for MediaStreamSourceSwitchStreamsRequestedEven
 unsafe impl ::core::marker::Sync for MediaStreamSourceSwitchStreamsRequestedEventArgs {}
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaTrackKind(pub i32);
 impl MediaTrackKind {
     pub const Audio: Self = Self(0i32);
@@ -9208,12 +9159,6 @@ impl ::core::clone::Clone for MediaTrackKind {
 unsafe impl ::windows::core::Abi for MediaTrackKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaTrackKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaTrackKind {}
 impl ::core::fmt::Debug for MediaTrackKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaTrackKind").field(&self.0).finish()
@@ -9227,6 +9172,7 @@ impl ::windows::core::DefaultType for MediaTrackKind {
 }
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MseAppendMode(pub i32);
 impl MseAppendMode {
     pub const Segments: Self = Self(0i32);
@@ -9241,12 +9187,6 @@ impl ::core::clone::Clone for MseAppendMode {
 unsafe impl ::windows::core::Abi for MseAppendMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MseAppendMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MseAppendMode {}
 impl ::core::fmt::Debug for MseAppendMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MseAppendMode").field(&self.0).finish()
@@ -9260,6 +9200,7 @@ impl ::windows::core::DefaultType for MseAppendMode {
 }
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MseEndOfStreamStatus(pub i32);
 impl MseEndOfStreamStatus {
     pub const Success: Self = Self(0i32);
@@ -9276,12 +9217,6 @@ impl ::core::clone::Clone for MseEndOfStreamStatus {
 unsafe impl ::windows::core::Abi for MseEndOfStreamStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MseEndOfStreamStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MseEndOfStreamStatus {}
 impl ::core::fmt::Debug for MseEndOfStreamStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MseEndOfStreamStatus").field(&self.0).finish()
@@ -9295,6 +9230,7 @@ impl ::windows::core::DefaultType for MseEndOfStreamStatus {
 }
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MseReadyState(pub i32);
 impl MseReadyState {
     pub const Closed: Self = Self(0i32);
@@ -9310,12 +9246,6 @@ impl ::core::clone::Clone for MseReadyState {
 unsafe impl ::windows::core::Abi for MseReadyState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MseReadyState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MseReadyState {}
 impl ::core::fmt::Debug for MseReadyState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MseReadyState").field(&self.0).finish()
@@ -10488,6 +10418,7 @@ unsafe impl ::core::marker::Send for SceneAnalysisEffectFrame {}
 unsafe impl ::core::marker::Sync for SceneAnalysisEffectFrame {}
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SceneAnalysisRecommendation(pub i32);
 impl SceneAnalysisRecommendation {
     pub const Standard: Self = Self(0i32);
@@ -10503,12 +10434,6 @@ impl ::core::clone::Clone for SceneAnalysisRecommendation {
 unsafe impl ::windows::core::Abi for SceneAnalysisRecommendation {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SceneAnalysisRecommendation {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SceneAnalysisRecommendation {}
 impl ::core::fmt::Debug for SceneAnalysisRecommendation {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SceneAnalysisRecommendation").field(&self.0).finish()
@@ -10791,6 +10716,7 @@ unsafe impl ::core::marker::Send for SpeechCue {}
 unsafe impl ::core::marker::Sync for SpeechCue {}
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TimedMetadataKind(pub i32);
 impl TimedMetadataKind {
     pub const Caption: Self = Self(0i32);
@@ -10811,12 +10737,6 @@ impl ::core::clone::Clone for TimedMetadataKind {
 unsafe impl ::windows::core::Abi for TimedMetadataKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TimedMetadataKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TimedMetadataKind {}
 impl ::core::fmt::Debug for TimedMetadataKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TimedMetadataKind").field(&self.0).finish()
@@ -11363,6 +11283,7 @@ unsafe impl ::core::marker::Send for TimedMetadataTrackError {}
 unsafe impl ::core::marker::Sync for TimedMetadataTrackError {}
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TimedMetadataTrackErrorCode(pub i32);
 impl TimedMetadataTrackErrorCode {
     pub const None: Self = Self(0i32);
@@ -11379,12 +11300,6 @@ impl ::core::clone::Clone for TimedMetadataTrackErrorCode {
 unsafe impl ::windows::core::Abi for TimedMetadataTrackErrorCode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TimedMetadataTrackErrorCode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TimedMetadataTrackErrorCode {}
 impl ::core::fmt::Debug for TimedMetadataTrackErrorCode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TimedMetadataTrackErrorCode").field(&self.0).finish()
@@ -11593,6 +11508,7 @@ unsafe impl ::core::marker::Send for TimedTextBouten {}
 unsafe impl ::core::marker::Sync for TimedTextBouten {}
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TimedTextBoutenPosition(pub i32);
 impl TimedTextBoutenPosition {
     pub const Before: Self = Self(0i32);
@@ -11608,12 +11524,6 @@ impl ::core::clone::Clone for TimedTextBoutenPosition {
 unsafe impl ::windows::core::Abi for TimedTextBoutenPosition {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TimedTextBoutenPosition {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TimedTextBoutenPosition {}
 impl ::core::fmt::Debug for TimedTextBoutenPosition {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TimedTextBoutenPosition").field(&self.0).finish()
@@ -11627,6 +11537,7 @@ impl ::windows::core::DefaultType for TimedTextBoutenPosition {
 }
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TimedTextBoutenType(pub i32);
 impl TimedTextBoutenType {
     pub const None: Self = Self(0i32);
@@ -11647,12 +11558,6 @@ impl ::core::clone::Clone for TimedTextBoutenType {
 unsafe impl ::windows::core::Abi for TimedTextBoutenType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TimedTextBoutenType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TimedTextBoutenType {}
 impl ::core::fmt::Debug for TimedTextBoutenType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TimedTextBoutenType").field(&self.0).finish()
@@ -11846,6 +11751,7 @@ unsafe impl ::core::marker::Send for TimedTextCue {}
 unsafe impl ::core::marker::Sync for TimedTextCue {}
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TimedTextDisplayAlignment(pub i32);
 impl TimedTextDisplayAlignment {
     pub const Before: Self = Self(0i32);
@@ -11861,12 +11767,6 @@ impl ::core::clone::Clone for TimedTextDisplayAlignment {
 unsafe impl ::windows::core::Abi for TimedTextDisplayAlignment {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TimedTextDisplayAlignment {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TimedTextDisplayAlignment {}
 impl ::core::fmt::Debug for TimedTextDisplayAlignment {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TimedTextDisplayAlignment").field(&self.0).finish()
@@ -11917,6 +11817,7 @@ impl ::core::default::Default for TimedTextDouble {
 }
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TimedTextFlowDirection(pub i32);
 impl TimedTextFlowDirection {
     pub const LeftToRight: Self = Self(0i32);
@@ -11931,12 +11832,6 @@ impl ::core::clone::Clone for TimedTextFlowDirection {
 unsafe impl ::windows::core::Abi for TimedTextFlowDirection {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TimedTextFlowDirection {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TimedTextFlowDirection {}
 impl ::core::fmt::Debug for TimedTextFlowDirection {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TimedTextFlowDirection").field(&self.0).finish()
@@ -11950,6 +11845,7 @@ impl ::windows::core::DefaultType for TimedTextFlowDirection {
 }
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TimedTextFontStyle(pub i32);
 impl TimedTextFontStyle {
     pub const Normal: Self = Self(0i32);
@@ -11965,12 +11861,6 @@ impl ::core::clone::Clone for TimedTextFontStyle {
 unsafe impl ::windows::core::Abi for TimedTextFontStyle {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TimedTextFontStyle {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TimedTextFontStyle {}
 impl ::core::fmt::Debug for TimedTextFontStyle {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TimedTextFontStyle").field(&self.0).finish()
@@ -12086,6 +11976,7 @@ unsafe impl ::core::marker::Send for TimedTextLine {}
 unsafe impl ::core::marker::Sync for TimedTextLine {}
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TimedTextLineAlignment(pub i32);
 impl TimedTextLineAlignment {
     pub const Start: Self = Self(0i32);
@@ -12101,12 +11992,6 @@ impl ::core::clone::Clone for TimedTextLineAlignment {
 unsafe impl ::windows::core::Abi for TimedTextLineAlignment {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TimedTextLineAlignment {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TimedTextLineAlignment {}
 impl ::core::fmt::Debug for TimedTextLineAlignment {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TimedTextLineAlignment").field(&self.0).finish()
@@ -12561,6 +12446,7 @@ unsafe impl ::core::marker::Send for TimedTextRuby {}
 unsafe impl ::core::marker::Sync for TimedTextRuby {}
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TimedTextRubyAlign(pub i32);
 impl TimedTextRubyAlign {
     pub const Center: Self = Self(0i32);
@@ -12579,12 +12465,6 @@ impl ::core::clone::Clone for TimedTextRubyAlign {
 unsafe impl ::windows::core::Abi for TimedTextRubyAlign {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TimedTextRubyAlign {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TimedTextRubyAlign {}
 impl ::core::fmt::Debug for TimedTextRubyAlign {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TimedTextRubyAlign").field(&self.0).finish()
@@ -12598,6 +12478,7 @@ impl ::windows::core::DefaultType for TimedTextRubyAlign {
 }
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TimedTextRubyPosition(pub i32);
 impl TimedTextRubyPosition {
     pub const Before: Self = Self(0i32);
@@ -12613,12 +12494,6 @@ impl ::core::clone::Clone for TimedTextRubyPosition {
 unsafe impl ::windows::core::Abi for TimedTextRubyPosition {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TimedTextRubyPosition {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TimedTextRubyPosition {}
 impl ::core::fmt::Debug for TimedTextRubyPosition {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TimedTextRubyPosition").field(&self.0).finish()
@@ -12632,6 +12507,7 @@ impl ::windows::core::DefaultType for TimedTextRubyPosition {
 }
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TimedTextRubyReserve(pub i32);
 impl TimedTextRubyReserve {
     pub const None: Self = Self(0i32);
@@ -12649,12 +12525,6 @@ impl ::core::clone::Clone for TimedTextRubyReserve {
 unsafe impl ::windows::core::Abi for TimedTextRubyReserve {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TimedTextRubyReserve {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TimedTextRubyReserve {}
 impl ::core::fmt::Debug for TimedTextRubyReserve {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TimedTextRubyReserve").field(&self.0).finish()
@@ -12668,6 +12538,7 @@ impl ::windows::core::DefaultType for TimedTextRubyReserve {
 }
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TimedTextScrollMode(pub i32);
 impl TimedTextScrollMode {
     pub const Popon: Self = Self(0i32);
@@ -12682,12 +12553,6 @@ impl ::core::clone::Clone for TimedTextScrollMode {
 unsafe impl ::windows::core::Abi for TimedTextScrollMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TimedTextScrollMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TimedTextScrollMode {}
 impl ::core::fmt::Debug for TimedTextScrollMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TimedTextScrollMode").field(&self.0).finish()
@@ -13446,6 +13311,7 @@ unsafe impl ::core::marker::Send for TimedTextSubformat {}
 unsafe impl ::core::marker::Sync for TimedTextSubformat {}
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TimedTextUnit(pub i32);
 impl TimedTextUnit {
     pub const Pixels: Self = Self(0i32);
@@ -13460,12 +13326,6 @@ impl ::core::clone::Clone for TimedTextUnit {
 unsafe impl ::windows::core::Abi for TimedTextUnit {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TimedTextUnit {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TimedTextUnit {}
 impl ::core::fmt::Debug for TimedTextUnit {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TimedTextUnit").field(&self.0).finish()
@@ -13479,6 +13339,7 @@ impl ::windows::core::DefaultType for TimedTextUnit {
 }
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TimedTextWeight(pub i32);
 impl TimedTextWeight {
     pub const Normal: Self = Self(400i32);
@@ -13493,12 +13354,6 @@ impl ::core::clone::Clone for TimedTextWeight {
 unsafe impl ::windows::core::Abi for TimedTextWeight {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TimedTextWeight {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TimedTextWeight {}
 impl ::core::fmt::Debug for TimedTextWeight {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TimedTextWeight").field(&self.0).finish()
@@ -13512,6 +13367,7 @@ impl ::windows::core::DefaultType for TimedTextWeight {
 }
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TimedTextWrapping(pub i32);
 impl TimedTextWrapping {
     pub const NoWrap: Self = Self(0i32);
@@ -13526,12 +13382,6 @@ impl ::core::clone::Clone for TimedTextWrapping {
 unsafe impl ::windows::core::Abi for TimedTextWrapping {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TimedTextWrapping {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TimedTextWrapping {}
 impl ::core::fmt::Debug for TimedTextWrapping {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TimedTextWrapping").field(&self.0).finish()
@@ -13545,6 +13395,7 @@ impl ::windows::core::DefaultType for TimedTextWrapping {
 }
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TimedTextWritingMode(pub i32);
 impl TimedTextWritingMode {
     pub const LeftRightTopBottom: Self = Self(0i32);
@@ -13564,12 +13415,6 @@ impl ::core::clone::Clone for TimedTextWritingMode {
 unsafe impl ::windows::core::Abi for TimedTextWritingMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TimedTextWritingMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TimedTextWritingMode {}
 impl ::core::fmt::Debug for TimedTextWritingMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TimedTextWritingMode").field(&self.0).finish()
@@ -13945,6 +13790,7 @@ unsafe impl ::core::marker::Send for VideoStabilizationEffectEnabledChangedEvent
 unsafe impl ::core::marker::Sync for VideoStabilizationEffectEnabledChangedEventArgs {}
 #[doc = "*Required features: 'Media_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VideoStabilizationEffectEnabledChangedReason(pub i32);
 impl VideoStabilizationEffectEnabledChangedReason {
     pub const Programmatic: Self = Self(0i32);
@@ -13960,12 +13806,6 @@ impl ::core::clone::Clone for VideoStabilizationEffectEnabledChangedReason {
 unsafe impl ::windows::core::Abi for VideoStabilizationEffectEnabledChangedReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VideoStabilizationEffectEnabledChangedReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VideoStabilizationEffectEnabledChangedReason {}
 impl ::core::fmt::Debug for VideoStabilizationEffectEnabledChangedReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VideoStabilizationEffectEnabledChangedReason").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Media/Devices/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Devices/Core/mod.rs
@@ -1209,6 +1209,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Fram
 }
 #[doc = "*Required features: 'Media_Devices_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FrameFlashMode(pub i32);
 impl FrameFlashMode {
     pub const Disable: Self = Self(0i32);
@@ -1224,12 +1225,6 @@ impl ::core::clone::Clone for FrameFlashMode {
 unsafe impl ::windows::core::Abi for FrameFlashMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FrameFlashMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FrameFlashMode {}
 impl ::core::fmt::Debug for FrameFlashMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FrameFlashMode").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Media/Devices/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Devices/mod.rs
@@ -199,6 +199,7 @@ unsafe impl ::core::marker::Send for AdvancedPhotoControl {}
 unsafe impl ::core::marker::Sync for AdvancedPhotoControl {}
 #[doc = "*Required features: 'Media_Devices'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AdvancedPhotoMode(pub i32);
 impl AdvancedPhotoMode {
     pub const Auto: Self = Self(0i32);
@@ -215,12 +216,6 @@ impl ::core::clone::Clone for AdvancedPhotoMode {
 unsafe impl ::windows::core::Abi for AdvancedPhotoMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AdvancedPhotoMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AdvancedPhotoMode {}
 impl ::core::fmt::Debug for AdvancedPhotoMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AdvancedPhotoMode").field(&self.0).finish()
@@ -708,6 +703,7 @@ unsafe impl ::core::marker::Send for AudioDeviceModulesManager {}
 unsafe impl ::core::marker::Sync for AudioDeviceModulesManager {}
 #[doc = "*Required features: 'Media_Devices'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AudioDeviceRole(pub i32);
 impl AudioDeviceRole {
     pub const Default: Self = Self(0i32);
@@ -722,12 +718,6 @@ impl ::core::clone::Clone for AudioDeviceRole {
 unsafe impl ::windows::core::Abi for AudioDeviceRole {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AudioDeviceRole {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AudioDeviceRole {}
 impl ::core::fmt::Debug for AudioDeviceRole {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AudioDeviceRole").field(&self.0).finish()
@@ -741,6 +731,7 @@ impl ::windows::core::DefaultType for AudioDeviceRole {
 }
 #[doc = "*Required features: 'Media_Devices'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AutoFocusRange(pub i32);
 impl AutoFocusRange {
     pub const FullRange: Self = Self(0i32);
@@ -756,12 +747,6 @@ impl ::core::clone::Clone for AutoFocusRange {
 unsafe impl ::windows::core::Abi for AutoFocusRange {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AutoFocusRange {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AutoFocusRange {}
 impl ::core::fmt::Debug for AutoFocusRange {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AutoFocusRange").field(&self.0).finish()
@@ -1170,6 +1155,7 @@ unsafe impl ::core::marker::Send for CameraOcclusionInfo {}
 unsafe impl ::core::marker::Sync for CameraOcclusionInfo {}
 #[doc = "*Required features: 'Media_Devices'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CameraOcclusionKind(pub i32);
 impl CameraOcclusionKind {
     pub const Lid: Self = Self(0i32);
@@ -1184,12 +1170,6 @@ impl ::core::clone::Clone for CameraOcclusionKind {
 unsafe impl ::windows::core::Abi for CameraOcclusionKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CameraOcclusionKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CameraOcclusionKind {}
 impl ::core::fmt::Debug for CameraOcclusionKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CameraOcclusionKind").field(&self.0).finish()
@@ -1373,6 +1353,7 @@ unsafe impl ::core::marker::Send for CameraOcclusionStateChangedEventArgs {}
 unsafe impl ::core::marker::Sync for CameraOcclusionStateChangedEventArgs {}
 #[doc = "*Required features: 'Media_Devices'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CameraStreamState(pub i32);
 impl CameraStreamState {
     pub const NotStreaming: Self = Self(0i32);
@@ -1389,12 +1370,6 @@ impl ::core::clone::Clone for CameraStreamState {
 unsafe impl ::windows::core::Abi for CameraStreamState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CameraStreamState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CameraStreamState {}
 impl ::core::fmt::Debug for CameraStreamState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CameraStreamState").field(&self.0).finish()
@@ -1408,6 +1383,7 @@ impl ::windows::core::DefaultType for CameraStreamState {
 }
 #[doc = "*Required features: 'Media_Devices'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CaptureSceneMode(pub i32);
 impl CaptureSceneMode {
     pub const Auto: Self = Self(0i32);
@@ -1433,12 +1409,6 @@ impl ::core::clone::Clone for CaptureSceneMode {
 unsafe impl ::windows::core::Abi for CaptureSceneMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CaptureSceneMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CaptureSceneMode {}
 impl ::core::fmt::Debug for CaptureSceneMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CaptureSceneMode").field(&self.0).finish()
@@ -1452,6 +1422,7 @@ impl ::windows::core::DefaultType for CaptureSceneMode {
 }
 #[doc = "*Required features: 'Media_Devices'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CaptureUse(pub i32);
 impl CaptureUse {
     pub const None: Self = Self(0i32);
@@ -1467,12 +1438,6 @@ impl ::core::clone::Clone for CaptureUse {
 unsafe impl ::windows::core::Abi for CaptureUse {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CaptureUse {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CaptureUse {}
 impl ::core::fmt::Debug for CaptureUse {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CaptureUse").field(&self.0).finish()
@@ -1486,6 +1451,7 @@ impl ::windows::core::DefaultType for CaptureUse {
 }
 #[doc = "*Required features: 'Media_Devices'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ColorTemperaturePreset(pub i32);
 impl ColorTemperaturePreset {
     pub const Auto: Self = Self(0i32);
@@ -1506,12 +1472,6 @@ impl ::core::clone::Clone for ColorTemperaturePreset {
 unsafe impl ::windows::core::Abi for ColorTemperaturePreset {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ColorTemperaturePreset {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ColorTemperaturePreset {}
 impl ::core::fmt::Debug for ColorTemperaturePreset {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ColorTemperaturePreset").field(&self.0).finish()
@@ -2281,6 +2241,7 @@ unsafe impl ::core::marker::Send for DigitalWindowControl {}
 unsafe impl ::core::marker::Sync for DigitalWindowControl {}
 #[doc = "*Required features: 'Media_Devices'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DigitalWindowMode(pub i32);
 impl DigitalWindowMode {
     pub const Off: Self = Self(0i32);
@@ -2296,12 +2257,6 @@ impl ::core::clone::Clone for DigitalWindowMode {
 unsafe impl ::windows::core::Abi for DigitalWindowMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DigitalWindowMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DigitalWindowMode {}
 impl ::core::fmt::Debug for DigitalWindowMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DigitalWindowMode").field(&self.0).finish()
@@ -3084,6 +3039,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Focu
 }
 #[doc = "*Required features: 'Media_Devices'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FocusMode(pub i32);
 impl FocusMode {
     pub const Auto: Self = Self(0i32);
@@ -3100,12 +3056,6 @@ impl ::core::clone::Clone for FocusMode {
 unsafe impl ::windows::core::Abi for FocusMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FocusMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FocusMode {}
 impl ::core::fmt::Debug for FocusMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FocusMode").field(&self.0).finish()
@@ -3119,6 +3069,7 @@ impl ::windows::core::DefaultType for FocusMode {
 }
 #[doc = "*Required features: 'Media_Devices'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FocusPreset(pub i32);
 impl FocusPreset {
     pub const Auto: Self = Self(0i32);
@@ -3137,12 +3088,6 @@ impl ::core::clone::Clone for FocusPreset {
 unsafe impl ::windows::core::Abi for FocusPreset {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FocusPreset {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FocusPreset {}
 impl ::core::fmt::Debug for FocusPreset {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FocusPreset").field(&self.0).finish()
@@ -3421,6 +3366,7 @@ unsafe impl ::core::marker::Send for HdrVideoControl {}
 unsafe impl ::core::marker::Sync for HdrVideoControl {}
 #[doc = "*Required features: 'Media_Devices'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HdrVideoMode(pub i32);
 impl HdrVideoMode {
     pub const Off: Self = Self(0i32);
@@ -3436,12 +3382,6 @@ impl ::core::clone::Clone for HdrVideoMode {
 unsafe impl ::windows::core::Abi for HdrVideoMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HdrVideoMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HdrVideoMode {}
 impl ::core::fmt::Debug for HdrVideoMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HdrVideoMode").field(&self.0).finish()
@@ -5248,6 +5188,7 @@ unsafe impl ::core::marker::Send for InfraredTorchControl {}
 unsafe impl ::core::marker::Sync for InfraredTorchControl {}
 #[doc = "*Required features: 'Media_Devices'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InfraredTorchMode(pub i32);
 impl InfraredTorchMode {
     pub const Off: Self = Self(0i32);
@@ -5263,12 +5204,6 @@ impl ::core::clone::Clone for InfraredTorchMode {
 unsafe impl ::windows::core::Abi for InfraredTorchMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InfraredTorchMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InfraredTorchMode {}
 impl ::core::fmt::Debug for InfraredTorchMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InfraredTorchMode").field(&self.0).finish()
@@ -5447,6 +5382,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &IsoS
 #[doc = "*Required features: 'Media_Devices', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct IsoSpeedPreset(pub i32);
 #[cfg(feature = "deprecated")]
 impl IsoSpeedPreset {
@@ -5475,14 +5411,6 @@ impl ::core::clone::Clone for IsoSpeedPreset {
 unsafe impl ::windows::core::Abi for IsoSpeedPreset {
     type Abi = Self;
 }
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for IsoSpeedPreset {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for IsoSpeedPreset {}
 #[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for IsoSpeedPreset {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -5981,6 +5909,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &LowL
 }
 #[doc = "*Required features: 'Media_Devices'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ManualFocusDistance(pub i32);
 impl ManualFocusDistance {
     pub const Infinity: Self = Self(0i32);
@@ -5996,12 +5925,6 @@ impl ::core::clone::Clone for ManualFocusDistance {
 unsafe impl ::windows::core::Abi for ManualFocusDistance {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ManualFocusDistance {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ManualFocusDistance {}
 impl ::core::fmt::Debug for ManualFocusDistance {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ManualFocusDistance").field(&self.0).finish()
@@ -6015,6 +5938,7 @@ impl ::windows::core::DefaultType for ManualFocusDistance {
 }
 #[doc = "*Required features: 'Media_Devices'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaCaptureFocusState(pub i32);
 impl MediaCaptureFocusState {
     pub const Uninitialized: Self = Self(0i32);
@@ -6032,12 +5956,6 @@ impl ::core::clone::Clone for MediaCaptureFocusState {
 unsafe impl ::windows::core::Abi for MediaCaptureFocusState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaCaptureFocusState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaCaptureFocusState {}
 impl ::core::fmt::Debug for MediaCaptureFocusState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaCaptureFocusState").field(&self.0).finish()
@@ -6051,6 +5969,7 @@ impl ::windows::core::DefaultType for MediaCaptureFocusState {
 }
 #[doc = "*Required features: 'Media_Devices'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaCaptureOptimization(pub i32);
 impl MediaCaptureOptimization {
     pub const Default: Self = Self(0i32);
@@ -6070,12 +5989,6 @@ impl ::core::clone::Clone for MediaCaptureOptimization {
 unsafe impl ::windows::core::Abi for MediaCaptureOptimization {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaCaptureOptimization {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaCaptureOptimization {}
 impl ::core::fmt::Debug for MediaCaptureOptimization {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaCaptureOptimization").field(&self.0).finish()
@@ -6089,6 +6002,7 @@ impl ::windows::core::DefaultType for MediaCaptureOptimization {
 }
 #[doc = "*Required features: 'Media_Devices'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaCapturePauseBehavior(pub i32);
 impl MediaCapturePauseBehavior {
     pub const RetainHardwareResources: Self = Self(0i32);
@@ -6103,12 +6017,6 @@ impl ::core::clone::Clone for MediaCapturePauseBehavior {
 unsafe impl ::windows::core::Abi for MediaCapturePauseBehavior {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaCapturePauseBehavior {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaCapturePauseBehavior {}
 impl ::core::fmt::Debug for MediaCapturePauseBehavior {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaCapturePauseBehavior").field(&self.0).finish()
@@ -6616,6 +6524,7 @@ unsafe impl ::core::marker::Send for OpticalImageStabilizationControl {}
 unsafe impl ::core::marker::Sync for OpticalImageStabilizationControl {}
 #[doc = "*Required features: 'Media_Devices'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct OpticalImageStabilizationMode(pub i32);
 impl OpticalImageStabilizationMode {
     pub const Off: Self = Self(0i32);
@@ -6631,12 +6540,6 @@ impl ::core::clone::Clone for OpticalImageStabilizationMode {
 unsafe impl ::windows::core::Abi for OpticalImageStabilizationMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for OpticalImageStabilizationMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for OpticalImageStabilizationMode {}
 impl ::core::fmt::Debug for OpticalImageStabilizationMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("OpticalImageStabilizationMode").field(&self.0).finish()
@@ -7179,6 +7082,7 @@ unsafe impl ::core::marker::Send for RegionOfInterest {}
 unsafe impl ::core::marker::Sync for RegionOfInterest {}
 #[doc = "*Required features: 'Media_Devices'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RegionOfInterestType(pub i32);
 impl RegionOfInterestType {
     pub const Unknown: Self = Self(0i32);
@@ -7193,12 +7097,6 @@ impl ::core::clone::Clone for RegionOfInterestType {
 unsafe impl ::windows::core::Abi for RegionOfInterestType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RegionOfInterestType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RegionOfInterestType {}
 impl ::core::fmt::Debug for RegionOfInterestType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RegionOfInterestType").field(&self.0).finish()
@@ -7439,6 +7337,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Scen
 }
 #[doc = "*Required features: 'Media_Devices'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SendCommandStatus(pub i32);
 impl SendCommandStatus {
     pub const Success: Self = Self(0i32);
@@ -7453,12 +7352,6 @@ impl ::core::clone::Clone for SendCommandStatus {
 unsafe impl ::windows::core::Abi for SendCommandStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SendCommandStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SendCommandStatus {}
 impl ::core::fmt::Debug for SendCommandStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SendCommandStatus").field(&self.0).finish()
@@ -7472,6 +7365,7 @@ impl ::windows::core::DefaultType for SendCommandStatus {
 }
 #[doc = "*Required features: 'Media_Devices'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TelephonyKey(pub i32);
 impl TelephonyKey {
     pub const D0: Self = Self(0i32);
@@ -7500,12 +7394,6 @@ impl ::core::clone::Clone for TelephonyKey {
 unsafe impl ::windows::core::Abi for TelephonyKey {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TelephonyKey {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TelephonyKey {}
 impl ::core::fmt::Debug for TelephonyKey {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TelephonyKey").field(&self.0).finish()
@@ -8213,6 +8101,7 @@ unsafe impl ::core::marker::Send for VideoDeviceControllerGetDevicePropertyResul
 unsafe impl ::core::marker::Sync for VideoDeviceControllerGetDevicePropertyResult {}
 #[doc = "*Required features: 'Media_Devices'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VideoDeviceControllerGetDevicePropertyStatus(pub i32);
 impl VideoDeviceControllerGetDevicePropertyStatus {
     pub const Success: Self = Self(0i32);
@@ -8232,12 +8121,6 @@ impl ::core::clone::Clone for VideoDeviceControllerGetDevicePropertyStatus {
 unsafe impl ::windows::core::Abi for VideoDeviceControllerGetDevicePropertyStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VideoDeviceControllerGetDevicePropertyStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VideoDeviceControllerGetDevicePropertyStatus {}
 impl ::core::fmt::Debug for VideoDeviceControllerGetDevicePropertyStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VideoDeviceControllerGetDevicePropertyStatus").field(&self.0).finish()
@@ -8251,6 +8134,7 @@ impl ::windows::core::DefaultType for VideoDeviceControllerGetDevicePropertyStat
 }
 #[doc = "*Required features: 'Media_Devices'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VideoDeviceControllerSetDevicePropertyStatus(pub i32);
 impl VideoDeviceControllerSetDevicePropertyStatus {
     pub const Success: Self = Self(0i32);
@@ -8269,12 +8153,6 @@ impl ::core::clone::Clone for VideoDeviceControllerSetDevicePropertyStatus {
 unsafe impl ::windows::core::Abi for VideoDeviceControllerSetDevicePropertyStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VideoDeviceControllerSetDevicePropertyStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VideoDeviceControllerSetDevicePropertyStatus {}
 impl ::core::fmt::Debug for VideoDeviceControllerSetDevicePropertyStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VideoDeviceControllerSetDevicePropertyStatus").field(&self.0).finish()
@@ -8391,6 +8269,7 @@ unsafe impl ::core::marker::Send for VideoTemporalDenoisingControl {}
 unsafe impl ::core::marker::Sync for VideoTemporalDenoisingControl {}
 #[doc = "*Required features: 'Media_Devices'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VideoTemporalDenoisingMode(pub i32);
 impl VideoTemporalDenoisingMode {
     pub const Off: Self = Self(0i32);
@@ -8406,12 +8285,6 @@ impl ::core::clone::Clone for VideoTemporalDenoisingMode {
 unsafe impl ::windows::core::Abi for VideoTemporalDenoisingMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VideoTemporalDenoisingMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VideoTemporalDenoisingMode {}
 impl ::core::fmt::Debug for VideoTemporalDenoisingMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VideoTemporalDenoisingMode").field(&self.0).finish()
@@ -8806,6 +8679,7 @@ unsafe impl ::core::marker::Send for ZoomSettings {}
 unsafe impl ::core::marker::Sync for ZoomSettings {}
 #[doc = "*Required features: 'Media_Devices'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ZoomTransitionMode(pub i32);
 impl ZoomTransitionMode {
     pub const Auto: Self = Self(0i32);
@@ -8821,12 +8695,6 @@ impl ::core::clone::Clone for ZoomTransitionMode {
 unsafe impl ::windows::core::Abi for ZoomTransitionMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ZoomTransitionMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ZoomTransitionMode {}
 impl ::core::fmt::Debug for ZoomTransitionMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ZoomTransitionMode").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Media/DialProtocol/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/DialProtocol/mod.rs
@@ -109,6 +109,7 @@ unsafe impl ::core::marker::Send for DialApp {}
 unsafe impl ::core::marker::Sync for DialApp {}
 #[doc = "*Required features: 'Media_DialProtocol'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DialAppLaunchResult(pub i32);
 impl DialAppLaunchResult {
     pub const Launched: Self = Self(0i32);
@@ -125,12 +126,6 @@ impl ::core::clone::Clone for DialAppLaunchResult {
 unsafe impl ::windows::core::Abi for DialAppLaunchResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DialAppLaunchResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DialAppLaunchResult {}
 impl ::core::fmt::Debug for DialAppLaunchResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DialAppLaunchResult").field(&self.0).finish()
@@ -144,6 +139,7 @@ impl ::windows::core::DefaultType for DialAppLaunchResult {
 }
 #[doc = "*Required features: 'Media_DialProtocol'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DialAppState(pub i32);
 impl DialAppState {
     pub const Unknown: Self = Self(0i32);
@@ -160,12 +156,6 @@ impl ::core::clone::Clone for DialAppState {
 unsafe impl ::windows::core::Abi for DialAppState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DialAppState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DialAppState {}
 impl ::core::fmt::Debug for DialAppState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DialAppState").field(&self.0).finish()
@@ -268,6 +258,7 @@ unsafe impl ::core::marker::Send for DialAppStateDetails {}
 unsafe impl ::core::marker::Sync for DialAppStateDetails {}
 #[doc = "*Required features: 'Media_DialProtocol'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DialAppStopResult(pub i32);
 impl DialAppStopResult {
     pub const Stopped: Self = Self(0i32);
@@ -284,12 +275,6 @@ impl ::core::clone::Clone for DialAppStopResult {
 unsafe impl ::windows::core::Abi for DialAppStopResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DialAppStopResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DialAppStopResult {}
 impl ::core::fmt::Debug for DialAppStopResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DialAppStopResult").field(&self.0).finish()
@@ -437,6 +422,7 @@ unsafe impl ::core::marker::Send for DialDevice {}
 unsafe impl ::core::marker::Sync for DialDevice {}
 #[doc = "*Required features: 'Media_DialProtocol'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DialDeviceDisplayStatus(pub i32);
 impl DialDeviceDisplayStatus {
     pub const None: Self = Self(0i32);
@@ -455,12 +441,6 @@ impl ::core::clone::Clone for DialDeviceDisplayStatus {
 unsafe impl ::windows::core::Abi for DialDeviceDisplayStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DialDeviceDisplayStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DialDeviceDisplayStatus {}
 impl ::core::fmt::Debug for DialDeviceDisplayStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DialDeviceDisplayStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Media/Editing/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Editing/mod.rs
@@ -1414,6 +1414,7 @@ unsafe impl ::core::marker::Send for MediaOverlayLayer {}
 unsafe impl ::core::marker::Sync for MediaOverlayLayer {}
 #[doc = "*Required features: 'Media_Editing'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaTrimmingPreference(pub i32);
 impl MediaTrimmingPreference {
     pub const Fast: Self = Self(0i32);
@@ -1428,12 +1429,6 @@ impl ::core::clone::Clone for MediaTrimmingPreference {
 unsafe impl ::windows::core::Abi for MediaTrimmingPreference {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaTrimmingPreference {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaTrimmingPreference {}
 impl ::core::fmt::Debug for MediaTrimmingPreference {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaTrimmingPreference").field(&self.0).finish()
@@ -1447,6 +1442,7 @@ impl ::windows::core::DefaultType for MediaTrimmingPreference {
 }
 #[doc = "*Required features: 'Media_Editing'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VideoFramePrecision(pub i32);
 impl VideoFramePrecision {
     pub const NearestFrame: Self = Self(0i32);
@@ -1461,12 +1457,6 @@ impl ::core::clone::Clone for VideoFramePrecision {
 unsafe impl ::windows::core::Abi for VideoFramePrecision {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VideoFramePrecision {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VideoFramePrecision {}
 impl ::core::fmt::Debug for VideoFramePrecision {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VideoFramePrecision").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Media/Effects/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Effects/mod.rs
@@ -311,6 +311,7 @@ unsafe impl ::core::marker::Send for AudioEffectDefinition {}
 unsafe impl ::core::marker::Sync for AudioEffectDefinition {}
 #[doc = "*Required features: 'Media_Effects'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AudioEffectType(pub i32);
 impl AudioEffectType {
     pub const Other: Self = Self(0i32);
@@ -343,12 +344,6 @@ impl ::core::clone::Clone for AudioEffectType {
 unsafe impl ::windows::core::Abi for AudioEffectType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AudioEffectType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AudioEffectType {}
 impl ::core::fmt::Debug for AudioEffectType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AudioEffectType").field(&self.0).finish()
@@ -1738,6 +1733,7 @@ pub struct IVideoTransformSphericalProjectionVtbl(
 );
 #[doc = "*Required features: 'Media_Effects'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaEffectClosedReason(pub i32);
 impl MediaEffectClosedReason {
     pub const Done: Self = Self(0i32);
@@ -1754,12 +1750,6 @@ impl ::core::clone::Clone for MediaEffectClosedReason {
 unsafe impl ::windows::core::Abi for MediaEffectClosedReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaEffectClosedReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaEffectClosedReason {}
 impl ::core::fmt::Debug for MediaEffectClosedReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaEffectClosedReason").field(&self.0).finish()
@@ -1773,6 +1763,7 @@ impl ::windows::core::DefaultType for MediaEffectClosedReason {
 }
 #[doc = "*Required features: 'Media_Effects'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaMemoryTypes(pub i32);
 impl MediaMemoryTypes {
     pub const Gpu: Self = Self(0i32);
@@ -1788,12 +1779,6 @@ impl ::core::clone::Clone for MediaMemoryTypes {
 unsafe impl ::windows::core::Abi for MediaMemoryTypes {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaMemoryTypes {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaMemoryTypes {}
 impl ::core::fmt::Debug for MediaMemoryTypes {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaMemoryTypes").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Media/Import/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Import/mod.rs
@@ -461,6 +461,7 @@ pub struct IPhotoImportVideoSegmentVtbl(
 );
 #[doc = "*Required features: 'Media_Import'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhotoImportAccessMode(pub i32);
 impl PhotoImportAccessMode {
     pub const ReadWrite: Self = Self(0i32);
@@ -476,12 +477,6 @@ impl ::core::clone::Clone for PhotoImportAccessMode {
 unsafe impl ::windows::core::Abi for PhotoImportAccessMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhotoImportAccessMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhotoImportAccessMode {}
 impl ::core::fmt::Debug for PhotoImportAccessMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhotoImportAccessMode").field(&self.0).finish()
@@ -495,6 +490,7 @@ impl ::windows::core::DefaultType for PhotoImportAccessMode {
 }
 #[doc = "*Required features: 'Media_Import'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhotoImportConnectionTransport(pub i32);
 impl PhotoImportConnectionTransport {
     pub const Unknown: Self = Self(0i32);
@@ -511,12 +507,6 @@ impl ::core::clone::Clone for PhotoImportConnectionTransport {
 unsafe impl ::windows::core::Abi for PhotoImportConnectionTransport {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhotoImportConnectionTransport {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhotoImportConnectionTransport {}
 impl ::core::fmt::Debug for PhotoImportConnectionTransport {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhotoImportConnectionTransport").field(&self.0).finish()
@@ -530,6 +520,7 @@ impl ::windows::core::DefaultType for PhotoImportConnectionTransport {
 }
 #[doc = "*Required features: 'Media_Import'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhotoImportContentType(pub i32);
 impl PhotoImportContentType {
     pub const Unknown: Self = Self(0i32);
@@ -545,12 +536,6 @@ impl ::core::clone::Clone for PhotoImportContentType {
 unsafe impl ::windows::core::Abi for PhotoImportContentType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhotoImportContentType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhotoImportContentType {}
 impl ::core::fmt::Debug for PhotoImportContentType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhotoImportContentType").field(&self.0).finish()
@@ -564,6 +549,7 @@ impl ::windows::core::DefaultType for PhotoImportContentType {
 }
 #[doc = "*Required features: 'Media_Import'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhotoImportContentTypeFilter(pub i32);
 impl PhotoImportContentTypeFilter {
     pub const OnlyImages: Self = Self(0i32);
@@ -580,12 +566,6 @@ impl ::core::clone::Clone for PhotoImportContentTypeFilter {
 unsafe impl ::windows::core::Abi for PhotoImportContentTypeFilter {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhotoImportContentTypeFilter {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhotoImportContentTypeFilter {}
 impl ::core::fmt::Debug for PhotoImportContentTypeFilter {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhotoImportContentTypeFilter").field(&self.0).finish()
@@ -1299,6 +1279,7 @@ unsafe impl ::core::marker::Send for PhotoImportImportItemsResult {}
 unsafe impl ::core::marker::Sync for PhotoImportImportItemsResult {}
 #[doc = "*Required features: 'Media_Import'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhotoImportImportMode(pub i32);
 impl PhotoImportImportMode {
     pub const ImportEverything: Self = Self(0i32);
@@ -1315,12 +1296,6 @@ impl ::core::clone::Clone for PhotoImportImportMode {
 unsafe impl ::windows::core::Abi for PhotoImportImportMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhotoImportImportMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhotoImportImportMode {}
 impl ::core::fmt::Debug for PhotoImportImportMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhotoImportImportMode").field(&self.0).finish()
@@ -1603,6 +1578,7 @@ unsafe impl ::core::marker::Send for PhotoImportItemImportedEventArgs {}
 unsafe impl ::core::marker::Sync for PhotoImportItemImportedEventArgs {}
 #[doc = "*Required features: 'Media_Import'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhotoImportItemSelectionMode(pub i32);
 impl PhotoImportItemSelectionMode {
     pub const SelectAll: Self = Self(0i32);
@@ -1618,12 +1594,6 @@ impl ::core::clone::Clone for PhotoImportItemSelectionMode {
 unsafe impl ::windows::core::Abi for PhotoImportItemSelectionMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhotoImportItemSelectionMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhotoImportItemSelectionMode {}
 impl ::core::fmt::Debug for PhotoImportItemSelectionMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhotoImportItemSelectionMode").field(&self.0).finish()
@@ -1789,6 +1759,7 @@ unsafe impl ::core::marker::Send for PhotoImportOperation {}
 unsafe impl ::core::marker::Sync for PhotoImportOperation {}
 #[doc = "*Required features: 'Media_Import'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhotoImportPowerSource(pub i32);
 impl PhotoImportPowerSource {
     pub const Unknown: Self = Self(0i32);
@@ -1804,12 +1775,6 @@ impl ::core::clone::Clone for PhotoImportPowerSource {
 unsafe impl ::windows::core::Abi for PhotoImportPowerSource {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhotoImportPowerSource {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhotoImportPowerSource {}
 impl ::core::fmt::Debug for PhotoImportPowerSource {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhotoImportPowerSource").field(&self.0).finish()
@@ -2487,6 +2452,7 @@ unsafe impl ::core::marker::Send for PhotoImportSource {}
 unsafe impl ::core::marker::Sync for PhotoImportSource {}
 #[doc = "*Required features: 'Media_Import'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhotoImportSourceType(pub i32);
 impl PhotoImportSourceType {
     pub const Generic: Self = Self(0i32);
@@ -2506,12 +2472,6 @@ impl ::core::clone::Clone for PhotoImportSourceType {
 unsafe impl ::windows::core::Abi for PhotoImportSourceType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhotoImportSourceType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhotoImportSourceType {}
 impl ::core::fmt::Debug for PhotoImportSourceType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhotoImportSourceType").field(&self.0).finish()
@@ -2525,6 +2485,7 @@ impl ::windows::core::DefaultType for PhotoImportSourceType {
 }
 #[doc = "*Required features: 'Media_Import'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhotoImportStage(pub i32);
 impl PhotoImportStage {
     pub const NotStarted: Self = Self(0i32);
@@ -2541,12 +2502,6 @@ impl ::core::clone::Clone for PhotoImportStage {
 unsafe impl ::windows::core::Abi for PhotoImportStage {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhotoImportStage {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhotoImportStage {}
 impl ::core::fmt::Debug for PhotoImportStage {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhotoImportStage").field(&self.0).finish()
@@ -2694,6 +2649,7 @@ unsafe impl ::core::marker::Send for PhotoImportStorageMedium {}
 unsafe impl ::core::marker::Sync for PhotoImportStorageMedium {}
 #[doc = "*Required features: 'Media_Import'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhotoImportStorageMediumType(pub i32);
 impl PhotoImportStorageMediumType {
     pub const Undefined: Self = Self(0i32);
@@ -2709,12 +2665,6 @@ impl ::core::clone::Clone for PhotoImportStorageMediumType {
 unsafe impl ::windows::core::Abi for PhotoImportStorageMediumType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhotoImportStorageMediumType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhotoImportStorageMediumType {}
 impl ::core::fmt::Debug for PhotoImportStorageMediumType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhotoImportStorageMediumType").field(&self.0).finish()
@@ -2728,6 +2678,7 @@ impl ::windows::core::DefaultType for PhotoImportStorageMediumType {
 }
 #[doc = "*Required features: 'Media_Import'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhotoImportSubfolderCreationMode(pub i32);
 impl PhotoImportSubfolderCreationMode {
     pub const DoNotCreateSubfolders: Self = Self(0i32);
@@ -2744,12 +2695,6 @@ impl ::core::clone::Clone for PhotoImportSubfolderCreationMode {
 unsafe impl ::windows::core::Abi for PhotoImportSubfolderCreationMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhotoImportSubfolderCreationMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhotoImportSubfolderCreationMode {}
 impl ::core::fmt::Debug for PhotoImportSubfolderCreationMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhotoImportSubfolderCreationMode").field(&self.0).finish()
@@ -2763,6 +2708,7 @@ impl ::windows::core::DefaultType for PhotoImportSubfolderCreationMode {
 }
 #[doc = "*Required features: 'Media_Import'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhotoImportSubfolderDateFormat(pub i32);
 impl PhotoImportSubfolderDateFormat {
     pub const Year: Self = Self(0i32);
@@ -2778,12 +2724,6 @@ impl ::core::clone::Clone for PhotoImportSubfolderDateFormat {
 unsafe impl ::windows::core::Abi for PhotoImportSubfolderDateFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhotoImportSubfolderDateFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhotoImportSubfolderDateFormat {}
 impl ::core::fmt::Debug for PhotoImportSubfolderDateFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhotoImportSubfolderDateFormat").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Media/MediaProperties/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/MediaProperties/mod.rs
@@ -270,6 +270,7 @@ unsafe impl ::core::marker::Send for AudioEncodingProperties {}
 unsafe impl ::core::marker::Sync for AudioEncodingProperties {}
 #[doc = "*Required features: 'Media_MediaProperties'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AudioEncodingQuality(pub i32);
 impl AudioEncodingQuality {
     pub const Auto: Self = Self(0i32);
@@ -286,12 +287,6 @@ impl ::core::clone::Clone for AudioEncodingQuality {
 unsafe impl ::windows::core::Abi for AudioEncodingQuality {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AudioEncodingQuality {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AudioEncodingQuality {}
 impl ::core::fmt::Debug for AudioEncodingQuality {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AudioEncodingQuality").field(&self.0).finish()
@@ -2318,6 +2313,7 @@ impl ::windows::core::RuntimeName for MediaEncodingSubtypes {
 }
 #[doc = "*Required features: 'Media_MediaProperties'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaMirroringOptions(pub u32);
 impl MediaMirroringOptions {
     pub const None: Self = Self(0u32);
@@ -2333,12 +2329,6 @@ impl ::core::clone::Clone for MediaMirroringOptions {
 unsafe impl ::windows::core::Abi for MediaMirroringOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaMirroringOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaMirroringOptions {}
 impl ::core::fmt::Debug for MediaMirroringOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaMirroringOptions").field(&self.0).finish()
@@ -2380,6 +2370,7 @@ impl ::windows::core::DefaultType for MediaMirroringOptions {
 }
 #[doc = "*Required features: 'Media_MediaProperties'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaPixelFormat(pub i32);
 impl MediaPixelFormat {
     pub const Nv12: Self = Self(0i32);
@@ -2395,12 +2386,6 @@ impl ::core::clone::Clone for MediaPixelFormat {
 unsafe impl ::windows::core::Abi for MediaPixelFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaPixelFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaPixelFormat {}
 impl ::core::fmt::Debug for MediaPixelFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaPixelFormat").field(&self.0).finish()
@@ -2746,6 +2731,7 @@ unsafe impl ::core::marker::Send for MediaRatio {}
 unsafe impl ::core::marker::Sync for MediaRatio {}
 #[doc = "*Required features: 'Media_MediaProperties'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaRotation(pub i32);
 impl MediaRotation {
     pub const None: Self = Self(0i32);
@@ -2762,12 +2748,6 @@ impl ::core::clone::Clone for MediaRotation {
 unsafe impl ::windows::core::Abi for MediaRotation {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaRotation {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaRotation {}
 impl ::core::fmt::Debug for MediaRotation {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaRotation").field(&self.0).finish()
@@ -2781,6 +2761,7 @@ impl ::windows::core::DefaultType for MediaRotation {
 }
 #[doc = "*Required features: 'Media_MediaProperties'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaThumbnailFormat(pub i32);
 impl MediaThumbnailFormat {
     pub const Bmp: Self = Self(0i32);
@@ -2795,12 +2776,6 @@ impl ::core::clone::Clone for MediaThumbnailFormat {
 unsafe impl ::windows::core::Abi for MediaThumbnailFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaThumbnailFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaThumbnailFormat {}
 impl ::core::fmt::Debug for MediaThumbnailFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaThumbnailFormat").field(&self.0).finish()
@@ -2861,6 +2836,7 @@ impl ::windows::core::RuntimeName for Mpeg2ProfileIds {
 }
 #[doc = "*Required features: 'Media_MediaProperties'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SphericalVideoFrameFormat(pub i32);
 impl SphericalVideoFrameFormat {
     pub const None: Self = Self(0i32);
@@ -2876,12 +2852,6 @@ impl ::core::clone::Clone for SphericalVideoFrameFormat {
 unsafe impl ::windows::core::Abi for SphericalVideoFrameFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SphericalVideoFrameFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SphericalVideoFrameFormat {}
 impl ::core::fmt::Debug for SphericalVideoFrameFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SphericalVideoFrameFormat").field(&self.0).finish()
@@ -2895,6 +2865,7 @@ impl ::windows::core::DefaultType for SphericalVideoFrameFormat {
 }
 #[doc = "*Required features: 'Media_MediaProperties'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StereoscopicVideoPackingMode(pub i32);
 impl StereoscopicVideoPackingMode {
     pub const None: Self = Self(0i32);
@@ -2910,12 +2881,6 @@ impl ::core::clone::Clone for StereoscopicVideoPackingMode {
 unsafe impl ::windows::core::Abi for StereoscopicVideoPackingMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StereoscopicVideoPackingMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StereoscopicVideoPackingMode {}
 impl ::core::fmt::Debug for StereoscopicVideoPackingMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StereoscopicVideoPackingMode").field(&self.0).finish()
@@ -3384,6 +3349,7 @@ unsafe impl ::core::marker::Send for VideoEncodingProperties {}
 unsafe impl ::core::marker::Sync for VideoEncodingProperties {}
 #[doc = "*Required features: 'Media_MediaProperties'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VideoEncodingQuality(pub i32);
 impl VideoEncodingQuality {
     pub const Auto: Self = Self(0i32);
@@ -3406,12 +3372,6 @@ impl ::core::clone::Clone for VideoEncodingQuality {
 unsafe impl ::windows::core::Abi for VideoEncodingQuality {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VideoEncodingQuality {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VideoEncodingQuality {}
 impl ::core::fmt::Debug for VideoEncodingQuality {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VideoEncodingQuality").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Media/Miracast/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Miracast/mod.rs
@@ -724,6 +724,7 @@ unsafe impl ::core::marker::Send for MiracastReceiverApplySettingsResult {}
 unsafe impl ::core::marker::Sync for MiracastReceiverApplySettingsResult {}
 #[doc = "*Required features: 'Media_Miracast'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MiracastReceiverApplySettingsStatus(pub i32);
 impl MiracastReceiverApplySettingsStatus {
     pub const Success: Self = Self(0i32);
@@ -744,12 +745,6 @@ impl ::core::clone::Clone for MiracastReceiverApplySettingsStatus {
 unsafe impl ::windows::core::Abi for MiracastReceiverApplySettingsStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MiracastReceiverApplySettingsStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MiracastReceiverApplySettingsStatus {}
 impl ::core::fmt::Debug for MiracastReceiverApplySettingsStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MiracastReceiverApplySettingsStatus").field(&self.0).finish()
@@ -763,6 +758,7 @@ impl ::windows::core::DefaultType for MiracastReceiverApplySettingsStatus {
 }
 #[doc = "*Required features: 'Media_Miracast'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MiracastReceiverAuthorizationMethod(pub i32);
 impl MiracastReceiverAuthorizationMethod {
     pub const None: Self = Self(0i32);
@@ -779,12 +775,6 @@ impl ::core::clone::Clone for MiracastReceiverAuthorizationMethod {
 unsafe impl ::windows::core::Abi for MiracastReceiverAuthorizationMethod {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MiracastReceiverAuthorizationMethod {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MiracastReceiverAuthorizationMethod {}
 impl ::core::fmt::Debug for MiracastReceiverAuthorizationMethod {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MiracastReceiverAuthorizationMethod").field(&self.0).finish()
@@ -1310,6 +1300,7 @@ unsafe impl ::core::marker::Send for MiracastReceiverCursorImageChannelSettings 
 unsafe impl ::core::marker::Sync for MiracastReceiverCursorImageChannelSettings {}
 #[doc = "*Required features: 'Media_Miracast'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MiracastReceiverDisconnectReason(pub i32);
 impl MiracastReceiverDisconnectReason {
     pub const Finished: Self = Self(0i32);
@@ -1330,12 +1321,6 @@ impl ::core::clone::Clone for MiracastReceiverDisconnectReason {
 unsafe impl ::windows::core::Abi for MiracastReceiverDisconnectReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MiracastReceiverDisconnectReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MiracastReceiverDisconnectReason {}
 impl ::core::fmt::Debug for MiracastReceiverDisconnectReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MiracastReceiverDisconnectReason").field(&self.0).finish()
@@ -1560,6 +1545,7 @@ unsafe impl ::core::marker::Send for MiracastReceiverGameControllerDevice {}
 unsafe impl ::core::marker::Sync for MiracastReceiverGameControllerDevice {}
 #[doc = "*Required features: 'Media_Miracast'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MiracastReceiverGameControllerDeviceUsageMode(pub i32);
 impl MiracastReceiverGameControllerDeviceUsageMode {
     pub const AsGameController: Self = Self(0i32);
@@ -1574,12 +1560,6 @@ impl ::core::clone::Clone for MiracastReceiverGameControllerDeviceUsageMode {
 unsafe impl ::windows::core::Abi for MiracastReceiverGameControllerDeviceUsageMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MiracastReceiverGameControllerDeviceUsageMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MiracastReceiverGameControllerDeviceUsageMode {}
 impl ::core::fmt::Debug for MiracastReceiverGameControllerDeviceUsageMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MiracastReceiverGameControllerDeviceUsageMode").field(&self.0).finish()
@@ -1799,6 +1779,7 @@ unsafe impl ::core::marker::Send for MiracastReceiverKeyboardDevice {}
 unsafe impl ::core::marker::Sync for MiracastReceiverKeyboardDevice {}
 #[doc = "*Required features: 'Media_Miracast'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MiracastReceiverListeningStatus(pub i32);
 impl MiracastReceiverListeningStatus {
     pub const NotListening: Self = Self(0i32);
@@ -1817,12 +1798,6 @@ impl ::core::clone::Clone for MiracastReceiverListeningStatus {
 unsafe impl ::windows::core::Abi for MiracastReceiverListeningStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MiracastReceiverListeningStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MiracastReceiverListeningStatus {}
 impl ::core::fmt::Debug for MiracastReceiverListeningStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MiracastReceiverListeningStatus").field(&self.0).finish()
@@ -2225,6 +2200,7 @@ unsafe impl ::core::marker::Send for MiracastReceiverSessionStartResult {}
 unsafe impl ::core::marker::Sync for MiracastReceiverSessionStartResult {}
 #[doc = "*Required features: 'Media_Miracast'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MiracastReceiverSessionStartStatus(pub i32);
 impl MiracastReceiverSessionStartStatus {
     pub const Success: Self = Self(0i32);
@@ -2241,12 +2217,6 @@ impl ::core::clone::Clone for MiracastReceiverSessionStartStatus {
 unsafe impl ::windows::core::Abi for MiracastReceiverSessionStartStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MiracastReceiverSessionStartStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MiracastReceiverSessionStartStatus {}
 impl ::core::fmt::Debug for MiracastReceiverSessionStartStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MiracastReceiverSessionStartStatus").field(&self.0).finish()
@@ -2730,6 +2700,7 @@ unsafe impl ::core::marker::Send for MiracastReceiverVideoStreamSettings {}
 unsafe impl ::core::marker::Sync for MiracastReceiverVideoStreamSettings {}
 #[doc = "*Required features: 'Media_Miracast'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MiracastReceiverWiFiStatus(pub i32);
 impl MiracastReceiverWiFiStatus {
     pub const MiracastSupportUndetermined: Self = Self(0i32);
@@ -2746,12 +2717,6 @@ impl ::core::clone::Clone for MiracastReceiverWiFiStatus {
 unsafe impl ::windows::core::Abi for MiracastReceiverWiFiStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MiracastReceiverWiFiStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MiracastReceiverWiFiStatus {}
 impl ::core::fmt::Debug for MiracastReceiverWiFiStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MiracastReceiverWiFiStatus").field(&self.0).finish()
@@ -2890,6 +2855,7 @@ unsafe impl ::core::marker::Send for MiracastTransmitter {}
 unsafe impl ::core::marker::Sync for MiracastTransmitter {}
 #[doc = "*Required features: 'Media_Miracast'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MiracastTransmitterAuthorizationStatus(pub i32);
 impl MiracastTransmitterAuthorizationStatus {
     pub const Undecided: Self = Self(0i32);
@@ -2906,12 +2872,6 @@ impl ::core::clone::Clone for MiracastTransmitterAuthorizationStatus {
 unsafe impl ::windows::core::Abi for MiracastTransmitterAuthorizationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MiracastTransmitterAuthorizationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MiracastTransmitterAuthorizationStatus {}
 impl ::core::fmt::Debug for MiracastTransmitterAuthorizationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MiracastTransmitterAuthorizationStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Media/PlayTo/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/PlayTo/mod.rs
@@ -809,6 +809,7 @@ unsafe impl ::core::marker::Sync for PlayToConnection {}
 #[doc = "*Required features: 'Media_PlayTo', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PlayToConnectionError(pub i32);
 #[cfg(feature = "deprecated")]
 impl PlayToConnectionError {
@@ -830,14 +831,6 @@ impl ::core::clone::Clone for PlayToConnectionError {
 unsafe impl ::windows::core::Abi for PlayToConnectionError {
     type Abi = Self;
 }
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for PlayToConnectionError {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for PlayToConnectionError {}
 #[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for PlayToConnectionError {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -965,6 +958,7 @@ unsafe impl ::core::marker::Sync for PlayToConnectionErrorEventArgs {}
 #[doc = "*Required features: 'Media_PlayTo', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PlayToConnectionState(pub i32);
 #[cfg(feature = "deprecated")]
 impl PlayToConnectionState {
@@ -984,14 +978,6 @@ impl ::core::clone::Clone for PlayToConnectionState {
 unsafe impl ::windows::core::Abi for PlayToConnectionState {
     type Abi = Self;
 }
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for PlayToConnectionState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for PlayToConnectionState {}
 #[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for PlayToConnectionState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {

--- a/crates/libs/windows/src/Windows/Media/Playback/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Playback/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'Media_Playback'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AutoLoadedDisplayPropertyKind(pub i32);
 impl AutoLoadedDisplayPropertyKind {
     pub const None: Self = Self(0i32);
@@ -17,12 +18,6 @@ impl ::core::clone::Clone for AutoLoadedDisplayPropertyKind {
 unsafe impl ::windows::core::Abi for AutoLoadedDisplayPropertyKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AutoLoadedDisplayPropertyKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AutoLoadedDisplayPropertyKind {}
 impl ::core::fmt::Debug for AutoLoadedDisplayPropertyKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AutoLoadedDisplayPropertyKind").field(&self.0).finish()
@@ -206,6 +201,7 @@ unsafe impl ::core::marker::Send for CurrentMediaPlaybackItemChangedEventArgs {}
 unsafe impl ::core::marker::Sync for CurrentMediaPlaybackItemChangedEventArgs {}
 #[doc = "*Required features: 'Media_Playback'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FailedMediaStreamKind(pub i32);
 impl FailedMediaStreamKind {
     pub const Unknown: Self = Self(0i32);
@@ -221,12 +217,6 @@ impl ::core::clone::Clone for FailedMediaStreamKind {
 unsafe impl ::windows::core::Abi for FailedMediaStreamKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FailedMediaStreamKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FailedMediaStreamKind {}
 impl ::core::fmt::Debug for FailedMediaStreamKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FailedMediaStreamKind").field(&self.0).finish()
@@ -2297,6 +2287,7 @@ unsafe impl ::core::marker::Send for MediaBreakEndedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaBreakEndedEventArgs {}
 #[doc = "*Required features: 'Media_Playback'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaBreakInsertionMethod(pub i32);
 impl MediaBreakInsertionMethod {
     pub const Interrupt: Self = Self(0i32);
@@ -2311,12 +2302,6 @@ impl ::core::clone::Clone for MediaBreakInsertionMethod {
 unsafe impl ::windows::core::Abi for MediaBreakInsertionMethod {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaBreakInsertionMethod {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaBreakInsertionMethod {}
 impl ::core::fmt::Debug for MediaBreakInsertionMethod {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaBreakInsertionMethod").field(&self.0).finish()
@@ -2892,6 +2877,7 @@ unsafe impl ::core::marker::Send for MediaBreakStartedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaBreakStartedEventArgs {}
 #[doc = "*Required features: 'Media_Playback'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaCommandEnablingRule(pub i32);
 impl MediaCommandEnablingRule {
     pub const Auto: Self = Self(0i32);
@@ -2907,12 +2893,6 @@ impl ::core::clone::Clone for MediaCommandEnablingRule {
 unsafe impl ::windows::core::Abi for MediaCommandEnablingRule {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaCommandEnablingRule {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaCommandEnablingRule {}
 impl ::core::fmt::Debug for MediaCommandEnablingRule {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaCommandEnablingRule").field(&self.0).finish()
@@ -5042,6 +5022,7 @@ unsafe impl ::core::marker::Send for MediaPlaybackItem {}
 unsafe impl ::core::marker::Sync for MediaPlaybackItem {}
 #[doc = "*Required features: 'Media_Playback'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaPlaybackItemChangedReason(pub i32);
 impl MediaPlaybackItemChangedReason {
     pub const InitialItem: Self = Self(0i32);
@@ -5058,12 +5039,6 @@ impl ::core::clone::Clone for MediaPlaybackItemChangedReason {
 unsafe impl ::windows::core::Abi for MediaPlaybackItemChangedReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaPlaybackItemChangedReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaPlaybackItemChangedReason {}
 impl ::core::fmt::Debug for MediaPlaybackItemChangedReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaPlaybackItemChangedReason").field(&self.0).finish()
@@ -5166,6 +5141,7 @@ unsafe impl ::core::marker::Send for MediaPlaybackItemError {}
 unsafe impl ::core::marker::Sync for MediaPlaybackItemError {}
 #[doc = "*Required features: 'Media_Playback'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaPlaybackItemErrorCode(pub i32);
 impl MediaPlaybackItemErrorCode {
     pub const None: Self = Self(0i32);
@@ -5184,12 +5160,6 @@ impl ::core::clone::Clone for MediaPlaybackItemErrorCode {
 unsafe impl ::windows::core::Abi for MediaPlaybackItemErrorCode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaPlaybackItemErrorCode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaPlaybackItemErrorCode {}
 impl ::core::fmt::Debug for MediaPlaybackItemErrorCode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaPlaybackItemErrorCode").field(&self.0).finish()
@@ -6316,6 +6286,7 @@ unsafe impl ::core::marker::Send for MediaPlaybackSessionOutputDegradationPolicy
 unsafe impl ::core::marker::Sync for MediaPlaybackSessionOutputDegradationPolicyState {}
 #[doc = "*Required features: 'Media_Playback'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaPlaybackSessionVideoConstrictionReason(pub i32);
 impl MediaPlaybackSessionVideoConstrictionReason {
     pub const None: Self = Self(0i32);
@@ -6335,12 +6306,6 @@ impl ::core::clone::Clone for MediaPlaybackSessionVideoConstrictionReason {
 unsafe impl ::windows::core::Abi for MediaPlaybackSessionVideoConstrictionReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaPlaybackSessionVideoConstrictionReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaPlaybackSessionVideoConstrictionReason {}
 impl ::core::fmt::Debug for MediaPlaybackSessionVideoConstrictionReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaPlaybackSessionVideoConstrictionReason").field(&self.0).finish()
@@ -6496,6 +6461,7 @@ unsafe impl ::core::marker::Send for MediaPlaybackSphericalVideoProjection {}
 unsafe impl ::core::marker::Sync for MediaPlaybackSphericalVideoProjection {}
 #[doc = "*Required features: 'Media_Playback'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaPlaybackState(pub i32);
 impl MediaPlaybackState {
     pub const None: Self = Self(0i32);
@@ -6513,12 +6479,6 @@ impl ::core::clone::Clone for MediaPlaybackState {
 unsafe impl ::windows::core::Abi for MediaPlaybackState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaPlaybackState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaPlaybackState {}
 impl ::core::fmt::Debug for MediaPlaybackState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaPlaybackState").field(&self.0).finish()
@@ -7804,6 +7764,7 @@ unsafe impl ::core::marker::Send for MediaPlayer {}
 unsafe impl ::core::marker::Sync for MediaPlayer {}
 #[doc = "*Required features: 'Media_Playback'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaPlayerAudioCategory(pub i32);
 impl MediaPlayerAudioCategory {
     pub const Other: Self = Self(0i32);
@@ -7826,12 +7787,6 @@ impl ::core::clone::Clone for MediaPlayerAudioCategory {
 unsafe impl ::windows::core::Abi for MediaPlayerAudioCategory {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaPlayerAudioCategory {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaPlayerAudioCategory {}
 impl ::core::fmt::Debug for MediaPlayerAudioCategory {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaPlayerAudioCategory").field(&self.0).finish()
@@ -7845,6 +7800,7 @@ impl ::windows::core::DefaultType for MediaPlayerAudioCategory {
 }
 #[doc = "*Required features: 'Media_Playback'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaPlayerAudioDeviceType(pub i32);
 impl MediaPlayerAudioDeviceType {
     pub const Console: Self = Self(0i32);
@@ -7860,12 +7816,6 @@ impl ::core::clone::Clone for MediaPlayerAudioDeviceType {
 unsafe impl ::windows::core::Abi for MediaPlayerAudioDeviceType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaPlayerAudioDeviceType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaPlayerAudioDeviceType {}
 impl ::core::fmt::Debug for MediaPlayerAudioDeviceType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaPlayerAudioDeviceType").field(&self.0).finish()
@@ -7961,6 +7911,7 @@ unsafe impl ::core::marker::Send for MediaPlayerDataReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaPlayerDataReceivedEventArgs {}
 #[doc = "*Required features: 'Media_Playback'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaPlayerError(pub i32);
 impl MediaPlayerError {
     pub const Unknown: Self = Self(0i32);
@@ -7978,12 +7929,6 @@ impl ::core::clone::Clone for MediaPlayerError {
 unsafe impl ::windows::core::Abi for MediaPlayerError {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaPlayerError {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaPlayerError {}
 impl ::core::fmt::Debug for MediaPlayerError {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaPlayerError").field(&self.0).finish()
@@ -8176,6 +8121,7 @@ unsafe impl ::core::marker::Sync for MediaPlayerRateChangedEventArgs {}
 #[doc = "*Required features: 'Media_Playback', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaPlayerState(pub i32);
 #[cfg(feature = "deprecated")]
 impl MediaPlayerState {
@@ -8198,14 +8144,6 @@ impl ::core::clone::Clone for MediaPlayerState {
 unsafe impl ::windows::core::Abi for MediaPlayerState {
     type Abi = Self;
 }
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for MediaPlayerState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for MediaPlayerState {}
 #[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for MediaPlayerState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -8695,6 +8633,7 @@ unsafe impl ::core::marker::Send for PlaybackMediaMarkerSequence {}
 unsafe impl ::core::marker::Sync for PlaybackMediaMarkerSequence {}
 #[doc = "*Required features: 'Media_Playback'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SphericalVideoProjectionMode(pub i32);
 impl SphericalVideoProjectionMode {
     pub const Spherical: Self = Self(0i32);
@@ -8709,12 +8648,6 @@ impl ::core::clone::Clone for SphericalVideoProjectionMode {
 unsafe impl ::windows::core::Abi for SphericalVideoProjectionMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SphericalVideoProjectionMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SphericalVideoProjectionMode {}
 impl ::core::fmt::Debug for SphericalVideoProjectionMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SphericalVideoProjectionMode").field(&self.0).finish()
@@ -8728,6 +8661,7 @@ impl ::windows::core::DefaultType for SphericalVideoProjectionMode {
 }
 #[doc = "*Required features: 'Media_Playback'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StereoscopicVideoRenderMode(pub i32);
 impl StereoscopicVideoRenderMode {
     pub const Mono: Self = Self(0i32);
@@ -8742,12 +8676,6 @@ impl ::core::clone::Clone for StereoscopicVideoRenderMode {
 unsafe impl ::windows::core::Abi for StereoscopicVideoRenderMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StereoscopicVideoRenderMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StereoscopicVideoRenderMode {}
 impl ::core::fmt::Debug for StereoscopicVideoRenderMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StereoscopicVideoRenderMode").field(&self.0).finish()
@@ -8859,6 +8787,7 @@ unsafe impl ::core::marker::Send for TimedMetadataPresentationModeChangedEventAr
 unsafe impl ::core::marker::Sync for TimedMetadataPresentationModeChangedEventArgs {}
 #[doc = "*Required features: 'Media_Playback'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TimedMetadataTrackPresentationMode(pub i32);
 impl TimedMetadataTrackPresentationMode {
     pub const Disabled: Self = Self(0i32);
@@ -8875,12 +8804,6 @@ impl ::core::clone::Clone for TimedMetadataTrackPresentationMode {
 unsafe impl ::windows::core::Abi for TimedMetadataTrackPresentationMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TimedMetadataTrackPresentationMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TimedMetadataTrackPresentationMode {}
 impl ::core::fmt::Debug for TimedMetadataTrackPresentationMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TimedMetadataTrackPresentationMode").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Media/Playlists/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Playlists/mod.rs
@@ -172,6 +172,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Play
 }
 #[doc = "*Required features: 'Media_Playlists'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PlaylistFormat(pub i32);
 impl PlaylistFormat {
     pub const WindowsMedia: Self = Self(0i32);
@@ -187,12 +188,6 @@ impl ::core::clone::Clone for PlaylistFormat {
 unsafe impl ::windows::core::Abi for PlaylistFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PlaylistFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PlaylistFormat {}
 impl ::core::fmt::Debug for PlaylistFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PlaylistFormat").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Media/Protection/PlayReady/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Protection/PlayReady/mod.rs
@@ -3931,6 +3931,7 @@ pub struct IPlayReadyStatics5Vtbl(
 #[doc = "*Required features: 'Media_Protection_PlayReady', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct NDCertificateFeature(pub i32);
 #[cfg(feature = "deprecated")]
 impl NDCertificateFeature {
@@ -3955,14 +3956,6 @@ unsafe impl ::windows::core::Abi for NDCertificateFeature {
     type Abi = Self;
 }
 #[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for NDCertificateFeature {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for NDCertificateFeature {}
-#[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for NDCertificateFeature {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NDCertificateFeature").field(&self.0).finish()
@@ -3979,6 +3972,7 @@ impl ::windows::core::DefaultType for NDCertificateFeature {
 #[doc = "*Required features: 'Media_Protection_PlayReady', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct NDCertificatePlatformID(pub i32);
 #[cfg(feature = "deprecated")]
 impl NDCertificatePlatformID {
@@ -4008,14 +4002,6 @@ unsafe impl ::windows::core::Abi for NDCertificatePlatformID {
     type Abi = Self;
 }
 #[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for NDCertificatePlatformID {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for NDCertificatePlatformID {}
-#[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for NDCertificatePlatformID {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NDCertificatePlatformID").field(&self.0).finish()
@@ -4032,6 +4018,7 @@ impl ::windows::core::DefaultType for NDCertificatePlatformID {
 #[doc = "*Required features: 'Media_Protection_PlayReady', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct NDCertificateType(pub i32);
 #[cfg(feature = "deprecated")]
 impl NDCertificateType {
@@ -4061,14 +4048,6 @@ impl ::core::clone::Clone for NDCertificateType {
 unsafe impl ::windows::core::Abi for NDCertificateType {
     type Abi = Self;
 }
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for NDCertificateType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for NDCertificateType {}
 #[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for NDCertificateType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -4296,6 +4275,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &NDCl
 #[doc = "*Required features: 'Media_Protection_PlayReady', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct NDClosedCaptionFormat(pub i32);
 #[cfg(feature = "deprecated")]
 impl NDClosedCaptionFormat {
@@ -4316,14 +4296,6 @@ unsafe impl ::windows::core::Abi for NDClosedCaptionFormat {
     type Abi = Self;
 }
 #[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for NDClosedCaptionFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for NDClosedCaptionFormat {}
-#[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for NDClosedCaptionFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NDClosedCaptionFormat").field(&self.0).finish()
@@ -4340,6 +4312,7 @@ impl ::windows::core::DefaultType for NDClosedCaptionFormat {
 #[doc = "*Required features: 'Media_Protection_PlayReady', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct NDContentIDType(pub i32);
 #[cfg(feature = "deprecated")]
 impl NDContentIDType {
@@ -4359,14 +4332,6 @@ impl ::core::clone::Clone for NDContentIDType {
 unsafe impl ::windows::core::Abi for NDContentIDType {
     type Abi = Self;
 }
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for NDContentIDType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for NDContentIDType {}
 #[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for NDContentIDType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -4848,6 +4813,7 @@ impl<'a> ::windows::core::IntoParam<'a, INDLicenseFetchDescriptor> for &NDLicens
 #[doc = "*Required features: 'Media_Protection_PlayReady', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct NDMediaStreamType(pub i32);
 #[cfg(feature = "deprecated")]
 impl NDMediaStreamType {
@@ -4867,14 +4833,6 @@ unsafe impl ::windows::core::Abi for NDMediaStreamType {
     type Abi = Self;
 }
 #[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for NDMediaStreamType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for NDMediaStreamType {}
-#[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for NDMediaStreamType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NDMediaStreamType").field(&self.0).finish()
@@ -4891,6 +4849,7 @@ impl ::windows::core::DefaultType for NDMediaStreamType {
 #[doc = "*Required features: 'Media_Protection_PlayReady', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct NDProximityDetectionType(pub i32);
 #[cfg(feature = "deprecated")]
 impl NDProximityDetectionType {
@@ -4911,14 +4870,6 @@ unsafe impl ::windows::core::Abi for NDProximityDetectionType {
     type Abi = Self;
 }
 #[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for NDProximityDetectionType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for NDProximityDetectionType {}
-#[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for NDProximityDetectionType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NDProximityDetectionType").field(&self.0).finish()
@@ -4935,6 +4886,7 @@ impl ::windows::core::DefaultType for NDProximityDetectionType {
 #[doc = "*Required features: 'Media_Protection_PlayReady', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct NDStartAsyncOptions(pub i32);
 #[cfg(feature = "deprecated")]
 impl NDStartAsyncOptions {
@@ -4953,14 +4905,6 @@ impl ::core::clone::Clone for NDStartAsyncOptions {
 unsafe impl ::windows::core::Abi for NDStartAsyncOptions {
     type Abi = Self;
 }
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for NDStartAsyncOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for NDStartAsyncOptions {}
 #[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for NDStartAsyncOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -5645,6 +5589,7 @@ impl ::windows::core::RuntimeName for PlayReadyContentResolver {
 }
 #[doc = "*Required features: 'Media_Protection_PlayReady'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PlayReadyDecryptorSetup(pub i32);
 impl PlayReadyDecryptorSetup {
     pub const Uninitialized: Self = Self(0i32);
@@ -5659,12 +5604,6 @@ impl ::core::clone::Clone for PlayReadyDecryptorSetup {
 unsafe impl ::windows::core::Abi for PlayReadyDecryptorSetup {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PlayReadyDecryptorSetup {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PlayReadyDecryptorSetup {}
 impl ::core::fmt::Debug for PlayReadyDecryptorSetup {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PlayReadyDecryptorSetup").field(&self.0).finish()
@@ -6593,6 +6532,7 @@ impl<'a> ::windows::core::IntoParam<'a, IPlayReadyServiceRequest> for &PlayReady
 }
 #[doc = "*Required features: 'Media_Protection_PlayReady'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PlayReadyEncryptionAlgorithm(pub i32);
 impl PlayReadyEncryptionAlgorithm {
     pub const Unprotected: Self = Self(0i32);
@@ -6611,12 +6551,6 @@ impl ::core::clone::Clone for PlayReadyEncryptionAlgorithm {
 unsafe impl ::windows::core::Abi for PlayReadyEncryptionAlgorithm {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PlayReadyEncryptionAlgorithm {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PlayReadyEncryptionAlgorithm {}
 impl ::core::fmt::Debug for PlayReadyEncryptionAlgorithm {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PlayReadyEncryptionAlgorithm").field(&self.0).finish()
@@ -6630,6 +6564,7 @@ impl ::windows::core::DefaultType for PlayReadyEncryptionAlgorithm {
 }
 #[doc = "*Required features: 'Media_Protection_PlayReady'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PlayReadyHardwareDRMFeatures(pub i32);
 impl PlayReadyHardwareDRMFeatures {
     pub const HardwareDRM: Self = Self(1i32);
@@ -6645,12 +6580,6 @@ impl ::core::clone::Clone for PlayReadyHardwareDRMFeatures {
 unsafe impl ::windows::core::Abi for PlayReadyHardwareDRMFeatures {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PlayReadyHardwareDRMFeatures {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PlayReadyHardwareDRMFeatures {}
 impl ::core::fmt::Debug for PlayReadyHardwareDRMFeatures {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PlayReadyHardwareDRMFeatures").field(&self.0).finish()
@@ -6664,6 +6593,7 @@ impl ::windows::core::DefaultType for PlayReadyHardwareDRMFeatures {
 }
 #[doc = "*Required features: 'Media_Protection_PlayReady'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PlayReadyITADataFormat(pub i32);
 impl PlayReadyITADataFormat {
     pub const SerializedProperties: Self = Self(0i32);
@@ -6678,12 +6608,6 @@ impl ::core::clone::Clone for PlayReadyITADataFormat {
 unsafe impl ::windows::core::Abi for PlayReadyITADataFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PlayReadyITADataFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PlayReadyITADataFormat {}
 impl ::core::fmt::Debug for PlayReadyITADataFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PlayReadyITADataFormat").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Media/Protection/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Protection/mod.rs
@@ -187,6 +187,7 @@ impl ::windows::core::RuntimeName for ComponentRenewal {
 }
 #[doc = "*Required features: 'Media_Protection'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GraphicsTrustStatus(pub i32);
 impl GraphicsTrustStatus {
     pub const TrustNotRequired: Self = Self(0i32);
@@ -205,12 +206,6 @@ impl ::core::clone::Clone for GraphicsTrustStatus {
 unsafe impl ::windows::core::Abi for GraphicsTrustStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GraphicsTrustStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GraphicsTrustStatus {}
 impl ::core::fmt::Debug for GraphicsTrustStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GraphicsTrustStatus").field(&self.0).finish()
@@ -224,6 +219,7 @@ impl ::windows::core::DefaultType for GraphicsTrustStatus {
 }
 #[doc = "*Required features: 'Media_Protection'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HdcpProtection(pub i32);
 impl HdcpProtection {
     pub const Off: Self = Self(0i32);
@@ -239,12 +235,6 @@ impl ::core::clone::Clone for HdcpProtection {
 unsafe impl ::windows::core::Abi for HdcpProtection {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HdcpProtection {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HdcpProtection {}
 impl ::core::fmt::Debug for HdcpProtection {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HdcpProtection").field(&self.0).finish()
@@ -411,6 +401,7 @@ unsafe impl ::core::marker::Send for HdcpSession {}
 unsafe impl ::core::marker::Sync for HdcpSession {}
 #[doc = "*Required features: 'Media_Protection'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HdcpSetProtectionResult(pub i32);
 impl HdcpSetProtectionResult {
     pub const Success: Self = Self(0i32);
@@ -427,12 +418,6 @@ impl ::core::clone::Clone for HdcpSetProtectionResult {
 unsafe impl ::windows::core::Abi for HdcpSetProtectionResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HdcpSetProtectionResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HdcpSetProtectionResult {}
 impl ::core::fmt::Debug for HdcpSetProtectionResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HdcpSetProtectionResult").field(&self.0).finish()
@@ -1185,6 +1170,7 @@ unsafe impl ::core::marker::Send for ProtectionCapabilities {}
 unsafe impl ::core::marker::Sync for ProtectionCapabilities {}
 #[doc = "*Required features: 'Media_Protection'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ProtectionCapabilityResult(pub i32);
 impl ProtectionCapabilityResult {
     pub const NotSupported: Self = Self(0i32);
@@ -1200,12 +1186,6 @@ impl ::core::clone::Clone for ProtectionCapabilityResult {
 unsafe impl ::windows::core::Abi for ProtectionCapabilityResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ProtectionCapabilityResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ProtectionCapabilityResult {}
 impl ::core::fmt::Debug for ProtectionCapabilityResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ProtectionCapabilityResult").field(&self.0).finish()
@@ -1294,6 +1274,7 @@ unsafe impl ::windows::core::RuntimeType for RebootNeededEventHandler {
 pub struct RebootNeededEventHandlerVtbl(pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: ::windows::core::RawPtr) -> ::windows::core::HRESULT);
 #[doc = "*Required features: 'Media_Protection'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RenewalStatus(pub i32);
 impl RenewalStatus {
     pub const NotStarted: Self = Self(0i32);
@@ -1311,12 +1292,6 @@ impl ::core::clone::Clone for RenewalStatus {
 unsafe impl ::windows::core::Abi for RenewalStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RenewalStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RenewalStatus {}
 impl ::core::fmt::Debug for RenewalStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RenewalStatus").field(&self.0).finish()
@@ -1525,6 +1500,7 @@ unsafe impl ::core::marker::Send for RevocationAndRenewalItem {}
 unsafe impl ::core::marker::Sync for RevocationAndRenewalItem {}
 #[doc = "*Required features: 'Media_Protection'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RevocationAndRenewalReasons(pub u32);
 impl RevocationAndRenewalReasons {
     pub const UserModeComponentLoad: Self = Self(1u32);
@@ -1552,12 +1528,6 @@ impl ::core::clone::Clone for RevocationAndRenewalReasons {
 unsafe impl ::windows::core::Abi for RevocationAndRenewalReasons {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RevocationAndRenewalReasons {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RevocationAndRenewalReasons {}
 impl ::core::fmt::Debug for RevocationAndRenewalReasons {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RevocationAndRenewalReasons").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Media/Render/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Render/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'Media_Render'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AudioRenderCategory(pub i32);
 impl AudioRenderCategory {
     pub const Other: Self = Self(0i32);
@@ -25,12 +26,6 @@ impl ::core::clone::Clone for AudioRenderCategory {
 unsafe impl ::windows::core::Abi for AudioRenderCategory {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AudioRenderCategory {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AudioRenderCategory {}
 impl ::core::fmt::Debug for AudioRenderCategory {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AudioRenderCategory").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Media/SpeechRecognition/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/SpeechRecognition/mod.rs
@@ -801,6 +801,7 @@ unsafe impl ::core::marker::Send for SpeechContinuousRecognitionCompletedEventAr
 unsafe impl ::core::marker::Sync for SpeechContinuousRecognitionCompletedEventArgs {}
 #[doc = "*Required features: 'Media_SpeechRecognition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SpeechContinuousRecognitionMode(pub i32);
 impl SpeechContinuousRecognitionMode {
     pub const Default: Self = Self(0i32);
@@ -815,12 +816,6 @@ impl ::core::clone::Clone for SpeechContinuousRecognitionMode {
 unsafe impl ::windows::core::Abi for SpeechContinuousRecognitionMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpeechContinuousRecognitionMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SpeechContinuousRecognitionMode {}
 impl ::core::fmt::Debug for SpeechContinuousRecognitionMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SpeechContinuousRecognitionMode").field(&self.0).finish()
@@ -1083,6 +1078,7 @@ unsafe impl ::core::marker::Send for SpeechContinuousRecognitionSession {}
 unsafe impl ::core::marker::Sync for SpeechContinuousRecognitionSession {}
 #[doc = "*Required features: 'Media_SpeechRecognition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SpeechRecognitionAudioProblem(pub i32);
 impl SpeechRecognitionAudioProblem {
     pub const None: Self = Self(0i32);
@@ -1102,12 +1098,6 @@ impl ::core::clone::Clone for SpeechRecognitionAudioProblem {
 unsafe impl ::windows::core::Abi for SpeechRecognitionAudioProblem {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpeechRecognitionAudioProblem {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SpeechRecognitionAudioProblem {}
 impl ::core::fmt::Debug for SpeechRecognitionAudioProblem {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SpeechRecognitionAudioProblem").field(&self.0).finish()
@@ -1202,6 +1192,7 @@ unsafe impl ::core::marker::Send for SpeechRecognitionCompilationResult {}
 unsafe impl ::core::marker::Sync for SpeechRecognitionCompilationResult {}
 #[doc = "*Required features: 'Media_SpeechRecognition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SpeechRecognitionConfidence(pub i32);
 impl SpeechRecognitionConfidence {
     pub const High: Self = Self(0i32);
@@ -1218,12 +1209,6 @@ impl ::core::clone::Clone for SpeechRecognitionConfidence {
 unsafe impl ::windows::core::Abi for SpeechRecognitionConfidence {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpeechRecognitionConfidence {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SpeechRecognitionConfidence {}
 impl ::core::fmt::Debug for SpeechRecognitionConfidence {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SpeechRecognitionConfidence").field(&self.0).finish()
@@ -1237,6 +1222,7 @@ impl ::windows::core::DefaultType for SpeechRecognitionConfidence {
 }
 #[doc = "*Required features: 'Media_SpeechRecognition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SpeechRecognitionConstraintProbability(pub i32);
 impl SpeechRecognitionConstraintProbability {
     pub const Default: Self = Self(0i32);
@@ -1252,12 +1238,6 @@ impl ::core::clone::Clone for SpeechRecognitionConstraintProbability {
 unsafe impl ::windows::core::Abi for SpeechRecognitionConstraintProbability {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpeechRecognitionConstraintProbability {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SpeechRecognitionConstraintProbability {}
 impl ::core::fmt::Debug for SpeechRecognitionConstraintProbability {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SpeechRecognitionConstraintProbability").field(&self.0).finish()
@@ -1271,6 +1251,7 @@ impl ::windows::core::DefaultType for SpeechRecognitionConstraintProbability {
 }
 #[doc = "*Required features: 'Media_SpeechRecognition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SpeechRecognitionConstraintType(pub i32);
 impl SpeechRecognitionConstraintType {
     pub const Topic: Self = Self(0i32);
@@ -1287,12 +1268,6 @@ impl ::core::clone::Clone for SpeechRecognitionConstraintType {
 unsafe impl ::windows::core::Abi for SpeechRecognitionConstraintType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpeechRecognitionConstraintType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SpeechRecognitionConstraintType {}
 impl ::core::fmt::Debug for SpeechRecognitionConstraintType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SpeechRecognitionConstraintType").field(&self.0).finish()
@@ -2050,6 +2025,7 @@ unsafe impl ::core::marker::Send for SpeechRecognitionResult {}
 unsafe impl ::core::marker::Sync for SpeechRecognitionResult {}
 #[doc = "*Required features: 'Media_SpeechRecognition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SpeechRecognitionResultStatus(pub i32);
 impl SpeechRecognitionResultStatus {
     pub const Success: Self = Self(0i32);
@@ -2073,12 +2049,6 @@ impl ::core::clone::Clone for SpeechRecognitionResultStatus {
 unsafe impl ::windows::core::Abi for SpeechRecognitionResultStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpeechRecognitionResultStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SpeechRecognitionResultStatus {}
 impl ::core::fmt::Debug for SpeechRecognitionResultStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SpeechRecognitionResultStatus").field(&self.0).finish()
@@ -2092,6 +2062,7 @@ impl ::windows::core::DefaultType for SpeechRecognitionResultStatus {
 }
 #[doc = "*Required features: 'Media_SpeechRecognition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SpeechRecognitionScenario(pub i32);
 impl SpeechRecognitionScenario {
     pub const WebSearch: Self = Self(0i32);
@@ -2107,12 +2078,6 @@ impl ::core::clone::Clone for SpeechRecognitionScenario {
 unsafe impl ::windows::core::Abi for SpeechRecognitionScenario {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpeechRecognitionScenario {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SpeechRecognitionScenario {}
 impl ::core::fmt::Debug for SpeechRecognitionScenario {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SpeechRecognitionScenario").field(&self.0).finish()
@@ -2825,6 +2790,7 @@ unsafe impl ::core::marker::Send for SpeechRecognizer {}
 unsafe impl ::core::marker::Sync for SpeechRecognizer {}
 #[doc = "*Required features: 'Media_SpeechRecognition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SpeechRecognizerState(pub i32);
 impl SpeechRecognizerState {
     pub const Idle: Self = Self(0i32);
@@ -2844,12 +2810,6 @@ impl ::core::clone::Clone for SpeechRecognizerState {
 unsafe impl ::windows::core::Abi for SpeechRecognizerState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpeechRecognizerState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SpeechRecognizerState {}
 impl ::core::fmt::Debug for SpeechRecognizerState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SpeechRecognizerState").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Media/SpeechSynthesis/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/SpeechSynthesis/mod.rs
@@ -187,6 +187,7 @@ pub struct IVoiceInformationVtbl(
 );
 #[doc = "*Required features: 'Media_SpeechSynthesis'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SpeechAppendedSilence(pub i32);
 impl SpeechAppendedSilence {
     pub const Default: Self = Self(0i32);
@@ -201,12 +202,6 @@ impl ::core::clone::Clone for SpeechAppendedSilence {
 unsafe impl ::windows::core::Abi for SpeechAppendedSilence {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpeechAppendedSilence {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SpeechAppendedSilence {}
 impl ::core::fmt::Debug for SpeechAppendedSilence {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SpeechAppendedSilence").field(&self.0).finish()
@@ -220,6 +215,7 @@ impl ::windows::core::DefaultType for SpeechAppendedSilence {
 }
 #[doc = "*Required features: 'Media_SpeechSynthesis'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SpeechPunctuationSilence(pub i32);
 impl SpeechPunctuationSilence {
     pub const Default: Self = Self(0i32);
@@ -234,12 +230,6 @@ impl ::core::clone::Clone for SpeechPunctuationSilence {
 unsafe impl ::windows::core::Abi for SpeechPunctuationSilence {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpeechPunctuationSilence {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SpeechPunctuationSilence {}
 impl ::core::fmt::Debug for SpeechPunctuationSilence {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SpeechPunctuationSilence").field(&self.0).finish()
@@ -991,6 +981,7 @@ unsafe impl ::core::marker::Send for SpeechSynthesizerOptions {}
 unsafe impl ::core::marker::Sync for SpeechSynthesizerOptions {}
 #[doc = "*Required features: 'Media_SpeechSynthesis'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VoiceGender(pub i32);
 impl VoiceGender {
     pub const Male: Self = Self(0i32);
@@ -1005,12 +996,6 @@ impl ::core::clone::Clone for VoiceGender {
 unsafe impl ::windows::core::Abi for VoiceGender {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VoiceGender {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VoiceGender {}
 impl ::core::fmt::Debug for VoiceGender {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VoiceGender").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Media/Streaming/Adaptive/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Streaming/Adaptive/mod.rs
@@ -752,6 +752,7 @@ unsafe impl ::core::marker::Send for AdaptiveMediaSourceCreationResult {}
 unsafe impl ::core::marker::Sync for AdaptiveMediaSourceCreationResult {}
 #[doc = "*Required features: 'Media_Streaming_Adaptive'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AdaptiveMediaSourceCreationStatus(pub i32);
 impl AdaptiveMediaSourceCreationStatus {
     pub const Success: Self = Self(0i32);
@@ -771,12 +772,6 @@ impl ::core::clone::Clone for AdaptiveMediaSourceCreationStatus {
 unsafe impl ::windows::core::Abi for AdaptiveMediaSourceCreationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AdaptiveMediaSourceCreationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AdaptiveMediaSourceCreationStatus {}
 impl ::core::fmt::Debug for AdaptiveMediaSourceCreationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AdaptiveMediaSourceCreationStatus").field(&self.0).finish()
@@ -968,6 +963,7 @@ unsafe impl ::core::marker::Send for AdaptiveMediaSourceDiagnosticAvailableEvent
 unsafe impl ::core::marker::Sync for AdaptiveMediaSourceDiagnosticAvailableEventArgs {}
 #[doc = "*Required features: 'Media_Streaming_Adaptive'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AdaptiveMediaSourceDiagnosticType(pub i32);
 impl AdaptiveMediaSourceDiagnosticType {
     pub const ManifestUnchangedUponReload: Self = Self(0i32);
@@ -989,12 +985,6 @@ impl ::core::clone::Clone for AdaptiveMediaSourceDiagnosticType {
 unsafe impl ::windows::core::Abi for AdaptiveMediaSourceDiagnosticType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AdaptiveMediaSourceDiagnosticType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AdaptiveMediaSourceDiagnosticType {}
 impl ::core::fmt::Debug for AdaptiveMediaSourceDiagnosticType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AdaptiveMediaSourceDiagnosticType").field(&self.0).finish()
@@ -1193,6 +1183,7 @@ unsafe impl ::core::marker::Send for AdaptiveMediaSourceDownloadBitrateChangedEv
 unsafe impl ::core::marker::Sync for AdaptiveMediaSourceDownloadBitrateChangedEventArgs {}
 #[doc = "*Required features: 'Media_Streaming_Adaptive'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AdaptiveMediaSourceDownloadBitrateChangedReason(pub i32);
 impl AdaptiveMediaSourceDownloadBitrateChangedReason {
     pub const SufficientInboundBitsPerSecond: Self = Self(0i32);
@@ -1212,12 +1203,6 @@ impl ::core::clone::Clone for AdaptiveMediaSourceDownloadBitrateChangedReason {
 unsafe impl ::windows::core::Abi for AdaptiveMediaSourceDownloadBitrateChangedReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AdaptiveMediaSourceDownloadBitrateChangedReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AdaptiveMediaSourceDownloadBitrateChangedReason {}
 impl ::core::fmt::Debug for AdaptiveMediaSourceDownloadBitrateChangedReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AdaptiveMediaSourceDownloadBitrateChangedReason").field(&self.0).finish()
@@ -2172,6 +2157,7 @@ unsafe impl ::core::marker::Send for AdaptiveMediaSourcePlaybackBitrateChangedEv
 unsafe impl ::core::marker::Sync for AdaptiveMediaSourcePlaybackBitrateChangedEventArgs {}
 #[doc = "*Required features: 'Media_Streaming_Adaptive'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AdaptiveMediaSourceResourceType(pub i32);
 impl AdaptiveMediaSourceResourceType {
     pub const Manifest: Self = Self(0i32);
@@ -2190,12 +2176,6 @@ impl ::core::clone::Clone for AdaptiveMediaSourceResourceType {
 unsafe impl ::windows::core::Abi for AdaptiveMediaSourceResourceType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AdaptiveMediaSourceResourceType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AdaptiveMediaSourceResourceType {}
 impl ::core::fmt::Debug for AdaptiveMediaSourceResourceType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AdaptiveMediaSourceResourceType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Media/Transcoding/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/Transcoding/mod.rs
@@ -286,6 +286,7 @@ unsafe impl ::core::marker::Send for MediaTranscoder {}
 unsafe impl ::core::marker::Sync for MediaTranscoder {}
 #[doc = "*Required features: 'Media_Transcoding'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaVideoProcessingAlgorithm(pub i32);
 impl MediaVideoProcessingAlgorithm {
     pub const Default: Self = Self(0i32);
@@ -300,12 +301,6 @@ impl ::core::clone::Clone for MediaVideoProcessingAlgorithm {
 unsafe impl ::windows::core::Abi for MediaVideoProcessingAlgorithm {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaVideoProcessingAlgorithm {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaVideoProcessingAlgorithm {}
 impl ::core::fmt::Debug for MediaVideoProcessingAlgorithm {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaVideoProcessingAlgorithm").field(&self.0).finish()
@@ -417,6 +412,7 @@ unsafe impl ::core::marker::Send for PrepareTranscodeResult {}
 unsafe impl ::core::marker::Sync for PrepareTranscodeResult {}
 #[doc = "*Required features: 'Media_Transcoding'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TranscodeFailureReason(pub i32);
 impl TranscodeFailureReason {
     pub const None: Self = Self(0i32);
@@ -433,12 +429,6 @@ impl ::core::clone::Clone for TranscodeFailureReason {
 unsafe impl ::windows::core::Abi for TranscodeFailureReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TranscodeFailureReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TranscodeFailureReason {}
 impl ::core::fmt::Debug for TranscodeFailureReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TranscodeFailureReason").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Media/mod.rs
+++ b/crates/libs/windows/src/Windows/Media/mod.rs
@@ -216,6 +216,7 @@ unsafe impl ::core::marker::Send for AudioBuffer {}
 unsafe impl ::core::marker::Sync for AudioBuffer {}
 #[doc = "*Required features: 'Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AudioBufferAccessMode(pub i32);
 impl AudioBufferAccessMode {
     pub const Read: Self = Self(0i32);
@@ -231,12 +232,6 @@ impl ::core::clone::Clone for AudioBufferAccessMode {
 unsafe impl ::windows::core::Abi for AudioBufferAccessMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AudioBufferAccessMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AudioBufferAccessMode {}
 impl ::core::fmt::Debug for AudioBufferAccessMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AudioBufferAccessMode").field(&self.0).finish()
@@ -480,6 +475,7 @@ unsafe impl ::core::marker::Send for AudioFrame {}
 unsafe impl ::core::marker::Sync for AudioFrame {}
 #[doc = "*Required features: 'Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AudioProcessing(pub i32);
 impl AudioProcessing {
     pub const Default: Self = Self(0i32);
@@ -494,12 +490,6 @@ impl ::core::clone::Clone for AudioProcessing {
 unsafe impl ::windows::core::Abi for AudioProcessing {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AudioProcessing {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AudioProcessing {}
 impl ::core::fmt::Debug for AudioProcessing {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AudioProcessing").field(&self.0).finish()
@@ -2425,6 +2415,7 @@ impl ::windows::core::RuntimeName for MediaMarkerTypes {
 }
 #[doc = "*Required features: 'Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaPlaybackAutoRepeatMode(pub i32);
 impl MediaPlaybackAutoRepeatMode {
     pub const None: Self = Self(0i32);
@@ -2440,12 +2431,6 @@ impl ::core::clone::Clone for MediaPlaybackAutoRepeatMode {
 unsafe impl ::windows::core::Abi for MediaPlaybackAutoRepeatMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaPlaybackAutoRepeatMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaPlaybackAutoRepeatMode {}
 impl ::core::fmt::Debug for MediaPlaybackAutoRepeatMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaPlaybackAutoRepeatMode").field(&self.0).finish()
@@ -2459,6 +2444,7 @@ impl ::windows::core::DefaultType for MediaPlaybackAutoRepeatMode {
 }
 #[doc = "*Required features: 'Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaPlaybackStatus(pub i32);
 impl MediaPlaybackStatus {
     pub const Closed: Self = Self(0i32);
@@ -2476,12 +2462,6 @@ impl ::core::clone::Clone for MediaPlaybackStatus {
 unsafe impl ::windows::core::Abi for MediaPlaybackStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaPlaybackStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaPlaybackStatus {}
 impl ::core::fmt::Debug for MediaPlaybackStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaPlaybackStatus").field(&self.0).finish()
@@ -2495,6 +2475,7 @@ impl ::windows::core::DefaultType for MediaPlaybackStatus {
 }
 #[doc = "*Required features: 'Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaPlaybackType(pub i32);
 impl MediaPlaybackType {
     pub const Unknown: Self = Self(0i32);
@@ -2511,12 +2492,6 @@ impl ::core::clone::Clone for MediaPlaybackType {
 unsafe impl ::windows::core::Abi for MediaPlaybackType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaPlaybackType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaPlaybackType {}
 impl ::core::fmt::Debug for MediaPlaybackType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaPlaybackType").field(&self.0).finish()
@@ -2959,6 +2934,7 @@ unsafe impl ::core::marker::Send for MediaTimelineControllerFailedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaTimelineControllerFailedEventArgs {}
 #[doc = "*Required features: 'Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaTimelineControllerState(pub i32);
 impl MediaTimelineControllerState {
     pub const Paused: Self = Self(0i32);
@@ -2975,12 +2951,6 @@ impl ::core::clone::Clone for MediaTimelineControllerState {
 unsafe impl ::windows::core::Abi for MediaTimelineControllerState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaTimelineControllerState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaTimelineControllerState {}
 impl ::core::fmt::Debug for MediaTimelineControllerState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaTimelineControllerState").field(&self.0).finish()
@@ -3398,6 +3368,7 @@ unsafe impl ::core::marker::Send for ShuffleEnabledChangeRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for ShuffleEnabledChangeRequestedEventArgs {}
 #[doc = "*Required features: 'Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SoundLevel(pub i32);
 impl SoundLevel {
     pub const Muted: Self = Self(0i32);
@@ -3413,12 +3384,6 @@ impl ::core::clone::Clone for SoundLevel {
 unsafe impl ::windows::core::Abi for SoundLevel {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SoundLevel {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SoundLevel {}
 impl ::core::fmt::Debug for SoundLevel {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SoundLevel").field(&self.0).finish()
@@ -3823,6 +3788,7 @@ unsafe impl ::core::marker::Send for SystemMediaTransportControls {}
 unsafe impl ::core::marker::Sync for SystemMediaTransportControls {}
 #[doc = "*Required features: 'Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SystemMediaTransportControlsButton(pub i32);
 impl SystemMediaTransportControlsButton {
     pub const Play: Self = Self(0i32);
@@ -3845,12 +3811,6 @@ impl ::core::clone::Clone for SystemMediaTransportControlsButton {
 unsafe impl ::windows::core::Abi for SystemMediaTransportControlsButton {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SystemMediaTransportControlsButton {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SystemMediaTransportControlsButton {}
 impl ::core::fmt::Debug for SystemMediaTransportControlsButton {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SystemMediaTransportControlsButton").field(&self.0).finish()
@@ -4102,6 +4062,7 @@ unsafe impl ::core::marker::Send for SystemMediaTransportControlsDisplayUpdater 
 unsafe impl ::core::marker::Sync for SystemMediaTransportControlsDisplayUpdater {}
 #[doc = "*Required features: 'Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SystemMediaTransportControlsProperty(pub i32);
 impl SystemMediaTransportControlsProperty {
     pub const SoundLevel: Self = Self(0i32);
@@ -4115,12 +4076,6 @@ impl ::core::clone::Clone for SystemMediaTransportControlsProperty {
 unsafe impl ::windows::core::Abi for SystemMediaTransportControlsProperty {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SystemMediaTransportControlsProperty {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SystemMediaTransportControlsProperty {}
 impl ::core::fmt::Debug for SystemMediaTransportControlsProperty {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SystemMediaTransportControlsProperty").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Networking/BackgroundTransfer/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/BackgroundTransfer/mod.rs
@@ -387,6 +387,7 @@ unsafe impl ::core::marker::Send for BackgroundDownloader {}
 unsafe impl ::core::marker::Sync for BackgroundDownloader {}
 #[doc = "*Required features: 'Networking_BackgroundTransfer'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BackgroundTransferBehavior(pub i32);
 impl BackgroundTransferBehavior {
     pub const Parallel: Self = Self(0i32);
@@ -401,12 +402,6 @@ impl ::core::clone::Clone for BackgroundTransferBehavior {
 unsafe impl ::windows::core::Abi for BackgroundTransferBehavior {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BackgroundTransferBehavior {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BackgroundTransferBehavior {}
 impl ::core::fmt::Debug for BackgroundTransferBehavior {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BackgroundTransferBehavior").field(&self.0).finish()
@@ -728,6 +723,7 @@ unsafe impl ::core::marker::Send for BackgroundTransferContentPart {}
 unsafe impl ::core::marker::Sync for BackgroundTransferContentPart {}
 #[doc = "*Required features: 'Networking_BackgroundTransfer'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BackgroundTransferCostPolicy(pub i32);
 impl BackgroundTransferCostPolicy {
     pub const Default: Self = Self(0i32);
@@ -743,12 +739,6 @@ impl ::core::clone::Clone for BackgroundTransferCostPolicy {
 unsafe impl ::windows::core::Abi for BackgroundTransferCostPolicy {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BackgroundTransferCostPolicy {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BackgroundTransferCostPolicy {}
 impl ::core::fmt::Debug for BackgroundTransferCostPolicy {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BackgroundTransferCostPolicy").field(&self.0).finish()
@@ -925,6 +915,7 @@ unsafe impl ::core::marker::Send for BackgroundTransferGroup {}
 unsafe impl ::core::marker::Sync for BackgroundTransferGroup {}
 #[doc = "*Required features: 'Networking_BackgroundTransfer'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BackgroundTransferPriority(pub i32);
 impl BackgroundTransferPriority {
     pub const Default: Self = Self(0i32);
@@ -940,12 +931,6 @@ impl ::core::clone::Clone for BackgroundTransferPriority {
 unsafe impl ::windows::core::Abi for BackgroundTransferPriority {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BackgroundTransferPriority {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BackgroundTransferPriority {}
 impl ::core::fmt::Debug for BackgroundTransferPriority {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BackgroundTransferPriority").field(&self.0).finish()
@@ -1058,6 +1043,7 @@ unsafe impl ::core::marker::Send for BackgroundTransferRangesDownloadedEventArgs
 unsafe impl ::core::marker::Sync for BackgroundTransferRangesDownloadedEventArgs {}
 #[doc = "*Required features: 'Networking_BackgroundTransfer'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BackgroundTransferStatus(pub i32);
 impl BackgroundTransferStatus {
     pub const Idle: Self = Self(0i32);
@@ -1080,12 +1066,6 @@ impl ::core::clone::Clone for BackgroundTransferStatus {
 unsafe impl ::windows::core::Abi for BackgroundTransferStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BackgroundTransferStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BackgroundTransferStatus {}
 impl ::core::fmt::Debug for BackgroundTransferStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BackgroundTransferStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Networking/Connectivity/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/Connectivity/mod.rs
@@ -115,6 +115,7 @@ unsafe impl ::core::marker::Send for AttributedNetworkUsage {}
 unsafe impl ::core::marker::Sync for AttributedNetworkUsage {}
 #[doc = "*Required features: 'Networking_Connectivity'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CellularApnAuthenticationType(pub i32);
 impl CellularApnAuthenticationType {
     pub const None: Self = Self(0i32);
@@ -131,12 +132,6 @@ impl ::core::clone::Clone for CellularApnAuthenticationType {
 unsafe impl ::windows::core::Abi for CellularApnAuthenticationType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CellularApnAuthenticationType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CellularApnAuthenticationType {}
 impl ::core::fmt::Debug for CellularApnAuthenticationType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CellularApnAuthenticationType").field(&self.0).finish()
@@ -693,6 +688,7 @@ unsafe impl ::core::marker::Send for ConnectionProfile {}
 unsafe impl ::core::marker::Sync for ConnectionProfile {}
 #[doc = "*Required features: 'Networking_Connectivity'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ConnectionProfileDeleteStatus(pub i32);
 impl ConnectionProfileDeleteStatus {
     pub const Success: Self = Self(0i32);
@@ -709,12 +705,6 @@ impl ::core::clone::Clone for ConnectionProfileDeleteStatus {
 unsafe impl ::windows::core::Abi for ConnectionProfileDeleteStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ConnectionProfileDeleteStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ConnectionProfileDeleteStatus {}
 impl ::core::fmt::Debug for ConnectionProfileDeleteStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ConnectionProfileDeleteStatus").field(&self.0).finish()
@@ -1502,6 +1492,7 @@ unsafe impl ::core::marker::Send for DataUsage {}
 unsafe impl ::core::marker::Sync for DataUsage {}
 #[doc = "*Required features: 'Networking_Connectivity'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DataUsageGranularity(pub i32);
 impl DataUsageGranularity {
     pub const PerMinute: Self = Self(0i32);
@@ -1518,12 +1509,6 @@ impl ::core::clone::Clone for DataUsageGranularity {
 unsafe impl ::windows::core::Abi for DataUsageGranularity {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DataUsageGranularity {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DataUsageGranularity {}
 impl ::core::fmt::Debug for DataUsageGranularity {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DataUsageGranularity").field(&self.0).finish()
@@ -1537,6 +1522,7 @@ impl ::windows::core::DefaultType for DataUsageGranularity {
 }
 #[doc = "*Required features: 'Networking_Connectivity'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DomainConnectivityLevel(pub i32);
 impl DomainConnectivityLevel {
     pub const None: Self = Self(0i32);
@@ -1552,12 +1538,6 @@ impl ::core::clone::Clone for DomainConnectivityLevel {
 unsafe impl ::windows::core::Abi for DomainConnectivityLevel {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DomainConnectivityLevel {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DomainConnectivityLevel {}
 impl ::core::fmt::Debug for DomainConnectivityLevel {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DomainConnectivityLevel").field(&self.0).finish()
@@ -2783,6 +2763,7 @@ unsafe impl ::core::marker::Send for NetworkAdapter {}
 unsafe impl ::core::marker::Sync for NetworkAdapter {}
 #[doc = "*Required features: 'Networking_Connectivity'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct NetworkAuthenticationType(pub i32);
 impl NetworkAuthenticationType {
     pub const None: Self = Self(0i32);
@@ -2810,12 +2791,6 @@ impl ::core::clone::Clone for NetworkAuthenticationType {
 unsafe impl ::windows::core::Abi for NetworkAuthenticationType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NetworkAuthenticationType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for NetworkAuthenticationType {}
 impl ::core::fmt::Debug for NetworkAuthenticationType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NetworkAuthenticationType").field(&self.0).finish()
@@ -2829,6 +2804,7 @@ impl ::windows::core::DefaultType for NetworkAuthenticationType {
 }
 #[doc = "*Required features: 'Networking_Connectivity'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct NetworkConnectivityLevel(pub i32);
 impl NetworkConnectivityLevel {
     pub const None: Self = Self(0i32);
@@ -2845,12 +2821,6 @@ impl ::core::clone::Clone for NetworkConnectivityLevel {
 unsafe impl ::windows::core::Abi for NetworkConnectivityLevel {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NetworkConnectivityLevel {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for NetworkConnectivityLevel {}
 impl ::core::fmt::Debug for NetworkConnectivityLevel {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NetworkConnectivityLevel").field(&self.0).finish()
@@ -2864,6 +2834,7 @@ impl ::windows::core::DefaultType for NetworkConnectivityLevel {
 }
 #[doc = "*Required features: 'Networking_Connectivity'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct NetworkCostType(pub i32);
 impl NetworkCostType {
     pub const Unknown: Self = Self(0i32);
@@ -2880,12 +2851,6 @@ impl ::core::clone::Clone for NetworkCostType {
 unsafe impl ::windows::core::Abi for NetworkCostType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NetworkCostType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for NetworkCostType {}
 impl ::core::fmt::Debug for NetworkCostType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NetworkCostType").field(&self.0).finish()
@@ -2899,6 +2864,7 @@ impl ::windows::core::DefaultType for NetworkCostType {
 }
 #[doc = "*Required features: 'Networking_Connectivity'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct NetworkEncryptionType(pub i32);
 impl NetworkEncryptionType {
     pub const None: Self = Self(0i32);
@@ -2923,12 +2889,6 @@ impl ::core::clone::Clone for NetworkEncryptionType {
 unsafe impl ::windows::core::Abi for NetworkEncryptionType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NetworkEncryptionType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for NetworkEncryptionType {}
 impl ::core::fmt::Debug for NetworkEncryptionType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NetworkEncryptionType").field(&self.0).finish()
@@ -3417,6 +3377,7 @@ unsafe impl ::windows::core::RuntimeType for NetworkStatusChangedEventHandler {
 pub struct NetworkStatusChangedEventHandlerVtbl(pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT);
 #[doc = "*Required features: 'Networking_Connectivity'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct NetworkTypes(pub u32);
 impl NetworkTypes {
     pub const None: Self = Self(0u32);
@@ -3432,12 +3393,6 @@ impl ::core::clone::Clone for NetworkTypes {
 unsafe impl ::windows::core::Abi for NetworkTypes {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NetworkTypes {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for NetworkTypes {}
 impl ::core::fmt::Debug for NetworkTypes {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NetworkTypes").field(&self.0).finish()
@@ -3801,6 +3756,7 @@ unsafe impl ::core::marker::Send for ProxyConfiguration {}
 unsafe impl ::core::marker::Sync for ProxyConfiguration {}
 #[doc = "*Required features: 'Networking_Connectivity'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RoamingStates(pub u32);
 impl RoamingStates {
     pub const None: Self = Self(0u32);
@@ -3816,12 +3772,6 @@ impl ::core::clone::Clone for RoamingStates {
 unsafe impl ::windows::core::Abi for RoamingStates {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RoamingStates {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RoamingStates {}
 impl ::core::fmt::Debug for RoamingStates {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RoamingStates").field(&self.0).finish()
@@ -3972,6 +3922,7 @@ unsafe impl ::core::marker::Send for RoutePolicy {}
 unsafe impl ::core::marker::Sync for RoutePolicy {}
 #[doc = "*Required features: 'Networking_Connectivity'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TriStates(pub i32);
 impl TriStates {
     pub const DoNotCare: Self = Self(0i32);
@@ -3987,12 +3938,6 @@ impl ::core::clone::Clone for TriStates {
 unsafe impl ::windows::core::Abi for TriStates {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TriStates {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TriStates {}
 impl ::core::fmt::Debug for TriStates {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TriStates").field(&self.0).finish()
@@ -4209,6 +4154,7 @@ unsafe impl ::core::marker::Send for WwanConnectionProfileDetails {}
 unsafe impl ::core::marker::Sync for WwanConnectionProfileDetails {}
 #[doc = "*Required features: 'Networking_Connectivity'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WwanDataClass(pub u32);
 impl WwanDataClass {
     pub const None: Self = Self(0u32);
@@ -4236,12 +4182,6 @@ impl ::core::clone::Clone for WwanDataClass {
 unsafe impl ::windows::core::Abi for WwanDataClass {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WwanDataClass {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WwanDataClass {}
 impl ::core::fmt::Debug for WwanDataClass {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WwanDataClass").field(&self.0).finish()
@@ -4283,6 +4223,7 @@ impl ::windows::core::DefaultType for WwanDataClass {
 }
 #[doc = "*Required features: 'Networking_Connectivity'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WwanNetworkIPKind(pub i32);
 impl WwanNetworkIPKind {
     pub const None: Self = Self(0i32);
@@ -4300,12 +4241,6 @@ impl ::core::clone::Clone for WwanNetworkIPKind {
 unsafe impl ::windows::core::Abi for WwanNetworkIPKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WwanNetworkIPKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WwanNetworkIPKind {}
 impl ::core::fmt::Debug for WwanNetworkIPKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WwanNetworkIPKind").field(&self.0).finish()
@@ -4319,6 +4254,7 @@ impl ::windows::core::DefaultType for WwanNetworkIPKind {
 }
 #[doc = "*Required features: 'Networking_Connectivity'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WwanNetworkRegistrationState(pub i32);
 impl WwanNetworkRegistrationState {
     pub const None: Self = Self(0i32);
@@ -4338,12 +4274,6 @@ impl ::core::clone::Clone for WwanNetworkRegistrationState {
 unsafe impl ::windows::core::Abi for WwanNetworkRegistrationState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WwanNetworkRegistrationState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WwanNetworkRegistrationState {}
 impl ::core::fmt::Debug for WwanNetworkRegistrationState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WwanNetworkRegistrationState").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Networking/NetworkOperators/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/NetworkOperators/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DataClasses(pub u32);
 impl DataClasses {
     pub const None: Self = Self(0u32);
@@ -30,12 +31,6 @@ impl ::core::clone::Clone for DataClasses {
 unsafe impl ::windows::core::Abi for DataClasses {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DataClasses {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DataClasses {}
 impl ::core::fmt::Debug for DataClasses {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DataClasses").field(&self.0).finish()
@@ -365,6 +360,7 @@ unsafe impl ::core::marker::Send for ESimAddedEventArgs {}
 unsafe impl ::core::marker::Sync for ESimAddedEventArgs {}
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ESimAuthenticationPreference(pub i32);
 impl ESimAuthenticationPreference {
     pub const OnEntry: Self = Self(0i32);
@@ -380,12 +376,6 @@ impl ::core::clone::Clone for ESimAuthenticationPreference {
 unsafe impl ::windows::core::Abi for ESimAuthenticationPreference {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ESimAuthenticationPreference {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ESimAuthenticationPreference {}
 impl ::core::fmt::Debug for ESimAuthenticationPreference {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ESimAuthenticationPreference").field(&self.0).finish()
@@ -594,6 +584,7 @@ unsafe impl ::core::marker::Send for ESimDiscoverResult {}
 unsafe impl ::core::marker::Sync for ESimDiscoverResult {}
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ESimDiscoverResultKind(pub i32);
 impl ESimDiscoverResultKind {
     pub const None: Self = Self(0i32);
@@ -609,12 +600,6 @@ impl ::core::clone::Clone for ESimDiscoverResultKind {
 unsafe impl ::windows::core::Abi for ESimDiscoverResultKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ESimDiscoverResultKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ESimDiscoverResultKind {}
 impl ::core::fmt::Debug for ESimDiscoverResultKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ESimDiscoverResultKind").field(&self.0).finish()
@@ -837,6 +822,7 @@ unsafe impl ::core::marker::Send for ESimOperationResult {}
 unsafe impl ::core::marker::Sync for ESimOperationResult {}
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ESimOperationStatus(pub i32);
 impl ESimOperationStatus {
     pub const Success: Self = Self(0i32);
@@ -878,12 +864,6 @@ impl ::core::clone::Clone for ESimOperationStatus {
 unsafe impl ::windows::core::Abi for ESimOperationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ESimOperationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ESimOperationStatus {}
 impl ::core::fmt::Debug for ESimOperationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ESimOperationStatus").field(&self.0).finish()
@@ -1143,6 +1123,7 @@ unsafe impl ::core::marker::Send for ESimProfile {}
 unsafe impl ::core::marker::Sync for ESimProfile {}
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ESimProfileClass(pub i32);
 impl ESimProfileClass {
     pub const Operational: Self = Self(0i32);
@@ -1158,12 +1139,6 @@ impl ::core::clone::Clone for ESimProfileClass {
 unsafe impl ::windows::core::Abi for ESimProfileClass {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ESimProfileClass {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ESimProfileClass {}
 impl ::core::fmt::Debug for ESimProfileClass {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ESimProfileClass").field(&self.0).finish()
@@ -1395,6 +1370,7 @@ unsafe impl ::core::marker::Send for ESimProfileMetadata {}
 unsafe impl ::core::marker::Sync for ESimProfileMetadata {}
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ESimProfileMetadataState(pub i32);
 impl ESimProfileMetadataState {
     pub const Unknown: Self = Self(0i32);
@@ -1415,12 +1391,6 @@ impl ::core::clone::Clone for ESimProfileMetadataState {
 unsafe impl ::windows::core::Abi for ESimProfileMetadataState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ESimProfileMetadataState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ESimProfileMetadataState {}
 impl ::core::fmt::Debug for ESimProfileMetadataState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ESimProfileMetadataState").field(&self.0).finish()
@@ -1531,6 +1501,7 @@ unsafe impl ::core::marker::Send for ESimProfilePolicy {}
 unsafe impl ::core::marker::Sync for ESimProfilePolicy {}
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ESimProfileState(pub i32);
 impl ESimProfileState {
     pub const Unknown: Self = Self(0i32);
@@ -1547,12 +1518,6 @@ impl ::core::clone::Clone for ESimProfileState {
 unsafe impl ::windows::core::Abi for ESimProfileState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ESimProfileState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ESimProfileState {}
 impl ::core::fmt::Debug for ESimProfileState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ESimProfileState").field(&self.0).finish()
@@ -1736,6 +1701,7 @@ unsafe impl ::core::marker::Send for ESimServiceInfo {}
 unsafe impl ::core::marker::Sync for ESimServiceInfo {}
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ESimState(pub i32);
 impl ESimState {
     pub const Unknown: Self = Self(0i32);
@@ -1752,12 +1718,6 @@ impl ::core::clone::Clone for ESimState {
 unsafe impl ::windows::core::Abi for ESimState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ESimState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ESimState {}
 impl ::core::fmt::Debug for ESimState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ESimState").field(&self.0).finish()
@@ -2018,6 +1978,7 @@ unsafe impl ::core::marker::Send for ESimWatcher {}
 unsafe impl ::core::marker::Sync for ESimWatcher {}
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ESimWatcherStatus(pub i32);
 impl ESimWatcherStatus {
     pub const Created: Self = Self(0i32);
@@ -2035,12 +1996,6 @@ impl ::core::clone::Clone for ESimWatcherStatus {
 unsafe impl ::windows::core::Abi for ESimWatcherStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ESimWatcherStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ESimWatcherStatus {}
 impl ::core::fmt::Debug for ESimWatcherStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ESimWatcherStatus").field(&self.0).finish()
@@ -2309,6 +2264,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Hots
 }
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HotspotAuthenticationResponseCode(pub i32);
 impl HotspotAuthenticationResponseCode {
     pub const NoError: Self = Self(0i32);
@@ -2328,12 +2284,6 @@ impl ::core::clone::Clone for HotspotAuthenticationResponseCode {
 unsafe impl ::windows::core::Abi for HotspotAuthenticationResponseCode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HotspotAuthenticationResponseCode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HotspotAuthenticationResponseCode {}
 impl ::core::fmt::Debug for HotspotAuthenticationResponseCode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HotspotAuthenticationResponseCode").field(&self.0).finish()
@@ -5594,6 +5544,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Mobi
 }
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MobileBroadbandAccountWatcherStatus(pub i32);
 impl MobileBroadbandAccountWatcherStatus {
     pub const Created: Self = Self(0i32);
@@ -5611,12 +5562,6 @@ impl ::core::clone::Clone for MobileBroadbandAccountWatcherStatus {
 unsafe impl ::windows::core::Abi for MobileBroadbandAccountWatcherStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MobileBroadbandAccountWatcherStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MobileBroadbandAccountWatcherStatus {}
 impl ::core::fmt::Debug for MobileBroadbandAccountWatcherStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MobileBroadbandAccountWatcherStatus").field(&self.0).finish()
@@ -7770,6 +7715,7 @@ unsafe impl ::core::marker::Send for MobileBroadbandDeviceServiceTriggerDetails 
 unsafe impl ::core::marker::Sync for MobileBroadbandDeviceServiceTriggerDetails {}
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MobileBroadbandDeviceType(pub i32);
 impl MobileBroadbandDeviceType {
     pub const Unknown: Self = Self(0i32);
@@ -7786,12 +7732,6 @@ impl ::core::clone::Clone for MobileBroadbandDeviceType {
 unsafe impl ::windows::core::Abi for MobileBroadbandDeviceType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MobileBroadbandDeviceType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MobileBroadbandDeviceType {}
 impl ::core::fmt::Debug for MobileBroadbandDeviceType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MobileBroadbandDeviceType").field(&self.0).finish()
@@ -8253,6 +8193,7 @@ unsafe impl ::core::marker::Send for MobileBroadbandModemIsolation {}
 unsafe impl ::core::marker::Sync for MobileBroadbandModemIsolation {}
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MobileBroadbandModemStatus(pub i32);
 impl MobileBroadbandModemStatus {
     pub const Success: Self = Self(0i32);
@@ -8269,12 +8210,6 @@ impl ::core::clone::Clone for MobileBroadbandModemStatus {
 unsafe impl ::windows::core::Abi for MobileBroadbandModemStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MobileBroadbandModemStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MobileBroadbandModemStatus {}
 impl ::core::fmt::Debug for MobileBroadbandModemStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MobileBroadbandModemStatus").field(&self.0).finish()
@@ -8988,6 +8923,7 @@ unsafe impl ::core::marker::Send for MobileBroadbandPin {}
 unsafe impl ::core::marker::Sync for MobileBroadbandPin {}
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MobileBroadbandPinFormat(pub i32);
 impl MobileBroadbandPinFormat {
     pub const Unknown: Self = Self(0i32);
@@ -9003,12 +8939,6 @@ impl ::core::clone::Clone for MobileBroadbandPinFormat {
 unsafe impl ::windows::core::Abi for MobileBroadbandPinFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MobileBroadbandPinFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MobileBroadbandPinFormat {}
 impl ::core::fmt::Debug for MobileBroadbandPinFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MobileBroadbandPinFormat").field(&self.0).finish()
@@ -9022,6 +8952,7 @@ impl ::windows::core::DefaultType for MobileBroadbandPinFormat {
 }
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MobileBroadbandPinLockState(pub i32);
 impl MobileBroadbandPinLockState {
     pub const Unknown: Self = Self(0i32);
@@ -9038,12 +8969,6 @@ impl ::core::clone::Clone for MobileBroadbandPinLockState {
 unsafe impl ::windows::core::Abi for MobileBroadbandPinLockState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MobileBroadbandPinLockState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MobileBroadbandPinLockState {}
 impl ::core::fmt::Debug for MobileBroadbandPinLockState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MobileBroadbandPinLockState").field(&self.0).finish()
@@ -9415,6 +9340,7 @@ unsafe impl ::core::marker::Send for MobileBroadbandPinOperationResult {}
 unsafe impl ::core::marker::Sync for MobileBroadbandPinOperationResult {}
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MobileBroadbandPinType(pub i32);
 impl MobileBroadbandPinType {
     pub const None: Self = Self(0i32);
@@ -9438,12 +9364,6 @@ impl ::core::clone::Clone for MobileBroadbandPinType {
 unsafe impl ::windows::core::Abi for MobileBroadbandPinType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MobileBroadbandPinType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MobileBroadbandPinType {}
 impl ::core::fmt::Debug for MobileBroadbandPinType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MobileBroadbandPinType").field(&self.0).finish()
@@ -9457,6 +9377,7 @@ impl ::windows::core::DefaultType for MobileBroadbandPinType {
 }
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MobileBroadbandRadioState(pub i32);
 impl MobileBroadbandRadioState {
     pub const Off: Self = Self(0i32);
@@ -9471,12 +9392,6 @@ impl ::core::clone::Clone for MobileBroadbandRadioState {
 unsafe impl ::windows::core::Abi for MobileBroadbandRadioState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MobileBroadbandRadioState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MobileBroadbandRadioState {}
 impl ::core::fmt::Debug for MobileBroadbandRadioState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MobileBroadbandRadioState").field(&self.0).finish()
@@ -10162,6 +10077,7 @@ unsafe impl ::core::marker::Send for MobileBroadbandSlotManager {}
 unsafe impl ::core::marker::Sync for MobileBroadbandSlotManager {}
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MobileBroadbandSlotState(pub i32);
 impl MobileBroadbandSlotState {
     pub const Unmanaged: Self = Self(0i32);
@@ -10184,12 +10100,6 @@ impl ::core::clone::Clone for MobileBroadbandSlotState {
 unsafe impl ::windows::core::Abi for MobileBroadbandSlotState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MobileBroadbandSlotState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MobileBroadbandSlotState {}
 impl ::core::fmt::Debug for MobileBroadbandSlotState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MobileBroadbandSlotState").field(&self.0).finish()
@@ -10482,6 +10392,7 @@ unsafe impl ::core::marker::Send for MobileBroadbandUiccApp {}
 unsafe impl ::core::marker::Sync for MobileBroadbandUiccApp {}
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MobileBroadbandUiccAppOperationStatus(pub i32);
 impl MobileBroadbandUiccAppOperationStatus {
     pub const Success: Self = Self(0i32);
@@ -10498,12 +10409,6 @@ impl ::core::clone::Clone for MobileBroadbandUiccAppOperationStatus {
 unsafe impl ::windows::core::Abi for MobileBroadbandUiccAppOperationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MobileBroadbandUiccAppOperationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MobileBroadbandUiccAppOperationStatus {}
 impl ::core::fmt::Debug for MobileBroadbandUiccAppOperationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MobileBroadbandUiccAppOperationStatus").field(&self.0).finish()
@@ -10818,6 +10723,7 @@ unsafe impl ::core::marker::Send for MobileBroadbandUiccAppsResult {}
 unsafe impl ::core::marker::Sync for MobileBroadbandUiccAppsResult {}
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct NetworkDeviceStatus(pub i32);
 impl NetworkDeviceStatus {
     pub const DeviceNotReady: Self = Self(0i32);
@@ -10838,12 +10744,6 @@ impl ::core::clone::Clone for NetworkDeviceStatus {
 unsafe impl ::windows::core::Abi for NetworkDeviceStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NetworkDeviceStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for NetworkDeviceStatus {}
 impl ::core::fmt::Debug for NetworkDeviceStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NetworkDeviceStatus").field(&self.0).finish()
@@ -10857,6 +10757,7 @@ impl ::windows::core::DefaultType for NetworkDeviceStatus {
 }
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct NetworkOperatorDataUsageNotificationKind(pub i32);
 impl NetworkOperatorDataUsageNotificationKind {
     pub const DataUsageProgress: Self = Self(0i32);
@@ -10870,12 +10771,6 @@ impl ::core::clone::Clone for NetworkOperatorDataUsageNotificationKind {
 unsafe impl ::windows::core::Abi for NetworkOperatorDataUsageNotificationKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NetworkOperatorDataUsageNotificationKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for NetworkOperatorDataUsageNotificationKind {}
 impl ::core::fmt::Debug for NetworkOperatorDataUsageNotificationKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NetworkOperatorDataUsageNotificationKind").field(&self.0).finish()
@@ -10970,6 +10865,7 @@ unsafe impl ::core::marker::Send for NetworkOperatorDataUsageTriggerDetails {}
 unsafe impl ::core::marker::Sync for NetworkOperatorDataUsageTriggerDetails {}
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct NetworkOperatorEventMessageType(pub i32);
 impl NetworkOperatorEventMessageType {
     pub const Gsm: Self = Self(0i32);
@@ -10995,12 +10891,6 @@ impl ::core::clone::Clone for NetworkOperatorEventMessageType {
 unsafe impl ::windows::core::Abi for NetworkOperatorEventMessageType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NetworkOperatorEventMessageType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for NetworkOperatorEventMessageType {}
 impl ::core::fmt::Debug for NetworkOperatorEventMessageType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NetworkOperatorEventMessageType").field(&self.0).finish()
@@ -11682,6 +11572,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Netw
 }
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct NetworkRegistrationState(pub i32);
 impl NetworkRegistrationState {
     pub const None: Self = Self(0i32);
@@ -11701,12 +11592,6 @@ impl ::core::clone::Clone for NetworkRegistrationState {
 unsafe impl ::windows::core::Abi for NetworkRegistrationState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NetworkRegistrationState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for NetworkRegistrationState {}
 impl ::core::fmt::Debug for NetworkRegistrationState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NetworkRegistrationState").field(&self.0).finish()
@@ -11720,6 +11605,7 @@ impl ::windows::core::DefaultType for NetworkRegistrationState {
 }
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ProfileMediaType(pub i32);
 impl ProfileMediaType {
     pub const Wlan: Self = Self(0i32);
@@ -11734,12 +11620,6 @@ impl ::core::clone::Clone for ProfileMediaType {
 unsafe impl ::windows::core::Abi for ProfileMediaType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ProfileMediaType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ProfileMediaType {}
 impl ::core::fmt::Debug for ProfileMediaType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ProfileMediaType").field(&self.0).finish()
@@ -12077,6 +11957,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Prov
 }
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TetheringCapability(pub i32);
 impl TetheringCapability {
     pub const Enabled: Self = Self(0i32);
@@ -12097,12 +11978,6 @@ impl ::core::clone::Clone for TetheringCapability {
 unsafe impl ::windows::core::Abi for TetheringCapability {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TetheringCapability {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TetheringCapability {}
 impl ::core::fmt::Debug for TetheringCapability {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TetheringCapability").field(&self.0).finish()
@@ -12207,6 +12082,7 @@ unsafe impl ::core::marker::Send for TetheringEntitlementCheckTriggerDetails {}
 unsafe impl ::core::marker::Sync for TetheringEntitlementCheckTriggerDetails {}
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TetheringOperationStatus(pub i32);
 impl TetheringOperationStatus {
     pub const Success: Self = Self(0i32);
@@ -12228,12 +12104,6 @@ impl ::core::clone::Clone for TetheringOperationStatus {
 unsafe impl ::windows::core::Abi for TetheringOperationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TetheringOperationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TetheringOperationStatus {}
 impl ::core::fmt::Debug for TetheringOperationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TetheringOperationStatus").field(&self.0).finish()
@@ -12247,6 +12117,7 @@ impl ::windows::core::DefaultType for TetheringOperationStatus {
 }
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TetheringOperationalState(pub i32);
 impl TetheringOperationalState {
     pub const Unknown: Self = Self(0i32);
@@ -12263,12 +12134,6 @@ impl ::core::clone::Clone for TetheringOperationalState {
 unsafe impl ::windows::core::Abi for TetheringOperationalState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TetheringOperationalState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TetheringOperationalState {}
 impl ::core::fmt::Debug for TetheringOperationalState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TetheringOperationalState").field(&self.0).finish()
@@ -12282,6 +12147,7 @@ impl ::windows::core::DefaultType for TetheringOperationalState {
 }
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TetheringWiFiBand(pub i32);
 impl TetheringWiFiBand {
     pub const Auto: Self = Self(0i32);
@@ -12297,12 +12163,6 @@ impl ::core::clone::Clone for TetheringWiFiBand {
 unsafe impl ::windows::core::Abi for TetheringWiFiBand {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TetheringWiFiBand {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TetheringWiFiBand {}
 impl ::core::fmt::Debug for TetheringWiFiBand {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TetheringWiFiBand").field(&self.0).finish()
@@ -12316,6 +12176,7 @@ impl ::windows::core::DefaultType for TetheringWiFiBand {
 }
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UiccAccessCondition(pub i32);
 impl UiccAccessCondition {
     pub const AlwaysAllowed: Self = Self(0i32);
@@ -12336,12 +12197,6 @@ impl ::core::clone::Clone for UiccAccessCondition {
 unsafe impl ::windows::core::Abi for UiccAccessCondition {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UiccAccessCondition {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UiccAccessCondition {}
 impl ::core::fmt::Debug for UiccAccessCondition {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UiccAccessCondition").field(&self.0).finish()
@@ -12355,6 +12210,7 @@ impl ::windows::core::DefaultType for UiccAccessCondition {
 }
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UiccAppKind(pub i32);
 impl UiccAppKind {
     pub const Unknown: Self = Self(0i32);
@@ -12374,12 +12230,6 @@ impl ::core::clone::Clone for UiccAppKind {
 unsafe impl ::windows::core::Abi for UiccAppKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UiccAppKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UiccAppKind {}
 impl ::core::fmt::Debug for UiccAppKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UiccAppKind").field(&self.0).finish()
@@ -12393,6 +12243,7 @@ impl ::windows::core::DefaultType for UiccAppKind {
 }
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UiccAppRecordKind(pub i32);
 impl UiccAppRecordKind {
     pub const Unknown: Self = Self(0i32);
@@ -12408,12 +12259,6 @@ impl ::core::clone::Clone for UiccAppRecordKind {
 unsafe impl ::windows::core::Abi for UiccAppRecordKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UiccAppRecordKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UiccAppRecordKind {}
 impl ::core::fmt::Debug for UiccAppRecordKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UiccAppRecordKind").field(&self.0).finish()
@@ -12638,6 +12483,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Ussd
 }
 #[doc = "*Required features: 'Networking_NetworkOperators'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UssdResultCode(pub i32);
 impl UssdResultCode {
     pub const NoActionRequired: Self = Self(0i32);
@@ -12656,12 +12502,6 @@ impl ::core::clone::Clone for UssdResultCode {
 unsafe impl ::windows::core::Abi for UssdResultCode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UssdResultCode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UssdResultCode {}
 impl ::core::fmt::Debug for UssdResultCode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UssdResultCode").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Networking/Proximity/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/Proximity/mod.rs
@@ -668,6 +668,7 @@ unsafe impl ::windows::core::RuntimeType for MessageTransmittedHandler {
 pub struct MessageTransmittedHandlerVtbl(pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: ::windows::core::RawPtr, messageid: i64) -> ::windows::core::HRESULT);
 #[doc = "*Required features: 'Networking_Proximity'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PeerDiscoveryTypes(pub u32);
 impl PeerDiscoveryTypes {
     pub const None: Self = Self(0u32);
@@ -683,12 +684,6 @@ impl ::core::clone::Clone for PeerDiscoveryTypes {
 unsafe impl ::windows::core::Abi for PeerDiscoveryTypes {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PeerDiscoveryTypes {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PeerDiscoveryTypes {}
 impl ::core::fmt::Debug for PeerDiscoveryTypes {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PeerDiscoveryTypes").field(&self.0).finish()
@@ -1005,6 +1000,7 @@ unsafe impl ::core::marker::Send for PeerInformation {}
 unsafe impl ::core::marker::Sync for PeerInformation {}
 #[doc = "*Required features: 'Networking_Proximity'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PeerRole(pub i32);
 impl PeerRole {
     pub const Peer: Self = Self(0i32);
@@ -1020,12 +1016,6 @@ impl ::core::clone::Clone for PeerRole {
 unsafe impl ::windows::core::Abi for PeerRole {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PeerRole {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PeerRole {}
 impl ::core::fmt::Debug for PeerRole {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PeerRole").field(&self.0).finish()
@@ -1205,6 +1195,7 @@ unsafe impl ::core::marker::Send for PeerWatcher {}
 unsafe impl ::core::marker::Sync for PeerWatcher {}
 #[doc = "*Required features: 'Networking_Proximity'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PeerWatcherStatus(pub i32);
 impl PeerWatcherStatus {
     pub const Created: Self = Self(0i32);
@@ -1223,12 +1214,6 @@ impl ::core::clone::Clone for PeerWatcherStatus {
 unsafe impl ::windows::core::Abi for PeerWatcherStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PeerWatcherStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PeerWatcherStatus {}
 impl ::core::fmt::Debug for PeerWatcherStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PeerWatcherStatus").field(&self.0).finish()
@@ -1571,6 +1556,7 @@ unsafe impl ::core::marker::Send for ProximityMessage {}
 unsafe impl ::core::marker::Sync for ProximityMessage {}
 #[doc = "*Required features: 'Networking_Proximity'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TriggeredConnectState(pub i32);
 impl TriggeredConnectState {
     pub const PeerFound: Self = Self(0i32);
@@ -1589,12 +1575,6 @@ impl ::core::clone::Clone for TriggeredConnectState {
 unsafe impl ::windows::core::Abi for TriggeredConnectState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TriggeredConnectState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TriggeredConnectState {}
 impl ::core::fmt::Debug for TriggeredConnectState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TriggeredConnectState").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Networking/PushNotifications/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/PushNotifications/mod.rs
@@ -771,6 +771,7 @@ unsafe impl ::core::marker::Send for PushNotificationReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for PushNotificationReceivedEventArgs {}
 #[doc = "*Required features: 'Networking_PushNotifications'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PushNotificationType(pub i32);
 impl PushNotificationType {
     pub const Toast: Self = Self(0i32);
@@ -788,12 +789,6 @@ impl ::core::clone::Clone for PushNotificationType {
 unsafe impl ::windows::core::Abi for PushNotificationType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PushNotificationType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PushNotificationType {}
 impl ::core::fmt::Debug for PushNotificationType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PushNotificationType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Networking/ServiceDiscovery/Dnssd/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/ServiceDiscovery/Dnssd/mod.rs
@@ -140,6 +140,7 @@ unsafe impl ::core::marker::Send for DnssdRegistrationResult {}
 unsafe impl ::core::marker::Sync for DnssdRegistrationResult {}
 #[doc = "*Required features: 'Networking_ServiceDiscovery_Dnssd'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DnssdRegistrationStatus(pub i32);
 impl DnssdRegistrationStatus {
     pub const Success: Self = Self(0i32);
@@ -156,12 +157,6 @@ impl ::core::clone::Clone for DnssdRegistrationStatus {
 unsafe impl ::windows::core::Abi for DnssdRegistrationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DnssdRegistrationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DnssdRegistrationStatus {}
 impl ::core::fmt::Debug for DnssdRegistrationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DnssdRegistrationStatus").field(&self.0).finish()
@@ -746,6 +741,7 @@ unsafe impl ::core::marker::Send for DnssdServiceWatcher {}
 unsafe impl ::core::marker::Sync for DnssdServiceWatcher {}
 #[doc = "*Required features: 'Networking_ServiceDiscovery_Dnssd'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DnssdServiceWatcherStatus(pub i32);
 impl DnssdServiceWatcherStatus {
     pub const Created: Self = Self(0i32);
@@ -764,12 +760,6 @@ impl ::core::clone::Clone for DnssdServiceWatcherStatus {
 unsafe impl ::windows::core::Abi for DnssdServiceWatcherStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DnssdServiceWatcherStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DnssdServiceWatcherStatus {}
 impl ::core::fmt::Debug for DnssdServiceWatcherStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DnssdServiceWatcherStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Networking/Sockets/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/Sockets/mod.rs
@@ -252,6 +252,7 @@ unsafe impl ::core::marker::Send for ControlChannelTrigger {}
 unsafe impl ::core::marker::Sync for ControlChannelTrigger {}
 #[doc = "*Required features: 'Networking_Sockets'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ControlChannelTriggerResetReason(pub i32);
 impl ControlChannelTriggerResetReason {
     pub const FastUserSwitched: Self = Self(0i32);
@@ -268,12 +269,6 @@ impl ::core::clone::Clone for ControlChannelTriggerResetReason {
 unsafe impl ::windows::core::Abi for ControlChannelTriggerResetReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ControlChannelTriggerResetReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ControlChannelTriggerResetReason {}
 impl ::core::fmt::Debug for ControlChannelTriggerResetReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ControlChannelTriggerResetReason").field(&self.0).finish()
@@ -287,6 +282,7 @@ impl ::windows::core::DefaultType for ControlChannelTriggerResetReason {
 }
 #[doc = "*Required features: 'Networking_Sockets'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ControlChannelTriggerResourceType(pub i32);
 impl ControlChannelTriggerResourceType {
     pub const RequestSoftwareSlot: Self = Self(0i32);
@@ -301,12 +297,6 @@ impl ::core::clone::Clone for ControlChannelTriggerResourceType {
 unsafe impl ::windows::core::Abi for ControlChannelTriggerResourceType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ControlChannelTriggerResourceType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ControlChannelTriggerResourceType {}
 impl ::core::fmt::Debug for ControlChannelTriggerResourceType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ControlChannelTriggerResourceType").field(&self.0).finish()
@@ -320,6 +310,7 @@ impl ::windows::core::DefaultType for ControlChannelTriggerResourceType {
 }
 #[doc = "*Required features: 'Networking_Sockets'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ControlChannelTriggerStatus(pub i32);
 impl ControlChannelTriggerStatus {
     pub const HardwareSlotRequested: Self = Self(0i32);
@@ -339,12 +330,6 @@ impl ::core::clone::Clone for ControlChannelTriggerStatus {
 unsafe impl ::windows::core::Abi for ControlChannelTriggerStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ControlChannelTriggerStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ControlChannelTriggerStatus {}
 impl ::core::fmt::Debug for ControlChannelTriggerStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ControlChannelTriggerStatus").field(&self.0).finish()
@@ -3910,6 +3895,7 @@ unsafe impl ::core::marker::Send for MessageWebSocketMessageReceivedEventArgs {}
 unsafe impl ::core::marker::Sync for MessageWebSocketMessageReceivedEventArgs {}
 #[doc = "*Required features: 'Networking_Sockets'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MessageWebSocketReceiveMode(pub i32);
 impl MessageWebSocketReceiveMode {
     pub const FullMessage: Self = Self(0i32);
@@ -3924,12 +3910,6 @@ impl ::core::clone::Clone for MessageWebSocketReceiveMode {
 unsafe impl ::windows::core::Abi for MessageWebSocketReceiveMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MessageWebSocketReceiveMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MessageWebSocketReceiveMode {}
 impl ::core::fmt::Debug for MessageWebSocketReceiveMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MessageWebSocketReceiveMode").field(&self.0).finish()
@@ -4578,6 +4558,7 @@ unsafe impl ::core::marker::Send for ServerStreamWebSocketInformation {}
 unsafe impl ::core::marker::Sync for ServerStreamWebSocketInformation {}
 #[doc = "*Required features: 'Networking_Sockets'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SocketActivityConnectedStandbyAction(pub i32);
 impl SocketActivityConnectedStandbyAction {
     pub const DoNotWake: Self = Self(0i32);
@@ -4592,12 +4573,6 @@ impl ::core::clone::Clone for SocketActivityConnectedStandbyAction {
 unsafe impl ::windows::core::Abi for SocketActivityConnectedStandbyAction {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SocketActivityConnectedStandbyAction {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SocketActivityConnectedStandbyAction {}
 impl ::core::fmt::Debug for SocketActivityConnectedStandbyAction {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SocketActivityConnectedStandbyAction").field(&self.0).finish()
@@ -4848,6 +4823,7 @@ unsafe impl ::core::marker::Send for SocketActivityInformation {}
 unsafe impl ::core::marker::Sync for SocketActivityInformation {}
 #[doc = "*Required features: 'Networking_Sockets'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SocketActivityKind(pub i32);
 impl SocketActivityKind {
     pub const None: Self = Self(0i32);
@@ -4864,12 +4840,6 @@ impl ::core::clone::Clone for SocketActivityKind {
 unsafe impl ::windows::core::Abi for SocketActivityKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SocketActivityKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SocketActivityKind {}
 impl ::core::fmt::Debug for SocketActivityKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SocketActivityKind").field(&self.0).finish()
@@ -4972,6 +4942,7 @@ unsafe impl ::core::marker::Send for SocketActivityTriggerDetails {}
 unsafe impl ::core::marker::Sync for SocketActivityTriggerDetails {}
 #[doc = "*Required features: 'Networking_Sockets'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SocketActivityTriggerReason(pub i32);
 impl SocketActivityTriggerReason {
     pub const None: Self = Self(0i32);
@@ -4989,12 +4960,6 @@ impl ::core::clone::Clone for SocketActivityTriggerReason {
 unsafe impl ::windows::core::Abi for SocketActivityTriggerReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SocketActivityTriggerReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SocketActivityTriggerReason {}
 impl ::core::fmt::Debug for SocketActivityTriggerReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SocketActivityTriggerReason").field(&self.0).finish()
@@ -5027,6 +4992,7 @@ impl ::windows::core::RuntimeName for SocketError {
 }
 #[doc = "*Required features: 'Networking_Sockets'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SocketErrorStatus(pub i32);
 impl SocketErrorStatus {
     pub const Unknown: Self = Self(0i32);
@@ -5070,12 +5036,6 @@ impl ::core::clone::Clone for SocketErrorStatus {
 unsafe impl ::windows::core::Abi for SocketErrorStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SocketErrorStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SocketErrorStatus {}
 impl ::core::fmt::Debug for SocketErrorStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SocketErrorStatus").field(&self.0).finish()
@@ -5089,6 +5049,7 @@ impl ::windows::core::DefaultType for SocketErrorStatus {
 }
 #[doc = "*Required features: 'Networking_Sockets'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SocketMessageType(pub i32);
 impl SocketMessageType {
     pub const Binary: Self = Self(0i32);
@@ -5103,12 +5064,6 @@ impl ::core::clone::Clone for SocketMessageType {
 unsafe impl ::windows::core::Abi for SocketMessageType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SocketMessageType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SocketMessageType {}
 impl ::core::fmt::Debug for SocketMessageType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SocketMessageType").field(&self.0).finish()
@@ -5122,6 +5077,7 @@ impl ::windows::core::DefaultType for SocketMessageType {
 }
 #[doc = "*Required features: 'Networking_Sockets'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SocketProtectionLevel(pub i32);
 impl SocketProtectionLevel {
     pub const PlainSocket: Self = Self(0i32);
@@ -5144,12 +5100,6 @@ impl ::core::clone::Clone for SocketProtectionLevel {
 unsafe impl ::windows::core::Abi for SocketProtectionLevel {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SocketProtectionLevel {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SocketProtectionLevel {}
 impl ::core::fmt::Debug for SocketProtectionLevel {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SocketProtectionLevel").field(&self.0).finish()
@@ -5163,6 +5113,7 @@ impl ::windows::core::DefaultType for SocketProtectionLevel {
 }
 #[doc = "*Required features: 'Networking_Sockets'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SocketQualityOfService(pub i32);
 impl SocketQualityOfService {
     pub const Normal: Self = Self(0i32);
@@ -5177,12 +5128,6 @@ impl ::core::clone::Clone for SocketQualityOfService {
 unsafe impl ::windows::core::Abi for SocketQualityOfService {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SocketQualityOfService {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SocketQualityOfService {}
 impl ::core::fmt::Debug for SocketQualityOfService {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SocketQualityOfService").field(&self.0).finish()
@@ -5196,6 +5141,7 @@ impl ::windows::core::DefaultType for SocketQualityOfService {
 }
 #[doc = "*Required features: 'Networking_Sockets'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SocketSslErrorSeverity(pub i32);
 impl SocketSslErrorSeverity {
     pub const None: Self = Self(0i32);
@@ -5211,12 +5157,6 @@ impl ::core::clone::Clone for SocketSslErrorSeverity {
 unsafe impl ::windows::core::Abi for SocketSslErrorSeverity {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SocketSslErrorSeverity {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SocketSslErrorSeverity {}
 impl ::core::fmt::Debug for SocketSslErrorSeverity {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SocketSslErrorSeverity").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Networking/Vpn/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/Vpn/mod.rs
@@ -2294,6 +2294,7 @@ unsafe impl ::core::marker::Send for VpnAppId {}
 unsafe impl ::core::marker::Sync for VpnAppId {}
 #[doc = "*Required features: 'Networking_Vpn'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VpnAppIdType(pub i32);
 impl VpnAppIdType {
     pub const PackageFamilyName: Self = Self(0i32);
@@ -2309,12 +2310,6 @@ impl ::core::clone::Clone for VpnAppIdType {
 unsafe impl ::windows::core::Abi for VpnAppIdType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VpnAppIdType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VpnAppIdType {}
 impl ::core::fmt::Debug for VpnAppIdType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VpnAppIdType").field(&self.0).finish()
@@ -2328,6 +2323,7 @@ impl ::windows::core::DefaultType for VpnAppIdType {
 }
 #[doc = "*Required features: 'Networking_Vpn'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VpnAuthenticationMethod(pub i32);
 impl VpnAuthenticationMethod {
     pub const Mschapv2: Self = Self(0i32);
@@ -2344,12 +2340,6 @@ impl ::core::clone::Clone for VpnAuthenticationMethod {
 unsafe impl ::windows::core::Abi for VpnAuthenticationMethod {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VpnAuthenticationMethod {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VpnAuthenticationMethod {}
 impl ::core::fmt::Debug for VpnAuthenticationMethod {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VpnAuthenticationMethod").field(&self.0).finish()
@@ -2823,6 +2813,7 @@ unsafe impl ::core::marker::Send for VpnChannelActivityEventArgs {}
 unsafe impl ::core::marker::Sync for VpnChannelActivityEventArgs {}
 #[doc = "*Required features: 'Networking_Vpn'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VpnChannelActivityEventType(pub i32);
 impl VpnChannelActivityEventType {
     pub const Idle: Self = Self(0i32);
@@ -2837,12 +2828,6 @@ impl ::core::clone::Clone for VpnChannelActivityEventType {
 unsafe impl ::windows::core::Abi for VpnChannelActivityEventType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VpnChannelActivityEventType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VpnChannelActivityEventType {}
 impl ::core::fmt::Debug for VpnChannelActivityEventType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VpnChannelActivityEventType").field(&self.0).finish()
@@ -3044,6 +3029,7 @@ unsafe impl ::core::marker::Send for VpnChannelConfiguration {}
 unsafe impl ::core::marker::Sync for VpnChannelConfiguration {}
 #[doc = "*Required features: 'Networking_Vpn'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VpnChannelRequestCredentialsOptions(pub u32);
 impl VpnChannelRequestCredentialsOptions {
     pub const None: Self = Self(0u32);
@@ -3059,12 +3045,6 @@ impl ::core::clone::Clone for VpnChannelRequestCredentialsOptions {
 unsafe impl ::windows::core::Abi for VpnChannelRequestCredentialsOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VpnChannelRequestCredentialsOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VpnChannelRequestCredentialsOptions {}
 impl ::core::fmt::Debug for VpnChannelRequestCredentialsOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VpnChannelRequestCredentialsOptions").field(&self.0).finish()
@@ -3236,6 +3216,7 @@ unsafe impl ::core::marker::Send for VpnCredential {}
 unsafe impl ::core::marker::Sync for VpnCredential {}
 #[doc = "*Required features: 'Networking_Vpn'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VpnCredentialType(pub i32);
 impl VpnCredentialType {
     pub const UsernamePassword: Self = Self(0i32);
@@ -3255,12 +3236,6 @@ impl ::core::clone::Clone for VpnCredentialType {
 unsafe impl ::windows::core::Abi for VpnCredentialType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VpnCredentialType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VpnCredentialType {}
 impl ::core::fmt::Debug for VpnCredentialType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VpnCredentialType").field(&self.0).finish()
@@ -4719,6 +4694,7 @@ unsafe impl ::core::marker::Send for VpnCustomTextBox {}
 unsafe impl ::core::marker::Sync for VpnCustomTextBox {}
 #[doc = "*Required features: 'Networking_Vpn'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VpnDataPathType(pub i32);
 impl VpnDataPathType {
     pub const Send: Self = Self(0i32);
@@ -4733,12 +4709,6 @@ impl ::core::clone::Clone for VpnDataPathType {
 unsafe impl ::windows::core::Abi for VpnDataPathType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VpnDataPathType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VpnDataPathType {}
 impl ::core::fmt::Debug for VpnDataPathType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VpnDataPathType").field(&self.0).finish()
@@ -4995,6 +4965,7 @@ unsafe impl ::core::marker::Send for VpnDomainNameInfo {}
 unsafe impl ::core::marker::Sync for VpnDomainNameInfo {}
 #[doc = "*Required features: 'Networking_Vpn'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VpnDomainNameType(pub i32);
 impl VpnDomainNameType {
     pub const Suffix: Self = Self(0i32);
@@ -5010,12 +4981,6 @@ impl ::core::clone::Clone for VpnDomainNameType {
 unsafe impl ::windows::core::Abi for VpnDomainNameType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VpnDomainNameType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VpnDomainNameType {}
 impl ::core::fmt::Debug for VpnDomainNameType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VpnDomainNameType").field(&self.0).finish()
@@ -5294,6 +5259,7 @@ unsafe impl ::core::marker::Send for VpnForegroundActivationOperation {}
 unsafe impl ::core::marker::Sync for VpnForegroundActivationOperation {}
 #[doc = "*Required features: 'Networking_Vpn'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VpnIPProtocol(pub i32);
 impl VpnIPProtocol {
     pub const None: Self = Self(0i32);
@@ -5313,12 +5279,6 @@ impl ::core::clone::Clone for VpnIPProtocol {
 unsafe impl ::windows::core::Abi for VpnIPProtocol {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VpnIPProtocol {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VpnIPProtocol {}
 impl ::core::fmt::Debug for VpnIPProtocol {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VpnIPProtocol").field(&self.0).finish()
@@ -5583,6 +5543,7 @@ unsafe impl ::core::marker::Send for VpnManagementAgent {}
 unsafe impl ::core::marker::Sync for VpnManagementAgent {}
 #[doc = "*Required features: 'Networking_Vpn'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VpnManagementConnectionStatus(pub i32);
 impl VpnManagementConnectionStatus {
     pub const Disconnected: Self = Self(0i32);
@@ -5599,12 +5560,6 @@ impl ::core::clone::Clone for VpnManagementConnectionStatus {
 unsafe impl ::windows::core::Abi for VpnManagementConnectionStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VpnManagementConnectionStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VpnManagementConnectionStatus {}
 impl ::core::fmt::Debug for VpnManagementConnectionStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VpnManagementConnectionStatus").field(&self.0).finish()
@@ -5618,6 +5573,7 @@ impl ::windows::core::DefaultType for VpnManagementConnectionStatus {
 }
 #[doc = "*Required features: 'Networking_Vpn'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VpnManagementErrorStatus(pub i32);
 impl VpnManagementErrorStatus {
     pub const Ok: Self = Self(0i32);
@@ -5649,12 +5605,6 @@ impl ::core::clone::Clone for VpnManagementErrorStatus {
 unsafe impl ::windows::core::Abi for VpnManagementErrorStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VpnManagementErrorStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VpnManagementErrorStatus {}
 impl ::core::fmt::Debug for VpnManagementErrorStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VpnManagementErrorStatus").field(&self.0).finish()
@@ -6179,6 +6129,7 @@ unsafe impl ::core::marker::Send for VpnNativeProfile {}
 unsafe impl ::core::marker::Sync for VpnNativeProfile {}
 #[doc = "*Required features: 'Networking_Vpn'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VpnNativeProtocolType(pub i32);
 impl VpnNativeProtocolType {
     pub const Pptp: Self = Self(0i32);
@@ -6194,12 +6145,6 @@ impl ::core::clone::Clone for VpnNativeProtocolType {
 unsafe impl ::windows::core::Abi for VpnNativeProtocolType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VpnNativeProtocolType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VpnNativeProtocolType {}
 impl ::core::fmt::Debug for VpnNativeProtocolType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VpnNativeProtocolType").field(&self.0).finish()
@@ -6530,6 +6475,7 @@ unsafe impl ::core::marker::Send for VpnPacketBufferList {}
 unsafe impl ::core::marker::Sync for VpnPacketBufferList {}
 #[doc = "*Required features: 'Networking_Vpn'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VpnPacketBufferStatus(pub i32);
 impl VpnPacketBufferStatus {
     pub const Ok: Self = Self(0i32);
@@ -6544,12 +6490,6 @@ impl ::core::clone::Clone for VpnPacketBufferStatus {
 unsafe impl ::windows::core::Abi for VpnPacketBufferStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VpnPacketBufferStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VpnPacketBufferStatus {}
 impl ::core::fmt::Debug for VpnPacketBufferStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VpnPacketBufferStatus").field(&self.0).finish()
@@ -7159,6 +7099,7 @@ unsafe impl ::core::marker::Send for VpnRouteAssignment {}
 unsafe impl ::core::marker::Sync for VpnRouteAssignment {}
 #[doc = "*Required features: 'Networking_Vpn'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VpnRoutingPolicyType(pub i32);
 impl VpnRoutingPolicyType {
     pub const SplitRouting: Self = Self(0i32);
@@ -7173,12 +7114,6 @@ impl ::core::clone::Clone for VpnRoutingPolicyType {
 unsafe impl ::windows::core::Abi for VpnRoutingPolicyType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VpnRoutingPolicyType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VpnRoutingPolicyType {}
 impl ::core::fmt::Debug for VpnRoutingPolicyType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VpnRoutingPolicyType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Networking/XboxLive/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/XboxLive/mod.rs
@@ -696,6 +696,7 @@ unsafe impl ::core::marker::Send for XboxLiveEndpointPair {}
 unsafe impl ::core::marker::Sync for XboxLiveEndpointPair {}
 #[doc = "*Required features: 'Networking_XboxLive'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct XboxLiveEndpointPairCreationBehaviors(pub u32);
 impl XboxLiveEndpointPairCreationBehaviors {
     pub const None: Self = Self(0u32);
@@ -710,12 +711,6 @@ impl ::core::clone::Clone for XboxLiveEndpointPairCreationBehaviors {
 unsafe impl ::windows::core::Abi for XboxLiveEndpointPairCreationBehaviors {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XboxLiveEndpointPairCreationBehaviors {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for XboxLiveEndpointPairCreationBehaviors {}
 impl ::core::fmt::Debug for XboxLiveEndpointPairCreationBehaviors {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("XboxLiveEndpointPairCreationBehaviors").field(&self.0).finish()
@@ -862,6 +857,7 @@ unsafe impl ::core::marker::Send for XboxLiveEndpointPairCreationResult {}
 unsafe impl ::core::marker::Sync for XboxLiveEndpointPairCreationResult {}
 #[doc = "*Required features: 'Networking_XboxLive'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct XboxLiveEndpointPairCreationStatus(pub i32);
 impl XboxLiveEndpointPairCreationStatus {
     pub const Succeeded: Self = Self(0i32);
@@ -883,12 +879,6 @@ impl ::core::clone::Clone for XboxLiveEndpointPairCreationStatus {
 unsafe impl ::windows::core::Abi for XboxLiveEndpointPairCreationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XboxLiveEndpointPairCreationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for XboxLiveEndpointPairCreationStatus {}
 impl ::core::fmt::Debug for XboxLiveEndpointPairCreationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("XboxLiveEndpointPairCreationStatus").field(&self.0).finish()
@@ -902,6 +892,7 @@ impl ::windows::core::DefaultType for XboxLiveEndpointPairCreationStatus {
 }
 #[doc = "*Required features: 'Networking_XboxLive'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct XboxLiveEndpointPairState(pub i32);
 impl XboxLiveEndpointPairState {
     pub const Invalid: Self = Self(0i32);
@@ -921,12 +912,6 @@ impl ::core::clone::Clone for XboxLiveEndpointPairState {
 unsafe impl ::windows::core::Abi for XboxLiveEndpointPairState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XboxLiveEndpointPairState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for XboxLiveEndpointPairState {}
 impl ::core::fmt::Debug for XboxLiveEndpointPairState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("XboxLiveEndpointPairState").field(&self.0).finish()
@@ -1311,6 +1296,7 @@ unsafe impl ::core::marker::Send for XboxLiveInboundEndpointPairCreatedEventArgs
 unsafe impl ::core::marker::Sync for XboxLiveInboundEndpointPairCreatedEventArgs {}
 #[doc = "*Required features: 'Networking_XboxLive'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct XboxLiveNetworkAccessKind(pub i32);
 impl XboxLiveNetworkAccessKind {
     pub const Open: Self = Self(0i32);
@@ -1326,12 +1312,6 @@ impl ::core::clone::Clone for XboxLiveNetworkAccessKind {
 unsafe impl ::windows::core::Abi for XboxLiveNetworkAccessKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XboxLiveNetworkAccessKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for XboxLiveNetworkAccessKind {}
 impl ::core::fmt::Debug for XboxLiveNetworkAccessKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("XboxLiveNetworkAccessKind").field(&self.0).finish()
@@ -1617,6 +1597,7 @@ unsafe impl ::core::marker::Send for XboxLiveQualityOfServiceMeasurement {}
 unsafe impl ::core::marker::Sync for XboxLiveQualityOfServiceMeasurement {}
 #[doc = "*Required features: 'Networking_XboxLive'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct XboxLiveQualityOfServiceMeasurementStatus(pub i32);
 impl XboxLiveQualityOfServiceMeasurementStatus {
     pub const NotStarted: Self = Self(0i32);
@@ -1641,12 +1622,6 @@ impl ::core::clone::Clone for XboxLiveQualityOfServiceMeasurementStatus {
 unsafe impl ::windows::core::Abi for XboxLiveQualityOfServiceMeasurementStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XboxLiveQualityOfServiceMeasurementStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for XboxLiveQualityOfServiceMeasurementStatus {}
 impl ::core::fmt::Debug for XboxLiveQualityOfServiceMeasurementStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("XboxLiveQualityOfServiceMeasurementStatus").field(&self.0).finish()
@@ -1660,6 +1635,7 @@ impl ::windows::core::DefaultType for XboxLiveQualityOfServiceMeasurementStatus 
 }
 #[doc = "*Required features: 'Networking_XboxLive'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct XboxLiveQualityOfServiceMetric(pub i32);
 impl XboxLiveQualityOfServiceMetric {
     pub const AverageLatencyInMilliseconds: Self = Self(0i32);
@@ -1681,12 +1657,6 @@ impl ::core::clone::Clone for XboxLiveQualityOfServiceMetric {
 unsafe impl ::windows::core::Abi for XboxLiveQualityOfServiceMetric {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XboxLiveQualityOfServiceMetric {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for XboxLiveQualityOfServiceMetric {}
 impl ::core::fmt::Debug for XboxLiveQualityOfServiceMetric {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("XboxLiveQualityOfServiceMetric").field(&self.0).finish()
@@ -1903,6 +1873,7 @@ unsafe impl ::core::marker::Send for XboxLiveQualityOfServicePrivatePayloadResul
 unsafe impl ::core::marker::Sync for XboxLiveQualityOfServicePrivatePayloadResult {}
 #[doc = "*Required features: 'Networking_XboxLive'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct XboxLiveSocketKind(pub i32);
 impl XboxLiveSocketKind {
     pub const None: Self = Self(0i32);
@@ -1918,12 +1889,6 @@ impl ::core::clone::Clone for XboxLiveSocketKind {
 unsafe impl ::windows::core::Abi for XboxLiveSocketKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XboxLiveSocketKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for XboxLiveSocketKind {}
 impl ::core::fmt::Debug for XboxLiveSocketKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("XboxLiveSocketKind").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Networking/mod.rs
+++ b/crates/libs/windows/src/Windows/Networking/mod.rs
@@ -19,6 +19,7 @@ pub mod Vpn;
 pub mod XboxLive;
 #[doc = "*Required features: 'Networking'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DomainNameType(pub i32);
 impl DomainNameType {
     pub const Suffix: Self = Self(0i32);
@@ -33,12 +34,6 @@ impl ::core::clone::Clone for DomainNameType {
 unsafe impl ::windows::core::Abi for DomainNameType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DomainNameType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DomainNameType {}
 impl ::core::fmt::Debug for DomainNameType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DomainNameType").field(&self.0).finish()
@@ -370,6 +365,7 @@ unsafe impl ::core::marker::Send for HostName {}
 unsafe impl ::core::marker::Sync for HostName {}
 #[doc = "*Required features: 'Networking'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HostNameSortOptions(pub u32);
 impl HostNameSortOptions {
     pub const None: Self = Self(0u32);
@@ -384,12 +380,6 @@ impl ::core::clone::Clone for HostNameSortOptions {
 unsafe impl ::windows::core::Abi for HostNameSortOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HostNameSortOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HostNameSortOptions {}
 impl ::core::fmt::Debug for HostNameSortOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HostNameSortOptions").field(&self.0).finish()
@@ -431,6 +421,7 @@ impl ::windows::core::DefaultType for HostNameSortOptions {
 }
 #[doc = "*Required features: 'Networking'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HostNameType(pub i32);
 impl HostNameType {
     pub const DomainName: Self = Self(0i32);
@@ -447,12 +438,6 @@ impl ::core::clone::Clone for HostNameType {
 unsafe impl ::windows::core::Abi for HostNameType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HostNameType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HostNameType {}
 impl ::core::fmt::Debug for HostNameType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HostNameType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Perception/People/mod.rs
+++ b/crates/libs/windows/src/Windows/Perception/People/mod.rs
@@ -119,6 +119,7 @@ unsafe impl ::core::marker::Send for EyesPose {}
 unsafe impl ::core::marker::Sync for EyesPose {}
 #[doc = "*Required features: 'Perception_People'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HandJointKind(pub i32);
 impl HandJointKind {
     pub const Palm: Self = Self(0i32);
@@ -157,12 +158,6 @@ impl ::core::clone::Clone for HandJointKind {
 unsafe impl ::windows::core::Abi for HandJointKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HandJointKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HandJointKind {}
 impl ::core::fmt::Debug for HandJointKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HandJointKind").field(&self.0).finish()
@@ -846,6 +841,7 @@ impl ::core::default::Default for JointPose {
 }
 #[doc = "*Required features: 'Perception_People'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct JointPoseAccuracy(pub i32);
 impl JointPoseAccuracy {
     pub const High: Self = Self(0i32);
@@ -860,12 +856,6 @@ impl ::core::clone::Clone for JointPoseAccuracy {
 unsafe impl ::windows::core::Abi for JointPoseAccuracy {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JointPoseAccuracy {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for JointPoseAccuracy {}
 impl ::core::fmt::Debug for JointPoseAccuracy {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("JointPoseAccuracy").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Perception/Spatial/mod.rs
+++ b/crates/libs/windows/src/Windows/Perception/Spatial/mod.rs
@@ -811,6 +811,7 @@ unsafe impl ::core::marker::Send for SpatialAnchor {}
 unsafe impl ::core::marker::Sync for SpatialAnchor {}
 #[doc = "*Required features: 'Perception_Spatial'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SpatialAnchorExportPurpose(pub i32);
 impl SpatialAnchorExportPurpose {
     pub const Relocalization: Self = Self(0i32);
@@ -825,12 +826,6 @@ impl ::core::clone::Clone for SpatialAnchorExportPurpose {
 unsafe impl ::windows::core::Abi for SpatialAnchorExportPurpose {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpatialAnchorExportPurpose {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SpatialAnchorExportPurpose {}
 impl ::core::fmt::Debug for SpatialAnchorExportPurpose {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SpatialAnchorExportPurpose").field(&self.0).finish()
@@ -2310,6 +2305,7 @@ unsafe impl ::core::marker::Send for SpatialEntityWatcher {}
 unsafe impl ::core::marker::Sync for SpatialEntityWatcher {}
 #[doc = "*Required features: 'Perception_Spatial'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SpatialEntityWatcherStatus(pub i32);
 impl SpatialEntityWatcherStatus {
     pub const Created: Self = Self(0i32);
@@ -2328,12 +2324,6 @@ impl ::core::clone::Clone for SpatialEntityWatcherStatus {
 unsafe impl ::windows::core::Abi for SpatialEntityWatcherStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpatialEntityWatcherStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SpatialEntityWatcherStatus {}
 impl ::core::fmt::Debug for SpatialEntityWatcherStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SpatialEntityWatcherStatus").field(&self.0).finish()
@@ -2347,6 +2337,7 @@ impl ::windows::core::DefaultType for SpatialEntityWatcherStatus {
 }
 #[doc = "*Required features: 'Perception_Spatial'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SpatialLocatability(pub i32);
 impl SpatialLocatability {
     pub const Unavailable: Self = Self(0i32);
@@ -2364,12 +2355,6 @@ impl ::core::clone::Clone for SpatialLocatability {
 unsafe impl ::windows::core::Abi for SpatialLocatability {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpatialLocatability {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SpatialLocatability {}
 impl ::core::fmt::Debug for SpatialLocatability {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SpatialLocatability").field(&self.0).finish()
@@ -2940,6 +2925,7 @@ unsafe impl ::core::marker::Send for SpatialLocatorPositionalTrackingDeactivatin
 unsafe impl ::core::marker::Sync for SpatialLocatorPositionalTrackingDeactivatingEventArgs {}
 #[doc = "*Required features: 'Perception_Spatial'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SpatialLookDirectionRange(pub i32);
 impl SpatialLookDirectionRange {
     pub const ForwardOnly: Self = Self(0i32);
@@ -2954,12 +2940,6 @@ impl ::core::clone::Clone for SpatialLookDirectionRange {
 unsafe impl ::windows::core::Abi for SpatialLookDirectionRange {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpatialLookDirectionRange {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SpatialLookDirectionRange {}
 impl ::core::fmt::Debug for SpatialLookDirectionRange {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SpatialLookDirectionRange").field(&self.0).finish()
@@ -2973,6 +2953,7 @@ impl ::windows::core::DefaultType for SpatialLookDirectionRange {
 }
 #[doc = "*Required features: 'Perception_Spatial'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SpatialMovementRange(pub i32);
 impl SpatialMovementRange {
     pub const NoMovement: Self = Self(0i32);
@@ -2987,12 +2968,6 @@ impl ::core::clone::Clone for SpatialMovementRange {
 unsafe impl ::windows::core::Abi for SpatialMovementRange {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpatialMovementRange {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SpatialMovementRange {}
 impl ::core::fmt::Debug for SpatialMovementRange {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SpatialMovementRange").field(&self.0).finish()
@@ -3006,6 +2981,7 @@ impl ::windows::core::DefaultType for SpatialMovementRange {
 }
 #[doc = "*Required features: 'Perception_Spatial'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SpatialPerceptionAccessStatus(pub i32);
 impl SpatialPerceptionAccessStatus {
     pub const Unspecified: Self = Self(0i32);
@@ -3022,12 +2998,6 @@ impl ::core::clone::Clone for SpatialPerceptionAccessStatus {
 unsafe impl ::windows::core::Abi for SpatialPerceptionAccessStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpatialPerceptionAccessStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SpatialPerceptionAccessStatus {}
 impl ::core::fmt::Debug for SpatialPerceptionAccessStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SpatialPerceptionAccessStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Phone/ApplicationModel/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/ApplicationModel/mod.rs
@@ -20,6 +20,7 @@ impl ::windows::core::RuntimeName for ApplicationProfile {
 }
 #[doc = "*Required features: 'Phone_ApplicationModel'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ApplicationProfileModes(pub u32);
 impl ApplicationProfileModes {
     pub const Default: Self = Self(0u32);
@@ -34,12 +35,6 @@ impl ::core::clone::Clone for ApplicationProfileModes {
 unsafe impl ::windows::core::Abi for ApplicationProfileModes {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ApplicationProfileModes {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ApplicationProfileModes {}
 impl ::core::fmt::Debug for ApplicationProfileModes {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ApplicationProfileModes").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Phone/Management/Deployment/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/Management/Deployment/mod.rs
@@ -262,6 +262,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Ente
 }
 #[doc = "*Required features: 'Phone_Management_Deployment'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EnterpriseEnrollmentStatus(pub i32);
 impl EnterpriseEnrollmentStatus {
     pub const Success: Self = Self(0i32);
@@ -277,12 +278,6 @@ impl ::core::clone::Clone for EnterpriseEnrollmentStatus {
 unsafe impl ::windows::core::Abi for EnterpriseEnrollmentStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EnterpriseEnrollmentStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EnterpriseEnrollmentStatus {}
 impl ::core::fmt::Debug for EnterpriseEnrollmentStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EnterpriseEnrollmentStatus").field(&self.0).finish()
@@ -296,6 +291,7 @@ impl ::windows::core::DefaultType for EnterpriseEnrollmentStatus {
 }
 #[doc = "*Required features: 'Phone_Management_Deployment'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EnterpriseStatus(pub i32);
 impl EnterpriseStatus {
     pub const Enrolled: Self = Self(0i32);
@@ -312,12 +308,6 @@ impl ::core::clone::Clone for EnterpriseStatus {
 unsafe impl ::windows::core::Abi for EnterpriseStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EnterpriseStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EnterpriseStatus {}
 impl ::core::fmt::Debug for EnterpriseStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EnterpriseStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Phone/Media/Devices/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/Media/Devices/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'Phone_Media_Devices'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AudioRoutingEndpoint(pub i32);
 impl AudioRoutingEndpoint {
     pub const Default: Self = Self(0i32);
@@ -21,12 +22,6 @@ impl ::core::clone::Clone for AudioRoutingEndpoint {
 unsafe impl ::windows::core::Abi for AudioRoutingEndpoint {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AudioRoutingEndpoint {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AudioRoutingEndpoint {}
 impl ::core::fmt::Debug for AudioRoutingEndpoint {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AudioRoutingEndpoint").field(&self.0).finish()
@@ -161,6 +156,7 @@ unsafe impl ::core::marker::Send for AudioRoutingManager {}
 unsafe impl ::core::marker::Sync for AudioRoutingManager {}
 #[doc = "*Required features: 'Phone_Media_Devices'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AvailableAudioRoutingEndpoints(pub u32);
 impl AvailableAudioRoutingEndpoints {
     pub const None: Self = Self(0u32);
@@ -177,12 +173,6 @@ impl ::core::clone::Clone for AvailableAudioRoutingEndpoints {
 unsafe impl ::windows::core::Abi for AvailableAudioRoutingEndpoints {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AvailableAudioRoutingEndpoints {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AvailableAudioRoutingEndpoints {}
 impl ::core::fmt::Debug for AvailableAudioRoutingEndpoints {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AvailableAudioRoutingEndpoints").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Phone/Notification/Management/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/Notification/Management/mod.rs
@@ -350,6 +350,7 @@ impl ::windows::core::RuntimeName for AccessoryManager {
 }
 #[doc = "*Required features: 'Phone_Notification_Management'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AccessoryNotificationType(pub u32);
 impl AccessoryNotificationType {
     pub const None: Self = Self(0u32);
@@ -378,12 +379,6 @@ impl ::core::clone::Clone for AccessoryNotificationType {
 unsafe impl ::windows::core::Abi for AccessoryNotificationType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AccessoryNotificationType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AccessoryNotificationType {}
 impl ::core::fmt::Debug for AccessoryNotificationType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AccessoryNotificationType").field(&self.0).finish()
@@ -779,6 +774,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Bina
 }
 #[doc = "*Required features: 'Phone_Notification_Management'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CalendarChangedEvent(pub i32);
 impl CalendarChangedEvent {
     pub const LostEvents: Self = Self(0i32);
@@ -798,12 +794,6 @@ impl ::core::clone::Clone for CalendarChangedEvent {
 unsafe impl ::windows::core::Abi for CalendarChangedEvent {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CalendarChangedEvent {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CalendarChangedEvent {}
 impl ::core::fmt::Debug for CalendarChangedEvent {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CalendarChangedEvent").field(&self.0).finish()
@@ -2780,6 +2770,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Medi
 }
 #[doc = "*Required features: 'Phone_Notification_Management'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneCallAudioEndpoint(pub i32);
 impl PhoneCallAudioEndpoint {
     pub const Default: Self = Self(0i32);
@@ -2795,12 +2786,6 @@ impl ::core::clone::Clone for PhoneCallAudioEndpoint {
 unsafe impl ::windows::core::Abi for PhoneCallAudioEndpoint {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneCallAudioEndpoint {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneCallAudioEndpoint {}
 impl ::core::fmt::Debug for PhoneCallAudioEndpoint {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneCallAudioEndpoint").field(&self.0).finish()
@@ -2984,6 +2969,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Phon
 }
 #[doc = "*Required features: 'Phone_Notification_Management'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneCallDirection(pub i32);
 impl PhoneCallDirection {
     pub const Incoming: Self = Self(0i32);
@@ -2998,12 +2984,6 @@ impl ::core::clone::Clone for PhoneCallDirection {
 unsafe impl ::windows::core::Abi for PhoneCallDirection {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneCallDirection {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneCallDirection {}
 impl ::core::fmt::Debug for PhoneCallDirection {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneCallDirection").field(&self.0).finish()
@@ -3017,6 +2997,7 @@ impl ::windows::core::DefaultType for PhoneCallDirection {
 }
 #[doc = "*Required features: 'Phone_Notification_Management'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneCallState(pub i32);
 impl PhoneCallState {
     pub const Unknown: Self = Self(0i32);
@@ -3034,12 +3015,6 @@ impl ::core::clone::Clone for PhoneCallState {
 unsafe impl ::windows::core::Abi for PhoneCallState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneCallState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneCallState {}
 impl ::core::fmt::Debug for PhoneCallState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneCallState").field(&self.0).finish()
@@ -3053,6 +3028,7 @@ impl ::windows::core::DefaultType for PhoneCallState {
 }
 #[doc = "*Required features: 'Phone_Notification_Management'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneCallTransport(pub i32);
 impl PhoneCallTransport {
     pub const Cellular: Self = Self(0i32);
@@ -3067,12 +3043,6 @@ impl ::core::clone::Clone for PhoneCallTransport {
 unsafe impl ::windows::core::Abi for PhoneCallTransport {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneCallTransport {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneCallTransport {}
 impl ::core::fmt::Debug for PhoneCallTransport {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneCallTransport").field(&self.0).finish()
@@ -3213,6 +3183,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Phon
 }
 #[doc = "*Required features: 'Phone_Notification_Management'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneLineRegistrationState(pub i32);
 impl PhoneLineRegistrationState {
     pub const Disconnected: Self = Self(0i32);
@@ -3228,12 +3199,6 @@ impl ::core::clone::Clone for PhoneLineRegistrationState {
 unsafe impl ::windows::core::Abi for PhoneLineRegistrationState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneLineRegistrationState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneLineRegistrationState {}
 impl ::core::fmt::Debug for PhoneLineRegistrationState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneLineRegistrationState").field(&self.0).finish()
@@ -3247,6 +3212,7 @@ impl ::windows::core::DefaultType for PhoneLineRegistrationState {
 }
 #[doc = "*Required features: 'Phone_Notification_Management'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneMediaType(pub i32);
 impl PhoneMediaType {
     pub const AudioOnly: Self = Self(0i32);
@@ -3261,12 +3227,6 @@ impl ::core::clone::Clone for PhoneMediaType {
 unsafe impl ::windows::core::Abi for PhoneMediaType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneMediaType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneMediaType {}
 impl ::core::fmt::Debug for PhoneMediaType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneMediaType").field(&self.0).finish()
@@ -3443,6 +3403,7 @@ impl<'a> ::windows::core::IntoParam<'a, IAccessoryNotificationTriggerDetails> fo
 }
 #[doc = "*Required features: 'Phone_Notification_Management'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhoneNotificationType(pub i32);
 impl PhoneNotificationType {
     pub const NewCall: Self = Self(0i32);
@@ -3460,12 +3421,6 @@ impl ::core::clone::Clone for PhoneNotificationType {
 unsafe impl ::windows::core::Abi for PhoneNotificationType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhoneNotificationType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhoneNotificationType {}
 impl ::core::fmt::Debug for PhoneNotificationType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhoneNotificationType").field(&self.0).finish()
@@ -3479,6 +3434,7 @@ impl ::windows::core::DefaultType for PhoneNotificationType {
 }
 #[doc = "*Required features: 'Phone_Notification_Management'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PlaybackCapability(pub u32);
 impl PlaybackCapability {
     pub const None: Self = Self(0u32);
@@ -3502,12 +3458,6 @@ impl ::core::clone::Clone for PlaybackCapability {
 unsafe impl ::windows::core::Abi for PlaybackCapability {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PlaybackCapability {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PlaybackCapability {}
 impl ::core::fmt::Debug for PlaybackCapability {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PlaybackCapability").field(&self.0).finish()
@@ -3549,6 +3499,7 @@ impl ::windows::core::DefaultType for PlaybackCapability {
 }
 #[doc = "*Required features: 'Phone_Notification_Management'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PlaybackCommand(pub i32);
 impl PlaybackCommand {
     pub const Play: Self = Self(0i32);
@@ -3571,12 +3522,6 @@ impl ::core::clone::Clone for PlaybackCommand {
 unsafe impl ::windows::core::Abi for PlaybackCommand {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PlaybackCommand {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PlaybackCommand {}
 impl ::core::fmt::Debug for PlaybackCommand {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PlaybackCommand").field(&self.0).finish()
@@ -3590,6 +3535,7 @@ impl ::windows::core::DefaultType for PlaybackCommand {
 }
 #[doc = "*Required features: 'Phone_Notification_Management'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PlaybackStatus(pub i32);
 impl PlaybackStatus {
     pub const None: Self = Self(0i32);
@@ -3607,12 +3553,6 @@ impl ::core::clone::Clone for PlaybackStatus {
 unsafe impl ::windows::core::Abi for PlaybackStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PlaybackStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PlaybackStatus {}
 impl ::core::fmt::Debug for PlaybackStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PlaybackStatus").field(&self.0).finish()
@@ -3831,6 +3771,7 @@ impl<'a> ::windows::core::IntoParam<'a, IAccessoryNotificationTriggerDetails> fo
 }
 #[doc = "*Required features: 'Phone_Notification_Management'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ReminderState(pub i32);
 impl ReminderState {
     pub const Active: Self = Self(0i32);
@@ -3846,12 +3787,6 @@ impl ::core::clone::Clone for ReminderState {
 unsafe impl ::windows::core::Abi for ReminderState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ReminderState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ReminderState {}
 impl ::core::fmt::Debug for ReminderState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ReminderState").field(&self.0).finish()
@@ -4234,6 +4169,7 @@ impl<'a> ::windows::core::IntoParam<'a, IAccessoryNotificationTriggerDetails> fo
 }
 #[doc = "*Required features: 'Phone_Notification_Management'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VibrateState(pub i32);
 impl VibrateState {
     pub const RingerOffVibrateOff: Self = Self(0i32);
@@ -4250,12 +4186,6 @@ impl ::core::clone::Clone for VibrateState {
 unsafe impl ::windows::core::Abi for VibrateState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VibrateState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VibrateState {}
 impl ::core::fmt::Debug for VibrateState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VibrateState").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Phone/PersonalInformation/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/PersonalInformation/mod.rs
@@ -253,6 +253,7 @@ unsafe impl ::core::marker::Send for ContactChangeRecord {}
 unsafe impl ::core::marker::Sync for ContactChangeRecord {}
 #[doc = "*Required features: 'Phone_PersonalInformation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ContactChangeType(pub i32);
 impl ContactChangeType {
     pub const Created: Self = Self(0i32);
@@ -268,12 +269,6 @@ impl ::core::clone::Clone for ContactChangeType {
 unsafe impl ::windows::core::Abi for ContactChangeType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ContactChangeType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ContactChangeType {}
 impl ::core::fmt::Debug for ContactChangeType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ContactChangeType").field(&self.0).finish()
@@ -731,6 +726,7 @@ unsafe impl ::core::marker::Send for ContactQueryResult {}
 unsafe impl ::core::marker::Sync for ContactQueryResult {}
 #[doc = "*Required features: 'Phone_PersonalInformation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ContactQueryResultOrdering(pub i32);
 impl ContactQueryResultOrdering {
     pub const SystemDefault: Self = Self(0i32);
@@ -746,12 +742,6 @@ impl ::core::clone::Clone for ContactQueryResultOrdering {
 unsafe impl ::windows::core::Abi for ContactQueryResultOrdering {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ContactQueryResultOrdering {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ContactQueryResultOrdering {}
 impl ::core::fmt::Debug for ContactQueryResultOrdering {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ContactQueryResultOrdering").field(&self.0).finish()
@@ -955,6 +945,7 @@ unsafe impl ::core::marker::Send for ContactStore {}
 unsafe impl ::core::marker::Sync for ContactStore {}
 #[doc = "*Required features: 'Phone_PersonalInformation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ContactStoreApplicationAccessMode(pub i32);
 impl ContactStoreApplicationAccessMode {
     pub const LimitedReadOnly: Self = Self(0i32);
@@ -969,12 +960,6 @@ impl ::core::clone::Clone for ContactStoreApplicationAccessMode {
 unsafe impl ::windows::core::Abi for ContactStoreApplicationAccessMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ContactStoreApplicationAccessMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ContactStoreApplicationAccessMode {}
 impl ::core::fmt::Debug for ContactStoreApplicationAccessMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ContactStoreApplicationAccessMode").field(&self.0).finish()
@@ -988,6 +973,7 @@ impl ::windows::core::DefaultType for ContactStoreApplicationAccessMode {
 }
 #[doc = "*Required features: 'Phone_PersonalInformation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ContactStoreSystemAccessMode(pub i32);
 impl ContactStoreSystemAccessMode {
     pub const ReadOnly: Self = Self(0i32);
@@ -1002,12 +988,6 @@ impl ::core::clone::Clone for ContactStoreSystemAccessMode {
 unsafe impl ::windows::core::Abi for ContactStoreSystemAccessMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ContactStoreSystemAccessMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ContactStoreSystemAccessMode {}
 impl ::core::fmt::Debug for ContactStoreSystemAccessMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ContactStoreSystemAccessMode").field(&self.0).finish()
@@ -2204,6 +2184,7 @@ unsafe impl ::core::marker::Send for StoredContact {}
 unsafe impl ::core::marker::Sync for StoredContact {}
 #[doc = "*Required features: 'Phone_PersonalInformation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VCardFormat(pub i32);
 impl VCardFormat {
     pub const Version2_1: Self = Self(0i32);
@@ -2218,12 +2199,6 @@ impl ::core::clone::Clone for VCardFormat {
 unsafe impl ::windows::core::Abi for VCardFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VCardFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VCardFormat {}
 impl ::core::fmt::Debug for VCardFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VCardFormat").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Phone/Speech/Recognition/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/Speech/Recognition/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'Phone_Speech_Recognition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SpeechRecognitionUIStatus(pub i32);
 impl SpeechRecognitionUIStatus {
     pub const Succeeded: Self = Self(0i32);
@@ -18,12 +19,6 @@ impl ::core::clone::Clone for SpeechRecognitionUIStatus {
 unsafe impl ::windows::core::Abi for SpeechRecognitionUIStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpeechRecognitionUIStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SpeechRecognitionUIStatus {}
 impl ::core::fmt::Debug for SpeechRecognitionUIStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SpeechRecognitionUIStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Phone/System/Power/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/System/Power/mod.rs
@@ -85,6 +85,7 @@ impl ::windows::core::RuntimeName for PowerManager {
 }
 #[doc = "*Required features: 'Phone_System_Power'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PowerSavingMode(pub i32);
 impl PowerSavingMode {
     pub const Off: Self = Self(0i32);
@@ -99,12 +100,6 @@ impl ::core::clone::Clone for PowerSavingMode {
 unsafe impl ::windows::core::Abi for PowerSavingMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PowerSavingMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PowerSavingMode {}
 impl ::core::fmt::Debug for PowerSavingMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PowerSavingMode").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Phone/System/UserProfile/GameServices/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Phone/System/UserProfile/GameServices/Core/mod.rs
@@ -83,6 +83,7 @@ impl ::windows::core::RuntimeName for GameService {
 }
 #[doc = "*Required features: 'Phone_System_UserProfile_GameServices_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GameServiceGameOutcome(pub i32);
 impl GameServiceGameOutcome {
     pub const None: Self = Self(0i32);
@@ -99,12 +100,6 @@ impl ::core::clone::Clone for GameServiceGameOutcome {
 unsafe impl ::windows::core::Abi for GameServiceGameOutcome {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GameServiceGameOutcome {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GameServiceGameOutcome {}
 impl ::core::fmt::Debug for GameServiceGameOutcome {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GameServiceGameOutcome").field(&self.0).finish()
@@ -200,6 +195,7 @@ unsafe impl ::core::marker::Send for GameServicePropertyCollection {}
 unsafe impl ::core::marker::Sync for GameServicePropertyCollection {}
 #[doc = "*Required features: 'Phone_System_UserProfile_GameServices_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GameServiceScoreKind(pub i32);
 impl GameServiceScoreKind {
     pub const Number: Self = Self(0i32);
@@ -214,12 +210,6 @@ impl ::core::clone::Clone for GameServiceScoreKind {
 unsafe impl ::windows::core::Abi for GameServiceScoreKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GameServiceScoreKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GameServiceScoreKind {}
 impl ::core::fmt::Debug for GameServiceScoreKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GameServiceScoreKind").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Security/Authentication/Identity/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/Identity/Core/mod.rs
@@ -322,6 +322,7 @@ unsafe impl ::core::marker::Send for MicrosoftAccountMultiFactorAuthenticationMa
 unsafe impl ::core::marker::Sync for MicrosoftAccountMultiFactorAuthenticationManager {}
 #[doc = "*Required features: 'Security_Authentication_Identity_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MicrosoftAccountMultiFactorAuthenticationType(pub i32);
 impl MicrosoftAccountMultiFactorAuthenticationType {
     pub const User: Self = Self(0i32);
@@ -336,12 +337,6 @@ impl ::core::clone::Clone for MicrosoftAccountMultiFactorAuthenticationType {
 unsafe impl ::windows::core::Abi for MicrosoftAccountMultiFactorAuthenticationType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MicrosoftAccountMultiFactorAuthenticationType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MicrosoftAccountMultiFactorAuthenticationType {}
 impl ::core::fmt::Debug for MicrosoftAccountMultiFactorAuthenticationType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MicrosoftAccountMultiFactorAuthenticationType").field(&self.0).finish()
@@ -552,6 +547,7 @@ unsafe impl ::core::marker::Send for MicrosoftAccountMultiFactorOneTimeCodedInfo
 unsafe impl ::core::marker::Sync for MicrosoftAccountMultiFactorOneTimeCodedInfo {}
 #[doc = "*Required features: 'Security_Authentication_Identity_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MicrosoftAccountMultiFactorServiceResponse(pub i32);
 impl MicrosoftAccountMultiFactorServiceResponse {
     pub const Success: Self = Self(0i32);
@@ -586,12 +582,6 @@ impl ::core::clone::Clone for MicrosoftAccountMultiFactorServiceResponse {
 unsafe impl ::windows::core::Abi for MicrosoftAccountMultiFactorServiceResponse {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MicrosoftAccountMultiFactorServiceResponse {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MicrosoftAccountMultiFactorServiceResponse {}
 impl ::core::fmt::Debug for MicrosoftAccountMultiFactorServiceResponse {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MicrosoftAccountMultiFactorServiceResponse").field(&self.0).finish()
@@ -605,6 +595,7 @@ impl ::windows::core::DefaultType for MicrosoftAccountMultiFactorServiceResponse
 }
 #[doc = "*Required features: 'Security_Authentication_Identity_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MicrosoftAccountMultiFactorSessionApprovalStatus(pub i32);
 impl MicrosoftAccountMultiFactorSessionApprovalStatus {
     pub const Pending: Self = Self(0i32);
@@ -620,12 +611,6 @@ impl ::core::clone::Clone for MicrosoftAccountMultiFactorSessionApprovalStatus {
 unsafe impl ::windows::core::Abi for MicrosoftAccountMultiFactorSessionApprovalStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MicrosoftAccountMultiFactorSessionApprovalStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MicrosoftAccountMultiFactorSessionApprovalStatus {}
 impl ::core::fmt::Debug for MicrosoftAccountMultiFactorSessionApprovalStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MicrosoftAccountMultiFactorSessionApprovalStatus").field(&self.0).finish()
@@ -639,6 +624,7 @@ impl ::windows::core::DefaultType for MicrosoftAccountMultiFactorSessionApproval
 }
 #[doc = "*Required features: 'Security_Authentication_Identity_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MicrosoftAccountMultiFactorSessionAuthenticationStatus(pub i32);
 impl MicrosoftAccountMultiFactorSessionAuthenticationStatus {
     pub const Authenticated: Self = Self(0i32);
@@ -653,12 +639,6 @@ impl ::core::clone::Clone for MicrosoftAccountMultiFactorSessionAuthenticationSt
 unsafe impl ::windows::core::Abi for MicrosoftAccountMultiFactorSessionAuthenticationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MicrosoftAccountMultiFactorSessionAuthenticationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MicrosoftAccountMultiFactorSessionAuthenticationStatus {}
 impl ::core::fmt::Debug for MicrosoftAccountMultiFactorSessionAuthenticationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MicrosoftAccountMultiFactorSessionAuthenticationStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Security/Authentication/Identity/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/Identity/Provider/mod.rs
@@ -483,6 +483,7 @@ unsafe impl ::core::marker::Sync for SecondaryAuthenticationFactorAuthentication
 #[doc = "*Required features: 'Security_Authentication_Identity_Provider', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SecondaryAuthenticationFactorAuthenticationMessage(pub i32);
 #[cfg(feature = "deprecated")]
 impl SecondaryAuthenticationFactorAuthenticationMessage {
@@ -528,14 +529,6 @@ impl ::core::clone::Clone for SecondaryAuthenticationFactorAuthenticationMessage
 unsafe impl ::windows::core::Abi for SecondaryAuthenticationFactorAuthenticationMessage {
     type Abi = Self;
 }
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for SecondaryAuthenticationFactorAuthenticationMessage {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for SecondaryAuthenticationFactorAuthenticationMessage {}
 #[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for SecondaryAuthenticationFactorAuthenticationMessage {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -663,6 +656,7 @@ unsafe impl ::core::marker::Sync for SecondaryAuthenticationFactorAuthentication
 #[doc = "*Required features: 'Security_Authentication_Identity_Provider', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SecondaryAuthenticationFactorAuthenticationScenario(pub i32);
 #[cfg(feature = "deprecated")]
 impl SecondaryAuthenticationFactorAuthenticationScenario {
@@ -682,14 +676,6 @@ unsafe impl ::windows::core::Abi for SecondaryAuthenticationFactorAuthentication
     type Abi = Self;
 }
 #[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for SecondaryAuthenticationFactorAuthenticationScenario {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for SecondaryAuthenticationFactorAuthenticationScenario {}
-#[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for SecondaryAuthenticationFactorAuthenticationScenario {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SecondaryAuthenticationFactorAuthenticationScenario").field(&self.0).finish()
@@ -706,6 +692,7 @@ impl ::windows::core::DefaultType for SecondaryAuthenticationFactorAuthenticatio
 #[doc = "*Required features: 'Security_Authentication_Identity_Provider', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SecondaryAuthenticationFactorAuthenticationStage(pub i32);
 #[cfg(feature = "deprecated")]
 impl SecondaryAuthenticationFactorAuthenticationStage {
@@ -731,14 +718,6 @@ impl ::core::clone::Clone for SecondaryAuthenticationFactorAuthenticationStage {
 unsafe impl ::windows::core::Abi for SecondaryAuthenticationFactorAuthenticationStage {
     type Abi = Self;
 }
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for SecondaryAuthenticationFactorAuthenticationStage {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for SecondaryAuthenticationFactorAuthenticationStage {}
 #[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for SecondaryAuthenticationFactorAuthenticationStage {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -976,6 +955,7 @@ unsafe impl ::core::marker::Sync for SecondaryAuthenticationFactorAuthentication
 #[doc = "*Required features: 'Security_Authentication_Identity_Provider', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SecondaryAuthenticationFactorAuthenticationStatus(pub i32);
 #[cfg(feature = "deprecated")]
 impl SecondaryAuthenticationFactorAuthenticationStatus {
@@ -998,14 +978,6 @@ unsafe impl ::windows::core::Abi for SecondaryAuthenticationFactorAuthentication
     type Abi = Self;
 }
 #[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for SecondaryAuthenticationFactorAuthenticationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for SecondaryAuthenticationFactorAuthenticationStatus {}
-#[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for SecondaryAuthenticationFactorAuthenticationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SecondaryAuthenticationFactorAuthenticationStatus").field(&self.0).finish()
@@ -1022,6 +994,7 @@ impl ::windows::core::DefaultType for SecondaryAuthenticationFactorAuthenticatio
 #[doc = "*Required features: 'Security_Authentication_Identity_Provider', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SecondaryAuthenticationFactorDeviceCapabilities(pub u32);
 #[cfg(feature = "deprecated")]
 impl SecondaryAuthenticationFactorDeviceCapabilities {
@@ -1046,14 +1019,6 @@ impl ::core::clone::Clone for SecondaryAuthenticationFactorDeviceCapabilities {
 unsafe impl ::windows::core::Abi for SecondaryAuthenticationFactorDeviceCapabilities {
     type Abi = Self;
 }
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for SecondaryAuthenticationFactorDeviceCapabilities {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for SecondaryAuthenticationFactorDeviceCapabilities {}
 #[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for SecondaryAuthenticationFactorDeviceCapabilities {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -1099,6 +1064,7 @@ impl ::windows::core::DefaultType for SecondaryAuthenticationFactorDeviceCapabil
 #[doc = "*Required features: 'Security_Authentication_Identity_Provider', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SecondaryAuthenticationFactorDeviceFindScope(pub i32);
 #[cfg(feature = "deprecated")]
 impl SecondaryAuthenticationFactorDeviceFindScope {
@@ -1118,14 +1084,6 @@ unsafe impl ::windows::core::Abi for SecondaryAuthenticationFactorDeviceFindScop
     type Abi = Self;
 }
 #[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for SecondaryAuthenticationFactorDeviceFindScope {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for SecondaryAuthenticationFactorDeviceFindScope {}
-#[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for SecondaryAuthenticationFactorDeviceFindScope {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SecondaryAuthenticationFactorDeviceFindScope").field(&self.0).finish()
@@ -1142,6 +1100,7 @@ impl ::windows::core::DefaultType for SecondaryAuthenticationFactorDeviceFindSco
 #[doc = "*Required features: 'Security_Authentication_Identity_Provider', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SecondaryAuthenticationFactorDevicePresence(pub i32);
 #[cfg(feature = "deprecated")]
 impl SecondaryAuthenticationFactorDevicePresence {
@@ -1161,14 +1120,6 @@ unsafe impl ::windows::core::Abi for SecondaryAuthenticationFactorDevicePresence
     type Abi = Self;
 }
 #[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for SecondaryAuthenticationFactorDevicePresence {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for SecondaryAuthenticationFactorDevicePresence {}
-#[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for SecondaryAuthenticationFactorDevicePresence {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SecondaryAuthenticationFactorDevicePresence").field(&self.0).finish()
@@ -1185,6 +1136,7 @@ impl ::windows::core::DefaultType for SecondaryAuthenticationFactorDevicePresenc
 #[doc = "*Required features: 'Security_Authentication_Identity_Provider', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SecondaryAuthenticationFactorDevicePresenceMonitoringMode(pub i32);
 #[cfg(feature = "deprecated")]
 impl SecondaryAuthenticationFactorDevicePresenceMonitoringMode {
@@ -1205,14 +1157,6 @@ unsafe impl ::windows::core::Abi for SecondaryAuthenticationFactorDevicePresence
     type Abi = Self;
 }
 #[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for SecondaryAuthenticationFactorDevicePresenceMonitoringMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for SecondaryAuthenticationFactorDevicePresenceMonitoringMode {}
-#[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for SecondaryAuthenticationFactorDevicePresenceMonitoringMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SecondaryAuthenticationFactorDevicePresenceMonitoringMode").field(&self.0).finish()
@@ -1229,6 +1173,7 @@ impl ::windows::core::DefaultType for SecondaryAuthenticationFactorDevicePresenc
 #[doc = "*Required features: 'Security_Authentication_Identity_Provider', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStatus(pub i32);
 #[cfg(feature = "deprecated")]
 impl SecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStatus {
@@ -1249,14 +1194,6 @@ unsafe impl ::windows::core::Abi for SecondaryAuthenticationFactorDevicePresence
     type Abi = Self;
 }
 #[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for SecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for SecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStatus {}
-#[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for SecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SecondaryAuthenticationFactorDevicePresenceMonitoringRegistrationStatus").field(&self.0).finish()
@@ -1273,6 +1210,7 @@ impl ::windows::core::DefaultType for SecondaryAuthenticationFactorDevicePresenc
 #[doc = "*Required features: 'Security_Authentication_Identity_Provider', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SecondaryAuthenticationFactorFinishAuthenticationStatus(pub i32);
 #[cfg(feature = "deprecated")]
 impl SecondaryAuthenticationFactorFinishAuthenticationStatus {
@@ -1292,14 +1230,6 @@ impl ::core::clone::Clone for SecondaryAuthenticationFactorFinishAuthenticationS
 unsafe impl ::windows::core::Abi for SecondaryAuthenticationFactorFinishAuthenticationStatus {
     type Abi = Self;
 }
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for SecondaryAuthenticationFactorFinishAuthenticationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for SecondaryAuthenticationFactorFinishAuthenticationStatus {}
 #[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for SecondaryAuthenticationFactorFinishAuthenticationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -1768,6 +1698,7 @@ unsafe impl ::core::marker::Sync for SecondaryAuthenticationFactorRegistrationRe
 #[doc = "*Required features: 'Security_Authentication_Identity_Provider', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SecondaryAuthenticationFactorRegistrationStatus(pub i32);
 #[cfg(feature = "deprecated")]
 impl SecondaryAuthenticationFactorRegistrationStatus {
@@ -1789,14 +1720,6 @@ impl ::core::clone::Clone for SecondaryAuthenticationFactorRegistrationStatus {
 unsafe impl ::windows::core::Abi for SecondaryAuthenticationFactorRegistrationStatus {
     type Abi = Self;
 }
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for SecondaryAuthenticationFactorRegistrationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for SecondaryAuthenticationFactorRegistrationStatus {}
 #[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for SecondaryAuthenticationFactorRegistrationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {

--- a/crates/libs/windows/src/Windows/Security/Authentication/OnlineId/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/OnlineId/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'Security_Authentication_OnlineId'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CredentialPromptType(pub i32);
 impl CredentialPromptType {
     pub const PromptIfNeeded: Self = Self(0i32);
@@ -16,12 +17,6 @@ impl ::core::clone::Clone for CredentialPromptType {
 unsafe impl ::windows::core::Abi for CredentialPromptType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CredentialPromptType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CredentialPromptType {}
 impl ::core::fmt::Debug for CredentialPromptType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CredentialPromptType").field(&self.0).finish()
@@ -886,6 +881,7 @@ unsafe impl ::core::marker::Send for OnlineIdSystemTicketResult {}
 unsafe impl ::core::marker::Sync for OnlineIdSystemTicketResult {}
 #[doc = "*Required features: 'Security_Authentication_OnlineId'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct OnlineIdSystemTicketStatus(pub i32);
 impl OnlineIdSystemTicketStatus {
     pub const Success: Self = Self(0i32);
@@ -901,12 +897,6 @@ impl ::core::clone::Clone for OnlineIdSystemTicketStatus {
 unsafe impl ::windows::core::Abi for OnlineIdSystemTicketStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for OnlineIdSystemTicketStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for OnlineIdSystemTicketStatus {}
 impl ::core::fmt::Debug for OnlineIdSystemTicketStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("OnlineIdSystemTicketStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Security/Authentication/Web/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/Web/Core/mod.rs
@@ -99,6 +99,7 @@ unsafe impl ::core::marker::Send for FindAllAccountsResult {}
 unsafe impl ::core::marker::Sync for FindAllAccountsResult {}
 #[doc = "*Required features: 'Security_Authentication_Web_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FindAllWebAccountsStatus(pub i32);
 impl FindAllWebAccountsStatus {
     pub const Success: Self = Self(0i32);
@@ -115,12 +116,6 @@ impl ::core::clone::Clone for FindAllWebAccountsStatus {
 unsafe impl ::windows::core::Abi for FindAllWebAccountsStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FindAllWebAccountsStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FindAllWebAccountsStatus {}
 impl ::core::fmt::Debug for FindAllWebAccountsStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FindAllWebAccountsStatus").field(&self.0).finish()
@@ -1152,6 +1147,7 @@ unsafe impl ::core::marker::Send for WebTokenRequest {}
 unsafe impl ::core::marker::Sync for WebTokenRequest {}
 #[doc = "*Required features: 'Security_Authentication_Web_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WebTokenRequestPromptType(pub i32);
 impl WebTokenRequestPromptType {
     pub const Default: Self = Self(0i32);
@@ -1166,12 +1162,6 @@ impl ::core::clone::Clone for WebTokenRequestPromptType {
 unsafe impl ::windows::core::Abi for WebTokenRequestPromptType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WebTokenRequestPromptType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WebTokenRequestPromptType {}
 impl ::core::fmt::Debug for WebTokenRequestPromptType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WebTokenRequestPromptType").field(&self.0).finish()
@@ -1292,6 +1282,7 @@ unsafe impl ::core::marker::Send for WebTokenRequestResult {}
 unsafe impl ::core::marker::Sync for WebTokenRequestResult {}
 #[doc = "*Required features: 'Security_Authentication_Web_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WebTokenRequestStatus(pub i32);
 impl WebTokenRequestStatus {
     pub const Success: Self = Self(0i32);
@@ -1310,12 +1301,6 @@ impl ::core::clone::Clone for WebTokenRequestStatus {
 unsafe impl ::windows::core::Abi for WebTokenRequestStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WebTokenRequestStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WebTokenRequestStatus {}
 impl ::core::fmt::Debug for WebTokenRequestStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WebTokenRequestStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Security/Authentication/Web/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/Web/Provider/mod.rs
@@ -1296,6 +1296,7 @@ unsafe impl ::core::marker::Send for WebAccountClientView {}
 unsafe impl ::core::marker::Sync for WebAccountClientView {}
 #[doc = "*Required features: 'Security_Authentication_Web_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WebAccountClientViewType(pub i32);
 impl WebAccountClientViewType {
     pub const IdOnly: Self = Self(0i32);
@@ -1310,12 +1311,6 @@ impl ::core::clone::Clone for WebAccountClientViewType {
 unsafe impl ::windows::core::Abi for WebAccountClientViewType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WebAccountClientViewType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WebAccountClientViewType {}
 impl ::core::fmt::Debug for WebAccountClientViewType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WebAccountClientViewType").field(&self.0).finish()
@@ -2151,6 +2146,7 @@ unsafe impl ::core::marker::Send for WebAccountProviderManageAccountOperation {}
 unsafe impl ::core::marker::Sync for WebAccountProviderManageAccountOperation {}
 #[doc = "*Required features: 'Security_Authentication_Web_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WebAccountProviderOperationKind(pub i32);
 impl WebAccountProviderOperationKind {
     pub const RequestToken: Self = Self(0i32);
@@ -2170,12 +2166,6 @@ impl ::core::clone::Clone for WebAccountProviderOperationKind {
 unsafe impl ::windows::core::Abi for WebAccountProviderOperationKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WebAccountProviderOperationKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WebAccountProviderOperationKind {}
 impl ::core::fmt::Debug for WebAccountProviderOperationKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WebAccountProviderOperationKind").field(&self.0).finish()
@@ -2880,6 +2870,7 @@ unsafe impl ::core::marker::Send for WebAccountProviderTriggerDetails {}
 unsafe impl ::core::marker::Sync for WebAccountProviderTriggerDetails {}
 #[doc = "*Required features: 'Security_Authentication_Web_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WebAccountScope(pub i32);
 impl WebAccountScope {
     pub const PerUser: Self = Self(0i32);
@@ -2894,12 +2885,6 @@ impl ::core::clone::Clone for WebAccountScope {
 unsafe impl ::windows::core::Abi for WebAccountScope {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WebAccountScope {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WebAccountScope {}
 impl ::core::fmt::Debug for WebAccountScope {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WebAccountScope").field(&self.0).finish()
@@ -2913,6 +2898,7 @@ impl ::windows::core::DefaultType for WebAccountScope {
 }
 #[doc = "*Required features: 'Security_Authentication_Web_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WebAccountSelectionOptions(pub u32);
 impl WebAccountSelectionOptions {
     pub const Default: Self = Self(0u32);
@@ -2927,12 +2913,6 @@ impl ::core::clone::Clone for WebAccountSelectionOptions {
 unsafe impl ::windows::core::Abi for WebAccountSelectionOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WebAccountSelectionOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WebAccountSelectionOptions {}
 impl ::core::fmt::Debug for WebAccountSelectionOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WebAccountSelectionOptions").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Security/Authentication/Web/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/Web/mod.rs
@@ -75,6 +75,7 @@ pub struct IWebAuthenticationResultVtbl(
 );
 #[doc = "*Required features: 'Security_Authentication_Web'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TokenBindingKeyType(pub i32);
 impl TokenBindingKeyType {
     pub const Rsa2048: Self = Self(0i32);
@@ -90,12 +91,6 @@ impl ::core::clone::Clone for TokenBindingKeyType {
 unsafe impl ::windows::core::Abi for TokenBindingKeyType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TokenBindingKeyType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TokenBindingKeyType {}
 impl ::core::fmt::Debug for TokenBindingKeyType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TokenBindingKeyType").field(&self.0).finish()
@@ -181,6 +176,7 @@ impl ::windows::core::RuntimeName for WebAuthenticationBroker {
 }
 #[doc = "*Required features: 'Security_Authentication_Web'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WebAuthenticationOptions(pub u32);
 impl WebAuthenticationOptions {
     pub const None: Self = Self(0u32);
@@ -198,12 +194,6 @@ impl ::core::clone::Clone for WebAuthenticationOptions {
 unsafe impl ::windows::core::Abi for WebAuthenticationOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WebAuthenticationOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WebAuthenticationOptions {}
 impl ::core::fmt::Debug for WebAuthenticationOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WebAuthenticationOptions").field(&self.0).finish()
@@ -340,6 +330,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &WebA
 }
 #[doc = "*Required features: 'Security_Authentication_Web'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WebAuthenticationStatus(pub i32);
 impl WebAuthenticationStatus {
     pub const Success: Self = Self(0i32);
@@ -355,12 +346,6 @@ impl ::core::clone::Clone for WebAuthenticationStatus {
 unsafe impl ::windows::core::Abi for WebAuthenticationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WebAuthenticationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WebAuthenticationStatus {}
 impl ::core::fmt::Debug for WebAuthenticationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WebAuthenticationStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Security/Authorization/AppCapabilityAccess/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authorization/AppCapabilityAccess/mod.rs
@@ -231,6 +231,7 @@ unsafe impl ::core::marker::Send for AppCapabilityAccessChangedEventArgs {}
 unsafe impl ::core::marker::Sync for AppCapabilityAccessChangedEventArgs {}
 #[doc = "*Required features: 'Security_Authorization_AppCapabilityAccess'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppCapabilityAccessStatus(pub i32);
 impl AppCapabilityAccessStatus {
     pub const DeniedBySystem: Self = Self(0i32);
@@ -248,12 +249,6 @@ impl ::core::clone::Clone for AppCapabilityAccessStatus {
 unsafe impl ::windows::core::Abi for AppCapabilityAccessStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppCapabilityAccessStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppCapabilityAccessStatus {}
 impl ::core::fmt::Debug for AppCapabilityAccessStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppCapabilityAccessStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Security/Credentials/UI/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Credentials/UI/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'Security_Credentials_UI'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AuthenticationProtocol(pub i32);
 impl AuthenticationProtocol {
     pub const Basic: Self = Self(0i32);
@@ -20,12 +21,6 @@ impl ::core::clone::Clone for AuthenticationProtocol {
 unsafe impl ::windows::core::Abi for AuthenticationProtocol {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AuthenticationProtocol {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AuthenticationProtocol {}
 impl ::core::fmt::Debug for AuthenticationProtocol {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AuthenticationProtocol").field(&self.0).finish()
@@ -413,6 +408,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Cred
 }
 #[doc = "*Required features: 'Security_Credentials_UI'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CredentialSaveOption(pub i32);
 impl CredentialSaveOption {
     pub const Unselected: Self = Self(0i32);
@@ -428,12 +424,6 @@ impl ::core::clone::Clone for CredentialSaveOption {
 unsafe impl ::windows::core::Abi for CredentialSaveOption {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CredentialSaveOption {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CredentialSaveOption {}
 impl ::core::fmt::Debug for CredentialSaveOption {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CredentialSaveOption").field(&self.0).finish()
@@ -555,6 +545,7 @@ pub struct IUserConsentVerifierStaticsVtbl(
 );
 #[doc = "*Required features: 'Security_Credentials_UI'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserConsentVerificationResult(pub i32);
 impl UserConsentVerificationResult {
     pub const Verified: Self = Self(0i32);
@@ -574,12 +565,6 @@ impl ::core::clone::Clone for UserConsentVerificationResult {
 unsafe impl ::windows::core::Abi for UserConsentVerificationResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserConsentVerificationResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserConsentVerificationResult {}
 impl ::core::fmt::Debug for UserConsentVerificationResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserConsentVerificationResult").field(&self.0).finish()
@@ -621,6 +606,7 @@ impl ::windows::core::RuntimeName for UserConsentVerifier {
 }
 #[doc = "*Required features: 'Security_Credentials_UI'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserConsentVerifierAvailability(pub i32);
 impl UserConsentVerifierAvailability {
     pub const Available: Self = Self(0i32);
@@ -638,12 +624,6 @@ impl ::core::clone::Clone for UserConsentVerifierAvailability {
 unsafe impl ::windows::core::Abi for UserConsentVerifierAvailability {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserConsentVerifierAvailability {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserConsentVerifierAvailability {}
 impl ::core::fmt::Debug for UserConsentVerifierAvailability {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserConsentVerifierAvailability").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Security/Credentials/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Credentials/mod.rs
@@ -648,6 +648,7 @@ unsafe impl ::core::marker::Send for KeyCredentialAttestationResult {}
 unsafe impl ::core::marker::Sync for KeyCredentialAttestationResult {}
 #[doc = "*Required features: 'Security_Credentials'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct KeyCredentialAttestationStatus(pub i32);
 impl KeyCredentialAttestationStatus {
     pub const Success: Self = Self(0i32);
@@ -664,12 +665,6 @@ impl ::core::clone::Clone for KeyCredentialAttestationStatus {
 unsafe impl ::windows::core::Abi for KeyCredentialAttestationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KeyCredentialAttestationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for KeyCredentialAttestationStatus {}
 impl ::core::fmt::Debug for KeyCredentialAttestationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("KeyCredentialAttestationStatus").field(&self.0).finish()
@@ -683,6 +678,7 @@ impl ::windows::core::DefaultType for KeyCredentialAttestationStatus {
 }
 #[doc = "*Required features: 'Security_Credentials'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct KeyCredentialCreationOption(pub i32);
 impl KeyCredentialCreationOption {
     pub const ReplaceExisting: Self = Self(0i32);
@@ -697,12 +693,6 @@ impl ::core::clone::Clone for KeyCredentialCreationOption {
 unsafe impl ::windows::core::Abi for KeyCredentialCreationOption {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KeyCredentialCreationOption {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for KeyCredentialCreationOption {}
 impl ::core::fmt::Debug for KeyCredentialCreationOption {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("KeyCredentialCreationOption").field(&self.0).finish()
@@ -947,6 +937,7 @@ unsafe impl ::core::marker::Send for KeyCredentialRetrievalResult {}
 unsafe impl ::core::marker::Sync for KeyCredentialRetrievalResult {}
 #[doc = "*Required features: 'Security_Credentials'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct KeyCredentialStatus(pub i32);
 impl KeyCredentialStatus {
     pub const Success: Self = Self(0i32);
@@ -966,12 +957,6 @@ impl ::core::clone::Clone for KeyCredentialStatus {
 unsafe impl ::windows::core::Abi for KeyCredentialStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KeyCredentialStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for KeyCredentialStatus {}
 impl ::core::fmt::Debug for KeyCredentialStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("KeyCredentialStatus").field(&self.0).finish()
@@ -1730,6 +1715,7 @@ unsafe impl ::core::marker::Send for WebAccount {}
 unsafe impl ::core::marker::Sync for WebAccount {}
 #[doc = "*Required features: 'Security_Credentials'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WebAccountPictureSize(pub i32);
 impl WebAccountPictureSize {
     pub const Size64x64: Self = Self(64i32);
@@ -1746,12 +1732,6 @@ impl ::core::clone::Clone for WebAccountPictureSize {
 unsafe impl ::windows::core::Abi for WebAccountPictureSize {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WebAccountPictureSize {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WebAccountPictureSize {}
 impl ::core::fmt::Debug for WebAccountPictureSize {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WebAccountPictureSize").field(&self.0).finish()
@@ -1909,6 +1889,7 @@ unsafe impl ::core::marker::Send for WebAccountProvider {}
 unsafe impl ::core::marker::Sync for WebAccountProvider {}
 #[doc = "*Required features: 'Security_Credentials'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WebAccountState(pub i32);
 impl WebAccountState {
     pub const None: Self = Self(0i32);
@@ -1924,12 +1905,6 @@ impl ::core::clone::Clone for WebAccountState {
 unsafe impl ::windows::core::Abi for WebAccountState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WebAccountState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WebAccountState {}
 impl ::core::fmt::Debug for WebAccountState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WebAccountState").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Security/Cryptography/Certificates/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Cryptography/Certificates/mod.rs
@@ -380,6 +380,7 @@ unsafe impl ::core::marker::Send for CertificateChain {}
 unsafe impl ::core::marker::Sync for CertificateChain {}
 #[doc = "*Required features: 'Security_Cryptography_Certificates'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CertificateChainPolicy(pub i32);
 impl CertificateChainPolicy {
     pub const Base: Self = Self(0i32);
@@ -396,12 +397,6 @@ impl ::core::clone::Clone for CertificateChainPolicy {
 unsafe impl ::windows::core::Abi for CertificateChainPolicy {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CertificateChainPolicy {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CertificateChainPolicy {}
 impl ::core::fmt::Debug for CertificateChainPolicy {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CertificateChainPolicy").field(&self.0).finish()
@@ -1724,6 +1719,7 @@ unsafe impl ::core::marker::Send for ChainValidationParameters {}
 unsafe impl ::core::marker::Sync for ChainValidationParameters {}
 #[doc = "*Required features: 'Security_Cryptography_Certificates'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ChainValidationResult(pub i32);
 impl ChainValidationResult {
     pub const Success: Self = Self(0i32);
@@ -1750,12 +1746,6 @@ impl ::core::clone::Clone for ChainValidationResult {
 unsafe impl ::windows::core::Abi for ChainValidationResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ChainValidationResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ChainValidationResult {}
 impl ::core::fmt::Debug for ChainValidationResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ChainValidationResult").field(&self.0).finish()
@@ -2241,6 +2231,7 @@ unsafe impl ::core::marker::Send for CmsTimestampInfo {}
 unsafe impl ::core::marker::Sync for CmsTimestampInfo {}
 #[doc = "*Required features: 'Security_Cryptography_Certificates'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EnrollKeyUsages(pub u32);
 impl EnrollKeyUsages {
     pub const None: Self = Self(0u32);
@@ -2258,12 +2249,6 @@ impl ::core::clone::Clone for EnrollKeyUsages {
 unsafe impl ::windows::core::Abi for EnrollKeyUsages {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EnrollKeyUsages {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EnrollKeyUsages {}
 impl ::core::fmt::Debug for EnrollKeyUsages {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EnrollKeyUsages").field(&self.0).finish()
@@ -2305,6 +2290,7 @@ impl ::windows::core::DefaultType for EnrollKeyUsages {
 }
 #[doc = "*Required features: 'Security_Cryptography_Certificates'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ExportOption(pub i32);
 impl ExportOption {
     pub const NotExportable: Self = Self(0i32);
@@ -2319,12 +2305,6 @@ impl ::core::clone::Clone for ExportOption {
 unsafe impl ::windows::core::Abi for ExportOption {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ExportOption {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ExportOption {}
 impl ::core::fmt::Debug for ExportOption {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ExportOption").field(&self.0).finish()
@@ -3333,6 +3313,7 @@ pub struct IUserCertificateStoreVtbl(
 );
 #[doc = "*Required features: 'Security_Cryptography_Certificates'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InstallOptions(pub u32);
 impl InstallOptions {
     pub const None: Self = Self(0u32);
@@ -3347,12 +3328,6 @@ impl ::core::clone::Clone for InstallOptions {
 unsafe impl ::windows::core::Abi for InstallOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InstallOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InstallOptions {}
 impl ::core::fmt::Debug for InstallOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InstallOptions").field(&self.0).finish()
@@ -3521,6 +3496,7 @@ impl ::windows::core::RuntimeName for KeyAttestationHelper {
 }
 #[doc = "*Required features: 'Security_Cryptography_Certificates'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct KeyProtectionLevel(pub i32);
 impl KeyProtectionLevel {
     pub const NoConsent: Self = Self(0i32);
@@ -3537,12 +3513,6 @@ impl ::core::clone::Clone for KeyProtectionLevel {
 unsafe impl ::windows::core::Abi for KeyProtectionLevel {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KeyProtectionLevel {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for KeyProtectionLevel {}
 impl ::core::fmt::Debug for KeyProtectionLevel {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("KeyProtectionLevel").field(&self.0).finish()
@@ -3556,6 +3526,7 @@ impl ::windows::core::DefaultType for KeyProtectionLevel {
 }
 #[doc = "*Required features: 'Security_Cryptography_Certificates'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct KeySize(pub i32);
 impl KeySize {
     pub const Invalid: Self = Self(0i32);
@@ -3571,12 +3542,6 @@ impl ::core::clone::Clone for KeySize {
 unsafe impl ::windows::core::Abi for KeySize {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KeySize {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for KeySize {}
 impl ::core::fmt::Debug for KeySize {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("KeySize").field(&self.0).finish()
@@ -3806,6 +3771,7 @@ unsafe impl ::core::marker::Send for PfxImportParameters {}
 unsafe impl ::core::marker::Sync for PfxImportParameters {}
 #[doc = "*Required features: 'Security_Cryptography_Certificates'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SignatureValidationResult(pub i32);
 impl SignatureValidationResult {
     pub const Success: Self = Self(0i32);
@@ -3823,12 +3789,6 @@ impl ::core::clone::Clone for SignatureValidationResult {
 unsafe impl ::windows::core::Abi for SignatureValidationResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SignatureValidationResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SignatureValidationResult {}
 impl ::core::fmt::Debug for SignatureValidationResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SignatureValidationResult").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Security/Cryptography/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Cryptography/Core/mod.rs
@@ -318,6 +318,7 @@ unsafe impl ::core::marker::Send for AsymmetricKeyAlgorithmProvider {}
 unsafe impl ::core::marker::Sync for AsymmetricKeyAlgorithmProvider {}
 #[doc = "*Required features: 'Security_Cryptography_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct Capi1KdfTargetAlgorithm(pub i32);
 impl Capi1KdfTargetAlgorithm {
     pub const NotAes: Self = Self(0i32);
@@ -332,12 +333,6 @@ impl ::core::clone::Clone for Capi1KdfTargetAlgorithm {
 unsafe impl ::windows::core::Abi for Capi1KdfTargetAlgorithm {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for Capi1KdfTargetAlgorithm {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for Capi1KdfTargetAlgorithm {}
 impl ::core::fmt::Debug for Capi1KdfTargetAlgorithm {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("Capi1KdfTargetAlgorithm").field(&self.0).finish()
@@ -669,6 +664,7 @@ unsafe impl ::core::marker::Send for CryptographicKey {}
 unsafe impl ::core::marker::Sync for CryptographicKey {}
 #[doc = "*Required features: 'Security_Cryptography_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CryptographicPadding(pub i32);
 impl CryptographicPadding {
     pub const None: Self = Self(0i32);
@@ -685,12 +681,6 @@ impl ::core::clone::Clone for CryptographicPadding {
 unsafe impl ::windows::core::Abi for CryptographicPadding {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CryptographicPadding {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CryptographicPadding {}
 impl ::core::fmt::Debug for CryptographicPadding {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CryptographicPadding").field(&self.0).finish()
@@ -704,6 +694,7 @@ impl ::windows::core::DefaultType for CryptographicPadding {
 }
 #[doc = "*Required features: 'Security_Cryptography_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CryptographicPrivateKeyBlobType(pub i32);
 impl CryptographicPrivateKeyBlobType {
     pub const Pkcs8RawPrivateKeyInfo: Self = Self(0i32);
@@ -721,12 +712,6 @@ impl ::core::clone::Clone for CryptographicPrivateKeyBlobType {
 unsafe impl ::windows::core::Abi for CryptographicPrivateKeyBlobType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CryptographicPrivateKeyBlobType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CryptographicPrivateKeyBlobType {}
 impl ::core::fmt::Debug for CryptographicPrivateKeyBlobType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CryptographicPrivateKeyBlobType").field(&self.0).finish()
@@ -740,6 +725,7 @@ impl ::windows::core::DefaultType for CryptographicPrivateKeyBlobType {
 }
 #[doc = "*Required features: 'Security_Cryptography_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CryptographicPublicKeyBlobType(pub i32);
 impl CryptographicPublicKeyBlobType {
     pub const X509SubjectPublicKeyInfo: Self = Self(0i32);
@@ -757,12 +743,6 @@ impl ::core::clone::Clone for CryptographicPublicKeyBlobType {
 unsafe impl ::windows::core::Abi for CryptographicPublicKeyBlobType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CryptographicPublicKeyBlobType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CryptographicPublicKeyBlobType {}
 impl ::core::fmt::Debug for CryptographicPublicKeyBlobType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CryptographicPublicKeyBlobType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Security/Cryptography/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Cryptography/mod.rs
@@ -7,6 +7,7 @@ pub mod Core;
 pub mod DataProtection;
 #[doc = "*Required features: 'Security_Cryptography'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BinaryStringEncoding(pub i32);
 impl BinaryStringEncoding {
     pub const Utf8: Self = Self(0i32);
@@ -22,12 +23,6 @@ impl ::core::clone::Clone for BinaryStringEncoding {
 unsafe impl ::windows::core::Abi for BinaryStringEncoding {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BinaryStringEncoding {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BinaryStringEncoding {}
 impl ::core::fmt::Debug for BinaryStringEncoding {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BinaryStringEncoding").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Security/DataProtection/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/DataProtection/mod.rs
@@ -108,6 +108,7 @@ pub struct IUserDataStorageItemProtectionInfoVtbl(
 );
 #[doc = "*Required features: 'Security_DataProtection'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserDataAvailability(pub i32);
 impl UserDataAvailability {
     pub const Always: Self = Self(0i32);
@@ -123,12 +124,6 @@ impl ::core::clone::Clone for UserDataAvailability {
 unsafe impl ::windows::core::Abi for UserDataAvailability {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserDataAvailability {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserDataAvailability {}
 impl ::core::fmt::Debug for UserDataAvailability {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserDataAvailability").field(&self.0).finish()
@@ -314,6 +309,7 @@ unsafe impl ::core::marker::Send for UserDataBufferUnprotectResult {}
 unsafe impl ::core::marker::Sync for UserDataBufferUnprotectResult {}
 #[doc = "*Required features: 'Security_DataProtection'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserDataBufferUnprotectStatus(pub i32);
 impl UserDataBufferUnprotectStatus {
     pub const Succeeded: Self = Self(0i32);
@@ -328,12 +324,6 @@ impl ::core::clone::Clone for UserDataBufferUnprotectStatus {
 unsafe impl ::windows::core::Abi for UserDataBufferUnprotectStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserDataBufferUnprotectStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserDataBufferUnprotectStatus {}
 impl ::core::fmt::Debug for UserDataBufferUnprotectStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserDataBufferUnprotectStatus").field(&self.0).finish()
@@ -580,6 +570,7 @@ unsafe impl ::core::marker::Send for UserDataStorageItemProtectionInfo {}
 unsafe impl ::core::marker::Sync for UserDataStorageItemProtectionInfo {}
 #[doc = "*Required features: 'Security_DataProtection'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserDataStorageItemProtectionStatus(pub i32);
 impl UserDataStorageItemProtectionStatus {
     pub const Succeeded: Self = Self(0i32);
@@ -595,12 +586,6 @@ impl ::core::clone::Clone for UserDataStorageItemProtectionStatus {
 unsafe impl ::windows::core::Abi for UserDataStorageItemProtectionStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserDataStorageItemProtectionStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserDataStorageItemProtectionStatus {}
 impl ::core::fmt::Debug for UserDataStorageItemProtectionStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserDataStorageItemProtectionStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Security/EnterpriseData/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/EnterpriseData/mod.rs
@@ -240,6 +240,7 @@ impl ::windows::core::RuntimeName for DataProtectionManager {
 }
 #[doc = "*Required features: 'Security_EnterpriseData'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DataProtectionStatus(pub i32);
 impl DataProtectionStatus {
     pub const ProtectedToOtherIdentity: Self = Self(0i32);
@@ -258,12 +259,6 @@ impl ::core::clone::Clone for DataProtectionStatus {
 unsafe impl ::windows::core::Abi for DataProtectionStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DataProtectionStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DataProtectionStatus {}
 impl ::core::fmt::Debug for DataProtectionStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DataProtectionStatus").field(&self.0).finish()
@@ -277,6 +272,7 @@ impl ::windows::core::DefaultType for DataProtectionStatus {
 }
 #[doc = "*Required features: 'Security_EnterpriseData'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EnforcementLevel(pub i32);
 impl EnforcementLevel {
     pub const NoProtection: Self = Self(0i32);
@@ -293,12 +289,6 @@ impl ::core::clone::Clone for EnforcementLevel {
 unsafe impl ::windows::core::Abi for EnforcementLevel {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EnforcementLevel {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EnforcementLevel {}
 impl ::core::fmt::Debug for EnforcementLevel {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EnforcementLevel").field(&self.0).finish()
@@ -535,6 +525,7 @@ impl ::windows::core::RuntimeName for FileProtectionManager {
 }
 #[doc = "*Required features: 'Security_EnterpriseData'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FileProtectionStatus(pub i32);
 impl FileProtectionStatus {
     pub const Undetermined: Self = Self(0i32);
@@ -559,12 +550,6 @@ impl ::core::clone::Clone for FileProtectionStatus {
 unsafe impl ::windows::core::Abi for FileProtectionStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FileProtectionStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FileProtectionStatus {}
 impl ::core::fmt::Debug for FileProtectionStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FileProtectionStatus").field(&self.0).finish()
@@ -1864,6 +1849,7 @@ unsafe impl ::core::marker::Send for ProtectedFileCreateResult {}
 unsafe impl ::core::marker::Sync for ProtectedFileCreateResult {}
 #[doc = "*Required features: 'Security_EnterpriseData'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ProtectedImportExportStatus(pub i32);
 impl ProtectedImportExportStatus {
     pub const Ok: Self = Self(0i32);
@@ -1884,12 +1870,6 @@ impl ::core::clone::Clone for ProtectedImportExportStatus {
 unsafe impl ::windows::core::Abi for ProtectedImportExportStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ProtectedImportExportStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ProtectedImportExportStatus {}
 impl ::core::fmt::Debug for ProtectedImportExportStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ProtectedImportExportStatus").field(&self.0).finish()
@@ -1903,6 +1883,7 @@ impl ::windows::core::DefaultType for ProtectedImportExportStatus {
 }
 #[doc = "*Required features: 'Security_EnterpriseData'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ProtectionPolicyAuditAction(pub i32);
 impl ProtectionPolicyAuditAction {
     pub const Decrypt: Self = Self(0i32);
@@ -1919,12 +1900,6 @@ impl ::core::clone::Clone for ProtectionPolicyAuditAction {
 unsafe impl ::windows::core::Abi for ProtectionPolicyAuditAction {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ProtectionPolicyAuditAction {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ProtectionPolicyAuditAction {}
 impl ::core::fmt::Debug for ProtectionPolicyAuditAction {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ProtectionPolicyAuditAction").field(&self.0).finish()
@@ -2082,6 +2057,7 @@ unsafe impl ::core::marker::Send for ProtectionPolicyAuditInfo {}
 unsafe impl ::core::marker::Sync for ProtectionPolicyAuditInfo {}
 #[doc = "*Required features: 'Security_EnterpriseData'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ProtectionPolicyEvaluationResult(pub i32);
 impl ProtectionPolicyEvaluationResult {
     pub const Allowed: Self = Self(0i32);
@@ -2097,12 +2073,6 @@ impl ::core::clone::Clone for ProtectionPolicyEvaluationResult {
 unsafe impl ::windows::core::Abi for ProtectionPolicyEvaluationResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ProtectionPolicyEvaluationResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ProtectionPolicyEvaluationResult {}
 impl ::core::fmt::Debug for ProtectionPolicyEvaluationResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ProtectionPolicyEvaluationResult").field(&self.0).finish()
@@ -2518,6 +2488,7 @@ unsafe impl ::core::marker::Send for ProtectionPolicyManager {}
 unsafe impl ::core::marker::Sync for ProtectionPolicyManager {}
 #[doc = "*Required features: 'Security_EnterpriseData'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ProtectionPolicyRequestAccessBehavior(pub i32);
 impl ProtectionPolicyRequestAccessBehavior {
     pub const Decrypt: Self = Self(0i32);
@@ -2532,12 +2503,6 @@ impl ::core::clone::Clone for ProtectionPolicyRequestAccessBehavior {
 unsafe impl ::windows::core::Abi for ProtectionPolicyRequestAccessBehavior {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ProtectionPolicyRequestAccessBehavior {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ProtectionPolicyRequestAccessBehavior {}
 impl ::core::fmt::Debug for ProtectionPolicyRequestAccessBehavior {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ProtectionPolicyRequestAccessBehavior").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Security/ExchangeActiveSyncProvisioning/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/ExchangeActiveSyncProvisioning/mod.rs
@@ -497,6 +497,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &EasC
 }
 #[doc = "*Required features: 'Security_ExchangeActiveSyncProvisioning'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EasDisallowConvenienceLogonResult(pub i32);
 impl EasDisallowConvenienceLogonResult {
     pub const NotEvaluated: Self = Self(0i32);
@@ -513,12 +514,6 @@ impl ::core::clone::Clone for EasDisallowConvenienceLogonResult {
 unsafe impl ::windows::core::Abi for EasDisallowConvenienceLogonResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EasDisallowConvenienceLogonResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EasDisallowConvenienceLogonResult {}
 impl ::core::fmt::Debug for EasDisallowConvenienceLogonResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EasDisallowConvenienceLogonResult").field(&self.0).finish()
@@ -532,6 +527,7 @@ impl ::windows::core::DefaultType for EasDisallowConvenienceLogonResult {
 }
 #[doc = "*Required features: 'Security_ExchangeActiveSyncProvisioning'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EasEncryptionProviderType(pub i32);
 impl EasEncryptionProviderType {
     pub const NotEvaluated: Self = Self(0i32);
@@ -547,12 +543,6 @@ impl ::core::clone::Clone for EasEncryptionProviderType {
 unsafe impl ::windows::core::Abi for EasEncryptionProviderType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EasEncryptionProviderType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EasEncryptionProviderType {}
 impl ::core::fmt::Debug for EasEncryptionProviderType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EasEncryptionProviderType").field(&self.0).finish()
@@ -566,6 +556,7 @@ impl ::windows::core::DefaultType for EasEncryptionProviderType {
 }
 #[doc = "*Required features: 'Security_ExchangeActiveSyncProvisioning'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EasMaxInactivityTimeLockResult(pub i32);
 impl EasMaxInactivityTimeLockResult {
     pub const NotEvaluated: Self = Self(0i32);
@@ -583,12 +574,6 @@ impl ::core::clone::Clone for EasMaxInactivityTimeLockResult {
 unsafe impl ::windows::core::Abi for EasMaxInactivityTimeLockResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EasMaxInactivityTimeLockResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EasMaxInactivityTimeLockResult {}
 impl ::core::fmt::Debug for EasMaxInactivityTimeLockResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EasMaxInactivityTimeLockResult").field(&self.0).finish()
@@ -602,6 +587,7 @@ impl ::windows::core::DefaultType for EasMaxInactivityTimeLockResult {
 }
 #[doc = "*Required features: 'Security_ExchangeActiveSyncProvisioning'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EasMaxPasswordFailedAttemptsResult(pub i32);
 impl EasMaxPasswordFailedAttemptsResult {
     pub const NotEvaluated: Self = Self(0i32);
@@ -619,12 +605,6 @@ impl ::core::clone::Clone for EasMaxPasswordFailedAttemptsResult {
 unsafe impl ::windows::core::Abi for EasMaxPasswordFailedAttemptsResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EasMaxPasswordFailedAttemptsResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EasMaxPasswordFailedAttemptsResult {}
 impl ::core::fmt::Debug for EasMaxPasswordFailedAttemptsResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EasMaxPasswordFailedAttemptsResult").field(&self.0).finish()
@@ -638,6 +618,7 @@ impl ::windows::core::DefaultType for EasMaxPasswordFailedAttemptsResult {
 }
 #[doc = "*Required features: 'Security_ExchangeActiveSyncProvisioning'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EasMinPasswordComplexCharactersResult(pub i32);
 impl EasMinPasswordComplexCharactersResult {
     pub const NotEvaluated: Self = Self(0i32);
@@ -665,12 +646,6 @@ impl ::core::clone::Clone for EasMinPasswordComplexCharactersResult {
 unsafe impl ::windows::core::Abi for EasMinPasswordComplexCharactersResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EasMinPasswordComplexCharactersResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EasMinPasswordComplexCharactersResult {}
 impl ::core::fmt::Debug for EasMinPasswordComplexCharactersResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EasMinPasswordComplexCharactersResult").field(&self.0).finish()
@@ -684,6 +659,7 @@ impl ::windows::core::DefaultType for EasMinPasswordComplexCharactersResult {
 }
 #[doc = "*Required features: 'Security_ExchangeActiveSyncProvisioning'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EasMinPasswordLengthResult(pub i32);
 impl EasMinPasswordLengthResult {
     pub const NotEvaluated: Self = Self(0i32);
@@ -711,12 +687,6 @@ impl ::core::clone::Clone for EasMinPasswordLengthResult {
 unsafe impl ::windows::core::Abi for EasMinPasswordLengthResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EasMinPasswordLengthResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EasMinPasswordLengthResult {}
 impl ::core::fmt::Debug for EasMinPasswordLengthResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EasMinPasswordLengthResult").field(&self.0).finish()
@@ -730,6 +700,7 @@ impl ::windows::core::DefaultType for EasMinPasswordLengthResult {
 }
 #[doc = "*Required features: 'Security_ExchangeActiveSyncProvisioning'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EasPasswordExpirationResult(pub i32);
 impl EasPasswordExpirationResult {
     pub const NotEvaluated: Self = Self(0i32);
@@ -751,12 +722,6 @@ impl ::core::clone::Clone for EasPasswordExpirationResult {
 unsafe impl ::windows::core::Abi for EasPasswordExpirationResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EasPasswordExpirationResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EasPasswordExpirationResult {}
 impl ::core::fmt::Debug for EasPasswordExpirationResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EasPasswordExpirationResult").field(&self.0).finish()
@@ -770,6 +735,7 @@ impl ::windows::core::DefaultType for EasPasswordExpirationResult {
 }
 #[doc = "*Required features: 'Security_ExchangeActiveSyncProvisioning'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EasPasswordHistoryResult(pub i32);
 impl EasPasswordHistoryResult {
     pub const NotEvaluated: Self = Self(0i32);
@@ -787,12 +753,6 @@ impl ::core::clone::Clone for EasPasswordHistoryResult {
 unsafe impl ::windows::core::Abi for EasPasswordHistoryResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EasPasswordHistoryResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EasPasswordHistoryResult {}
 impl ::core::fmt::Debug for EasPasswordHistoryResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EasPasswordHistoryResult").field(&self.0).finish()
@@ -806,6 +766,7 @@ impl ::windows::core::DefaultType for EasPasswordHistoryResult {
 }
 #[doc = "*Required features: 'Security_ExchangeActiveSyncProvisioning'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EasRequireEncryptionResult(pub i32);
 impl EasRequireEncryptionResult {
     pub const NotEvaluated: Self = Self(0i32);
@@ -837,12 +798,6 @@ impl ::core::clone::Clone for EasRequireEncryptionResult {
 unsafe impl ::windows::core::Abi for EasRequireEncryptionResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EasRequireEncryptionResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EasRequireEncryptionResult {}
 impl ::core::fmt::Debug for EasRequireEncryptionResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EasRequireEncryptionResult").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Security/Isolation/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Isolation/mod.rs
@@ -876,6 +876,7 @@ unsafe impl ::core::marker::Send for IsolatedWindowsEnvironment {}
 unsafe impl ::core::marker::Sync for IsolatedWindowsEnvironment {}
 #[doc = "*Required features: 'Security_Isolation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct IsolatedWindowsEnvironmentActivator(pub i32);
 impl IsolatedWindowsEnvironmentActivator {
     pub const System: Self = Self(0i32);
@@ -890,12 +891,6 @@ impl ::core::clone::Clone for IsolatedWindowsEnvironmentActivator {
 unsafe impl ::windows::core::Abi for IsolatedWindowsEnvironmentActivator {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IsolatedWindowsEnvironmentActivator {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for IsolatedWindowsEnvironmentActivator {}
 impl ::core::fmt::Debug for IsolatedWindowsEnvironmentActivator {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IsolatedWindowsEnvironmentActivator").field(&self.0).finish()
@@ -909,6 +904,7 @@ impl ::windows::core::DefaultType for IsolatedWindowsEnvironmentActivator {
 }
 #[doc = "*Required features: 'Security_Isolation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct IsolatedWindowsEnvironmentAllowedClipboardFormats(pub u32);
 impl IsolatedWindowsEnvironmentAllowedClipboardFormats {
     pub const None: Self = Self(0u32);
@@ -924,12 +920,6 @@ impl ::core::clone::Clone for IsolatedWindowsEnvironmentAllowedClipboardFormats 
 unsafe impl ::windows::core::Abi for IsolatedWindowsEnvironmentAllowedClipboardFormats {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IsolatedWindowsEnvironmentAllowedClipboardFormats {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for IsolatedWindowsEnvironmentAllowedClipboardFormats {}
 impl ::core::fmt::Debug for IsolatedWindowsEnvironmentAllowedClipboardFormats {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IsolatedWindowsEnvironmentAllowedClipboardFormats").field(&self.0).finish()
@@ -971,6 +961,7 @@ impl ::windows::core::DefaultType for IsolatedWindowsEnvironmentAllowedClipboard
 }
 #[doc = "*Required features: 'Security_Isolation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct IsolatedWindowsEnvironmentAvailablePrinters(pub u32);
 impl IsolatedWindowsEnvironmentAvailablePrinters {
     pub const None: Self = Self(0u32);
@@ -988,12 +979,6 @@ impl ::core::clone::Clone for IsolatedWindowsEnvironmentAvailablePrinters {
 unsafe impl ::windows::core::Abi for IsolatedWindowsEnvironmentAvailablePrinters {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IsolatedWindowsEnvironmentAvailablePrinters {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for IsolatedWindowsEnvironmentAvailablePrinters {}
 impl ::core::fmt::Debug for IsolatedWindowsEnvironmentAvailablePrinters {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IsolatedWindowsEnvironmentAvailablePrinters").field(&self.0).finish()
@@ -1035,6 +1020,7 @@ impl ::windows::core::DefaultType for IsolatedWindowsEnvironmentAvailablePrinter
 }
 #[doc = "*Required features: 'Security_Isolation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct IsolatedWindowsEnvironmentClipboardCopyPasteDirections(pub u32);
 impl IsolatedWindowsEnvironmentClipboardCopyPasteDirections {
     pub const None: Self = Self(0u32);
@@ -1050,12 +1036,6 @@ impl ::core::clone::Clone for IsolatedWindowsEnvironmentClipboardCopyPasteDirect
 unsafe impl ::windows::core::Abi for IsolatedWindowsEnvironmentClipboardCopyPasteDirections {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IsolatedWindowsEnvironmentClipboardCopyPasteDirections {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for IsolatedWindowsEnvironmentClipboardCopyPasteDirections {}
 impl ::core::fmt::Debug for IsolatedWindowsEnvironmentClipboardCopyPasteDirections {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IsolatedWindowsEnvironmentClipboardCopyPasteDirections").field(&self.0).finish()
@@ -1231,6 +1211,7 @@ unsafe impl ::core::marker::Send for IsolatedWindowsEnvironmentCreateResult {}
 unsafe impl ::core::marker::Sync for IsolatedWindowsEnvironmentCreateResult {}
 #[doc = "*Required features: 'Security_Isolation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct IsolatedWindowsEnvironmentCreateStatus(pub i32);
 impl IsolatedWindowsEnvironmentCreateStatus {
     pub const Success: Self = Self(0i32);
@@ -1246,12 +1227,6 @@ impl ::core::clone::Clone for IsolatedWindowsEnvironmentCreateStatus {
 unsafe impl ::windows::core::Abi for IsolatedWindowsEnvironmentCreateStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IsolatedWindowsEnvironmentCreateStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for IsolatedWindowsEnvironmentCreateStatus {}
 impl ::core::fmt::Debug for IsolatedWindowsEnvironmentCreateStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IsolatedWindowsEnvironmentCreateStatus").field(&self.0).finish()
@@ -1402,6 +1377,7 @@ impl ::windows::core::RuntimeName for IsolatedWindowsEnvironmentHost {
 }
 #[doc = "*Required features: 'Security_Isolation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct IsolatedWindowsEnvironmentHostError(pub i32);
 impl IsolatedWindowsEnvironmentHostError {
     pub const AdminPolicyIsDisabledOrNotPresent: Self = Self(0i32);
@@ -1419,12 +1395,6 @@ impl ::core::clone::Clone for IsolatedWindowsEnvironmentHostError {
 unsafe impl ::windows::core::Abi for IsolatedWindowsEnvironmentHostError {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IsolatedWindowsEnvironmentHostError {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for IsolatedWindowsEnvironmentHostError {}
 impl ::core::fmt::Debug for IsolatedWindowsEnvironmentHostError {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IsolatedWindowsEnvironmentHostError").field(&self.0).finish()
@@ -1535,6 +1505,7 @@ unsafe impl ::core::marker::Send for IsolatedWindowsEnvironmentLaunchFileResult 
 unsafe impl ::core::marker::Sync for IsolatedWindowsEnvironmentLaunchFileResult {}
 #[doc = "*Required features: 'Security_Isolation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct IsolatedWindowsEnvironmentLaunchFileStatus(pub i32);
 impl IsolatedWindowsEnvironmentLaunchFileStatus {
     pub const Success: Self = Self(0i32);
@@ -1553,12 +1524,6 @@ impl ::core::clone::Clone for IsolatedWindowsEnvironmentLaunchFileStatus {
 unsafe impl ::windows::core::Abi for IsolatedWindowsEnvironmentLaunchFileStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IsolatedWindowsEnvironmentLaunchFileStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for IsolatedWindowsEnvironmentLaunchFileStatus {}
 impl ::core::fmt::Debug for IsolatedWindowsEnvironmentLaunchFileStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IsolatedWindowsEnvironmentLaunchFileStatus").field(&self.0).finish()
@@ -2005,6 +1970,7 @@ unsafe impl ::core::marker::Send for IsolatedWindowsEnvironmentOwnerRegistration
 unsafe impl ::core::marker::Sync for IsolatedWindowsEnvironmentOwnerRegistrationResult {}
 #[doc = "*Required features: 'Security_Isolation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct IsolatedWindowsEnvironmentOwnerRegistrationStatus(pub i32);
 impl IsolatedWindowsEnvironmentOwnerRegistrationStatus {
     pub const Success: Self = Self(0i32);
@@ -2022,12 +1988,6 @@ impl ::core::clone::Clone for IsolatedWindowsEnvironmentOwnerRegistrationStatus 
 unsafe impl ::windows::core::Abi for IsolatedWindowsEnvironmentOwnerRegistrationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IsolatedWindowsEnvironmentOwnerRegistrationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for IsolatedWindowsEnvironmentOwnerRegistrationStatus {}
 impl ::core::fmt::Debug for IsolatedWindowsEnvironmentOwnerRegistrationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IsolatedWindowsEnvironmentOwnerRegistrationStatus").field(&self.0).finish()
@@ -2130,6 +2090,7 @@ unsafe impl ::core::marker::Send for IsolatedWindowsEnvironmentPostMessageResult
 unsafe impl ::core::marker::Sync for IsolatedWindowsEnvironmentPostMessageResult {}
 #[doc = "*Required features: 'Security_Isolation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct IsolatedWindowsEnvironmentPostMessageStatus(pub i32);
 impl IsolatedWindowsEnvironmentPostMessageStatus {
     pub const Success: Self = Self(0i32);
@@ -2145,12 +2106,6 @@ impl ::core::clone::Clone for IsolatedWindowsEnvironmentPostMessageStatus {
 unsafe impl ::windows::core::Abi for IsolatedWindowsEnvironmentPostMessageStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IsolatedWindowsEnvironmentPostMessageStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for IsolatedWindowsEnvironmentPostMessageStatus {}
 impl ::core::fmt::Debug for IsolatedWindowsEnvironmentPostMessageStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IsolatedWindowsEnvironmentPostMessageStatus").field(&self.0).finish()
@@ -2272,6 +2227,7 @@ unsafe impl ::core::marker::Send for IsolatedWindowsEnvironmentProcess {}
 unsafe impl ::core::marker::Sync for IsolatedWindowsEnvironmentProcess {}
 #[doc = "*Required features: 'Security_Isolation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct IsolatedWindowsEnvironmentProcessState(pub i32);
 impl IsolatedWindowsEnvironmentProcessState {
     pub const Running: Self = Self(1i32);
@@ -2287,12 +2243,6 @@ impl ::core::clone::Clone for IsolatedWindowsEnvironmentProcessState {
 unsafe impl ::windows::core::Abi for IsolatedWindowsEnvironmentProcessState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IsolatedWindowsEnvironmentProcessState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for IsolatedWindowsEnvironmentProcessState {}
 impl ::core::fmt::Debug for IsolatedWindowsEnvironmentProcessState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IsolatedWindowsEnvironmentProcessState").field(&self.0).finish()
@@ -2306,6 +2256,7 @@ impl ::windows::core::DefaultType for IsolatedWindowsEnvironmentProcessState {
 }
 #[doc = "*Required features: 'Security_Isolation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct IsolatedWindowsEnvironmentProgressState(pub i32);
 impl IsolatedWindowsEnvironmentProgressState {
     pub const Queued: Self = Self(0i32);
@@ -2321,12 +2272,6 @@ impl ::core::clone::Clone for IsolatedWindowsEnvironmentProgressState {
 unsafe impl ::windows::core::Abi for IsolatedWindowsEnvironmentProgressState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IsolatedWindowsEnvironmentProgressState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for IsolatedWindowsEnvironmentProgressState {}
 impl ::core::fmt::Debug for IsolatedWindowsEnvironmentProgressState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IsolatedWindowsEnvironmentProgressState").field(&self.0).finish()
@@ -2530,6 +2475,7 @@ unsafe impl ::core::marker::Send for IsolatedWindowsEnvironmentShareFileResult {
 unsafe impl ::core::marker::Sync for IsolatedWindowsEnvironmentShareFileResult {}
 #[doc = "*Required features: 'Security_Isolation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct IsolatedWindowsEnvironmentShareFileStatus(pub i32);
 impl IsolatedWindowsEnvironmentShareFileStatus {
     pub const Success: Self = Self(0i32);
@@ -2548,12 +2494,6 @@ impl ::core::clone::Clone for IsolatedWindowsEnvironmentShareFileStatus {
 unsafe impl ::windows::core::Abi for IsolatedWindowsEnvironmentShareFileStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IsolatedWindowsEnvironmentShareFileStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for IsolatedWindowsEnvironmentShareFileStatus {}
 impl ::core::fmt::Debug for IsolatedWindowsEnvironmentShareFileStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IsolatedWindowsEnvironmentShareFileStatus").field(&self.0).finish()
@@ -2749,6 +2689,7 @@ unsafe impl ::core::marker::Send for IsolatedWindowsEnvironmentShareFolderResult
 unsafe impl ::core::marker::Sync for IsolatedWindowsEnvironmentShareFolderResult {}
 #[doc = "*Required features: 'Security_Isolation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct IsolatedWindowsEnvironmentShareFolderStatus(pub i32);
 impl IsolatedWindowsEnvironmentShareFolderStatus {
     pub const Success: Self = Self(0i32);
@@ -2766,12 +2707,6 @@ impl ::core::clone::Clone for IsolatedWindowsEnvironmentShareFolderStatus {
 unsafe impl ::windows::core::Abi for IsolatedWindowsEnvironmentShareFolderStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IsolatedWindowsEnvironmentShareFolderStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for IsolatedWindowsEnvironmentShareFolderStatus {}
 impl ::core::fmt::Debug for IsolatedWindowsEnvironmentShareFolderStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IsolatedWindowsEnvironmentShareFolderStatus").field(&self.0).finish()
@@ -2882,6 +2817,7 @@ unsafe impl ::core::marker::Send for IsolatedWindowsEnvironmentStartProcessResul
 unsafe impl ::core::marker::Sync for IsolatedWindowsEnvironmentStartProcessResult {}
 #[doc = "*Required features: 'Security_Isolation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct IsolatedWindowsEnvironmentStartProcessStatus(pub i32);
 impl IsolatedWindowsEnvironmentStartProcessStatus {
     pub const Success: Self = Self(0i32);
@@ -2899,12 +2835,6 @@ impl ::core::clone::Clone for IsolatedWindowsEnvironmentStartProcessStatus {
 unsafe impl ::windows::core::Abi for IsolatedWindowsEnvironmentStartProcessStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IsolatedWindowsEnvironmentStartProcessStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for IsolatedWindowsEnvironmentStartProcessStatus {}
 impl ::core::fmt::Debug for IsolatedWindowsEnvironmentStartProcessStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IsolatedWindowsEnvironmentStartProcessStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Services/Cortana/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/Cortana/mod.rs
@@ -317,6 +317,7 @@ unsafe impl ::core::marker::Sync for CortanaActionableInsightsOptions {}
 #[doc = "*Required features: 'Services_Cortana', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CortanaPermission(pub i32);
 #[cfg(feature = "deprecated")]
 impl CortanaPermission {
@@ -345,14 +346,6 @@ unsafe impl ::windows::core::Abi for CortanaPermission {
     type Abi = Self;
 }
 #[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for CortanaPermission {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for CortanaPermission {}
-#[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for CortanaPermission {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CortanaPermission").field(&self.0).finish()
@@ -369,6 +362,7 @@ impl ::windows::core::DefaultType for CortanaPermission {
 #[doc = "*Required features: 'Services_Cortana', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CortanaPermissionsChangeResult(pub i32);
 #[cfg(feature = "deprecated")]
 impl CortanaPermissionsChangeResult {
@@ -388,14 +382,6 @@ impl ::core::clone::Clone for CortanaPermissionsChangeResult {
 unsafe impl ::windows::core::Abi for CortanaPermissionsChangeResult {
     type Abi = Self;
 }
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for CortanaPermissionsChangeResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for CortanaPermissionsChangeResult {}
 #[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for CortanaPermissionsChangeResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {

--- a/crates/libs/windows/src/Windows/Services/Maps/Guidance/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/Maps/Guidance/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'Services_Maps_Guidance'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GuidanceAudioMeasurementSystem(pub i32);
 impl GuidanceAudioMeasurementSystem {
     pub const Meters: Self = Self(0i32);
@@ -16,12 +17,6 @@ impl ::core::clone::Clone for GuidanceAudioMeasurementSystem {
 unsafe impl ::windows::core::Abi for GuidanceAudioMeasurementSystem {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GuidanceAudioMeasurementSystem {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GuidanceAudioMeasurementSystem {}
 impl ::core::fmt::Debug for GuidanceAudioMeasurementSystem {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GuidanceAudioMeasurementSystem").field(&self.0).finish()
@@ -35,6 +30,7 @@ impl ::windows::core::DefaultType for GuidanceAudioMeasurementSystem {
 }
 #[doc = "*Required features: 'Services_Maps_Guidance'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GuidanceAudioNotificationKind(pub i32);
 impl GuidanceAudioNotificationKind {
     pub const Maneuver: Self = Self(0i32);
@@ -53,12 +49,6 @@ impl ::core::clone::Clone for GuidanceAudioNotificationKind {
 unsafe impl ::windows::core::Abi for GuidanceAudioNotificationKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GuidanceAudioNotificationKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GuidanceAudioNotificationKind {}
 impl ::core::fmt::Debug for GuidanceAudioNotificationKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GuidanceAudioNotificationKind").field(&self.0).finish()
@@ -170,6 +160,7 @@ unsafe impl ::core::marker::Send for GuidanceAudioNotificationRequestedEventArgs
 unsafe impl ::core::marker::Sync for GuidanceAudioNotificationRequestedEventArgs {}
 #[doc = "*Required features: 'Services_Maps_Guidance'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GuidanceAudioNotifications(pub u32);
 impl GuidanceAudioNotifications {
     pub const None: Self = Self(0u32);
@@ -189,12 +180,6 @@ impl ::core::clone::Clone for GuidanceAudioNotifications {
 unsafe impl ::windows::core::Abi for GuidanceAudioNotifications {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GuidanceAudioNotifications {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GuidanceAudioNotifications {}
 impl ::core::fmt::Debug for GuidanceAudioNotifications {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GuidanceAudioNotifications").field(&self.0).finish()
@@ -325,6 +310,7 @@ unsafe impl ::core::marker::Send for GuidanceLaneInfo {}
 unsafe impl ::core::marker::Sync for GuidanceLaneInfo {}
 #[doc = "*Required features: 'Services_Maps_Guidance'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GuidanceLaneMarkers(pub u32);
 impl GuidanceLaneMarkers {
     pub const None: Self = Self(0u32);
@@ -348,12 +334,6 @@ impl ::core::clone::Clone for GuidanceLaneMarkers {
 unsafe impl ::windows::core::Abi for GuidanceLaneMarkers {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GuidanceLaneMarkers {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GuidanceLaneMarkers {}
 impl ::core::fmt::Debug for GuidanceLaneMarkers {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GuidanceLaneMarkers").field(&self.0).finish()
@@ -565,6 +545,7 @@ unsafe impl ::core::marker::Send for GuidanceManeuver {}
 unsafe impl ::core::marker::Sync for GuidanceManeuver {}
 #[doc = "*Required features: 'Services_Maps_Guidance'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GuidanceManeuverKind(pub i32);
 impl GuidanceManeuverKind {
     pub const None: Self = Self(0i32);
@@ -625,12 +606,6 @@ impl ::core::clone::Clone for GuidanceManeuverKind {
 unsafe impl ::windows::core::Abi for GuidanceManeuverKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GuidanceManeuverKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GuidanceManeuverKind {}
 impl ::core::fmt::Debug for GuidanceManeuverKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GuidanceManeuverKind").field(&self.0).finish()
@@ -758,6 +733,7 @@ unsafe impl ::core::marker::Send for GuidanceMapMatchedCoordinate {}
 unsafe impl ::core::marker::Sync for GuidanceMapMatchedCoordinate {}
 #[doc = "*Required features: 'Services_Maps_Guidance'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GuidanceMode(pub i32);
 impl GuidanceMode {
     pub const None: Self = Self(0i32);
@@ -774,12 +750,6 @@ impl ::core::clone::Clone for GuidanceMode {
 unsafe impl ::windows::core::Abi for GuidanceMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GuidanceMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GuidanceMode {}
 impl ::core::fmt::Debug for GuidanceMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GuidanceMode").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Services/Maps/LocalSearch/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/Maps/LocalSearch/mod.rs
@@ -507,6 +507,7 @@ unsafe impl ::core::marker::Send for LocalLocationFinderResult {}
 unsafe impl ::core::marker::Sync for LocalLocationFinderResult {}
 #[doc = "*Required features: 'Services_Maps_LocalSearch'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LocalLocationFinderStatus(pub i32);
 impl LocalLocationFinderStatus {
     pub const Success: Self = Self(0i32);
@@ -527,12 +528,6 @@ impl ::core::clone::Clone for LocalLocationFinderStatus {
 unsafe impl ::windows::core::Abi for LocalLocationFinderStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LocalLocationFinderStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LocalLocationFinderStatus {}
 impl ::core::fmt::Debug for LocalLocationFinderStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LocalLocationFinderStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Services/Maps/OfflineMaps/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/Maps/OfflineMaps/mod.rs
@@ -337,6 +337,7 @@ unsafe impl ::core::marker::Send for OfflineMapPackageQueryResult {}
 unsafe impl ::core::marker::Sync for OfflineMapPackageQueryResult {}
 #[doc = "*Required features: 'Services_Maps_OfflineMaps'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct OfflineMapPackageQueryStatus(pub i32);
 impl OfflineMapPackageQueryStatus {
     pub const Success: Self = Self(0i32);
@@ -353,12 +354,6 @@ impl ::core::clone::Clone for OfflineMapPackageQueryStatus {
 unsafe impl ::windows::core::Abi for OfflineMapPackageQueryStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for OfflineMapPackageQueryStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for OfflineMapPackageQueryStatus {}
 impl ::core::fmt::Debug for OfflineMapPackageQueryStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("OfflineMapPackageQueryStatus").field(&self.0).finish()
@@ -453,6 +448,7 @@ unsafe impl ::core::marker::Send for OfflineMapPackageStartDownloadResult {}
 unsafe impl ::core::marker::Sync for OfflineMapPackageStartDownloadResult {}
 #[doc = "*Required features: 'Services_Maps_OfflineMaps'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct OfflineMapPackageStartDownloadStatus(pub i32);
 impl OfflineMapPackageStartDownloadStatus {
     pub const Success: Self = Self(0i32);
@@ -469,12 +465,6 @@ impl ::core::clone::Clone for OfflineMapPackageStartDownloadStatus {
 unsafe impl ::windows::core::Abi for OfflineMapPackageStartDownloadStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for OfflineMapPackageStartDownloadStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for OfflineMapPackageStartDownloadStatus {}
 impl ::core::fmt::Debug for OfflineMapPackageStartDownloadStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("OfflineMapPackageStartDownloadStatus").field(&self.0).finish()
@@ -488,6 +478,7 @@ impl ::windows::core::DefaultType for OfflineMapPackageStartDownloadStatus {
 }
 #[doc = "*Required features: 'Services_Maps_OfflineMaps'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct OfflineMapPackageStatus(pub i32);
 impl OfflineMapPackageStatus {
     pub const NotDownloaded: Self = Self(0i32);
@@ -504,12 +495,6 @@ impl ::core::clone::Clone for OfflineMapPackageStatus {
 unsafe impl ::windows::core::Abi for OfflineMapPackageStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for OfflineMapPackageStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for OfflineMapPackageStatus {}
 impl ::core::fmt::Debug for OfflineMapPackageStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("OfflineMapPackageStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Services/Maps/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/Maps/mod.rs
@@ -932,6 +932,7 @@ unsafe impl ::core::marker::Send for ManeuverWarning {}
 unsafe impl ::core::marker::Sync for ManeuverWarning {}
 #[doc = "*Required features: 'Services_Maps'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ManeuverWarningKind(pub i32);
 impl ManeuverWarningKind {
     pub const None: Self = Self(0i32);
@@ -980,12 +981,6 @@ impl ::core::clone::Clone for ManeuverWarningKind {
 unsafe impl ::windows::core::Abi for ManeuverWarningKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ManeuverWarningKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ManeuverWarningKind {}
 impl ::core::fmt::Debug for ManeuverWarningKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ManeuverWarningKind").field(&self.0).finish()
@@ -999,6 +994,7 @@ impl ::windows::core::DefaultType for ManeuverWarningKind {
 }
 #[doc = "*Required features: 'Services_Maps'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ManeuverWarningSeverity(pub i32);
 impl ManeuverWarningSeverity {
     pub const None: Self = Self(0i32);
@@ -1016,12 +1012,6 @@ impl ::core::clone::Clone for ManeuverWarningSeverity {
 unsafe impl ::windows::core::Abi for ManeuverWarningSeverity {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ManeuverWarningSeverity {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ManeuverWarningSeverity {}
 impl ::core::fmt::Debug for ManeuverWarningSeverity {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ManeuverWarningSeverity").field(&self.0).finish()
@@ -1342,6 +1332,7 @@ unsafe impl ::core::marker::Send for MapLocation {}
 unsafe impl ::core::marker::Sync for MapLocation {}
 #[doc = "*Required features: 'Services_Maps'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MapLocationDesiredAccuracy(pub i32);
 impl MapLocationDesiredAccuracy {
     pub const High: Self = Self(0i32);
@@ -1356,12 +1347,6 @@ impl ::core::clone::Clone for MapLocationDesiredAccuracy {
 unsafe impl ::windows::core::Abi for MapLocationDesiredAccuracy {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MapLocationDesiredAccuracy {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MapLocationDesiredAccuracy {}
 impl ::core::fmt::Debug for MapLocationDesiredAccuracy {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MapLocationDesiredAccuracy").field(&self.0).finish()
@@ -1514,6 +1499,7 @@ unsafe impl ::core::marker::Send for MapLocationFinderResult {}
 unsafe impl ::core::marker::Sync for MapLocationFinderResult {}
 #[doc = "*Required features: 'Services_Maps'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MapLocationFinderStatus(pub i32);
 impl MapLocationFinderStatus {
     pub const Success: Self = Self(0i32);
@@ -1533,12 +1519,6 @@ impl ::core::clone::Clone for MapLocationFinderStatus {
 unsafe impl ::windows::core::Abi for MapLocationFinderStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MapLocationFinderStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MapLocationFinderStatus {}
 impl ::core::fmt::Debug for MapLocationFinderStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MapLocationFinderStatus").field(&self.0).finish()
@@ -1572,6 +1552,7 @@ impl ::windows::core::RuntimeName for MapManager {
 }
 #[doc = "*Required features: 'Services_Maps'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MapManeuverNotices(pub u32);
 impl MapManeuverNotices {
     pub const None: Self = Self(0u32);
@@ -1587,12 +1568,6 @@ impl ::core::clone::Clone for MapManeuverNotices {
 unsafe impl ::windows::core::Abi for MapManeuverNotices {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MapManeuverNotices {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MapManeuverNotices {}
 impl ::core::fmt::Debug for MapManeuverNotices {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MapManeuverNotices").field(&self.0).finish()
@@ -2173,6 +2148,7 @@ unsafe impl ::core::marker::Send for MapRouteFinderResult {}
 unsafe impl ::core::marker::Sync for MapRouteFinderResult {}
 #[doc = "*Required features: 'Services_Maps'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MapRouteFinderStatus(pub i32);
 impl MapRouteFinderStatus {
     pub const Success: Self = Self(0i32);
@@ -2195,12 +2171,6 @@ impl ::core::clone::Clone for MapRouteFinderStatus {
 unsafe impl ::windows::core::Abi for MapRouteFinderStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MapRouteFinderStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MapRouteFinderStatus {}
 impl ::core::fmt::Debug for MapRouteFinderStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MapRouteFinderStatus").field(&self.0).finish()
@@ -2503,6 +2473,7 @@ unsafe impl ::core::marker::Send for MapRouteManeuver {}
 unsafe impl ::core::marker::Sync for MapRouteManeuver {}
 #[doc = "*Required features: 'Services_Maps'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MapRouteManeuverKind(pub i32);
 impl MapRouteManeuverKind {
     pub const None: Self = Self(0i32);
@@ -2540,12 +2511,6 @@ impl ::core::clone::Clone for MapRouteManeuverKind {
 unsafe impl ::windows::core::Abi for MapRouteManeuverKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MapRouteManeuverKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MapRouteManeuverKind {}
 impl ::core::fmt::Debug for MapRouteManeuverKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MapRouteManeuverKind").field(&self.0).finish()
@@ -2559,6 +2524,7 @@ impl ::windows::core::DefaultType for MapRouteManeuverKind {
 }
 #[doc = "*Required features: 'Services_Maps'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MapRouteOptimization(pub i32);
 impl MapRouteOptimization {
     pub const Time: Self = Self(0i32);
@@ -2575,12 +2541,6 @@ impl ::core::clone::Clone for MapRouteOptimization {
 unsafe impl ::windows::core::Abi for MapRouteOptimization {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MapRouteOptimization {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MapRouteOptimization {}
 impl ::core::fmt::Debug for MapRouteOptimization {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MapRouteOptimization").field(&self.0).finish()
@@ -2594,6 +2554,7 @@ impl ::windows::core::DefaultType for MapRouteOptimization {
 }
 #[doc = "*Required features: 'Services_Maps'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MapRouteRestrictions(pub u32);
 impl MapRouteRestrictions {
     pub const None: Self = Self(0u32);
@@ -2613,12 +2574,6 @@ impl ::core::clone::Clone for MapRouteRestrictions {
 unsafe impl ::windows::core::Abi for MapRouteRestrictions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MapRouteRestrictions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MapRouteRestrictions {}
 impl ::core::fmt::Debug for MapRouteRestrictions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MapRouteRestrictions").field(&self.0).finish()
@@ -2723,6 +2678,7 @@ impl ::windows::core::RuntimeName for MapService {
 }
 #[doc = "*Required features: 'Services_Maps'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MapServiceDataUsagePreference(pub i32);
 impl MapServiceDataUsagePreference {
     pub const Default: Self = Self(0i32);
@@ -2737,12 +2693,6 @@ impl ::core::clone::Clone for MapServiceDataUsagePreference {
 unsafe impl ::windows::core::Abi for MapServiceDataUsagePreference {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MapServiceDataUsagePreference {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MapServiceDataUsagePreference {}
 impl ::core::fmt::Debug for MapServiceDataUsagePreference {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MapServiceDataUsagePreference").field(&self.0).finish()
@@ -3049,6 +2999,7 @@ unsafe impl ::core::marker::Send for PlaceInfoCreateOptions {}
 unsafe impl ::core::marker::Sync for PlaceInfoCreateOptions {}
 #[doc = "*Required features: 'Services_Maps'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TrafficCongestion(pub i32);
 impl TrafficCongestion {
     pub const Unknown: Self = Self(0i32);
@@ -3066,12 +3017,6 @@ impl ::core::clone::Clone for TrafficCongestion {
 unsafe impl ::windows::core::Abi for TrafficCongestion {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TrafficCongestion {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TrafficCongestion {}
 impl ::core::fmt::Debug for TrafficCongestion {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TrafficCongestion").field(&self.0).finish()
@@ -3085,6 +3030,7 @@ impl ::windows::core::DefaultType for TrafficCongestion {
 }
 #[doc = "*Required features: 'Services_Maps'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WaypointKind(pub i32);
 impl WaypointKind {
     pub const Stop: Self = Self(0i32);
@@ -3099,12 +3045,6 @@ impl ::core::clone::Clone for WaypointKind {
 unsafe impl ::windows::core::Abi for WaypointKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WaypointKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WaypointKind {}
 impl ::core::fmt::Debug for WaypointKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WaypointKind").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Services/Store/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/Store/mod.rs
@@ -1424,6 +1424,7 @@ unsafe impl ::core::marker::Send for StoreCanAcquireLicenseResult {}
 unsafe impl ::core::marker::Sync for StoreCanAcquireLicenseResult {}
 #[doc = "*Required features: 'Services_Store'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StoreCanLicenseStatus(pub i32);
 impl StoreCanLicenseStatus {
     pub const NotLicensableToUser: Self = Self(0i32);
@@ -1441,12 +1442,6 @@ impl ::core::clone::Clone for StoreCanLicenseStatus {
 unsafe impl ::windows::core::Abi for StoreCanLicenseStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StoreCanLicenseStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StoreCanLicenseStatus {}
 impl ::core::fmt::Debug for StoreCanLicenseStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StoreCanLicenseStatus").field(&self.0).finish()
@@ -1706,6 +1701,7 @@ unsafe impl ::core::marker::Send for StoreConsumableResult {}
 unsafe impl ::core::marker::Sync for StoreConsumableResult {}
 #[doc = "*Required features: 'Services_Store'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StoreConsumableStatus(pub i32);
 impl StoreConsumableStatus {
     pub const Succeeded: Self = Self(0i32);
@@ -1722,12 +1718,6 @@ impl ::core::clone::Clone for StoreConsumableStatus {
 unsafe impl ::windows::core::Abi for StoreConsumableStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StoreConsumableStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StoreConsumableStatus {}
 impl ::core::fmt::Debug for StoreConsumableStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StoreConsumableStatus").field(&self.0).finish()
@@ -2172,6 +2162,7 @@ unsafe impl ::core::marker::Send for StoreContext {}
 unsafe impl ::core::marker::Sync for StoreContext {}
 #[doc = "*Required features: 'Services_Store'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StoreDurationUnit(pub i32);
 impl StoreDurationUnit {
     pub const Minute: Self = Self(0i32);
@@ -2190,12 +2181,6 @@ impl ::core::clone::Clone for StoreDurationUnit {
 unsafe impl ::windows::core::Abi for StoreDurationUnit {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StoreDurationUnit {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StoreDurationUnit {}
 impl ::core::fmt::Debug for StoreDurationUnit {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StoreDurationUnit").field(&self.0).finish()
@@ -2861,6 +2846,7 @@ unsafe impl ::core::marker::Send for StorePackageUpdateResult {}
 unsafe impl ::core::marker::Sync for StorePackageUpdateResult {}
 #[doc = "*Required features: 'Services_Store'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StorePackageUpdateState(pub i32);
 impl StorePackageUpdateState {
     pub const Pending: Self = Self(0i32);
@@ -2882,12 +2868,6 @@ impl ::core::clone::Clone for StorePackageUpdateState {
 unsafe impl ::windows::core::Abi for StorePackageUpdateState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StorePackageUpdateState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StorePackageUpdateState {}
 impl ::core::fmt::Debug for StorePackageUpdateState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StorePackageUpdateState").field(&self.0).finish()
@@ -3877,6 +3857,7 @@ unsafe impl ::core::marker::Send for StorePurchaseResult {}
 unsafe impl ::core::marker::Sync for StorePurchaseResult {}
 #[doc = "*Required features: 'Services_Store'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StorePurchaseStatus(pub i32);
 impl StorePurchaseStatus {
     pub const Succeeded: Self = Self(0i32);
@@ -3894,12 +3875,6 @@ impl ::core::clone::Clone for StorePurchaseStatus {
 unsafe impl ::windows::core::Abi for StorePurchaseStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StorePurchaseStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StorePurchaseStatus {}
 impl ::core::fmt::Debug for StorePurchaseStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StorePurchaseStatus").field(&self.0).finish()
@@ -4156,6 +4131,7 @@ unsafe impl ::core::marker::Send for StoreQueueItemCompletedEventArgs {}
 unsafe impl ::core::marker::Sync for StoreQueueItemCompletedEventArgs {}
 #[doc = "*Required features: 'Services_Store'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StoreQueueItemExtendedState(pub i32);
 impl StoreQueueItemExtendedState {
     pub const ActivePending: Self = Self(0i32);
@@ -4183,12 +4159,6 @@ impl ::core::clone::Clone for StoreQueueItemExtendedState {
 unsafe impl ::windows::core::Abi for StoreQueueItemExtendedState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StoreQueueItemExtendedState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StoreQueueItemExtendedState {}
 impl ::core::fmt::Debug for StoreQueueItemExtendedState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StoreQueueItemExtendedState").field(&self.0).finish()
@@ -4202,6 +4172,7 @@ impl ::windows::core::DefaultType for StoreQueueItemExtendedState {
 }
 #[doc = "*Required features: 'Services_Store'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StoreQueueItemKind(pub i32);
 impl StoreQueueItemKind {
     pub const Install: Self = Self(0i32);
@@ -4217,12 +4188,6 @@ impl ::core::clone::Clone for StoreQueueItemKind {
 unsafe impl ::windows::core::Abi for StoreQueueItemKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StoreQueueItemKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StoreQueueItemKind {}
 impl ::core::fmt::Debug for StoreQueueItemKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StoreQueueItemKind").field(&self.0).finish()
@@ -4236,6 +4201,7 @@ impl ::windows::core::DefaultType for StoreQueueItemKind {
 }
 #[doc = "*Required features: 'Services_Store'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StoreQueueItemState(pub i32);
 impl StoreQueueItemState {
     pub const Active: Self = Self(0i32);
@@ -4253,12 +4219,6 @@ impl ::core::clone::Clone for StoreQueueItemState {
 unsafe impl ::windows::core::Abi for StoreQueueItemState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StoreQueueItemState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StoreQueueItemState {}
 impl ::core::fmt::Debug for StoreQueueItemState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StoreQueueItemState").field(&self.0).finish()
@@ -4482,6 +4442,7 @@ unsafe impl ::core::marker::Send for StoreRateAndReviewResult {}
 unsafe impl ::core::marker::Sync for StoreRateAndReviewResult {}
 #[doc = "*Required features: 'Services_Store'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StoreRateAndReviewStatus(pub i32);
 impl StoreRateAndReviewStatus {
     pub const Succeeded: Self = Self(0i32);
@@ -4498,12 +4459,6 @@ impl ::core::clone::Clone for StoreRateAndReviewStatus {
 unsafe impl ::windows::core::Abi for StoreRateAndReviewStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StoreRateAndReviewStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StoreRateAndReviewStatus {}
 impl ::core::fmt::Debug for StoreRateAndReviewStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StoreRateAndReviewStatus").field(&self.0).finish()
@@ -5069,6 +5024,7 @@ unsafe impl ::core::marker::Send for StoreUninstallStorePackageResult {}
 unsafe impl ::core::marker::Sync for StoreUninstallStorePackageResult {}
 #[doc = "*Required features: 'Services_Store'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StoreUninstallStorePackageStatus(pub i32);
 impl StoreUninstallStorePackageStatus {
     pub const Succeeded: Self = Self(0i32);
@@ -5086,12 +5042,6 @@ impl ::core::clone::Clone for StoreUninstallStorePackageStatus {
 unsafe impl ::windows::core::Abi for StoreUninstallStorePackageStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StoreUninstallStorePackageStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StoreUninstallStorePackageStatus {}
 impl ::core::fmt::Debug for StoreUninstallStorePackageStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StoreUninstallStorePackageStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Services/TargetedContent/mod.rs
+++ b/crates/libs/windows/src/Windows/Services/TargetedContent/mod.rs
@@ -432,6 +432,7 @@ unsafe impl ::core::marker::Send for TargetedContentAction {}
 unsafe impl ::core::marker::Sync for TargetedContentAction {}
 #[doc = "*Required features: 'Services_TargetedContent'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TargetedContentAppInstallationState(pub i32);
 impl TargetedContentAppInstallationState {
     pub const NotApplicable: Self = Self(0i32);
@@ -447,12 +448,6 @@ impl ::core::clone::Clone for TargetedContentAppInstallationState {
 unsafe impl ::windows::core::Abi for TargetedContentAppInstallationState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TargetedContentAppInstallationState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TargetedContentAppInstallationState {}
 impl ::core::fmt::Debug for TargetedContentAppInstallationState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TargetedContentAppInstallationState").field(&self.0).finish()
@@ -466,6 +461,7 @@ impl ::windows::core::DefaultType for TargetedContentAppInstallationState {
 }
 #[doc = "*Required features: 'Services_TargetedContent'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TargetedContentAvailability(pub i32);
 impl TargetedContentAvailability {
     pub const None: Self = Self(0i32);
@@ -481,12 +477,6 @@ impl ::core::clone::Clone for TargetedContentAvailability {
 unsafe impl ::windows::core::Abi for TargetedContentAvailability {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TargetedContentAvailability {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TargetedContentAvailability {}
 impl ::core::fmt::Debug for TargetedContentAvailability {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TargetedContentAvailability").field(&self.0).finish()
@@ -1176,6 +1166,7 @@ unsafe impl ::core::marker::Send for TargetedContentImage {}
 unsafe impl ::core::marker::Sync for TargetedContentImage {}
 #[doc = "*Required features: 'Services_TargetedContent'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TargetedContentInteraction(pub i32);
 impl TargetedContentInteraction {
     pub const Impression: Self = Self(0i32);
@@ -1201,12 +1192,6 @@ impl ::core::clone::Clone for TargetedContentInteraction {
 unsafe impl ::windows::core::Abi for TargetedContentInteraction {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TargetedContentInteraction {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TargetedContentInteraction {}
 impl ::core::fmt::Debug for TargetedContentInteraction {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TargetedContentInteraction").field(&self.0).finish()
@@ -1531,6 +1516,7 @@ unsafe impl ::core::marker::Send for TargetedContentObject {}
 unsafe impl ::core::marker::Sync for TargetedContentObject {}
 #[doc = "*Required features: 'Services_TargetedContent'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TargetedContentObjectKind(pub i32);
 impl TargetedContentObjectKind {
     pub const Collection: Self = Self(0i32);
@@ -1546,12 +1532,6 @@ impl ::core::clone::Clone for TargetedContentObjectKind {
 unsafe impl ::windows::core::Abi for TargetedContentObjectKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TargetedContentObjectKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TargetedContentObjectKind {}
 impl ::core::fmt::Debug for TargetedContentObjectKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TargetedContentObjectKind").field(&self.0).finish()
@@ -2129,6 +2109,7 @@ unsafe impl ::core::marker::Send for TargetedContentValue {}
 unsafe impl ::core::marker::Sync for TargetedContentValue {}
 #[doc = "*Required features: 'Services_TargetedContent'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TargetedContentValueKind(pub i32);
 impl TargetedContentValueKind {
     pub const String: Self = Self(0i32);
@@ -2155,12 +2136,6 @@ impl ::core::clone::Clone for TargetedContentValueKind {
 unsafe impl ::windows::core::Abi for TargetedContentValueKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TargetedContentValueKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TargetedContentValueKind {}
 impl ::core::fmt::Debug for TargetedContentValueKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TargetedContentValueKind").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Storage/AccessCache/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/AccessCache/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'Storage_AccessCache'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AccessCacheOptions(pub u32);
 impl AccessCacheOptions {
     pub const None: Self = Self(0u32);
@@ -18,12 +19,6 @@ impl ::core::clone::Clone for AccessCacheOptions {
 unsafe impl ::windows::core::Abi for AccessCacheOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AccessCacheOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AccessCacheOptions {}
 impl ::core::fmt::Debug for AccessCacheOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AccessCacheOptions").field(&self.0).finish()
@@ -703,6 +698,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Item
 }
 #[doc = "*Required features: 'Storage_AccessCache'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RecentStorageItemVisibility(pub i32);
 impl RecentStorageItemVisibility {
     pub const AppOnly: Self = Self(0i32);
@@ -717,12 +713,6 @@ impl ::core::clone::Clone for RecentStorageItemVisibility {
 unsafe impl ::windows::core::Abi for RecentStorageItemVisibility {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RecentStorageItemVisibility {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RecentStorageItemVisibility {}
 impl ::core::fmt::Debug for RecentStorageItemVisibility {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RecentStorageItemVisibility").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Storage/Compression/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Compression/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'Storage_Compression'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CompressAlgorithm(pub i32);
 impl CompressAlgorithm {
     pub const InvalidAlgorithm: Self = Self(0i32);
@@ -19,12 +20,6 @@ impl ::core::clone::Clone for CompressAlgorithm {
 unsafe impl ::windows::core::Abi for CompressAlgorithm {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CompressAlgorithm {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CompressAlgorithm {}
 impl ::core::fmt::Debug for CompressAlgorithm {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CompressAlgorithm").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Storage/FileProperties/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/FileProperties/mod.rs
@@ -1253,6 +1253,7 @@ impl<'a> ::windows::core::IntoParam<'a, IStorageItemExtraProperties> for &MusicP
 }
 #[doc = "*Required features: 'Storage_FileProperties'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PhotoOrientation(pub i32);
 impl PhotoOrientation {
     pub const Unspecified: Self = Self(0i32);
@@ -1274,12 +1275,6 @@ impl ::core::clone::Clone for PhotoOrientation {
 unsafe impl ::windows::core::Abi for PhotoOrientation {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PhotoOrientation {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PhotoOrientation {}
 impl ::core::fmt::Debug for PhotoOrientation {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PhotoOrientation").field(&self.0).finish()
@@ -1293,6 +1288,7 @@ impl ::windows::core::DefaultType for PhotoOrientation {
 }
 #[doc = "*Required features: 'Storage_FileProperties'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PropertyPrefetchOptions(pub u32);
 impl PropertyPrefetchOptions {
     pub const None: Self = Self(0u32);
@@ -1311,12 +1307,6 @@ impl ::core::clone::Clone for PropertyPrefetchOptions {
 unsafe impl ::windows::core::Abi for PropertyPrefetchOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PropertyPrefetchOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PropertyPrefetchOptions {}
 impl ::core::fmt::Debug for PropertyPrefetchOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PropertyPrefetchOptions").field(&self.0).finish()
@@ -1907,6 +1897,7 @@ impl<'a> ::windows::core::IntoParam<'a, super::Streams::IRandomAccessStreamWithC
 }
 #[doc = "*Required features: 'Storage_FileProperties'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ThumbnailMode(pub i32);
 impl ThumbnailMode {
     pub const PicturesView: Self = Self(0i32);
@@ -1925,12 +1916,6 @@ impl ::core::clone::Clone for ThumbnailMode {
 unsafe impl ::windows::core::Abi for ThumbnailMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ThumbnailMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ThumbnailMode {}
 impl ::core::fmt::Debug for ThumbnailMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ThumbnailMode").field(&self.0).finish()
@@ -1944,6 +1929,7 @@ impl ::windows::core::DefaultType for ThumbnailMode {
 }
 #[doc = "*Required features: 'Storage_FileProperties'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ThumbnailOptions(pub u32);
 impl ThumbnailOptions {
     pub const None: Self = Self(0u32);
@@ -1960,12 +1946,6 @@ impl ::core::clone::Clone for ThumbnailOptions {
 unsafe impl ::windows::core::Abi for ThumbnailOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ThumbnailOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ThumbnailOptions {}
 impl ::core::fmt::Debug for ThumbnailOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ThumbnailOptions").field(&self.0).finish()
@@ -2007,6 +1987,7 @@ impl ::windows::core::DefaultType for ThumbnailOptions {
 }
 #[doc = "*Required features: 'Storage_FileProperties'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ThumbnailType(pub i32);
 impl ThumbnailType {
     pub const Image: Self = Self(0i32);
@@ -2021,12 +2002,6 @@ impl ::core::clone::Clone for ThumbnailType {
 unsafe impl ::windows::core::Abi for ThumbnailType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ThumbnailType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ThumbnailType {}
 impl ::core::fmt::Debug for ThumbnailType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ThumbnailType").field(&self.0).finish()
@@ -2040,6 +2015,7 @@ impl ::windows::core::DefaultType for ThumbnailType {
 }
 #[doc = "*Required features: 'Storage_FileProperties'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VideoOrientation(pub i32);
 impl VideoOrientation {
     pub const Normal: Self = Self(0i32);
@@ -2056,12 +2032,6 @@ impl ::core::clone::Clone for VideoOrientation {
 unsafe impl ::windows::core::Abi for VideoOrientation {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VideoOrientation {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VideoOrientation {}
 impl ::core::fmt::Debug for VideoOrientation {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VideoOrientation").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Storage/Pickers/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Pickers/Provider/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'Storage_Pickers_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AddFileResult(pub i32);
 impl AddFileResult {
     pub const Added: Self = Self(0i32);
@@ -17,12 +18,6 @@ impl ::core::clone::Clone for AddFileResult {
 unsafe impl ::windows::core::Abi for AddFileResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AddFileResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AddFileResult {}
 impl ::core::fmt::Debug for AddFileResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AddFileResult").field(&self.0).finish()
@@ -448,6 +443,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &File
 }
 #[doc = "*Required features: 'Storage_Pickers_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FileSelectionMode(pub i32);
 impl FileSelectionMode {
     pub const Single: Self = Self(0i32);
@@ -462,12 +458,6 @@ impl ::core::clone::Clone for FileSelectionMode {
 unsafe impl ::windows::core::Abi for FileSelectionMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FileSelectionMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FileSelectionMode {}
 impl ::core::fmt::Debug for FileSelectionMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FileSelectionMode").field(&self.0).finish()
@@ -934,6 +924,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Pick
 }
 #[doc = "*Required features: 'Storage_Pickers_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SetFileNameResult(pub i32);
 impl SetFileNameResult {
     pub const Succeeded: Self = Self(0i32);
@@ -949,12 +940,6 @@ impl ::core::clone::Clone for SetFileNameResult {
 unsafe impl ::windows::core::Abi for SetFileNameResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SetFileNameResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SetFileNameResult {}
 impl ::core::fmt::Debug for SetFileNameResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SetFileNameResult").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Storage/Pickers/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Pickers/mod.rs
@@ -1656,6 +1656,7 @@ pub struct IFolderPickerStaticsVtbl(
 );
 #[doc = "*Required features: 'Storage_Pickers'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PickerLocationId(pub i32);
 impl PickerLocationId {
     pub const DocumentsLibrary: Self = Self(0i32);
@@ -1678,12 +1679,6 @@ impl ::core::clone::Clone for PickerLocationId {
 unsafe impl ::windows::core::Abi for PickerLocationId {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PickerLocationId {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PickerLocationId {}
 impl ::core::fmt::Debug for PickerLocationId {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PickerLocationId").field(&self.0).finish()
@@ -1697,6 +1692,7 @@ impl ::windows::core::DefaultType for PickerLocationId {
 }
 #[doc = "*Required features: 'Storage_Pickers'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PickerViewMode(pub i32);
 impl PickerViewMode {
     pub const List: Self = Self(0i32);
@@ -1711,12 +1707,6 @@ impl ::core::clone::Clone for PickerViewMode {
 unsafe impl ::windows::core::Abi for PickerViewMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PickerViewMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PickerViewMode {}
 impl ::core::fmt::Debug for PickerViewMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PickerViewMode").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Storage/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Provider/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'Storage_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CachedFileOptions(pub u32);
 impl CachedFileOptions {
     pub const None: Self = Self(0u32);
@@ -17,12 +18,6 @@ impl ::core::clone::Clone for CachedFileOptions {
 unsafe impl ::windows::core::Abi for CachedFileOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CachedFileOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CachedFileOptions {}
 impl ::core::fmt::Debug for CachedFileOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CachedFileOptions").field(&self.0).finish()
@@ -64,6 +59,7 @@ impl ::windows::core::DefaultType for CachedFileOptions {
 }
 #[doc = "*Required features: 'Storage_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CachedFileTarget(pub i32);
 impl CachedFileTarget {
     pub const Local: Self = Self(0i32);
@@ -78,12 +74,6 @@ impl ::core::clone::Clone for CachedFileTarget {
 unsafe impl ::windows::core::Abi for CachedFileTarget {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CachedFileTarget {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CachedFileTarget {}
 impl ::core::fmt::Debug for CachedFileTarget {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CachedFileTarget").field(&self.0).finish()
@@ -540,6 +530,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &File
 }
 #[doc = "*Required features: 'Storage_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FileUpdateStatus(pub i32);
 impl FileUpdateStatus {
     pub const Incomplete: Self = Self(0i32);
@@ -558,12 +549,6 @@ impl ::core::clone::Clone for FileUpdateStatus {
 unsafe impl ::windows::core::Abi for FileUpdateStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FileUpdateStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FileUpdateStatus {}
 impl ::core::fmt::Debug for FileUpdateStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FileUpdateStatus").field(&self.0).finish()
@@ -1582,6 +1567,7 @@ pub struct IStorageProviderUriSourceVtbl(
 );
 #[doc = "*Required features: 'Storage_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ReadActivationMode(pub i32);
 impl ReadActivationMode {
     pub const NotNeeded: Self = Self(0i32);
@@ -1596,12 +1582,6 @@ impl ::core::clone::Clone for ReadActivationMode {
 unsafe impl ::windows::core::Abi for ReadActivationMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ReadActivationMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ReadActivationMode {}
 impl ::core::fmt::Debug for ReadActivationMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ReadActivationMode").field(&self.0).finish()
@@ -2205,6 +2185,7 @@ unsafe impl ::core::marker::Send for StorageProviderGetPathForContentUriResult {
 unsafe impl ::core::marker::Sync for StorageProviderGetPathForContentUriResult {}
 #[doc = "*Required features: 'Storage_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StorageProviderHardlinkPolicy(pub u32);
 impl StorageProviderHardlinkPolicy {
     pub const None: Self = Self(0u32);
@@ -2219,12 +2200,6 @@ impl ::core::clone::Clone for StorageProviderHardlinkPolicy {
 unsafe impl ::windows::core::Abi for StorageProviderHardlinkPolicy {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StorageProviderHardlinkPolicy {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StorageProviderHardlinkPolicy {}
 impl ::core::fmt::Debug for StorageProviderHardlinkPolicy {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StorageProviderHardlinkPolicy").field(&self.0).finish()
@@ -2266,6 +2241,7 @@ impl ::windows::core::DefaultType for StorageProviderHardlinkPolicy {
 }
 #[doc = "*Required features: 'Storage_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StorageProviderHydrationPolicy(pub i32);
 impl StorageProviderHydrationPolicy {
     pub const Partial: Self = Self(0i32);
@@ -2282,12 +2258,6 @@ impl ::core::clone::Clone for StorageProviderHydrationPolicy {
 unsafe impl ::windows::core::Abi for StorageProviderHydrationPolicy {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StorageProviderHydrationPolicy {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StorageProviderHydrationPolicy {}
 impl ::core::fmt::Debug for StorageProviderHydrationPolicy {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StorageProviderHydrationPolicy").field(&self.0).finish()
@@ -2301,6 +2271,7 @@ impl ::windows::core::DefaultType for StorageProviderHydrationPolicy {
 }
 #[doc = "*Required features: 'Storage_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StorageProviderHydrationPolicyModifier(pub u32);
 impl StorageProviderHydrationPolicyModifier {
     pub const None: Self = Self(0u32);
@@ -2318,12 +2289,6 @@ impl ::core::clone::Clone for StorageProviderHydrationPolicyModifier {
 unsafe impl ::windows::core::Abi for StorageProviderHydrationPolicyModifier {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StorageProviderHydrationPolicyModifier {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StorageProviderHydrationPolicyModifier {}
 impl ::core::fmt::Debug for StorageProviderHydrationPolicyModifier {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StorageProviderHydrationPolicyModifier").field(&self.0).finish()
@@ -2365,6 +2330,7 @@ impl ::windows::core::DefaultType for StorageProviderHydrationPolicyModifier {
 }
 #[doc = "*Required features: 'Storage_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StorageProviderInSyncPolicy(pub u32);
 impl StorageProviderInSyncPolicy {
     pub const Default: Self = Self(0u32);
@@ -2389,12 +2355,6 @@ impl ::core::clone::Clone for StorageProviderInSyncPolicy {
 unsafe impl ::windows::core::Abi for StorageProviderInSyncPolicy {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StorageProviderInSyncPolicy {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StorageProviderInSyncPolicy {}
 impl ::core::fmt::Debug for StorageProviderInSyncPolicy {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StorageProviderInSyncPolicy").field(&self.0).finish()
@@ -2681,6 +2641,7 @@ unsafe impl ::core::marker::Send for StorageProviderItemPropertyDefinition {}
 unsafe impl ::core::marker::Sync for StorageProviderItemPropertyDefinition {}
 #[doc = "*Required features: 'Storage_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StorageProviderPopulationPolicy(pub i32);
 impl StorageProviderPopulationPolicy {
     pub const Full: Self = Self(1i32);
@@ -2695,12 +2656,6 @@ impl ::core::clone::Clone for StorageProviderPopulationPolicy {
 unsafe impl ::windows::core::Abi for StorageProviderPopulationPolicy {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StorageProviderPopulationPolicy {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StorageProviderPopulationPolicy {}
 impl ::core::fmt::Debug for StorageProviderPopulationPolicy {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StorageProviderPopulationPolicy").field(&self.0).finish()
@@ -2714,6 +2669,7 @@ impl ::windows::core::DefaultType for StorageProviderPopulationPolicy {
 }
 #[doc = "*Required features: 'Storage_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StorageProviderProtectionMode(pub i32);
 impl StorageProviderProtectionMode {
     pub const Unknown: Self = Self(0i32);
@@ -2728,12 +2684,6 @@ impl ::core::clone::Clone for StorageProviderProtectionMode {
 unsafe impl ::windows::core::Abi for StorageProviderProtectionMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StorageProviderProtectionMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StorageProviderProtectionMode {}
 impl ::core::fmt::Debug for StorageProviderProtectionMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StorageProviderProtectionMode").field(&self.0).finish()
@@ -2747,6 +2697,7 @@ impl ::windows::core::DefaultType for StorageProviderProtectionMode {
 }
 #[doc = "*Required features: 'Storage_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StorageProviderState(pub i32);
 impl StorageProviderState {
     pub const InSync: Self = Self(0i32);
@@ -2765,12 +2716,6 @@ impl ::core::clone::Clone for StorageProviderState {
 unsafe impl ::windows::core::Abi for StorageProviderState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StorageProviderState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StorageProviderState {}
 impl ::core::fmt::Debug for StorageProviderState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StorageProviderState").field(&self.0).finish()
@@ -3266,6 +3211,7 @@ impl ::windows::core::RuntimeName for StorageProviderSyncRootManager {
 }
 #[doc = "*Required features: 'Storage_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StorageProviderUriSourceStatus(pub i32);
 impl StorageProviderUriSourceStatus {
     pub const Success: Self = Self(0i32);
@@ -3281,12 +3227,6 @@ impl ::core::clone::Clone for StorageProviderUriSourceStatus {
 unsafe impl ::windows::core::Abi for StorageProviderUriSourceStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StorageProviderUriSourceStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StorageProviderUriSourceStatus {}
 impl ::core::fmt::Debug for StorageProviderUriSourceStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StorageProviderUriSourceStatus").field(&self.0).finish()
@@ -3300,6 +3240,7 @@ impl ::windows::core::DefaultType for StorageProviderUriSourceStatus {
 }
 #[doc = "*Required features: 'Storage_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UIStatus(pub i32);
 impl UIStatus {
     pub const Unavailable: Self = Self(0i32);
@@ -3316,12 +3257,6 @@ impl ::core::clone::Clone for UIStatus {
 unsafe impl ::windows::core::Abi for UIStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UIStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UIStatus {}
 impl ::core::fmt::Debug for UIStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UIStatus").field(&self.0).finish()
@@ -3335,6 +3270,7 @@ impl ::windows::core::DefaultType for UIStatus {
 }
 #[doc = "*Required features: 'Storage_Provider'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WriteActivationMode(pub i32);
 impl WriteActivationMode {
     pub const ReadOnly: Self = Self(0i32);
@@ -3350,12 +3286,6 @@ impl ::core::clone::Clone for WriteActivationMode {
 unsafe impl ::windows::core::Abi for WriteActivationMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WriteActivationMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WriteActivationMode {}
 impl ::core::fmt::Debug for WriteActivationMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WriteActivationMode").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Storage/Search/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Search/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'Storage_Search'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CommonFileQuery(pub i32);
 impl CommonFileQuery {
     pub const DefaultQuery: Self = Self(0i32);
@@ -19,12 +20,6 @@ impl ::core::clone::Clone for CommonFileQuery {
 unsafe impl ::windows::core::Abi for CommonFileQuery {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CommonFileQuery {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CommonFileQuery {}
 impl ::core::fmt::Debug for CommonFileQuery {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CommonFileQuery").field(&self.0).finish()
@@ -38,6 +33,7 @@ impl ::windows::core::DefaultType for CommonFileQuery {
 }
 #[doc = "*Required features: 'Storage_Search'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CommonFolderQuery(pub i32);
 impl CommonFolderQuery {
     pub const DefaultQuery: Self = Self(0i32);
@@ -63,12 +59,6 @@ impl ::core::clone::Clone for CommonFolderQuery {
 unsafe impl ::windows::core::Abi for CommonFolderQuery {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CommonFolderQuery {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CommonFolderQuery {}
 impl ::core::fmt::Debug for CommonFolderQuery {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CommonFolderQuery").field(&self.0).finish()
@@ -389,6 +379,7 @@ unsafe impl ::core::marker::Send for ContentIndexerQuery {}
 unsafe impl ::core::marker::Sync for ContentIndexerQuery {}
 #[doc = "*Required features: 'Storage_Search'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DateStackOption(pub i32);
 impl DateStackOption {
     pub const None: Self = Self(0i32);
@@ -404,12 +395,6 @@ impl ::core::clone::Clone for DateStackOption {
 unsafe impl ::windows::core::Abi for DateStackOption {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DateStackOption {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DateStackOption {}
 impl ::core::fmt::Debug for DateStackOption {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DateStackOption").field(&self.0).finish()
@@ -423,6 +408,7 @@ impl ::windows::core::DefaultType for DateStackOption {
 }
 #[doc = "*Required features: 'Storage_Search'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FolderDepth(pub i32);
 impl FolderDepth {
     pub const Shallow: Self = Self(0i32);
@@ -437,12 +423,6 @@ impl ::core::clone::Clone for FolderDepth {
 unsafe impl ::windows::core::Abi for FolderDepth {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FolderDepth {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FolderDepth {}
 impl ::core::fmt::Debug for FolderDepth {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FolderDepth").field(&self.0).finish()
@@ -1471,6 +1451,7 @@ unsafe impl ::core::marker::Send for IndexableContent {}
 unsafe impl ::core::marker::Sync for IndexableContent {}
 #[doc = "*Required features: 'Storage_Search'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct IndexedState(pub i32);
 impl IndexedState {
     pub const Unknown: Self = Self(0i32);
@@ -1487,12 +1468,6 @@ impl ::core::clone::Clone for IndexedState {
 unsafe impl ::windows::core::Abi for IndexedState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IndexedState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for IndexedState {}
 impl ::core::fmt::Debug for IndexedState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IndexedState").field(&self.0).finish()
@@ -1506,6 +1481,7 @@ impl ::windows::core::DefaultType for IndexedState {
 }
 #[doc = "*Required features: 'Storage_Search'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct IndexerOption(pub i32);
 impl IndexerOption {
     pub const UseIndexerWhenAvailable: Self = Self(0i32);
@@ -1522,12 +1498,6 @@ impl ::core::clone::Clone for IndexerOption {
 unsafe impl ::windows::core::Abi for IndexerOption {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for IndexerOption {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for IndexerOption {}
 impl ::core::fmt::Debug for IndexerOption {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("IndexerOption").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Storage/Streams/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/Streams/mod.rs
@@ -150,6 +150,7 @@ unsafe impl ::core::marker::Send for Buffer {}
 unsafe impl ::core::marker::Sync for Buffer {}
 #[doc = "*Required features: 'Storage_Streams'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ByteOrder(pub i32);
 impl ByteOrder {
     pub const LittleEndian: Self = Self(0i32);
@@ -164,12 +165,6 @@ impl ::core::clone::Clone for ByteOrder {
 unsafe impl ::windows::core::Abi for ByteOrder {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ByteOrder {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ByteOrder {}
 impl ::core::fmt::Debug for ByteOrder {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ByteOrder").field(&self.0).finish()
@@ -1457,6 +1452,7 @@ unsafe impl ::core::marker::Send for FileInputStream {}
 unsafe impl ::core::marker::Sync for FileInputStream {}
 #[doc = "*Required features: 'Storage_Streams'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FileOpenDisposition(pub i32);
 impl FileOpenDisposition {
     pub const OpenExisting: Self = Self(0i32);
@@ -1474,12 +1470,6 @@ impl ::core::clone::Clone for FileOpenDisposition {
 unsafe impl ::windows::core::Abi for FileOpenDisposition {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FileOpenDisposition {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FileOpenDisposition {}
 impl ::core::fmt::Debug for FileOpenDisposition {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FileOpenDisposition").field(&self.0).finish()
@@ -4265,6 +4255,7 @@ unsafe impl ::core::marker::Send for InMemoryRandomAccessStream {}
 unsafe impl ::core::marker::Sync for InMemoryRandomAccessStream {}
 #[doc = "*Required features: 'Storage_Streams'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InputStreamOptions(pub u32);
 impl InputStreamOptions {
     pub const None: Self = Self(0u32);
@@ -4280,12 +4271,6 @@ impl ::core::clone::Clone for InputStreamOptions {
 unsafe impl ::windows::core::Abi for InputStreamOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InputStreamOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InputStreamOptions {}
 impl ::core::fmt::Debug for InputStreamOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InputStreamOptions").field(&self.0).finish()
@@ -5039,6 +5024,7 @@ unsafe impl ::core::marker::Send for RandomAccessStreamReference {}
 unsafe impl ::core::marker::Sync for RandomAccessStreamReference {}
 #[doc = "*Required features: 'Storage_Streams'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UnicodeEncoding(pub i32);
 impl UnicodeEncoding {
     pub const Utf8: Self = Self(0i32);
@@ -5054,12 +5040,6 @@ impl ::core::clone::Clone for UnicodeEncoding {
 unsafe impl ::windows::core::Abi for UnicodeEncoding {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UnicodeEncoding {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UnicodeEncoding {}
 impl ::core::fmt::Debug for UnicodeEncoding {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UnicodeEncoding").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Storage/mod.rs
+++ b/crates/libs/windows/src/Windows/Storage/mod.rs
@@ -1193,6 +1193,7 @@ unsafe impl ::core::marker::Send for ApplicationDataContainerSettings {}
 unsafe impl ::core::marker::Sync for ApplicationDataContainerSettings {}
 #[doc = "*Required features: 'Storage'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ApplicationDataCreateDisposition(pub i32);
 impl ApplicationDataCreateDisposition {
     pub const Always: Self = Self(0i32);
@@ -1207,12 +1208,6 @@ impl ::core::clone::Clone for ApplicationDataCreateDisposition {
 unsafe impl ::windows::core::Abi for ApplicationDataCreateDisposition {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ApplicationDataCreateDisposition {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ApplicationDataCreateDisposition {}
 impl ::core::fmt::Debug for ApplicationDataCreateDisposition {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ApplicationDataCreateDisposition").field(&self.0).finish()
@@ -1226,6 +1221,7 @@ impl ::windows::core::DefaultType for ApplicationDataCreateDisposition {
 }
 #[doc = "*Required features: 'Storage'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ApplicationDataLocality(pub i32);
 impl ApplicationDataLocality {
     pub const Local: Self = Self(0i32);
@@ -1243,12 +1239,6 @@ impl ::core::clone::Clone for ApplicationDataLocality {
 unsafe impl ::windows::core::Abi for ApplicationDataLocality {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ApplicationDataLocality {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ApplicationDataLocality {}
 impl ::core::fmt::Debug for ApplicationDataLocality {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ApplicationDataLocality").field(&self.0).finish()
@@ -1361,6 +1351,7 @@ impl ::windows::core::RuntimeName for CachedFileManager {
 }
 #[doc = "*Required features: 'Storage'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CreationCollisionOption(pub i32);
 impl CreationCollisionOption {
     pub const GenerateUniqueName: Self = Self(0i32);
@@ -1377,12 +1368,6 @@ impl ::core::clone::Clone for CreationCollisionOption {
 unsafe impl ::windows::core::Abi for CreationCollisionOption {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CreationCollisionOption {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CreationCollisionOption {}
 impl ::core::fmt::Debug for CreationCollisionOption {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CreationCollisionOption").field(&self.0).finish()
@@ -1477,6 +1462,7 @@ impl ::windows::core::RuntimeName for DownloadsFolder {
 }
 #[doc = "*Required features: 'Storage'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FileAccessMode(pub i32);
 impl FileAccessMode {
     pub const Read: Self = Self(0i32);
@@ -1491,12 +1477,6 @@ impl ::core::clone::Clone for FileAccessMode {
 unsafe impl ::windows::core::Abi for FileAccessMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FileAccessMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FileAccessMode {}
 impl ::core::fmt::Debug for FileAccessMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FileAccessMode").field(&self.0).finish()
@@ -1510,6 +1490,7 @@ impl ::windows::core::DefaultType for FileAccessMode {
 }
 #[doc = "*Required features: 'Storage'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FileAttributes(pub u32);
 impl FileAttributes {
     pub const Normal: Self = Self(0u32);
@@ -1528,12 +1509,6 @@ impl ::core::clone::Clone for FileAttributes {
 unsafe impl ::windows::core::Abi for FileAttributes {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FileAttributes {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FileAttributes {}
 impl ::core::fmt::Debug for FileAttributes {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FileAttributes").field(&self.0).finish()
@@ -4874,6 +4849,7 @@ pub struct IUserDataPathsStaticsVtbl(
 );
 #[doc = "*Required features: 'Storage'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct KnownFolderId(pub i32);
 impl KnownFolderId {
     pub const AppCaptures: Self = Self(0i32);
@@ -4903,12 +4879,6 @@ impl ::core::clone::Clone for KnownFolderId {
 unsafe impl ::windows::core::Abi for KnownFolderId {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KnownFolderId {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for KnownFolderId {}
 impl ::core::fmt::Debug for KnownFolderId {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("KnownFolderId").field(&self.0).finish()
@@ -5087,6 +5057,7 @@ impl ::windows::core::RuntimeName for KnownFolders {
 }
 #[doc = "*Required features: 'Storage'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct KnownFoldersAccessStatus(pub i32);
 impl KnownFoldersAccessStatus {
     pub const DeniedBySystem: Self = Self(0i32);
@@ -5105,12 +5076,6 @@ impl ::core::clone::Clone for KnownFoldersAccessStatus {
 unsafe impl ::windows::core::Abi for KnownFoldersAccessStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KnownFoldersAccessStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for KnownFoldersAccessStatus {}
 impl ::core::fmt::Debug for KnownFoldersAccessStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("KnownFoldersAccessStatus").field(&self.0).finish()
@@ -5124,6 +5089,7 @@ impl ::windows::core::DefaultType for KnownFoldersAccessStatus {
 }
 #[doc = "*Required features: 'Storage'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct KnownLibraryId(pub i32);
 impl KnownLibraryId {
     pub const Music: Self = Self(0i32);
@@ -5140,12 +5106,6 @@ impl ::core::clone::Clone for KnownLibraryId {
 unsafe impl ::windows::core::Abi for KnownLibraryId {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KnownLibraryId {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for KnownLibraryId {}
 impl ::core::fmt::Debug for KnownLibraryId {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("KnownLibraryId").field(&self.0).finish()
@@ -5159,6 +5119,7 @@ impl ::windows::core::DefaultType for KnownLibraryId {
 }
 #[doc = "*Required features: 'Storage'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct NameCollisionOption(pub i32);
 impl NameCollisionOption {
     pub const GenerateUniqueName: Self = Self(0i32);
@@ -5174,12 +5135,6 @@ impl ::core::clone::Clone for NameCollisionOption {
 unsafe impl ::windows::core::Abi for NameCollisionOption {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NameCollisionOption {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for NameCollisionOption {}
 impl ::core::fmt::Debug for NameCollisionOption {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NameCollisionOption").field(&self.0).finish()
@@ -5500,6 +5455,7 @@ unsafe impl ::core::marker::Send for SetVersionRequest {}
 unsafe impl ::core::marker::Sync for SetVersionRequest {}
 #[doc = "*Required features: 'Storage'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StorageDeleteOption(pub i32);
 impl StorageDeleteOption {
     pub const Default: Self = Self(0i32);
@@ -5514,12 +5470,6 @@ impl ::core::clone::Clone for StorageDeleteOption {
 unsafe impl ::windows::core::Abi for StorageDeleteOption {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StorageDeleteOption {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StorageDeleteOption {}
 impl ::core::fmt::Debug for StorageDeleteOption {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StorageDeleteOption").field(&self.0).finish()
@@ -6981,6 +6931,7 @@ impl<'a> ::windows::core::IntoParam<'a, IStorageItemPropertiesWithProvider> for 
 }
 #[doc = "*Required features: 'Storage'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StorageItemTypes(pub u32);
 impl StorageItemTypes {
     pub const None: Self = Self(0u32);
@@ -6996,12 +6947,6 @@ impl ::core::clone::Clone for StorageItemTypes {
 unsafe impl ::windows::core::Abi for StorageItemTypes {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StorageItemTypes {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StorageItemTypes {}
 impl ::core::fmt::Debug for StorageItemTypes {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StorageItemTypes").field(&self.0).finish()
@@ -7614,6 +7559,7 @@ unsafe impl ::core::marker::Send for StorageLibraryChangeTrackerOptions {}
 unsafe impl ::core::marker::Sync for StorageLibraryChangeTrackerOptions {}
 #[doc = "*Required features: 'Storage'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StorageLibraryChangeType(pub i32);
 impl StorageLibraryChangeType {
     pub const Created: Self = Self(0i32);
@@ -7636,12 +7582,6 @@ impl ::core::clone::Clone for StorageLibraryChangeType {
 unsafe impl ::windows::core::Abi for StorageLibraryChangeType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StorageLibraryChangeType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StorageLibraryChangeType {}
 impl ::core::fmt::Debug for StorageLibraryChangeType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StorageLibraryChangeType").field(&self.0).finish()
@@ -7740,6 +7680,7 @@ unsafe impl ::core::marker::Send for StorageLibraryLastChangeId {}
 unsafe impl ::core::marker::Sync for StorageLibraryLastChangeId {}
 #[doc = "*Required features: 'Storage'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StorageOpenOptions(pub u32);
 impl StorageOpenOptions {
     pub const None: Self = Self(0u32);
@@ -7755,12 +7696,6 @@ impl ::core::clone::Clone for StorageOpenOptions {
 unsafe impl ::windows::core::Abi for StorageOpenOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StorageOpenOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StorageOpenOptions {}
 impl ::core::fmt::Debug for StorageOpenOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StorageOpenOptions").field(&self.0).finish()
@@ -8307,6 +8242,7 @@ pub struct StreamedFileDataRequestedHandlerVtbl(
 );
 #[doc = "*Required features: 'Storage'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StreamedFileFailureMode(pub i32);
 impl StreamedFileFailureMode {
     pub const Failed: Self = Self(0i32);
@@ -8322,12 +8258,6 @@ impl ::core::clone::Clone for StreamedFileFailureMode {
 unsafe impl ::windows::core::Abi for StreamedFileFailureMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StreamedFileFailureMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StreamedFileFailureMode {}
 impl ::core::fmt::Debug for StreamedFileFailureMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StreamedFileFailureMode").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/System/Diagnostics/DevicePortal/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Diagnostics/DevicePortal/mod.rs
@@ -243,6 +243,7 @@ unsafe impl ::core::marker::Send for DevicePortalConnectionClosedEventArgs {}
 unsafe impl ::core::marker::Sync for DevicePortalConnectionClosedEventArgs {}
 #[doc = "*Required features: 'System_Diagnostics_DevicePortal'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DevicePortalConnectionClosedReason(pub i32);
 impl DevicePortalConnectionClosedReason {
     pub const Unknown: Self = Self(0i32);
@@ -261,12 +262,6 @@ impl ::core::clone::Clone for DevicePortalConnectionClosedReason {
 unsafe impl ::windows::core::Abi for DevicePortalConnectionClosedReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DevicePortalConnectionClosedReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DevicePortalConnectionClosedReason {}
 impl ::core::fmt::Debug for DevicePortalConnectionClosedReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DevicePortalConnectionClosedReason").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/System/Diagnostics/Telemetry/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Diagnostics/Telemetry/mod.rs
@@ -272,6 +272,7 @@ unsafe impl ::core::marker::Send for PlatformTelemetryRegistrationSettings {}
 unsafe impl ::core::marker::Sync for PlatformTelemetryRegistrationSettings {}
 #[doc = "*Required features: 'System_Diagnostics_Telemetry'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PlatformTelemetryRegistrationStatus(pub i32);
 impl PlatformTelemetryRegistrationStatus {
     pub const Success: Self = Self(0i32);
@@ -287,12 +288,6 @@ impl ::core::clone::Clone for PlatformTelemetryRegistrationStatus {
 unsafe impl ::windows::core::Abi for PlatformTelemetryRegistrationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PlatformTelemetryRegistrationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PlatformTelemetryRegistrationStatus {}
 impl ::core::fmt::Debug for PlatformTelemetryRegistrationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PlatformTelemetryRegistrationStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/System/Diagnostics/TraceReporting/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Diagnostics/TraceReporting/mod.rs
@@ -71,6 +71,7 @@ pub struct IPlatformDiagnosticTraceRuntimeInfoVtbl(
 );
 #[doc = "*Required features: 'System_Diagnostics_TraceReporting'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PlatformDiagnosticActionState(pub i32);
 impl PlatformDiagnosticActionState {
     pub const Success: Self = Self(0i32);
@@ -86,12 +87,6 @@ impl ::core::clone::Clone for PlatformDiagnosticActionState {
 unsafe impl ::windows::core::Abi for PlatformDiagnosticActionState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PlatformDiagnosticActionState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PlatformDiagnosticActionState {}
 impl ::core::fmt::Debug for PlatformDiagnosticActionState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PlatformDiagnosticActionState").field(&self.0).finish()
@@ -176,6 +171,7 @@ impl ::windows::core::RuntimeName for PlatformDiagnosticActions {
 }
 #[doc = "*Required features: 'System_Diagnostics_TraceReporting'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PlatformDiagnosticEscalationType(pub i32);
 impl PlatformDiagnosticEscalationType {
     pub const OnCompletion: Self = Self(0i32);
@@ -190,12 +186,6 @@ impl ::core::clone::Clone for PlatformDiagnosticEscalationType {
 unsafe impl ::windows::core::Abi for PlatformDiagnosticEscalationType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PlatformDiagnosticEscalationType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PlatformDiagnosticEscalationType {}
 impl ::core::fmt::Debug for PlatformDiagnosticEscalationType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PlatformDiagnosticEscalationType").field(&self.0).finish()
@@ -209,6 +199,7 @@ impl ::windows::core::DefaultType for PlatformDiagnosticEscalationType {
 }
 #[doc = "*Required features: 'System_Diagnostics_TraceReporting'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PlatformDiagnosticEventBufferLatencies(pub u32);
 impl PlatformDiagnosticEventBufferLatencies {
     pub const Normal: Self = Self(1u32);
@@ -224,12 +215,6 @@ impl ::core::clone::Clone for PlatformDiagnosticEventBufferLatencies {
 unsafe impl ::windows::core::Abi for PlatformDiagnosticEventBufferLatencies {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PlatformDiagnosticEventBufferLatencies {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PlatformDiagnosticEventBufferLatencies {}
 impl ::core::fmt::Debug for PlatformDiagnosticEventBufferLatencies {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PlatformDiagnosticEventBufferLatencies").field(&self.0).finish()
@@ -392,6 +377,7 @@ unsafe impl ::core::marker::Send for PlatformDiagnosticTraceInfo {}
 unsafe impl ::core::marker::Sync for PlatformDiagnosticTraceInfo {}
 #[doc = "*Required features: 'System_Diagnostics_TraceReporting'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PlatformDiagnosticTracePriority(pub i32);
 impl PlatformDiagnosticTracePriority {
     pub const Normal: Self = Self(0i32);
@@ -406,12 +392,6 @@ impl ::core::clone::Clone for PlatformDiagnosticTracePriority {
 unsafe impl ::windows::core::Abi for PlatformDiagnosticTracePriority {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PlatformDiagnosticTracePriority {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PlatformDiagnosticTracePriority {}
 impl ::core::fmt::Debug for PlatformDiagnosticTracePriority {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PlatformDiagnosticTracePriority").field(&self.0).finish()
@@ -514,6 +494,7 @@ unsafe impl ::core::marker::Send for PlatformDiagnosticTraceRuntimeInfo {}
 unsafe impl ::core::marker::Sync for PlatformDiagnosticTraceRuntimeInfo {}
 #[doc = "*Required features: 'System_Diagnostics_TraceReporting'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PlatformDiagnosticTraceSlotState(pub i32);
 impl PlatformDiagnosticTraceSlotState {
     pub const NotRunning: Self = Self(0i32);
@@ -529,12 +510,6 @@ impl ::core::clone::Clone for PlatformDiagnosticTraceSlotState {
 unsafe impl ::windows::core::Abi for PlatformDiagnosticTraceSlotState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PlatformDiagnosticTraceSlotState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PlatformDiagnosticTraceSlotState {}
 impl ::core::fmt::Debug for PlatformDiagnosticTraceSlotState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PlatformDiagnosticTraceSlotState").field(&self.0).finish()
@@ -548,6 +523,7 @@ impl ::windows::core::DefaultType for PlatformDiagnosticTraceSlotState {
 }
 #[doc = "*Required features: 'System_Diagnostics_TraceReporting'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PlatformDiagnosticTraceSlotType(pub i32);
 impl PlatformDiagnosticTraceSlotType {
     pub const Alternative: Self = Self(0i32);
@@ -563,12 +539,6 @@ impl ::core::clone::Clone for PlatformDiagnosticTraceSlotType {
 unsafe impl ::windows::core::Abi for PlatformDiagnosticTraceSlotType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PlatformDiagnosticTraceSlotType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PlatformDiagnosticTraceSlotType {}
 impl ::core::fmt::Debug for PlatformDiagnosticTraceSlotType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PlatformDiagnosticTraceSlotType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/System/Diagnostics/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Diagnostics/mod.rs
@@ -97,6 +97,7 @@ unsafe impl ::core::marker::Send for DiagnosticActionResult {}
 unsafe impl ::core::marker::Sync for DiagnosticActionResult {}
 #[doc = "*Required features: 'System_Diagnostics'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DiagnosticActionState(pub i32);
 impl DiagnosticActionState {
     pub const Initializing: Self = Self(0i32);
@@ -116,12 +117,6 @@ impl ::core::clone::Clone for DiagnosticActionState {
 unsafe impl ::windows::core::Abi for DiagnosticActionState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DiagnosticActionState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DiagnosticActionState {}
 impl ::core::fmt::Debug for DiagnosticActionState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DiagnosticActionState").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/System/Power/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Power/mod.rs
@@ -109,6 +109,7 @@ impl ::windows::core::RuntimeName for BackgroundEnergyManager {
 }
 #[doc = "*Required features: 'System_Power'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BatteryStatus(pub i32);
 impl BatteryStatus {
     pub const NotPresent: Self = Self(0i32);
@@ -125,12 +126,6 @@ impl ::core::clone::Clone for BatteryStatus {
 unsafe impl ::windows::core::Abi for BatteryStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BatteryStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BatteryStatus {}
 impl ::core::fmt::Debug for BatteryStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BatteryStatus").field(&self.0).finish()
@@ -144,6 +139,7 @@ impl ::windows::core::DefaultType for BatteryStatus {
 }
 #[doc = "*Required features: 'System_Power'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EnergySaverStatus(pub i32);
 impl EnergySaverStatus {
     pub const Disabled: Self = Self(0i32);
@@ -159,12 +155,6 @@ impl ::core::clone::Clone for EnergySaverStatus {
 unsafe impl ::windows::core::Abi for EnergySaverStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EnergySaverStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EnergySaverStatus {}
 impl ::core::fmt::Debug for EnergySaverStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EnergySaverStatus").field(&self.0).finish()
@@ -508,6 +498,7 @@ impl ::windows::core::RuntimeName for PowerManager {
 }
 #[doc = "*Required features: 'System_Power'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PowerSupplyStatus(pub i32);
 impl PowerSupplyStatus {
     pub const NotPresent: Self = Self(0i32);
@@ -523,12 +514,6 @@ impl ::core::clone::Clone for PowerSupplyStatus {
 unsafe impl ::windows::core::Abi for PowerSupplyStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PowerSupplyStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PowerSupplyStatus {}
 impl ::core::fmt::Debug for PowerSupplyStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PowerSupplyStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/System/Preview/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Preview/mod.rs
@@ -2,6 +2,7 @@
 #[doc = "*Required features: 'System_Preview', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HingeState(pub i32);
 #[cfg(feature = "deprecated")]
 impl HingeState {
@@ -24,14 +25,6 @@ impl ::core::clone::Clone for HingeState {
 unsafe impl ::windows::core::Abi for HingeState {
     type Abi = Self;
 }
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for HingeState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for HingeState {}
 #[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for HingeState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {

--- a/crates/libs/windows/src/Windows/System/Profile/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Profile/mod.rs
@@ -841,6 +841,7 @@ impl ::windows::core::RuntimeName for KnownRetailInfoProperties {
 }
 #[doc = "*Required features: 'System_Profile'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PlatformDataCollectionLevel(pub i32);
 impl PlatformDataCollectionLevel {
     pub const Security: Self = Self(0i32);
@@ -857,12 +858,6 @@ impl ::core::clone::Clone for PlatformDataCollectionLevel {
 unsafe impl ::windows::core::Abi for PlatformDataCollectionLevel {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PlatformDataCollectionLevel {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PlatformDataCollectionLevel {}
 impl ::core::fmt::Debug for PlatformDataCollectionLevel {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PlatformDataCollectionLevel").field(&self.0).finish()
@@ -1089,6 +1084,7 @@ unsafe impl ::core::marker::Send for SystemIdentificationInfo {}
 unsafe impl ::core::marker::Sync for SystemIdentificationInfo {}
 #[doc = "*Required features: 'System_Profile'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SystemIdentificationSource(pub i32);
 impl SystemIdentificationSource {
     pub const None: Self = Self(0i32);
@@ -1105,12 +1101,6 @@ impl ::core::clone::Clone for SystemIdentificationSource {
 unsafe impl ::windows::core::Abi for SystemIdentificationSource {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SystemIdentificationSource {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SystemIdentificationSource {}
 impl ::core::fmt::Debug for SystemIdentificationSource {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SystemIdentificationSource").field(&self.0).finish()
@@ -1124,6 +1114,7 @@ impl ::windows::core::DefaultType for SystemIdentificationSource {
 }
 #[doc = "*Required features: 'System_Profile'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SystemOutOfBoxExperienceState(pub i32);
 impl SystemOutOfBoxExperienceState {
     pub const NotStarted: Self = Self(0i32);
@@ -1139,12 +1130,6 @@ impl ::core::clone::Clone for SystemOutOfBoxExperienceState {
 unsafe impl ::windows::core::Abi for SystemOutOfBoxExperienceState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SystemOutOfBoxExperienceState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SystemOutOfBoxExperienceState {}
 impl ::core::fmt::Debug for SystemOutOfBoxExperienceState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SystemOutOfBoxExperienceState").field(&self.0).finish()
@@ -1279,6 +1264,7 @@ unsafe impl ::core::marker::Send for UnsupportedAppRequirement {}
 unsafe impl ::core::marker::Sync for UnsupportedAppRequirement {}
 #[doc = "*Required features: 'System_Profile'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UnsupportedAppRequirementReasons(pub u32);
 impl UnsupportedAppRequirementReasons {
     pub const Unknown: Self = Self(0u32);
@@ -1293,12 +1279,6 @@ impl ::core::clone::Clone for UnsupportedAppRequirementReasons {
 unsafe impl ::windows::core::Abi for UnsupportedAppRequirementReasons {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UnsupportedAppRequirementReasons {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UnsupportedAppRequirementReasons {}
 impl ::core::fmt::Debug for UnsupportedAppRequirementReasons {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UnsupportedAppRequirementReasons").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/System/RemoteSystems/mod.rs
+++ b/crates/libs/windows/src/Windows/System/RemoteSystems/mod.rs
@@ -1697,6 +1697,7 @@ unsafe impl ::core::marker::Send for RemoteSystem {}
 unsafe impl ::core::marker::Sync for RemoteSystem {}
 #[doc = "*Required features: 'System_RemoteSystems'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RemoteSystemAccessStatus(pub i32);
 impl RemoteSystemAccessStatus {
     pub const Unspecified: Self = Self(0i32);
@@ -1713,12 +1714,6 @@ impl ::core::clone::Clone for RemoteSystemAccessStatus {
 unsafe impl ::windows::core::Abi for RemoteSystemAccessStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RemoteSystemAccessStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RemoteSystemAccessStatus {}
 impl ::core::fmt::Debug for RemoteSystemAccessStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RemoteSystemAccessStatus").field(&self.0).finish()
@@ -2061,6 +2056,7 @@ unsafe impl ::core::marker::Send for RemoteSystemAppRegistration {}
 unsafe impl ::core::marker::Sync for RemoteSystemAppRegistration {}
 #[doc = "*Required features: 'System_RemoteSystems'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RemoteSystemAuthorizationKind(pub i32);
 impl RemoteSystemAuthorizationKind {
     pub const SameUser: Self = Self(0i32);
@@ -2075,12 +2071,6 @@ impl ::core::clone::Clone for RemoteSystemAuthorizationKind {
 unsafe impl ::windows::core::Abi for RemoteSystemAuthorizationKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RemoteSystemAuthorizationKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RemoteSystemAuthorizationKind {}
 impl ::core::fmt::Debug for RemoteSystemAuthorizationKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RemoteSystemAuthorizationKind").field(&self.0).finish()
@@ -2443,6 +2433,7 @@ unsafe impl ::core::marker::Send for RemoteSystemConnectionRequest {}
 unsafe impl ::core::marker::Sync for RemoteSystemConnectionRequest {}
 #[doc = "*Required features: 'System_RemoteSystems'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RemoteSystemDiscoveryType(pub i32);
 impl RemoteSystemDiscoveryType {
     pub const Any: Self = Self(0i32);
@@ -2459,12 +2450,6 @@ impl ::core::clone::Clone for RemoteSystemDiscoveryType {
 unsafe impl ::windows::core::Abi for RemoteSystemDiscoveryType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RemoteSystemDiscoveryType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RemoteSystemDiscoveryType {}
 impl ::core::fmt::Debug for RemoteSystemDiscoveryType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RemoteSystemDiscoveryType").field(&self.0).finish()
@@ -2855,6 +2840,7 @@ impl ::windows::core::RuntimeName for RemoteSystemKinds {
 }
 #[doc = "*Required features: 'System_RemoteSystems'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RemoteSystemPlatform(pub i32);
 impl RemoteSystemPlatform {
     pub const Unknown: Self = Self(0i32);
@@ -2872,12 +2858,6 @@ impl ::core::clone::Clone for RemoteSystemPlatform {
 unsafe impl ::windows::core::Abi for RemoteSystemPlatform {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RemoteSystemPlatform {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RemoteSystemPlatform {}
 impl ::core::fmt::Debug for RemoteSystemPlatform {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RemoteSystemPlatform").field(&self.0).finish()
@@ -3440,6 +3420,7 @@ unsafe impl ::core::marker::Send for RemoteSystemSessionCreationResult {}
 unsafe impl ::core::marker::Sync for RemoteSystemSessionCreationResult {}
 #[doc = "*Required features: 'System_RemoteSystems'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RemoteSystemSessionCreationStatus(pub i32);
 impl RemoteSystemSessionCreationStatus {
     pub const Success: Self = Self(0i32);
@@ -3455,12 +3436,6 @@ impl ::core::clone::Clone for RemoteSystemSessionCreationStatus {
 unsafe impl ::windows::core::Abi for RemoteSystemSessionCreationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RemoteSystemSessionCreationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RemoteSystemSessionCreationStatus {}
 impl ::core::fmt::Debug for RemoteSystemSessionCreationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RemoteSystemSessionCreationStatus").field(&self.0).finish()
@@ -3555,6 +3530,7 @@ unsafe impl ::core::marker::Send for RemoteSystemSessionDisconnectedEventArgs {}
 unsafe impl ::core::marker::Sync for RemoteSystemSessionDisconnectedEventArgs {}
 #[doc = "*Required features: 'System_RemoteSystems'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RemoteSystemSessionDisconnectedReason(pub i32);
 impl RemoteSystemSessionDisconnectedReason {
     pub const SessionUnavailable: Self = Self(0i32);
@@ -3570,12 +3546,6 @@ impl ::core::clone::Clone for RemoteSystemSessionDisconnectedReason {
 unsafe impl ::windows::core::Abi for RemoteSystemSessionDisconnectedReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RemoteSystemSessionDisconnectedReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RemoteSystemSessionDisconnectedReason {}
 impl ::core::fmt::Debug for RemoteSystemSessionDisconnectedReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RemoteSystemSessionDisconnectedReason").field(&self.0).finish()
@@ -4217,6 +4187,7 @@ unsafe impl ::core::marker::Send for RemoteSystemSessionJoinResult {}
 unsafe impl ::core::marker::Sync for RemoteSystemSessionJoinResult {}
 #[doc = "*Required features: 'System_RemoteSystems'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RemoteSystemSessionJoinStatus(pub i32);
 impl RemoteSystemSessionJoinStatus {
     pub const Success: Self = Self(0i32);
@@ -4234,12 +4205,6 @@ impl ::core::clone::Clone for RemoteSystemSessionJoinStatus {
 unsafe impl ::windows::core::Abi for RemoteSystemSessionJoinStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RemoteSystemSessionJoinStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RemoteSystemSessionJoinStatus {}
 impl ::core::fmt::Debug for RemoteSystemSessionJoinStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RemoteSystemSessionJoinStatus").field(&self.0).finish()
@@ -4395,6 +4360,7 @@ unsafe impl ::core::marker::Send for RemoteSystemSessionMessageChannel {}
 unsafe impl ::core::marker::Sync for RemoteSystemSessionMessageChannel {}
 #[doc = "*Required features: 'System_RemoteSystems'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RemoteSystemSessionMessageChannelReliability(pub i32);
 impl RemoteSystemSessionMessageChannelReliability {
     pub const Reliable: Self = Self(0i32);
@@ -4409,12 +4375,6 @@ impl ::core::clone::Clone for RemoteSystemSessionMessageChannelReliability {
 unsafe impl ::windows::core::Abi for RemoteSystemSessionMessageChannelReliability {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RemoteSystemSessionMessageChannelReliability {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RemoteSystemSessionMessageChannelReliability {}
 impl ::core::fmt::Debug for RemoteSystemSessionMessageChannelReliability {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RemoteSystemSessionMessageChannelReliability").field(&self.0).finish()
@@ -4909,6 +4869,7 @@ unsafe impl ::core::marker::Send for RemoteSystemSessionParticipantWatcher {}
 unsafe impl ::core::marker::Sync for RemoteSystemSessionParticipantWatcher {}
 #[doc = "*Required features: 'System_RemoteSystems'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RemoteSystemSessionParticipantWatcherStatus(pub i32);
 impl RemoteSystemSessionParticipantWatcherStatus {
     pub const Created: Self = Self(0i32);
@@ -4927,12 +4888,6 @@ impl ::core::clone::Clone for RemoteSystemSessionParticipantWatcherStatus {
 unsafe impl ::windows::core::Abi for RemoteSystemSessionParticipantWatcherStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RemoteSystemSessionParticipantWatcherStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RemoteSystemSessionParticipantWatcherStatus {}
 impl ::core::fmt::Debug for RemoteSystemSessionParticipantWatcherStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RemoteSystemSessionParticipantWatcherStatus").field(&self.0).finish()
@@ -5334,6 +5289,7 @@ unsafe impl ::core::marker::Send for RemoteSystemSessionWatcher {}
 unsafe impl ::core::marker::Sync for RemoteSystemSessionWatcher {}
 #[doc = "*Required features: 'System_RemoteSystems'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RemoteSystemSessionWatcherStatus(pub i32);
 impl RemoteSystemSessionWatcherStatus {
     pub const Created: Self = Self(0i32);
@@ -5352,12 +5308,6 @@ impl ::core::clone::Clone for RemoteSystemSessionWatcherStatus {
 unsafe impl ::windows::core::Abi for RemoteSystemSessionWatcherStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RemoteSystemSessionWatcherStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RemoteSystemSessionWatcherStatus {}
 impl ::core::fmt::Debug for RemoteSystemSessionWatcherStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RemoteSystemSessionWatcherStatus").field(&self.0).finish()
@@ -5371,6 +5321,7 @@ impl ::windows::core::DefaultType for RemoteSystemSessionWatcherStatus {
 }
 #[doc = "*Required features: 'System_RemoteSystems'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RemoteSystemStatus(pub i32);
 impl RemoteSystemStatus {
     pub const Unavailable: Self = Self(0i32);
@@ -5387,12 +5338,6 @@ impl ::core::clone::Clone for RemoteSystemStatus {
 unsafe impl ::windows::core::Abi for RemoteSystemStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RemoteSystemStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RemoteSystemStatus {}
 impl ::core::fmt::Debug for RemoteSystemStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RemoteSystemStatus").field(&self.0).finish()
@@ -5406,6 +5351,7 @@ impl ::windows::core::DefaultType for RemoteSystemStatus {
 }
 #[doc = "*Required features: 'System_RemoteSystems'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RemoteSystemStatusType(pub i32);
 impl RemoteSystemStatusType {
     pub const Any: Self = Self(0i32);
@@ -5420,12 +5366,6 @@ impl ::core::clone::Clone for RemoteSystemStatusType {
 unsafe impl ::windows::core::Abi for RemoteSystemStatusType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RemoteSystemStatusType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RemoteSystemStatusType {}
 impl ::core::fmt::Debug for RemoteSystemStatusType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RemoteSystemStatusType").field(&self.0).finish()
@@ -5801,6 +5741,7 @@ unsafe impl ::core::marker::Send for RemoteSystemWatcher {}
 unsafe impl ::core::marker::Sync for RemoteSystemWatcher {}
 #[doc = "*Required features: 'System_RemoteSystems'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RemoteSystemWatcherError(pub i32);
 impl RemoteSystemWatcherError {
     pub const Unknown: Self = Self(0i32);
@@ -5816,12 +5757,6 @@ impl ::core::clone::Clone for RemoteSystemWatcherError {
 unsafe impl ::windows::core::Abi for RemoteSystemWatcherError {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RemoteSystemWatcherError {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RemoteSystemWatcherError {}
 impl ::core::fmt::Debug for RemoteSystemWatcherError {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RemoteSystemWatcherError").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/System/Threading/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Threading/mod.rs
@@ -485,6 +485,7 @@ pub struct WorkItemHandlerVtbl(
 );
 #[doc = "*Required features: 'System_Threading'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WorkItemOptions(pub u32);
 impl WorkItemOptions {
     pub const None: Self = Self(0u32);
@@ -499,12 +500,6 @@ impl ::core::clone::Clone for WorkItemOptions {
 unsafe impl ::windows::core::Abi for WorkItemOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WorkItemOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WorkItemOptions {}
 impl ::core::fmt::Debug for WorkItemOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WorkItemOptions").field(&self.0).finish()
@@ -546,6 +541,7 @@ impl ::windows::core::DefaultType for WorkItemOptions {
 }
 #[doc = "*Required features: 'System_Threading'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WorkItemPriority(pub i32);
 impl WorkItemPriority {
     pub const Low: Self = Self(-1i32);
@@ -561,12 +557,6 @@ impl ::core::clone::Clone for WorkItemPriority {
 unsafe impl ::windows::core::Abi for WorkItemPriority {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WorkItemPriority {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WorkItemPriority {}
 impl ::core::fmt::Debug for WorkItemPriority {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WorkItemPriority").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/System/Update/mod.rs
+++ b/crates/libs/windows/src/Windows/System/Update/mod.rs
@@ -98,6 +98,7 @@ pub struct ISystemUpdateManagerStaticsVtbl(
 );
 #[doc = "*Required features: 'System_Update'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SystemUpdateAttentionRequiredReason(pub i32);
 impl SystemUpdateAttentionRequiredReason {
     pub const None: Self = Self(0i32);
@@ -115,12 +116,6 @@ impl ::core::clone::Clone for SystemUpdateAttentionRequiredReason {
 unsafe impl ::windows::core::Abi for SystemUpdateAttentionRequiredReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SystemUpdateAttentionRequiredReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SystemUpdateAttentionRequiredReason {}
 impl ::core::fmt::Debug for SystemUpdateAttentionRequiredReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SystemUpdateAttentionRequiredReason").field(&self.0).finish()
@@ -271,6 +266,7 @@ unsafe impl ::core::marker::Send for SystemUpdateItem {}
 unsafe impl ::core::marker::Sync for SystemUpdateItem {}
 #[doc = "*Required features: 'System_Update'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SystemUpdateItemState(pub i32);
 impl SystemUpdateItemState {
     pub const NotStarted: Self = Self(0i32);
@@ -292,12 +288,6 @@ impl ::core::clone::Clone for SystemUpdateItemState {
 unsafe impl ::windows::core::Abi for SystemUpdateItemState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SystemUpdateItemState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SystemUpdateItemState {}
 impl ::core::fmt::Debug for SystemUpdateItemState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SystemUpdateItemState").field(&self.0).finish()
@@ -587,6 +577,7 @@ impl ::windows::core::RuntimeName for SystemUpdateManager {
 }
 #[doc = "*Required features: 'System_Update'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SystemUpdateManagerState(pub i32);
 impl SystemUpdateManagerState {
     pub const Idle: Self = Self(0i32);
@@ -611,12 +602,6 @@ impl ::core::clone::Clone for SystemUpdateManagerState {
 unsafe impl ::windows::core::Abi for SystemUpdateManagerState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SystemUpdateManagerState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SystemUpdateManagerState {}
 impl ::core::fmt::Debug for SystemUpdateManagerState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SystemUpdateManagerState").field(&self.0).finish()
@@ -630,6 +615,7 @@ impl ::windows::core::DefaultType for SystemUpdateManagerState {
 }
 #[doc = "*Required features: 'System_Update'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SystemUpdateStartInstallAction(pub i32);
 impl SystemUpdateStartInstallAction {
     pub const UpToReboot: Self = Self(0i32);
@@ -644,12 +630,6 @@ impl ::core::clone::Clone for SystemUpdateStartInstallAction {
 unsafe impl ::windows::core::Abi for SystemUpdateStartInstallAction {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SystemUpdateStartInstallAction {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SystemUpdateStartInstallAction {}
 impl ::core::fmt::Debug for SystemUpdateStartInstallAction {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SystemUpdateStartInstallAction").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/System/UserProfile/mod.rs
+++ b/crates/libs/windows/src/Windows/System/UserProfile/mod.rs
@@ -2,6 +2,7 @@
 #[doc = "*Required features: 'System_UserProfile', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AccountPictureKind(pub i32);
 #[cfg(feature = "deprecated")]
 impl AccountPictureKind {
@@ -21,14 +22,6 @@ impl ::core::clone::Clone for AccountPictureKind {
 unsafe impl ::windows::core::Abi for AccountPictureKind {
     type Abi = Self;
 }
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for AccountPictureKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for AccountPictureKind {}
 #[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for AccountPictureKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -1271,6 +1264,7 @@ impl ::windows::core::RuntimeName for LockScreen {
 #[doc = "*Required features: 'System_UserProfile', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SetAccountPictureResult(pub i32);
 #[cfg(feature = "deprecated")]
 impl SetAccountPictureResult {
@@ -1294,14 +1288,6 @@ unsafe impl ::windows::core::Abi for SetAccountPictureResult {
     type Abi = Self;
 }
 #[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for SetAccountPictureResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for SetAccountPictureResult {}
-#[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for SetAccountPictureResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SetAccountPictureResult").field(&self.0).finish()
@@ -1317,6 +1303,7 @@ impl ::windows::core::DefaultType for SetAccountPictureResult {
 }
 #[doc = "*Required features: 'System_UserProfile'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SetImageFeedResult(pub i32);
 impl SetImageFeedResult {
     pub const Success: Self = Self(0i32);
@@ -1332,12 +1319,6 @@ impl ::core::clone::Clone for SetImageFeedResult {
 unsafe impl ::windows::core::Abi for SetImageFeedResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SetImageFeedResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SetImageFeedResult {}
 impl ::core::fmt::Debug for SetImageFeedResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SetImageFeedResult").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/System/mod.rs
+++ b/crates/libs/windows/src/Windows/System/mod.rs
@@ -511,6 +511,7 @@ unsafe impl ::core::marker::Send for AppDiagnosticInfoWatcherEventArgs {}
 unsafe impl ::core::marker::Sync for AppDiagnosticInfoWatcherEventArgs {}
 #[doc = "*Required features: 'System'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppDiagnosticInfoWatcherStatus(pub i32);
 impl AppDiagnosticInfoWatcherStatus {
     pub const Created: Self = Self(0i32);
@@ -529,12 +530,6 @@ impl ::core::clone::Clone for AppDiagnosticInfoWatcherStatus {
 unsafe impl ::windows::core::Abi for AppDiagnosticInfoWatcherStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppDiagnosticInfoWatcherStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppDiagnosticInfoWatcherStatus {}
 impl ::core::fmt::Debug for AppDiagnosticInfoWatcherStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppDiagnosticInfoWatcherStatus").field(&self.0).finish()
@@ -742,6 +737,7 @@ unsafe impl ::core::marker::Send for AppMemoryReport {}
 unsafe impl ::core::marker::Sync for AppMemoryReport {}
 #[doc = "*Required features: 'System'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppMemoryUsageLevel(pub i32);
 impl AppMemoryUsageLevel {
     pub const Low: Self = Self(0i32);
@@ -758,12 +754,6 @@ impl ::core::clone::Clone for AppMemoryUsageLevel {
 unsafe impl ::windows::core::Abi for AppMemoryUsageLevel {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppMemoryUsageLevel {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppMemoryUsageLevel {}
 impl ::core::fmt::Debug for AppMemoryUsageLevel {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppMemoryUsageLevel").field(&self.0).finish()
@@ -971,6 +961,7 @@ unsafe impl ::core::marker::Send for AppResourceGroupBackgroundTaskReport {}
 unsafe impl ::core::marker::Sync for AppResourceGroupBackgroundTaskReport {}
 #[doc = "*Required features: 'System'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppResourceGroupEnergyQuotaState(pub i32);
 impl AppResourceGroupEnergyQuotaState {
     pub const Unknown: Self = Self(0i32);
@@ -986,12 +977,6 @@ impl ::core::clone::Clone for AppResourceGroupEnergyQuotaState {
 unsafe impl ::windows::core::Abi for AppResourceGroupEnergyQuotaState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppResourceGroupEnergyQuotaState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppResourceGroupEnergyQuotaState {}
 impl ::core::fmt::Debug for AppResourceGroupEnergyQuotaState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppResourceGroupEnergyQuotaState").field(&self.0).finish()
@@ -1005,6 +990,7 @@ impl ::windows::core::DefaultType for AppResourceGroupEnergyQuotaState {
 }
 #[doc = "*Required features: 'System'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppResourceGroupExecutionState(pub i32);
 impl AppResourceGroupExecutionState {
     pub const Unknown: Self = Self(0i32);
@@ -1022,12 +1008,6 @@ impl ::core::clone::Clone for AppResourceGroupExecutionState {
 unsafe impl ::windows::core::Abi for AppResourceGroupExecutionState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppResourceGroupExecutionState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppResourceGroupExecutionState {}
 impl ::core::fmt::Debug for AppResourceGroupExecutionState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppResourceGroupExecutionState").field(&self.0).finish()
@@ -1537,6 +1517,7 @@ unsafe impl ::core::marker::Send for AppResourceGroupInfoWatcherExecutionStateCh
 unsafe impl ::core::marker::Sync for AppResourceGroupInfoWatcherExecutionStateChangedEventArgs {}
 #[doc = "*Required features: 'System'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppResourceGroupInfoWatcherStatus(pub i32);
 impl AppResourceGroupInfoWatcherStatus {
     pub const Created: Self = Self(0i32);
@@ -1555,12 +1536,6 @@ impl ::core::clone::Clone for AppResourceGroupInfoWatcherStatus {
 unsafe impl ::windows::core::Abi for AppResourceGroupInfoWatcherStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppResourceGroupInfoWatcherStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppResourceGroupInfoWatcherStatus {}
 impl ::core::fmt::Debug for AppResourceGroupInfoWatcherStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppResourceGroupInfoWatcherStatus").field(&self.0).finish()
@@ -2151,6 +2126,7 @@ unsafe impl ::core::marker::Send for AppUriHandlerRegistrationManager {}
 unsafe impl ::core::marker::Sync for AppUriHandlerRegistrationManager {}
 #[doc = "*Required features: 'System'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AutoUpdateTimeZoneStatus(pub i32);
 impl AutoUpdateTimeZoneStatus {
     pub const Attempted: Self = Self(0i32);
@@ -2166,12 +2142,6 @@ impl ::core::clone::Clone for AutoUpdateTimeZoneStatus {
 unsafe impl ::windows::core::Abi for AutoUpdateTimeZoneStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AutoUpdateTimeZoneStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AutoUpdateTimeZoneStatus {}
 impl ::core::fmt::Debug for AutoUpdateTimeZoneStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AutoUpdateTimeZoneStatus").field(&self.0).finish()
@@ -2202,6 +2172,7 @@ impl ::windows::core::RuntimeName for DateTimeSettings {
 }
 #[doc = "*Required features: 'System'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DiagnosticAccessStatus(pub i32);
 impl DiagnosticAccessStatus {
     pub const Unspecified: Self = Self(0i32);
@@ -2218,12 +2189,6 @@ impl ::core::clone::Clone for DiagnosticAccessStatus {
 unsafe impl ::windows::core::Abi for DiagnosticAccessStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DiagnosticAccessStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DiagnosticAccessStatus {}
 impl ::core::fmt::Debug for DiagnosticAccessStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DiagnosticAccessStatus").field(&self.0).finish()
@@ -2561,6 +2526,7 @@ unsafe impl ::windows::core::RuntimeType for DispatcherQueueHandler {
 pub struct DispatcherQueueHandlerVtbl(pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> ::windows::core::HRESULT);
 #[doc = "*Required features: 'System'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DispatcherQueuePriority(pub i32);
 impl DispatcherQueuePriority {
     pub const Low: Self = Self(-10i32);
@@ -2576,12 +2542,6 @@ impl ::core::clone::Clone for DispatcherQueuePriority {
 unsafe impl ::windows::core::Abi for DispatcherQueuePriority {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DispatcherQueuePriority {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DispatcherQueuePriority {}
 impl ::core::fmt::Debug for DispatcherQueuePriority {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DispatcherQueuePriority").field(&self.0).finish()
@@ -4872,6 +4832,7 @@ impl ::windows::core::RuntimeName for KnownUserProperties {
 }
 #[doc = "*Required features: 'System'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LaunchFileStatus(pub i32);
 impl LaunchFileStatus {
     pub const Success: Self = Self(0i32);
@@ -4889,12 +4850,6 @@ impl ::core::clone::Clone for LaunchFileStatus {
 unsafe impl ::windows::core::Abi for LaunchFileStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LaunchFileStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LaunchFileStatus {}
 impl ::core::fmt::Debug for LaunchFileStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LaunchFileStatus").field(&self.0).finish()
@@ -4908,6 +4863,7 @@ impl ::windows::core::DefaultType for LaunchFileStatus {
 }
 #[doc = "*Required features: 'System'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LaunchQuerySupportStatus(pub i32);
 impl LaunchQuerySupportStatus {
     pub const Available: Self = Self(0i32);
@@ -4925,12 +4881,6 @@ impl ::core::clone::Clone for LaunchQuerySupportStatus {
 unsafe impl ::windows::core::Abi for LaunchQuerySupportStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LaunchQuerySupportStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LaunchQuerySupportStatus {}
 impl ::core::fmt::Debug for LaunchQuerySupportStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LaunchQuerySupportStatus").field(&self.0).finish()
@@ -4944,6 +4894,7 @@ impl ::windows::core::DefaultType for LaunchQuerySupportStatus {
 }
 #[doc = "*Required features: 'System'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LaunchQuerySupportType(pub i32);
 impl LaunchQuerySupportType {
     pub const Uri: Self = Self(0i32);
@@ -4958,12 +4909,6 @@ impl ::core::clone::Clone for LaunchQuerySupportType {
 unsafe impl ::windows::core::Abi for LaunchQuerySupportType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LaunchQuerySupportType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LaunchQuerySupportType {}
 impl ::core::fmt::Debug for LaunchQuerySupportType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LaunchQuerySupportType").field(&self.0).finish()
@@ -5067,6 +5012,7 @@ unsafe impl ::core::marker::Send for LaunchUriResult {}
 unsafe impl ::core::marker::Sync for LaunchUriResult {}
 #[doc = "*Required features: 'System'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LaunchUriStatus(pub i32);
 impl LaunchUriStatus {
     pub const Success: Self = Self(0i32);
@@ -5083,12 +5029,6 @@ impl ::core::clone::Clone for LaunchUriStatus {
 unsafe impl ::windows::core::Abi for LaunchUriStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LaunchUriStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LaunchUriStatus {}
 impl ::core::fmt::Debug for LaunchUriStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LaunchUriStatus").field(&self.0).finish()
@@ -5850,6 +5790,7 @@ impl ::windows::core::RuntimeName for MemoryManager {
 }
 #[doc = "*Required features: 'System'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PowerState(pub i32);
 impl PowerState {
     pub const ConnectedStandby: Self = Self(0i32);
@@ -5864,12 +5805,6 @@ impl ::core::clone::Clone for PowerState {
 unsafe impl ::windows::core::Abi for PowerState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PowerState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PowerState {}
 impl ::core::fmt::Debug for PowerState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PowerState").field(&self.0).finish()
@@ -6219,6 +6154,7 @@ unsafe impl ::core::marker::Send for ProcessMemoryReport {}
 unsafe impl ::core::marker::Sync for ProcessMemoryReport {}
 #[doc = "*Required features: 'System'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ProcessorArchitecture(pub i32);
 impl ProcessorArchitecture {
     pub const X86: Self = Self(0i32);
@@ -6238,12 +6174,6 @@ impl ::core::clone::Clone for ProcessorArchitecture {
 unsafe impl ::windows::core::Abi for ProcessorArchitecture {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ProcessorArchitecture {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ProcessorArchitecture {}
 impl ::core::fmt::Debug for ProcessorArchitecture {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ProcessorArchitecture").field(&self.0).finish()
@@ -6336,6 +6266,7 @@ unsafe impl ::core::marker::Send for ProtocolForResultsOperation {}
 unsafe impl ::core::marker::Sync for ProtocolForResultsOperation {}
 #[doc = "*Required features: 'System'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RemoteLaunchUriStatus(pub i32);
 impl RemoteLaunchUriStatus {
     pub const Unknown: Self = Self(0i32);
@@ -6356,12 +6287,6 @@ impl ::core::clone::Clone for RemoteLaunchUriStatus {
 unsafe impl ::windows::core::Abi for RemoteLaunchUriStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RemoteLaunchUriStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RemoteLaunchUriStatus {}
 impl ::core::fmt::Debug for RemoteLaunchUriStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RemoteLaunchUriStatus").field(&self.0).finish()
@@ -6515,6 +6440,7 @@ unsafe impl ::core::marker::Send for RemoteLauncherOptions {}
 unsafe impl ::core::marker::Sync for RemoteLauncherOptions {}
 #[doc = "*Required features: 'System'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ShutdownKind(pub i32);
 impl ShutdownKind {
     pub const Shutdown: Self = Self(0i32);
@@ -6529,12 +6455,6 @@ impl ::core::clone::Clone for ShutdownKind {
 unsafe impl ::windows::core::Abi for ShutdownKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ShutdownKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ShutdownKind {}
 impl ::core::fmt::Debug for ShutdownKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ShutdownKind").field(&self.0).finish()
@@ -6829,6 +6749,7 @@ unsafe impl ::core::marker::Send for User {}
 unsafe impl ::core::marker::Sync for User {}
 #[doc = "*Required features: 'System'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserAgeConsentGroup(pub i32);
 impl UserAgeConsentGroup {
     pub const Child: Self = Self(0i32);
@@ -6844,12 +6765,6 @@ impl ::core::clone::Clone for UserAgeConsentGroup {
 unsafe impl ::windows::core::Abi for UserAgeConsentGroup {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserAgeConsentGroup {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserAgeConsentGroup {}
 impl ::core::fmt::Debug for UserAgeConsentGroup {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserAgeConsentGroup").field(&self.0).finish()
@@ -6863,6 +6778,7 @@ impl ::windows::core::DefaultType for UserAgeConsentGroup {
 }
 #[doc = "*Required features: 'System'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserAgeConsentResult(pub i32);
 impl UserAgeConsentResult {
     pub const NotEnforced: Self = Self(0i32);
@@ -6880,12 +6796,6 @@ impl ::core::clone::Clone for UserAgeConsentResult {
 unsafe impl ::windows::core::Abi for UserAgeConsentResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserAgeConsentResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserAgeConsentResult {}
 impl ::core::fmt::Debug for UserAgeConsentResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserAgeConsentResult").field(&self.0).finish()
@@ -6899,6 +6809,7 @@ impl ::windows::core::DefaultType for UserAgeConsentResult {
 }
 #[doc = "*Required features: 'System'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserAuthenticationStatus(pub i32);
 impl UserAuthenticationStatus {
     pub const Unauthenticated: Self = Self(0i32);
@@ -6914,12 +6825,6 @@ impl ::core::clone::Clone for UserAuthenticationStatus {
 unsafe impl ::windows::core::Abi for UserAuthenticationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserAuthenticationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserAuthenticationStatus {}
 impl ::core::fmt::Debug for UserAuthenticationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserAuthenticationStatus").field(&self.0).finish()
@@ -7462,6 +7367,7 @@ unsafe impl ::core::marker::Send for UserPicker {}
 unsafe impl ::core::marker::Sync for UserPicker {}
 #[doc = "*Required features: 'System'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserPictureSize(pub i32);
 impl UserPictureSize {
     pub const Size64x64: Self = Self(0i32);
@@ -7478,12 +7384,6 @@ impl ::core::clone::Clone for UserPictureSize {
 unsafe impl ::windows::core::Abi for UserPictureSize {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserPictureSize {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserPictureSize {}
 impl ::core::fmt::Debug for UserPictureSize {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserPictureSize").field(&self.0).finish()
@@ -7497,6 +7397,7 @@ impl ::windows::core::DefaultType for UserPictureSize {
 }
 #[doc = "*Required features: 'System'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserType(pub i32);
 impl UserType {
     pub const LocalUser: Self = Self(0i32);
@@ -7514,12 +7415,6 @@ impl ::core::clone::Clone for UserType {
 unsafe impl ::windows::core::Abi for UserType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserType {}
 impl ::core::fmt::Debug for UserType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserType").field(&self.0).finish()
@@ -7729,6 +7624,7 @@ unsafe impl ::core::marker::Send for UserWatcher {}
 unsafe impl ::core::marker::Sync for UserWatcher {}
 #[doc = "*Required features: 'System'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserWatcherStatus(pub i32);
 impl UserWatcherStatus {
     pub const Created: Self = Self(0i32);
@@ -7747,12 +7643,6 @@ impl ::core::clone::Clone for UserWatcherStatus {
 unsafe impl ::windows::core::Abi for UserWatcherStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserWatcherStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserWatcherStatus {}
 impl ::core::fmt::Debug for UserWatcherStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserWatcherStatus").field(&self.0).finish()
@@ -7766,6 +7656,7 @@ impl ::windows::core::DefaultType for UserWatcherStatus {
 }
 #[doc = "*Required features: 'System'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserWatcherUpdateKind(pub i32);
 impl UserWatcherUpdateKind {
     pub const Properties: Self = Self(0i32);
@@ -7780,12 +7671,6 @@ impl ::core::clone::Clone for UserWatcherUpdateKind {
 unsafe impl ::windows::core::Abi for UserWatcherUpdateKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserWatcherUpdateKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserWatcherUpdateKind {}
 impl ::core::fmt::Debug for UserWatcherUpdateKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserWatcherUpdateKind").field(&self.0).finish()
@@ -7799,6 +7684,7 @@ impl ::windows::core::DefaultType for UserWatcherUpdateKind {
 }
 #[doc = "*Required features: 'System'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VirtualKey(pub i32);
 impl VirtualKey {
     pub const None: Self = Self(0i32);
@@ -7983,12 +7869,6 @@ impl ::core::clone::Clone for VirtualKey {
 unsafe impl ::windows::core::Abi for VirtualKey {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VirtualKey {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VirtualKey {}
 impl ::core::fmt::Debug for VirtualKey {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VirtualKey").field(&self.0).finish()
@@ -8002,6 +7882,7 @@ impl ::windows::core::DefaultType for VirtualKey {
 }
 #[doc = "*Required features: 'System'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VirtualKeyModifiers(pub u32);
 impl VirtualKeyModifiers {
     pub const None: Self = Self(0u32);
@@ -8019,12 +7900,6 @@ impl ::core::clone::Clone for VirtualKeyModifiers {
 unsafe impl ::windows::core::Abi for VirtualKeyModifiers {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VirtualKeyModifiers {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VirtualKeyModifiers {}
 impl ::core::fmt::Debug for VirtualKeyModifiers {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VirtualKeyModifiers").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/ApplicationSettings/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/ApplicationSettings/mod.rs
@@ -1145,6 +1145,7 @@ impl<'a> ::windows::core::IntoParam<'a, super::Popups::IUICommand> for &Settings
 #[doc = "*Required features: 'UI_ApplicationSettings', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SettingsEdgeLocation(pub i32);
 #[cfg(feature = "deprecated")]
 impl SettingsEdgeLocation {
@@ -1163,14 +1164,6 @@ impl ::core::clone::Clone for SettingsEdgeLocation {
 unsafe impl ::windows::core::Abi for SettingsEdgeLocation {
     type Abi = Self;
 }
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for SettingsEdgeLocation {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for SettingsEdgeLocation {}
 #[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for SettingsEdgeLocation {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -1511,6 +1504,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Sett
 }
 #[doc = "*Required features: 'UI_ApplicationSettings'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SupportedWebAccountActions(pub u32);
 impl SupportedWebAccountActions {
     pub const None: Self = Self(0u32);
@@ -1529,12 +1523,6 @@ impl ::core::clone::Clone for SupportedWebAccountActions {
 unsafe impl ::windows::core::Abi for SupportedWebAccountActions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SupportedWebAccountActions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SupportedWebAccountActions {}
 impl ::core::fmt::Debug for SupportedWebAccountActions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SupportedWebAccountActions").field(&self.0).finish()
@@ -1576,6 +1564,7 @@ impl ::windows::core::DefaultType for SupportedWebAccountActions {
 }
 #[doc = "*Required features: 'UI_ApplicationSettings'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WebAccountAction(pub i32);
 impl WebAccountAction {
     pub const Reconnect: Self = Self(0i32);
@@ -1593,12 +1582,6 @@ impl ::core::clone::Clone for WebAccountAction {
 unsafe impl ::windows::core::Abi for WebAccountAction {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WebAccountAction {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WebAccountAction {}
 impl ::core::fmt::Debug for WebAccountAction {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WebAccountAction").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Composition/Diagnostics/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/Diagnostics/mod.rs
@@ -94,6 +94,7 @@ unsafe impl ::core::marker::Send for CompositionDebugHeatMaps {}
 unsafe impl ::core::marker::Sync for CompositionDebugHeatMaps {}
 #[doc = "*Required features: 'UI_Composition_Diagnostics'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CompositionDebugOverdrawContentKinds(pub u32);
 impl CompositionDebugOverdrawContentKinds {
     pub const None: Self = Self(0u32);
@@ -115,12 +116,6 @@ impl ::core::clone::Clone for CompositionDebugOverdrawContentKinds {
 unsafe impl ::windows::core::Abi for CompositionDebugOverdrawContentKinds {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CompositionDebugOverdrawContentKinds {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CompositionDebugOverdrawContentKinds {}
 impl ::core::fmt::Debug for CompositionDebugOverdrawContentKinds {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CompositionDebugOverdrawContentKinds").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Composition/Effects/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/Effects/mod.rs
@@ -276,6 +276,7 @@ unsafe impl ::core::marker::Send for SceneLightingEffect {}
 unsafe impl ::core::marker::Sync for SceneLightingEffect {}
 #[doc = "*Required features: 'UI_Composition_Effects'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SceneLightingEffectReflectanceModel(pub i32);
 impl SceneLightingEffectReflectanceModel {
     pub const BlinnPhong: Self = Self(0i32);
@@ -290,12 +291,6 @@ impl ::core::clone::Clone for SceneLightingEffectReflectanceModel {
 unsafe impl ::windows::core::Abi for SceneLightingEffectReflectanceModel {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SceneLightingEffectReflectanceModel {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SceneLightingEffectReflectanceModel {}
 impl ::core::fmt::Debug for SceneLightingEffectReflectanceModel {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SceneLightingEffectReflectanceModel").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Composition/Interactions/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/Interactions/mod.rs
@@ -1636,6 +1636,7 @@ pub struct IVisualInteractionSourceStatics2Vtbl(
 );
 #[doc = "*Required features: 'UI_Composition_Interactions'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InteractionBindingAxisModes(pub u32);
 impl InteractionBindingAxisModes {
     pub const None: Self = Self(0u32);
@@ -1652,12 +1653,6 @@ impl ::core::clone::Clone for InteractionBindingAxisModes {
 unsafe impl ::windows::core::Abi for InteractionBindingAxisModes {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InteractionBindingAxisModes {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InteractionBindingAxisModes {}
 impl ::core::fmt::Debug for InteractionBindingAxisModes {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InteractionBindingAxisModes").field(&self.0).finish()
@@ -1699,6 +1694,7 @@ impl ::windows::core::DefaultType for InteractionBindingAxisModes {
 }
 #[doc = "*Required features: 'UI_Composition_Interactions'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InteractionChainingMode(pub i32);
 impl InteractionChainingMode {
     pub const Auto: Self = Self(0i32);
@@ -1714,12 +1710,6 @@ impl ::core::clone::Clone for InteractionChainingMode {
 unsafe impl ::windows::core::Abi for InteractionChainingMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InteractionChainingMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InteractionChainingMode {}
 impl ::core::fmt::Debug for InteractionChainingMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InteractionChainingMode").field(&self.0).finish()
@@ -2012,6 +2002,7 @@ unsafe impl ::core::marker::Send for InteractionSourceConfiguration {}
 unsafe impl ::core::marker::Sync for InteractionSourceConfiguration {}
 #[doc = "*Required features: 'UI_Composition_Interactions'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InteractionSourceMode(pub i32);
 impl InteractionSourceMode {
     pub const Disabled: Self = Self(0i32);
@@ -2027,12 +2018,6 @@ impl ::core::clone::Clone for InteractionSourceMode {
 unsafe impl ::windows::core::Abi for InteractionSourceMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InteractionSourceMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InteractionSourceMode {}
 impl ::core::fmt::Debug for InteractionSourceMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InteractionSourceMode").field(&self.0).finish()
@@ -2046,6 +2031,7 @@ impl ::windows::core::DefaultType for InteractionSourceMode {
 }
 #[doc = "*Required features: 'UI_Composition_Interactions'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InteractionSourceRedirectionMode(pub i32);
 impl InteractionSourceRedirectionMode {
     pub const Disabled: Self = Self(0i32);
@@ -2060,12 +2046,6 @@ impl ::core::clone::Clone for InteractionSourceRedirectionMode {
 unsafe impl ::windows::core::Abi for InteractionSourceRedirectionMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InteractionSourceRedirectionMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InteractionSourceRedirectionMode {}
 impl ::core::fmt::Debug for InteractionSourceRedirectionMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InteractionSourceRedirectionMode").field(&self.0).finish()
@@ -2658,6 +2638,7 @@ unsafe impl ::core::marker::Send for InteractionTracker {}
 unsafe impl ::core::marker::Sync for InteractionTracker {}
 #[doc = "*Required features: 'UI_Composition_Interactions'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InteractionTrackerClampingOption(pub i32);
 impl InteractionTrackerClampingOption {
     pub const Auto: Self = Self(0i32);
@@ -2672,12 +2653,6 @@ impl ::core::clone::Clone for InteractionTrackerClampingOption {
 unsafe impl ::windows::core::Abi for InteractionTrackerClampingOption {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InteractionTrackerClampingOption {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InteractionTrackerClampingOption {}
 impl ::core::fmt::Debug for InteractionTrackerClampingOption {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InteractionTrackerClampingOption").field(&self.0).finish()
@@ -4241,6 +4216,7 @@ unsafe impl ::core::marker::Send for InteractionTrackerInteractingStateEnteredAr
 unsafe impl ::core::marker::Sync for InteractionTrackerInteractingStateEnteredArgs {}
 #[doc = "*Required features: 'UI_Composition_Interactions'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InteractionTrackerPositionUpdateOption(pub i32);
 impl InteractionTrackerPositionUpdateOption {
     pub const Default: Self = Self(0i32);
@@ -4255,12 +4231,6 @@ impl ::core::clone::Clone for InteractionTrackerPositionUpdateOption {
 unsafe impl ::windows::core::Abi for InteractionTrackerPositionUpdateOption {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InteractionTrackerPositionUpdateOption {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InteractionTrackerPositionUpdateOption {}
 impl ::core::fmt::Debug for InteractionTrackerPositionUpdateOption {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InteractionTrackerPositionUpdateOption").field(&self.0).finish()
@@ -5497,6 +5467,7 @@ unsafe impl ::core::marker::Send for VisualInteractionSource {}
 unsafe impl ::core::marker::Sync for VisualInteractionSource {}
 #[doc = "*Required features: 'UI_Composition_Interactions'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VisualInteractionSourceRedirectionMode(pub i32);
 impl VisualInteractionSourceRedirectionMode {
     pub const Off: Self = Self(0i32);
@@ -5513,12 +5484,6 @@ impl ::core::clone::Clone for VisualInteractionSourceRedirectionMode {
 unsafe impl ::windows::core::Abi for VisualInteractionSourceRedirectionMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VisualInteractionSourceRedirectionMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VisualInteractionSourceRedirectionMode {}
 impl ::core::fmt::Debug for VisualInteractionSourceRedirectionMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VisualInteractionSourceRedirectionMode").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Composition/Scenes/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/Scenes/mod.rs
@@ -592,6 +592,7 @@ pub struct ISceneVisualStaticsVtbl(
 );
 #[doc = "*Required features: 'UI_Composition_Scenes'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SceneAlphaMode(pub i32);
 impl SceneAlphaMode {
     pub const Opaque: Self = Self(0i32);
@@ -607,12 +608,6 @@ impl ::core::clone::Clone for SceneAlphaMode {
 unsafe impl ::windows::core::Abi for SceneAlphaMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SceneAlphaMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SceneAlphaMode {}
 impl ::core::fmt::Debug for SceneAlphaMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SceneAlphaMode").field(&self.0).finish()
@@ -626,6 +621,7 @@ impl ::windows::core::DefaultType for SceneAlphaMode {
 }
 #[doc = "*Required features: 'UI_Composition_Scenes'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SceneAttributeSemantic(pub i32);
 impl SceneAttributeSemantic {
     pub const Index: Self = Self(0i32);
@@ -645,12 +641,6 @@ impl ::core::clone::Clone for SceneAttributeSemantic {
 unsafe impl ::windows::core::Abi for SceneAttributeSemantic {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SceneAttributeSemantic {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SceneAttributeSemantic {}
 impl ::core::fmt::Debug for SceneAttributeSemantic {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SceneAttributeSemantic").field(&self.0).finish()
@@ -1692,6 +1682,7 @@ unsafe impl ::core::marker::Send for SceneComponentCollection {}
 unsafe impl ::core::marker::Sync for SceneComponentCollection {}
 #[doc = "*Required features: 'UI_Composition_Scenes'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SceneComponentType(pub i32);
 impl SceneComponentType {
     pub const MeshRendererComponent: Self = Self(0i32);
@@ -1705,12 +1696,6 @@ impl ::core::clone::Clone for SceneComponentType {
 unsafe impl ::windows::core::Abi for SceneComponentType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SceneComponentType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SceneComponentType {}
 impl ::core::fmt::Debug for SceneComponentType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SceneComponentType").field(&self.0).finish()
@@ -6791,6 +6776,7 @@ unsafe impl ::core::marker::Send for SceneVisual {}
 unsafe impl ::core::marker::Sync for SceneVisual {}
 #[doc = "*Required features: 'UI_Composition_Scenes'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SceneWrappingMode(pub i32);
 impl SceneWrappingMode {
     pub const ClampToEdge: Self = Self(0i32);
@@ -6806,12 +6792,6 @@ impl ::core::clone::Clone for SceneWrappingMode {
 unsafe impl ::windows::core::Abi for SceneWrappingMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SceneWrappingMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SceneWrappingMode {}
 impl ::core::fmt::Debug for SceneWrappingMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SceneWrappingMode").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Composition/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Composition/mod.rs
@@ -636,6 +636,7 @@ unsafe impl ::core::marker::Send for AnimationController {}
 unsafe impl ::core::marker::Sync for AnimationController {}
 #[doc = "*Required features: 'UI_Composition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AnimationControllerProgressBehavior(pub i32);
 impl AnimationControllerProgressBehavior {
     pub const Default: Self = Self(0i32);
@@ -650,12 +651,6 @@ impl ::core::clone::Clone for AnimationControllerProgressBehavior {
 unsafe impl ::windows::core::Abi for AnimationControllerProgressBehavior {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AnimationControllerProgressBehavior {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AnimationControllerProgressBehavior {}
 impl ::core::fmt::Debug for AnimationControllerProgressBehavior {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AnimationControllerProgressBehavior").field(&self.0).finish()
@@ -669,6 +664,7 @@ impl ::windows::core::DefaultType for AnimationControllerProgressBehavior {
 }
 #[doc = "*Required features: 'UI_Composition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AnimationDelayBehavior(pub i32);
 impl AnimationDelayBehavior {
     pub const SetInitialValueAfterDelay: Self = Self(0i32);
@@ -683,12 +679,6 @@ impl ::core::clone::Clone for AnimationDelayBehavior {
 unsafe impl ::windows::core::Abi for AnimationDelayBehavior {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AnimationDelayBehavior {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AnimationDelayBehavior {}
 impl ::core::fmt::Debug for AnimationDelayBehavior {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AnimationDelayBehavior").field(&self.0).finish()
@@ -702,6 +692,7 @@ impl ::windows::core::DefaultType for AnimationDelayBehavior {
 }
 #[doc = "*Required features: 'UI_Composition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AnimationDirection(pub i32);
 impl AnimationDirection {
     pub const Normal: Self = Self(0i32);
@@ -718,12 +709,6 @@ impl ::core::clone::Clone for AnimationDirection {
 unsafe impl ::windows::core::Abi for AnimationDirection {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AnimationDirection {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AnimationDirection {}
 impl ::core::fmt::Debug for AnimationDirection {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AnimationDirection").field(&self.0).finish()
@@ -737,6 +722,7 @@ impl ::windows::core::DefaultType for AnimationDirection {
 }
 #[doc = "*Required features: 'UI_Composition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AnimationIterationBehavior(pub i32);
 impl AnimationIterationBehavior {
     pub const Count: Self = Self(0i32);
@@ -751,12 +737,6 @@ impl ::core::clone::Clone for AnimationIterationBehavior {
 unsafe impl ::windows::core::Abi for AnimationIterationBehavior {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AnimationIterationBehavior {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AnimationIterationBehavior {}
 impl ::core::fmt::Debug for AnimationIterationBehavior {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AnimationIterationBehavior").field(&self.0).finish()
@@ -770,6 +750,7 @@ impl ::windows::core::DefaultType for AnimationIterationBehavior {
 }
 #[doc = "*Required features: 'UI_Composition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AnimationPropertyAccessMode(pub i32);
 impl AnimationPropertyAccessMode {
     pub const None: Self = Self(0i32);
@@ -786,12 +767,6 @@ impl ::core::clone::Clone for AnimationPropertyAccessMode {
 unsafe impl ::windows::core::Abi for AnimationPropertyAccessMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AnimationPropertyAccessMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AnimationPropertyAccessMode {}
 impl ::core::fmt::Debug for AnimationPropertyAccessMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AnimationPropertyAccessMode").field(&self.0).finish()
@@ -1074,6 +1049,7 @@ unsafe impl ::core::marker::Send for AnimationPropertyInfo {}
 unsafe impl ::core::marker::Sync for AnimationPropertyInfo {}
 #[doc = "*Required features: 'UI_Composition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AnimationStopBehavior(pub i32);
 impl AnimationStopBehavior {
     pub const LeaveCurrentValue: Self = Self(0i32);
@@ -1089,12 +1065,6 @@ impl ::core::clone::Clone for AnimationStopBehavior {
 unsafe impl ::windows::core::Abi for AnimationStopBehavior {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AnimationStopBehavior {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AnimationStopBehavior {}
 impl ::core::fmt::Debug for AnimationStopBehavior {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AnimationStopBehavior").field(&self.0).finish()
@@ -5510,6 +5480,7 @@ unsafe impl ::core::marker::Send for CompositionBackdropBrush {}
 unsafe impl ::core::marker::Sync for CompositionBackdropBrush {}
 #[doc = "*Required features: 'UI_Composition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CompositionBackfaceVisibility(pub i32);
 impl CompositionBackfaceVisibility {
     pub const Inherit: Self = Self(0i32);
@@ -5525,12 +5496,6 @@ impl ::core::clone::Clone for CompositionBackfaceVisibility {
 unsafe impl ::windows::core::Abi for CompositionBackfaceVisibility {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CompositionBackfaceVisibility {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CompositionBackfaceVisibility {}
 impl ::core::fmt::Debug for CompositionBackfaceVisibility {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CompositionBackfaceVisibility").field(&self.0).finish()
@@ -5784,6 +5749,7 @@ unsafe impl ::core::marker::Send for CompositionBatchCompletedEventArgs {}
 unsafe impl ::core::marker::Sync for CompositionBatchCompletedEventArgs {}
 #[doc = "*Required features: 'UI_Composition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CompositionBatchTypes(pub u32);
 impl CompositionBatchTypes {
     pub const None: Self = Self(0u32);
@@ -5801,12 +5767,6 @@ impl ::core::clone::Clone for CompositionBatchTypes {
 unsafe impl ::windows::core::Abi for CompositionBatchTypes {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CompositionBatchTypes {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CompositionBatchTypes {}
 impl ::core::fmt::Debug for CompositionBatchTypes {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CompositionBatchTypes").field(&self.0).finish()
@@ -5848,6 +5808,7 @@ impl ::windows::core::DefaultType for CompositionBatchTypes {
 }
 #[doc = "*Required features: 'UI_Composition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CompositionBitmapInterpolationMode(pub i32);
 impl CompositionBitmapInterpolationMode {
     pub const NearestNeighbor: Self = Self(0i32);
@@ -5870,12 +5831,6 @@ impl ::core::clone::Clone for CompositionBitmapInterpolationMode {
 unsafe impl ::windows::core::Abi for CompositionBitmapInterpolationMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CompositionBitmapInterpolationMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CompositionBitmapInterpolationMode {}
 impl ::core::fmt::Debug for CompositionBitmapInterpolationMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CompositionBitmapInterpolationMode").field(&self.0).finish()
@@ -5889,6 +5844,7 @@ impl ::windows::core::DefaultType for CompositionBitmapInterpolationMode {
 }
 #[doc = "*Required features: 'UI_Composition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CompositionBorderMode(pub i32);
 impl CompositionBorderMode {
     pub const Inherit: Self = Self(0i32);
@@ -5904,12 +5860,6 @@ impl ::core::clone::Clone for CompositionBorderMode {
 unsafe impl ::windows::core::Abi for CompositionBorderMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CompositionBorderMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CompositionBorderMode {}
 impl ::core::fmt::Debug for CompositionBorderMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CompositionBorderMode").field(&self.0).finish()
@@ -7396,6 +7346,7 @@ unsafe impl ::core::marker::Send for CompositionColorGradientStopCollection {}
 unsafe impl ::core::marker::Sync for CompositionColorGradientStopCollection {}
 #[doc = "*Required features: 'UI_Composition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CompositionColorSpace(pub i32);
 impl CompositionColorSpace {
     pub const Auto: Self = Self(0i32);
@@ -7413,12 +7364,6 @@ impl ::core::clone::Clone for CompositionColorSpace {
 unsafe impl ::windows::core::Abi for CompositionColorSpace {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CompositionColorSpace {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CompositionColorSpace {}
 impl ::core::fmt::Debug for CompositionColorSpace {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CompositionColorSpace").field(&self.0).finish()
@@ -7703,6 +7648,7 @@ unsafe impl ::core::marker::Send for CompositionCommitBatch {}
 unsafe impl ::core::marker::Sync for CompositionCommitBatch {}
 #[doc = "*Required features: 'UI_Composition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CompositionCompositeMode(pub i32);
 impl CompositionCompositeMode {
     pub const Inherit: Self = Self(0i32);
@@ -7719,12 +7665,6 @@ impl ::core::clone::Clone for CompositionCompositeMode {
 unsafe impl ::windows::core::Abi for CompositionCompositeMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CompositionCompositeMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CompositionCompositeMode {}
 impl ::core::fmt::Debug for CompositionCompositeMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CompositionCompositeMode").field(&self.0).finish()
@@ -8421,6 +8361,7 @@ unsafe impl ::core::marker::Send for CompositionDrawingSurface {}
 unsafe impl ::core::marker::Sync for CompositionDrawingSurface {}
 #[doc = "*Required features: 'UI_Composition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CompositionDropShadowSourcePolicy(pub i32);
 impl CompositionDropShadowSourcePolicy {
     pub const Default: Self = Self(0i32);
@@ -8435,12 +8376,6 @@ impl ::core::clone::Clone for CompositionDropShadowSourcePolicy {
 unsafe impl ::windows::core::Abi for CompositionDropShadowSourcePolicy {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CompositionDropShadowSourcePolicy {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CompositionDropShadowSourcePolicy {}
 impl ::core::fmt::Debug for CompositionDropShadowSourcePolicy {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CompositionDropShadowSourcePolicy").field(&self.0).finish()
@@ -8777,6 +8712,7 @@ unsafe impl ::core::marker::Send for CompositionEasingFunction {}
 unsafe impl ::core::marker::Sync for CompositionEasingFunction {}
 #[doc = "*Required features: 'UI_Composition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CompositionEasingFunctionMode(pub i32);
 impl CompositionEasingFunctionMode {
     pub const In: Self = Self(0i32);
@@ -8792,12 +8728,6 @@ impl ::core::clone::Clone for CompositionEasingFunctionMode {
 unsafe impl ::windows::core::Abi for CompositionEasingFunctionMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CompositionEasingFunctionMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CompositionEasingFunctionMode {}
 impl ::core::fmt::Debug for CompositionEasingFunctionMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CompositionEasingFunctionMode").field(&self.0).finish()
@@ -9348,6 +9278,7 @@ unsafe impl ::core::marker::Send for CompositionEffectFactory {}
 unsafe impl ::core::marker::Sync for CompositionEffectFactory {}
 #[doc = "*Required features: 'UI_Composition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CompositionEffectFactoryLoadStatus(pub i32);
 impl CompositionEffectFactoryLoadStatus {
     pub const Success: Self = Self(0i32);
@@ -9364,12 +9295,6 @@ impl ::core::clone::Clone for CompositionEffectFactoryLoadStatus {
 unsafe impl ::windows::core::Abi for CompositionEffectFactoryLoadStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CompositionEffectFactoryLoadStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CompositionEffectFactoryLoadStatus {}
 impl ::core::fmt::Debug for CompositionEffectFactoryLoadStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CompositionEffectFactoryLoadStatus").field(&self.0).finish()
@@ -10497,6 +10422,7 @@ unsafe impl ::core::marker::Send for CompositionGeometry {}
 unsafe impl ::core::marker::Sync for CompositionGeometry {}
 #[doc = "*Required features: 'UI_Composition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CompositionGetValueStatus(pub i32);
 impl CompositionGetValueStatus {
     pub const Succeeded: Self = Self(0i32);
@@ -10512,12 +10438,6 @@ impl ::core::clone::Clone for CompositionGetValueStatus {
 unsafe impl ::windows::core::Abi for CompositionGetValueStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CompositionGetValueStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CompositionGetValueStatus {}
 impl ::core::fmt::Debug for CompositionGetValueStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CompositionGetValueStatus").field(&self.0).finish()
@@ -10939,6 +10859,7 @@ unsafe impl ::core::marker::Send for CompositionGradientBrush {}
 unsafe impl ::core::marker::Sync for CompositionGradientBrush {}
 #[doc = "*Required features: 'UI_Composition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CompositionGradientExtendMode(pub i32);
 impl CompositionGradientExtendMode {
     pub const Clamp: Self = Self(0i32);
@@ -10954,12 +10875,6 @@ impl ::core::clone::Clone for CompositionGradientExtendMode {
 unsafe impl ::windows::core::Abi for CompositionGradientExtendMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CompositionGradientExtendMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CompositionGradientExtendMode {}
 impl ::core::fmt::Debug for CompositionGradientExtendMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CompositionGradientExtendMode").field(&self.0).finish()
@@ -12334,6 +12249,7 @@ unsafe impl ::core::marker::Send for CompositionLinearGradientBrush {}
 unsafe impl ::core::marker::Sync for CompositionLinearGradientBrush {}
 #[doc = "*Required features: 'UI_Composition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CompositionMappingMode(pub i32);
 impl CompositionMappingMode {
     pub const Absolute: Self = Self(0i32);
@@ -12348,12 +12264,6 @@ impl ::core::clone::Clone for CompositionMappingMode {
 unsafe impl ::windows::core::Abi for CompositionMappingMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CompositionMappingMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CompositionMappingMode {}
 impl ::core::fmt::Debug for CompositionMappingMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CompositionMappingMode").field(&self.0).finish()
@@ -18803,6 +18713,7 @@ unsafe impl ::core::marker::Send for CompositionSpriteShape {}
 unsafe impl ::core::marker::Sync for CompositionSpriteShape {}
 #[doc = "*Required features: 'UI_Composition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CompositionStretch(pub i32);
 impl CompositionStretch {
     pub const None: Self = Self(0i32);
@@ -18819,12 +18730,6 @@ impl ::core::clone::Clone for CompositionStretch {
 unsafe impl ::windows::core::Abi for CompositionStretch {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CompositionStretch {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CompositionStretch {}
 impl ::core::fmt::Debug for CompositionStretch {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CompositionStretch").field(&self.0).finish()
@@ -18838,6 +18743,7 @@ impl ::windows::core::DefaultType for CompositionStretch {
 }
 #[doc = "*Required features: 'UI_Composition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CompositionStrokeCap(pub i32);
 impl CompositionStrokeCap {
     pub const Flat: Self = Self(0i32);
@@ -18854,12 +18760,6 @@ impl ::core::clone::Clone for CompositionStrokeCap {
 unsafe impl ::windows::core::Abi for CompositionStrokeCap {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CompositionStrokeCap {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CompositionStrokeCap {}
 impl ::core::fmt::Debug for CompositionStrokeCap {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CompositionStrokeCap").field(&self.0).finish()
@@ -19304,6 +19204,7 @@ unsafe impl ::core::marker::Send for CompositionStrokeDashArray {}
 unsafe impl ::core::marker::Sync for CompositionStrokeDashArray {}
 #[doc = "*Required features: 'UI_Composition'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CompositionStrokeLineJoin(pub i32);
 impl CompositionStrokeLineJoin {
     pub const Miter: Self = Self(0i32);
@@ -19320,12 +19221,6 @@ impl ::core::clone::Clone for CompositionStrokeLineJoin {
 unsafe impl ::windows::core::Abi for CompositionStrokeLineJoin {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CompositionStrokeLineJoin {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CompositionStrokeLineJoin {}
 impl ::core::fmt::Debug for CompositionStrokeLineJoin {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CompositionStrokeLineJoin").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Core/AnimationMetrics/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Core/AnimationMetrics/mod.rs
@@ -129,6 +129,7 @@ unsafe impl ::core::marker::Send for AnimationDescription {}
 unsafe impl ::core::marker::Sync for AnimationDescription {}
 #[doc = "*Required features: 'UI_Core_AnimationMetrics'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AnimationEffect(pub i32);
 impl AnimationEffect {
     pub const Expand: Self = Self(0i32);
@@ -177,12 +178,6 @@ impl ::core::clone::Clone for AnimationEffect {
 unsafe impl ::windows::core::Abi for AnimationEffect {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AnimationEffect {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AnimationEffect {}
 impl ::core::fmt::Debug for AnimationEffect {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AnimationEffect").field(&self.0).finish()
@@ -196,6 +191,7 @@ impl ::windows::core::DefaultType for AnimationEffect {
 }
 #[doc = "*Required features: 'UI_Core_AnimationMetrics'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AnimationEffectTarget(pub i32);
 impl AnimationEffectTarget {
     pub const Primary: Self = Self(0i32);
@@ -228,12 +224,6 @@ impl ::core::clone::Clone for AnimationEffectTarget {
 unsafe impl ::windows::core::Abi for AnimationEffectTarget {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AnimationEffectTarget {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AnimationEffectTarget {}
 impl ::core::fmt::Debug for AnimationEffectTarget {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AnimationEffectTarget").field(&self.0).finish()
@@ -761,6 +751,7 @@ unsafe impl ::core::marker::Send for PropertyAnimation {}
 unsafe impl ::core::marker::Sync for PropertyAnimation {}
 #[doc = "*Required features: 'UI_Core_AnimationMetrics'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PropertyAnimationType(pub i32);
 impl PropertyAnimationType {
     pub const Scale: Self = Self(0i32);
@@ -776,12 +767,6 @@ impl ::core::clone::Clone for PropertyAnimationType {
 unsafe impl ::windows::core::Abi for PropertyAnimationType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PropertyAnimationType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PropertyAnimationType {}
 impl ::core::fmt::Debug for PropertyAnimationType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PropertyAnimationType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Core/mod.rs
@@ -146,6 +146,7 @@ unsafe impl ::core::marker::Send for AcceleratorKeyEventArgs {}
 unsafe impl ::core::marker::Sync for AcceleratorKeyEventArgs {}
 #[doc = "*Required features: 'UI_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppViewBackButtonVisibility(pub i32);
 impl AppViewBackButtonVisibility {
     pub const Visible: Self = Self(0i32);
@@ -161,12 +162,6 @@ impl ::core::clone::Clone for AppViewBackButtonVisibility {
 unsafe impl ::windows::core::Abi for AppViewBackButtonVisibility {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppViewBackButtonVisibility {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppViewBackButtonVisibility {}
 impl ::core::fmt::Debug for AppViewBackButtonVisibility {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppViewBackButtonVisibility").field(&self.0).finish()
@@ -611,6 +606,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Clos
 }
 #[doc = "*Required features: 'UI_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CoreAcceleratorKeyEventType(pub i32);
 impl CoreAcceleratorKeyEventType {
     pub const Character: Self = Self(2i32);
@@ -632,12 +628,6 @@ impl ::core::clone::Clone for CoreAcceleratorKeyEventType {
 unsafe impl ::windows::core::Abi for CoreAcceleratorKeyEventType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CoreAcceleratorKeyEventType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CoreAcceleratorKeyEventType {}
 impl ::core::fmt::Debug for CoreAcceleratorKeyEventType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CoreAcceleratorKeyEventType").field(&self.0).finish()
@@ -1321,6 +1311,7 @@ unsafe impl ::core::marker::Send for CoreCursor {}
 unsafe impl ::core::marker::Sync for CoreCursor {}
 #[doc = "*Required features: 'UI_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CoreCursorType(pub i32);
 impl CoreCursorType {
     pub const Arrow: Self = Self(0i32);
@@ -1349,12 +1340,6 @@ impl ::core::clone::Clone for CoreCursorType {
 unsafe impl ::windows::core::Abi for CoreCursorType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CoreCursorType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CoreCursorType {}
 impl ::core::fmt::Debug for CoreCursorType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CoreCursorType").field(&self.0).finish()
@@ -1561,6 +1546,7 @@ unsafe impl ::core::marker::Send for CoreDispatcher {}
 unsafe impl ::core::marker::Sync for CoreDispatcher {}
 #[doc = "*Required features: 'UI_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CoreDispatcherPriority(pub i32);
 impl CoreDispatcherPriority {
     pub const Idle: Self = Self(-2i32);
@@ -1577,12 +1563,6 @@ impl ::core::clone::Clone for CoreDispatcherPriority {
 unsafe impl ::windows::core::Abi for CoreDispatcherPriority {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CoreDispatcherPriority {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CoreDispatcherPriority {}
 impl ::core::fmt::Debug for CoreDispatcherPriority {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CoreDispatcherPriority").field(&self.0).finish()
@@ -1596,6 +1576,7 @@ impl ::windows::core::DefaultType for CoreDispatcherPriority {
 }
 #[doc = "*Required features: 'UI_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CoreIndependentInputFilters(pub u32);
 impl CoreIndependentInputFilters {
     pub const None: Self = Self(0u32);
@@ -1614,12 +1595,6 @@ impl ::core::clone::Clone for CoreIndependentInputFilters {
 unsafe impl ::windows::core::Abi for CoreIndependentInputFilters {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CoreIndependentInputFilters {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CoreIndependentInputFilters {}
 impl ::core::fmt::Debug for CoreIndependentInputFilters {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CoreIndependentInputFilters").field(&self.0).finish()
@@ -2227,6 +2202,7 @@ unsafe impl ::core::marker::Send for CoreIndependentInputSourceController {}
 unsafe impl ::core::marker::Sync for CoreIndependentInputSourceController {}
 #[doc = "*Required features: 'UI_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CoreInputDeviceTypes(pub u32);
 impl CoreInputDeviceTypes {
     pub const None: Self = Self(0u32);
@@ -2243,12 +2219,6 @@ impl ::core::clone::Clone for CoreInputDeviceTypes {
 unsafe impl ::windows::core::Abi for CoreInputDeviceTypes {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CoreInputDeviceTypes {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CoreInputDeviceTypes {}
 impl ::core::fmt::Debug for CoreInputDeviceTypes {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CoreInputDeviceTypes").field(&self.0).finish()
@@ -2331,6 +2301,7 @@ impl ::core::default::Default for CorePhysicalKeyStatus {
 }
 #[doc = "*Required features: 'UI_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CoreProcessEventsOption(pub i32);
 impl CoreProcessEventsOption {
     pub const ProcessOneAndAllPending: Self = Self(0i32);
@@ -2347,12 +2318,6 @@ impl ::core::clone::Clone for CoreProcessEventsOption {
 unsafe impl ::windows::core::Abi for CoreProcessEventsOption {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CoreProcessEventsOption {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CoreProcessEventsOption {}
 impl ::core::fmt::Debug for CoreProcessEventsOption {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CoreProcessEventsOption").field(&self.0).finish()
@@ -2413,6 +2378,7 @@ impl ::core::default::Default for CoreProximityEvaluation {
 }
 #[doc = "*Required features: 'UI_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CoreProximityEvaluationScore(pub i32);
 impl CoreProximityEvaluationScore {
     pub const Closest: Self = Self(0i32);
@@ -2427,12 +2393,6 @@ impl ::core::clone::Clone for CoreProximityEvaluationScore {
 unsafe impl ::windows::core::Abi for CoreProximityEvaluationScore {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CoreProximityEvaluationScore {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CoreProximityEvaluationScore {}
 impl ::core::fmt::Debug for CoreProximityEvaluationScore {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CoreProximityEvaluationScore").field(&self.0).finish()
@@ -2446,6 +2406,7 @@ impl ::windows::core::DefaultType for CoreProximityEvaluationScore {
 }
 #[doc = "*Required features: 'UI_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CoreVirtualKeyStates(pub u32);
 impl CoreVirtualKeyStates {
     pub const None: Self = Self(0u32);
@@ -2461,12 +2422,6 @@ impl ::core::clone::Clone for CoreVirtualKeyStates {
 unsafe impl ::windows::core::Abi for CoreVirtualKeyStates {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CoreVirtualKeyStates {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CoreVirtualKeyStates {}
 impl ::core::fmt::Debug for CoreVirtualKeyStates {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CoreVirtualKeyStates").field(&self.0).finish()
@@ -3147,6 +3102,7 @@ impl<'a> ::windows::core::IntoParam<'a, ICoreWindow> for &CoreWindow {
 }
 #[doc = "*Required features: 'UI_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CoreWindowActivationMode(pub i32);
 impl CoreWindowActivationMode {
     pub const None: Self = Self(0i32);
@@ -3163,12 +3119,6 @@ impl ::core::clone::Clone for CoreWindowActivationMode {
 unsafe impl ::windows::core::Abi for CoreWindowActivationMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CoreWindowActivationMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CoreWindowActivationMode {}
 impl ::core::fmt::Debug for CoreWindowActivationMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CoreWindowActivationMode").field(&self.0).finish()
@@ -3182,6 +3132,7 @@ impl ::windows::core::DefaultType for CoreWindowActivationMode {
 }
 #[doc = "*Required features: 'UI_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CoreWindowActivationState(pub i32);
 impl CoreWindowActivationState {
     pub const CodeActivated: Self = Self(0i32);
@@ -3197,12 +3148,6 @@ impl ::core::clone::Clone for CoreWindowActivationState {
 unsafe impl ::windows::core::Abi for CoreWindowActivationState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CoreWindowActivationState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CoreWindowActivationState {}
 impl ::core::fmt::Debug for CoreWindowActivationState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CoreWindowActivationState").field(&self.0).finish()
@@ -3530,6 +3475,7 @@ impl<'a> ::windows::core::IntoParam<'a, ICoreWindowEventArgs> for &CoreWindowEve
 }
 #[doc = "*Required features: 'UI_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CoreWindowFlowDirection(pub i32);
 impl CoreWindowFlowDirection {
     pub const LeftToRight: Self = Self(0i32);
@@ -3544,12 +3490,6 @@ impl ::core::clone::Clone for CoreWindowFlowDirection {
 unsafe impl ::windows::core::Abi for CoreWindowFlowDirection {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CoreWindowFlowDirection {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CoreWindowFlowDirection {}
 impl ::core::fmt::Debug for CoreWindowFlowDirection {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CoreWindowFlowDirection").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Input/Inking/Analysis/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Inking/Analysis/mod.rs
@@ -438,6 +438,7 @@ pub struct IInkAnalyzerFactoryVtbl(
 );
 #[doc = "*Required features: 'UI_Input_Inking_Analysis'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InkAnalysisDrawingKind(pub i32);
 impl InkAnalysisDrawingKind {
     pub const Drawing: Self = Self(0i32);
@@ -465,12 +466,6 @@ impl ::core::clone::Clone for InkAnalysisDrawingKind {
 unsafe impl ::windows::core::Abi for InkAnalysisDrawingKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InkAnalysisDrawingKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InkAnalysisDrawingKind {}
 impl ::core::fmt::Debug for InkAnalysisDrawingKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InkAnalysisDrawingKind").field(&self.0).finish()
@@ -1489,6 +1484,7 @@ unsafe impl ::core::marker::Send for InkAnalysisNode {}
 unsafe impl ::core::marker::Sync for InkAnalysisNode {}
 #[doc = "*Required features: 'UI_Input_Inking_Analysis'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InkAnalysisNodeKind(pub i32);
 impl InkAnalysisNodeKind {
     pub const UnclassifiedInk: Self = Self(0i32);
@@ -1510,12 +1506,6 @@ impl ::core::clone::Clone for InkAnalysisNodeKind {
 unsafe impl ::windows::core::Abi for InkAnalysisNodeKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InkAnalysisNodeKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InkAnalysisNodeKind {}
 impl ::core::fmt::Debug for InkAnalysisNodeKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InkAnalysisNodeKind").field(&self.0).finish()
@@ -1945,6 +1935,7 @@ unsafe impl ::core::marker::Send for InkAnalysisRoot {}
 unsafe impl ::core::marker::Sync for InkAnalysisRoot {}
 #[doc = "*Required features: 'UI_Input_Inking_Analysis'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InkAnalysisStatus(pub i32);
 impl InkAnalysisStatus {
     pub const Updated: Self = Self(0i32);
@@ -1959,12 +1950,6 @@ impl ::core::clone::Clone for InkAnalysisStatus {
 unsafe impl ::windows::core::Abi for InkAnalysisStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InkAnalysisStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InkAnalysisStatus {}
 impl ::core::fmt::Debug for InkAnalysisStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InkAnalysisStatus").field(&self.0).finish()
@@ -1978,6 +1963,7 @@ impl ::windows::core::DefaultType for InkAnalysisStatus {
 }
 #[doc = "*Required features: 'UI_Input_Inking_Analysis'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InkAnalysisStrokeKind(pub i32);
 impl InkAnalysisStrokeKind {
     pub const Auto: Self = Self(0i32);
@@ -1993,12 +1979,6 @@ impl ::core::clone::Clone for InkAnalysisStrokeKind {
 unsafe impl ::windows::core::Abi for InkAnalysisStrokeKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InkAnalysisStrokeKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InkAnalysisStrokeKind {}
 impl ::core::fmt::Debug for InkAnalysisStrokeKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InkAnalysisStrokeKind").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Input/Inking/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Inking/Core/mod.rs
@@ -446,6 +446,7 @@ unsafe impl ::core::marker::Send for CoreInkPresenterHost {}
 unsafe impl ::core::marker::Sync for CoreInkPresenterHost {}
 #[doc = "*Required features: 'UI_Input_Inking_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CoreWetStrokeDisposition(pub i32);
 impl CoreWetStrokeDisposition {
     pub const Inking: Self = Self(0i32);
@@ -461,12 +462,6 @@ impl ::core::clone::Clone for CoreWetStrokeDisposition {
 unsafe impl ::windows::core::Abi for CoreWetStrokeDisposition {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CoreWetStrokeDisposition {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CoreWetStrokeDisposition {}
 impl ::core::fmt::Debug for CoreWetStrokeDisposition {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CoreWetStrokeDisposition").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Input/Inking/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Inking/mod.rs
@@ -7,6 +7,7 @@ pub mod Core;
 pub mod Preview;
 #[doc = "*Required features: 'UI_Input_Inking'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HandwritingLineHeight(pub i32);
 impl HandwritingLineHeight {
     pub const Small: Self = Self(0i32);
@@ -22,12 +23,6 @@ impl ::core::clone::Clone for HandwritingLineHeight {
 unsafe impl ::windows::core::Abi for HandwritingLineHeight {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HandwritingLineHeight {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HandwritingLineHeight {}
 impl ::core::fmt::Debug for HandwritingLineHeight {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HandwritingLineHeight").field(&self.0).finish()
@@ -1876,6 +1871,7 @@ unsafe impl ::core::marker::Send for InkDrawingAttributes {}
 unsafe impl ::core::marker::Sync for InkDrawingAttributes {}
 #[doc = "*Required features: 'UI_Input_Inking'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InkDrawingAttributesKind(pub i32);
 impl InkDrawingAttributesKind {
     pub const Default: Self = Self(0i32);
@@ -1890,12 +1886,6 @@ impl ::core::clone::Clone for InkDrawingAttributesKind {
 unsafe impl ::windows::core::Abi for InkDrawingAttributesKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InkDrawingAttributesKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InkDrawingAttributesKind {}
 impl ::core::fmt::Debug for InkDrawingAttributesKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InkDrawingAttributesKind").field(&self.0).finish()
@@ -1995,6 +1985,7 @@ unsafe impl ::core::marker::Send for InkDrawingAttributesPencilProperties {}
 unsafe impl ::core::marker::Sync for InkDrawingAttributesPencilProperties {}
 #[doc = "*Required features: 'UI_Input_Inking'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InkHighContrastAdjustment(pub i32);
 impl InkHighContrastAdjustment {
     pub const UseSystemColorsWhenNecessary: Self = Self(0i32);
@@ -2010,12 +2001,6 @@ impl ::core::clone::Clone for InkHighContrastAdjustment {
 unsafe impl ::windows::core::Abi for InkHighContrastAdjustment {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InkHighContrastAdjustment {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InkHighContrastAdjustment {}
 impl ::core::fmt::Debug for InkHighContrastAdjustment {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InkHighContrastAdjustment").field(&self.0).finish()
@@ -2240,6 +2225,7 @@ unsafe impl ::core::marker::Send for InkInputProcessingConfiguration {}
 unsafe impl ::core::marker::Sync for InkInputProcessingConfiguration {}
 #[doc = "*Required features: 'UI_Input_Inking'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InkInputProcessingMode(pub i32);
 impl InkInputProcessingMode {
     pub const None: Self = Self(0i32);
@@ -2255,12 +2241,6 @@ impl ::core::clone::Clone for InkInputProcessingMode {
 unsafe impl ::windows::core::Abi for InkInputProcessingMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InkInputProcessingMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InkInputProcessingMode {}
 impl ::core::fmt::Debug for InkInputProcessingMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InkInputProcessingMode").field(&self.0).finish()
@@ -2274,6 +2254,7 @@ impl ::windows::core::DefaultType for InkInputProcessingMode {
 }
 #[doc = "*Required features: 'UI_Input_Inking'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InkInputRightDragAction(pub i32);
 impl InkInputRightDragAction {
     pub const LeaveUnprocessed: Self = Self(0i32);
@@ -2288,12 +2269,6 @@ impl ::core::clone::Clone for InkInputRightDragAction {
 unsafe impl ::windows::core::Abi for InkInputRightDragAction {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InkInputRightDragAction {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InkInputRightDragAction {}
 impl ::core::fmt::Debug for InkInputRightDragAction {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InkInputRightDragAction").field(&self.0).finish()
@@ -2615,6 +2590,7 @@ impl<'a> ::windows::core::IntoParam<'a, IInkStrokeContainer> for &InkManager {
 }
 #[doc = "*Required features: 'UI_Input_Inking'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InkManipulationMode(pub i32);
 impl InkManipulationMode {
     pub const Inking: Self = Self(0i32);
@@ -2630,12 +2606,6 @@ impl ::core::clone::Clone for InkManipulationMode {
 unsafe impl ::windows::core::Abi for InkManipulationMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InkManipulationMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InkManipulationMode {}
 impl ::core::fmt::Debug for InkManipulationMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InkManipulationMode").field(&self.0).finish()
@@ -2763,6 +2733,7 @@ unsafe impl ::core::marker::Send for InkModelerAttributes {}
 unsafe impl ::core::marker::Sync for InkModelerAttributes {}
 #[doc = "*Required features: 'UI_Input_Inking'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InkPersistenceFormat(pub i32);
 impl InkPersistenceFormat {
     pub const GifWithEmbeddedIsf: Self = Self(0i32);
@@ -2777,12 +2748,6 @@ impl ::core::clone::Clone for InkPersistenceFormat {
 unsafe impl ::windows::core::Abi for InkPersistenceFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InkPersistenceFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InkPersistenceFormat {}
 impl ::core::fmt::Debug for InkPersistenceFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InkPersistenceFormat").field(&self.0).finish()
@@ -3151,6 +3116,7 @@ unsafe impl ::core::marker::Send for InkPresenter {}
 unsafe impl ::core::marker::Sync for InkPresenter {}
 #[doc = "*Required features: 'UI_Input_Inking'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InkPresenterPredefinedConfiguration(pub i32);
 impl InkPresenterPredefinedConfiguration {
     pub const SimpleSinglePointer: Self = Self(0i32);
@@ -3165,12 +3131,6 @@ impl ::core::clone::Clone for InkPresenterPredefinedConfiguration {
 unsafe impl ::windows::core::Abi for InkPresenterPredefinedConfiguration {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InkPresenterPredefinedConfiguration {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InkPresenterPredefinedConfiguration {}
 impl ::core::fmt::Debug for InkPresenterPredefinedConfiguration {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InkPresenterPredefinedConfiguration").field(&self.0).finish()
@@ -3665,6 +3625,7 @@ unsafe impl ::core::marker::Send for InkPresenterRuler {}
 unsafe impl ::core::marker::Sync for InkPresenterRuler {}
 #[doc = "*Required features: 'UI_Input_Inking'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InkPresenterStencilKind(pub i32);
 impl InkPresenterStencilKind {
     pub const Other: Self = Self(0i32);
@@ -3680,12 +3641,6 @@ impl ::core::clone::Clone for InkPresenterStencilKind {
 unsafe impl ::windows::core::Abi for InkPresenterStencilKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InkPresenterStencilKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InkPresenterStencilKind {}
 impl ::core::fmt::Debug for InkPresenterStencilKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InkPresenterStencilKind").field(&self.0).finish()
@@ -3799,6 +3754,7 @@ unsafe impl ::core::marker::Send for InkRecognitionResult {}
 unsafe impl ::core::marker::Sync for InkRecognitionResult {}
 #[doc = "*Required features: 'UI_Input_Inking'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InkRecognitionTarget(pub i32);
 impl InkRecognitionTarget {
     pub const All: Self = Self(0i32);
@@ -3814,12 +3770,6 @@ impl ::core::clone::Clone for InkRecognitionTarget {
 unsafe impl ::windows::core::Abi for InkRecognitionTarget {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InkRecognitionTarget {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InkRecognitionTarget {}
 impl ::core::fmt::Debug for InkRecognitionTarget {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InkRecognitionTarget").field(&self.0).finish()
@@ -5453,6 +5403,7 @@ unsafe impl ::core::marker::Send for PenAndInkSettings {}
 unsafe impl ::core::marker::Sync for PenAndInkSettings {}
 #[doc = "*Required features: 'UI_Input_Inking'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PenHandedness(pub i32);
 impl PenHandedness {
     pub const Right: Self = Self(0i32);
@@ -5467,12 +5418,6 @@ impl ::core::clone::Clone for PenHandedness {
 unsafe impl ::windows::core::Abi for PenHandedness {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PenHandedness {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PenHandedness {}
 impl ::core::fmt::Debug for PenHandedness {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PenHandedness").field(&self.0).finish()
@@ -5486,6 +5431,7 @@ impl ::windows::core::DefaultType for PenHandedness {
 }
 #[doc = "*Required features: 'UI_Input_Inking'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PenTipShape(pub i32);
 impl PenTipShape {
     pub const Circle: Self = Self(0i32);
@@ -5500,12 +5446,6 @@ impl ::core::clone::Clone for PenTipShape {
 unsafe impl ::windows::core::Abi for PenTipShape {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PenTipShape {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PenTipShape {}
 impl ::core::fmt::Debug for PenTipShape {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PenTipShape").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Input/Preview/Injection/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Preview/Injection/mod.rs
@@ -246,6 +246,7 @@ pub struct IInputInjectorStatics2Vtbl(
 );
 #[doc = "*Required features: 'UI_Input_Preview_Injection'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InjectedInputButtonChangeKind(pub i32);
 impl InjectedInputButtonChangeKind {
     pub const None: Self = Self(0i32);
@@ -269,12 +270,6 @@ impl ::core::clone::Clone for InjectedInputButtonChangeKind {
 unsafe impl ::windows::core::Abi for InjectedInputButtonChangeKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InjectedInputButtonChangeKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InjectedInputButtonChangeKind {}
 impl ::core::fmt::Debug for InjectedInputButtonChangeKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InjectedInputButtonChangeKind").field(&self.0).finish()
@@ -472,6 +467,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Inje
 }
 #[doc = "*Required features: 'UI_Input_Preview_Injection'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InjectedInputKeyOptions(pub u32);
 impl InjectedInputKeyOptions {
     pub const None: Self = Self(0u32);
@@ -489,12 +485,6 @@ impl ::core::clone::Clone for InjectedInputKeyOptions {
 unsafe impl ::windows::core::Abi for InjectedInputKeyOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InjectedInputKeyOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InjectedInputKeyOptions {}
 impl ::core::fmt::Debug for InjectedInputKeyOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InjectedInputKeyOptions").field(&self.0).finish()
@@ -796,6 +786,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Inje
 }
 #[doc = "*Required features: 'UI_Input_Preview_Injection'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InjectedInputMouseOptions(pub u32);
 impl InjectedInputMouseOptions {
     pub const None: Self = Self(0u32);
@@ -823,12 +814,6 @@ impl ::core::clone::Clone for InjectedInputMouseOptions {
 unsafe impl ::windows::core::Abi for InjectedInputMouseOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InjectedInputMouseOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InjectedInputMouseOptions {}
 impl ::core::fmt::Debug for InjectedInputMouseOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InjectedInputMouseOptions").field(&self.0).finish()
@@ -870,6 +855,7 @@ impl ::windows::core::DefaultType for InjectedInputMouseOptions {
 }
 #[doc = "*Required features: 'UI_Input_Preview_Injection'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InjectedInputPenButtons(pub u32);
 impl InjectedInputPenButtons {
     pub const None: Self = Self(0u32);
@@ -886,12 +872,6 @@ impl ::core::clone::Clone for InjectedInputPenButtons {
 unsafe impl ::windows::core::Abi for InjectedInputPenButtons {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InjectedInputPenButtons {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InjectedInputPenButtons {}
 impl ::core::fmt::Debug for InjectedInputPenButtons {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InjectedInputPenButtons").field(&self.0).finish()
@@ -1102,6 +1082,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Inje
 }
 #[doc = "*Required features: 'UI_Input_Preview_Injection'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InjectedInputPenParameters(pub u32);
 impl InjectedInputPenParameters {
     pub const None: Self = Self(0u32);
@@ -1119,12 +1100,6 @@ impl ::core::clone::Clone for InjectedInputPenParameters {
 unsafe impl ::windows::core::Abi for InjectedInputPenParameters {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InjectedInputPenParameters {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InjectedInputPenParameters {}
 impl ::core::fmt::Debug for InjectedInputPenParameters {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InjectedInputPenParameters").field(&self.0).finish()
@@ -1243,6 +1218,7 @@ impl ::core::default::Default for InjectedInputPointerInfo {
 }
 #[doc = "*Required features: 'UI_Input_Preview_Injection'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InjectedInputPointerOptions(pub u32);
 impl InjectedInputPointerOptions {
     pub const None: Self = Self(0u32);
@@ -1268,12 +1244,6 @@ impl ::core::clone::Clone for InjectedInputPointerOptions {
 unsafe impl ::windows::core::Abi for InjectedInputPointerOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InjectedInputPointerOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InjectedInputPointerOptions {}
 impl ::core::fmt::Debug for InjectedInputPointerOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InjectedInputPointerOptions").field(&self.0).finish()
@@ -1354,6 +1324,7 @@ impl ::core::default::Default for InjectedInputRectangle {
 }
 #[doc = "*Required features: 'UI_Input_Preview_Injection'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InjectedInputShortcut(pub i32);
 impl InjectedInputShortcut {
     pub const Back: Self = Self(0i32);
@@ -1369,12 +1340,6 @@ impl ::core::clone::Clone for InjectedInputShortcut {
 unsafe impl ::windows::core::Abi for InjectedInputShortcut {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InjectedInputShortcut {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InjectedInputShortcut {}
 impl ::core::fmt::Debug for InjectedInputShortcut {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InjectedInputShortcut").field(&self.0).finish()
@@ -1531,6 +1496,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Inje
 }
 #[doc = "*Required features: 'UI_Input_Preview_Injection'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InjectedInputTouchParameters(pub u32);
 impl InjectedInputTouchParameters {
     pub const None: Self = Self(0u32);
@@ -1547,12 +1513,6 @@ impl ::core::clone::Clone for InjectedInputTouchParameters {
 unsafe impl ::windows::core::Abi for InjectedInputTouchParameters {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InjectedInputTouchParameters {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InjectedInputTouchParameters {}
 impl ::core::fmt::Debug for InjectedInputTouchParameters {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InjectedInputTouchParameters").field(&self.0).finish()
@@ -1594,6 +1554,7 @@ impl ::windows::core::DefaultType for InjectedInputTouchParameters {
 }
 #[doc = "*Required features: 'UI_Input_Preview_Injection'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InjectedInputVisualizationMode(pub i32);
 impl InjectedInputVisualizationMode {
     pub const None: Self = Self(0i32);
@@ -1609,12 +1570,6 @@ impl ::core::clone::Clone for InjectedInputVisualizationMode {
 unsafe impl ::windows::core::Abi for InjectedInputVisualizationMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InjectedInputVisualizationMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InjectedInputVisualizationMode {}
 impl ::core::fmt::Debug for InjectedInputVisualizationMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InjectedInputVisualizationMode").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Input/Spatial/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/Spatial/mod.rs
@@ -1319,6 +1319,7 @@ unsafe impl ::core::marker::Send for SpatialGestureRecognizer {}
 unsafe impl ::core::marker::Sync for SpatialGestureRecognizer {}
 #[doc = "*Required features: 'UI_Input_Spatial'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SpatialGestureSettings(pub u32);
 impl SpatialGestureSettings {
     pub const None: Self = Self(0u32);
@@ -1342,12 +1343,6 @@ impl ::core::clone::Clone for SpatialGestureSettings {
 unsafe impl ::windows::core::Abi for SpatialGestureSettings {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpatialGestureSettings {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SpatialGestureSettings {}
 impl ::core::fmt::Debug for SpatialGestureSettings {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SpatialGestureSettings").field(&self.0).finish()
@@ -2293,6 +2288,7 @@ unsafe impl ::core::marker::Send for SpatialInteractionManager {}
 unsafe impl ::core::marker::Sync for SpatialInteractionManager {}
 #[doc = "*Required features: 'UI_Input_Spatial'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SpatialInteractionPressKind(pub i32);
 impl SpatialInteractionPressKind {
     pub const None: Self = Self(0i32);
@@ -2311,12 +2307,6 @@ impl ::core::clone::Clone for SpatialInteractionPressKind {
 unsafe impl ::windows::core::Abi for SpatialInteractionPressKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpatialInteractionPressKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SpatialInteractionPressKind {}
 impl ::core::fmt::Debug for SpatialInteractionPressKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SpatialInteractionPressKind").field(&self.0).finish()
@@ -2575,6 +2565,7 @@ unsafe impl ::core::marker::Send for SpatialInteractionSourceEventArgs {}
 unsafe impl ::core::marker::Sync for SpatialInteractionSourceEventArgs {}
 #[doc = "*Required features: 'UI_Input_Spatial'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SpatialInteractionSourceHandedness(pub i32);
 impl SpatialInteractionSourceHandedness {
     pub const Unspecified: Self = Self(0i32);
@@ -2590,12 +2581,6 @@ impl ::core::clone::Clone for SpatialInteractionSourceHandedness {
 unsafe impl ::windows::core::Abi for SpatialInteractionSourceHandedness {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpatialInteractionSourceHandedness {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SpatialInteractionSourceHandedness {}
 impl ::core::fmt::Debug for SpatialInteractionSourceHandedness {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SpatialInteractionSourceHandedness").field(&self.0).finish()
@@ -2609,6 +2594,7 @@ impl ::windows::core::DefaultType for SpatialInteractionSourceHandedness {
 }
 #[doc = "*Required features: 'UI_Input_Spatial'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SpatialInteractionSourceKind(pub i32);
 impl SpatialInteractionSourceKind {
     pub const Other: Self = Self(0i32);
@@ -2625,12 +2611,6 @@ impl ::core::clone::Clone for SpatialInteractionSourceKind {
 unsafe impl ::windows::core::Abi for SpatialInteractionSourceKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpatialInteractionSourceKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SpatialInteractionSourceKind {}
 impl ::core::fmt::Debug for SpatialInteractionSourceKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SpatialInteractionSourceKind").field(&self.0).finish()
@@ -2769,6 +2749,7 @@ unsafe impl ::core::marker::Send for SpatialInteractionSourceLocation {}
 unsafe impl ::core::marker::Sync for SpatialInteractionSourceLocation {}
 #[doc = "*Required features: 'UI_Input_Spatial'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SpatialInteractionSourcePositionAccuracy(pub i32);
 impl SpatialInteractionSourcePositionAccuracy {
     pub const High: Self = Self(0i32);
@@ -2783,12 +2764,6 @@ impl ::core::clone::Clone for SpatialInteractionSourcePositionAccuracy {
 unsafe impl ::windows::core::Abi for SpatialInteractionSourcePositionAccuracy {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SpatialInteractionSourcePositionAccuracy {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SpatialInteractionSourcePositionAccuracy {}
 impl ::core::fmt::Debug for SpatialInteractionSourcePositionAccuracy {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SpatialInteractionSourcePositionAccuracy").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Input/mod.rs
@@ -258,6 +258,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Cros
 }
 #[doc = "*Required features: 'UI_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CrossSlidingState(pub i32);
 impl CrossSlidingState {
     pub const Started: Self = Self(0i32);
@@ -277,12 +278,6 @@ impl ::core::clone::Clone for CrossSlidingState {
 unsafe impl ::windows::core::Abi for CrossSlidingState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CrossSlidingState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CrossSlidingState {}
 impl ::core::fmt::Debug for CrossSlidingState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CrossSlidingState").field(&self.0).finish()
@@ -401,6 +396,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Drag
 }
 #[doc = "*Required features: 'UI_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DraggingState(pub i32);
 impl DraggingState {
     pub const Started: Self = Self(0i32);
@@ -416,12 +412,6 @@ impl ::core::clone::Clone for DraggingState {
 unsafe impl ::windows::core::Abi for DraggingState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DraggingState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DraggingState {}
 impl ::core::fmt::Debug for DraggingState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DraggingState").field(&self.0).finish()
@@ -642,6 +632,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Edge
 }
 #[doc = "*Required features: 'UI_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EdgeGestureKind(pub i32);
 impl EdgeGestureKind {
     pub const Touch: Self = Self(0i32);
@@ -657,12 +648,6 @@ impl ::core::clone::Clone for EdgeGestureKind {
 unsafe impl ::windows::core::Abi for EdgeGestureKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EdgeGestureKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EdgeGestureKind {}
 impl ::core::fmt::Debug for EdgeGestureKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EdgeGestureKind").field(&self.0).finish()
@@ -676,6 +661,7 @@ impl ::windows::core::DefaultType for EdgeGestureKind {
 }
 #[doc = "*Required features: 'UI_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GazeInputAccessStatus(pub i32);
 impl GazeInputAccessStatus {
     pub const Unspecified: Self = Self(0i32);
@@ -692,12 +678,6 @@ impl ::core::clone::Clone for GazeInputAccessStatus {
 unsafe impl ::windows::core::Abi for GazeInputAccessStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GazeInputAccessStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GazeInputAccessStatus {}
 impl ::core::fmt::Debug for GazeInputAccessStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GazeInputAccessStatus").field(&self.0).finish()
@@ -1290,6 +1270,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Gest
 }
 #[doc = "*Required features: 'UI_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GestureSettings(pub u32);
 impl GestureSettings {
     pub const None: Self = Self(0u32);
@@ -1320,12 +1301,6 @@ impl ::core::clone::Clone for GestureSettings {
 unsafe impl ::windows::core::Abi for GestureSettings {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GestureSettings {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GestureSettings {}
 impl ::core::fmt::Debug for GestureSettings {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GestureSettings").field(&self.0).finish()
@@ -1480,6 +1455,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Hold
 }
 #[doc = "*Required features: 'UI_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HoldingState(pub i32);
 impl HoldingState {
     pub const Started: Self = Self(0i32);
@@ -1495,12 +1471,6 @@ impl ::core::clone::Clone for HoldingState {
 unsafe impl ::windows::core::Abi for HoldingState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HoldingState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HoldingState {}
 impl ::core::fmt::Debug for HoldingState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HoldingState").field(&self.0).finish()
@@ -3396,6 +3366,7 @@ unsafe impl ::core::marker::Send for InputActivationListenerActivationChangedEve
 unsafe impl ::core::marker::Sync for InputActivationListenerActivationChangedEventArgs {}
 #[doc = "*Required features: 'UI_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InputActivationState(pub i32);
 impl InputActivationState {
     pub const None: Self = Self(0i32);
@@ -3412,12 +3383,6 @@ impl ::core::clone::Clone for InputActivationState {
 unsafe impl ::windows::core::Abi for InputActivationState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InputActivationState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InputActivationState {}
 impl ::core::fmt::Debug for InputActivationState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InputActivationState").field(&self.0).finish()
@@ -4715,6 +4680,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Poin
 }
 #[doc = "*Required features: 'UI_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PointerUpdateKind(pub i32);
 impl PointerUpdateKind {
     pub const Other: Self = Self(0i32);
@@ -4738,12 +4704,6 @@ impl ::core::clone::Clone for PointerUpdateKind {
 unsafe impl ::windows::core::Abi for PointerUpdateKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PointerUpdateKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PointerUpdateKind {}
 impl ::core::fmt::Debug for PointerUpdateKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PointerUpdateKind").field(&self.0).finish()
@@ -6024,6 +5984,7 @@ unsafe impl ::core::marker::Send for RadialControllerMenuItem {}
 unsafe impl ::core::marker::Sync for RadialControllerMenuItem {}
 #[doc = "*Required features: 'UI_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RadialControllerMenuKnownIcon(pub i32);
 impl RadialControllerMenuKnownIcon {
     pub const Scroll: Self = Self(0i32);
@@ -6045,12 +6006,6 @@ impl ::core::clone::Clone for RadialControllerMenuKnownIcon {
 unsafe impl ::windows::core::Abi for RadialControllerMenuKnownIcon {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RadialControllerMenuKnownIcon {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RadialControllerMenuKnownIcon {}
 impl ::core::fmt::Debug for RadialControllerMenuKnownIcon {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RadialControllerMenuKnownIcon").field(&self.0).finish()
@@ -6547,6 +6502,7 @@ unsafe impl ::core::marker::Send for RadialControllerScreenContactStartedEventAr
 unsafe impl ::core::marker::Sync for RadialControllerScreenContactStartedEventArgs {}
 #[doc = "*Required features: 'UI_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RadialControllerSystemMenuItemKind(pub i32);
 impl RadialControllerSystemMenuItemKind {
     pub const Scroll: Self = Self(0i32);
@@ -6564,12 +6520,6 @@ impl ::core::clone::Clone for RadialControllerSystemMenuItemKind {
 unsafe impl ::windows::core::Abi for RadialControllerSystemMenuItemKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RadialControllerSystemMenuItemKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RadialControllerSystemMenuItemKind {}
 impl ::core::fmt::Debug for RadialControllerSystemMenuItemKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RadialControllerSystemMenuItemKind").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Notifications/Management/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Notifications/Management/mod.rs
@@ -192,6 +192,7 @@ unsafe impl ::core::marker::Send for UserNotificationListener {}
 unsafe impl ::core::marker::Sync for UserNotificationListener {}
 #[doc = "*Required features: 'UI_Notifications_Management'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserNotificationListenerAccessStatus(pub i32);
 impl UserNotificationListenerAccessStatus {
     pub const Unspecified: Self = Self(0i32);
@@ -207,12 +208,6 @@ impl ::core::clone::Clone for UserNotificationListenerAccessStatus {
 unsafe impl ::windows::core::Abi for UserNotificationListenerAccessStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserNotificationListenerAccessStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserNotificationListenerAccessStatus {}
 impl ::core::fmt::Debug for UserNotificationListenerAccessStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserNotificationListenerAccessStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Notifications/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Notifications/mod.rs
@@ -3,6 +3,7 @@
 pub mod Management;
 #[doc = "*Required features: 'UI_Notifications'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AdaptiveNotificationContentKind(pub i32);
 impl AdaptiveNotificationContentKind {
     pub const Text: Self = Self(0i32);
@@ -16,12 +17,6 @@ impl ::core::clone::Clone for AdaptiveNotificationContentKind {
 unsafe impl ::windows::core::Abi for AdaptiveNotificationContentKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AdaptiveNotificationContentKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AdaptiveNotificationContentKind {}
 impl ::core::fmt::Debug for AdaptiveNotificationContentKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AdaptiveNotificationContentKind").field(&self.0).finish()
@@ -290,6 +285,7 @@ unsafe impl ::core::marker::Send for BadgeNotification {}
 unsafe impl ::core::marker::Sync for BadgeNotification {}
 #[doc = "*Required features: 'UI_Notifications'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BadgeTemplateType(pub i32);
 impl BadgeTemplateType {
     pub const BadgeGlyph: Self = Self(0i32);
@@ -304,12 +300,6 @@ impl ::core::clone::Clone for BadgeTemplateType {
 unsafe impl ::windows::core::Abi for BadgeTemplateType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BadgeTemplateType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BadgeTemplateType {}
 impl ::core::fmt::Debug for BadgeTemplateType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BadgeTemplateType").field(&self.0).finish()
@@ -2651,6 +2641,7 @@ unsafe impl ::core::marker::Send for NotificationData {}
 unsafe impl ::core::marker::Sync for NotificationData {}
 #[doc = "*Required features: 'UI_Notifications'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct NotificationKinds(pub u32);
 impl NotificationKinds {
     pub const Unknown: Self = Self(0u32);
@@ -2665,12 +2656,6 @@ impl ::core::clone::Clone for NotificationKinds {
 unsafe impl ::windows::core::Abi for NotificationKinds {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NotificationKinds {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for NotificationKinds {}
 impl ::core::fmt::Debug for NotificationKinds {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NotificationKinds").field(&self.0).finish()
@@ -2712,6 +2697,7 @@ impl ::windows::core::DefaultType for NotificationKinds {
 }
 #[doc = "*Required features: 'UI_Notifications'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct NotificationMirroring(pub i32);
 impl NotificationMirroring {
     pub const Allowed: Self = Self(0i32);
@@ -2726,12 +2712,6 @@ impl ::core::clone::Clone for NotificationMirroring {
 unsafe impl ::windows::core::Abi for NotificationMirroring {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NotificationMirroring {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for NotificationMirroring {}
 impl ::core::fmt::Debug for NotificationMirroring {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NotificationMirroring").field(&self.0).finish()
@@ -2745,6 +2725,7 @@ impl ::windows::core::DefaultType for NotificationMirroring {
 }
 #[doc = "*Required features: 'UI_Notifications'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct NotificationSetting(pub i32);
 impl NotificationSetting {
     pub const Enabled: Self = Self(0i32);
@@ -2762,12 +2743,6 @@ impl ::core::clone::Clone for NotificationSetting {
 unsafe impl ::windows::core::Abi for NotificationSetting {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NotificationSetting {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for NotificationSetting {}
 impl ::core::fmt::Debug for NotificationSetting {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NotificationSetting").field(&self.0).finish()
@@ -2781,6 +2756,7 @@ impl ::windows::core::DefaultType for NotificationSetting {
 }
 #[doc = "*Required features: 'UI_Notifications'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct NotificationUpdateResult(pub i32);
 impl NotificationUpdateResult {
     pub const Succeeded: Self = Self(0i32);
@@ -2796,12 +2772,6 @@ impl ::core::clone::Clone for NotificationUpdateResult {
 unsafe impl ::windows::core::Abi for NotificationUpdateResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NotificationUpdateResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for NotificationUpdateResult {}
 impl ::core::fmt::Debug for NotificationUpdateResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NotificationUpdateResult").field(&self.0).finish()
@@ -2918,6 +2888,7 @@ unsafe impl ::core::marker::Send for NotificationVisual {}
 unsafe impl ::core::marker::Sync for NotificationVisual {}
 #[doc = "*Required features: 'UI_Notifications'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PeriodicUpdateRecurrence(pub i32);
 impl PeriodicUpdateRecurrence {
     pub const HalfHour: Self = Self(0i32);
@@ -2935,12 +2906,6 @@ impl ::core::clone::Clone for PeriodicUpdateRecurrence {
 unsafe impl ::windows::core::Abi for PeriodicUpdateRecurrence {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PeriodicUpdateRecurrence {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PeriodicUpdateRecurrence {}
 impl ::core::fmt::Debug for PeriodicUpdateRecurrence {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PeriodicUpdateRecurrence").field(&self.0).finish()
@@ -3615,6 +3580,7 @@ unsafe impl ::core::marker::Send for TileFlyoutNotification {}
 unsafe impl ::core::marker::Sync for TileFlyoutNotification {}
 #[doc = "*Required features: 'UI_Notifications'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TileFlyoutTemplateType(pub i32);
 impl TileFlyoutTemplateType {
     pub const TileFlyoutTemplate01: Self = Self(0i32);
@@ -3628,12 +3594,6 @@ impl ::core::clone::Clone for TileFlyoutTemplateType {
 unsafe impl ::windows::core::Abi for TileFlyoutTemplateType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TileFlyoutTemplateType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TileFlyoutTemplateType {}
 impl ::core::fmt::Debug for TileFlyoutTemplateType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TileFlyoutTemplateType").field(&self.0).finish()
@@ -3917,6 +3877,7 @@ unsafe impl ::core::marker::Send for TileNotification {}
 unsafe impl ::core::marker::Sync for TileNotification {}
 #[doc = "*Required features: 'UI_Notifications'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TileTemplateType(pub i32);
 impl TileTemplateType {
     pub const TileSquareImage: Self = Self(0i32);
@@ -4055,12 +4016,6 @@ impl ::core::clone::Clone for TileTemplateType {
 unsafe impl ::windows::core::Abi for TileTemplateType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TileTemplateType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TileTemplateType {}
 impl ::core::fmt::Debug for TileTemplateType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TileTemplateType").field(&self.0).finish()
@@ -4751,6 +4706,7 @@ unsafe impl ::core::marker::Send for ToastCollectionManager {}
 unsafe impl ::core::marker::Sync for ToastCollectionManager {}
 #[doc = "*Required features: 'UI_Notifications'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ToastDismissalReason(pub i32);
 impl ToastDismissalReason {
     pub const UserCanceled: Self = Self(0i32);
@@ -4766,12 +4722,6 @@ impl ::core::clone::Clone for ToastDismissalReason {
 unsafe impl ::windows::core::Abi for ToastDismissalReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ToastDismissalReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ToastDismissalReason {}
 impl ::core::fmt::Debug for ToastDismissalReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ToastDismissalReason").field(&self.0).finish()
@@ -4947,6 +4897,7 @@ unsafe impl ::core::marker::Send for ToastFailedEventArgs {}
 unsafe impl ::core::marker::Sync for ToastFailedEventArgs {}
 #[doc = "*Required features: 'UI_Notifications'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ToastHistoryChangedType(pub i32);
 impl ToastHistoryChangedType {
     pub const Cleared: Self = Self(0i32);
@@ -4963,12 +4914,6 @@ impl ::core::clone::Clone for ToastHistoryChangedType {
 unsafe impl ::windows::core::Abi for ToastHistoryChangedType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ToastHistoryChangedType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ToastHistoryChangedType {}
 impl ::core::fmt::Debug for ToastHistoryChangedType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ToastHistoryChangedType").field(&self.0).finish()
@@ -5755,6 +5700,7 @@ unsafe impl ::core::marker::Send for ToastNotificationManagerForUser {}
 unsafe impl ::core::marker::Sync for ToastNotificationManagerForUser {}
 #[doc = "*Required features: 'UI_Notifications'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ToastNotificationPriority(pub i32);
 impl ToastNotificationPriority {
     pub const Default: Self = Self(0i32);
@@ -5769,12 +5715,6 @@ impl ::core::clone::Clone for ToastNotificationPriority {
 unsafe impl ::windows::core::Abi for ToastNotificationPriority {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ToastNotificationPriority {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ToastNotificationPriority {}
 impl ::core::fmt::Debug for ToastNotificationPriority {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ToastNotificationPriority").field(&self.0).finish()
@@ -5929,6 +5869,7 @@ unsafe impl ::core::marker::Send for ToastNotifier {}
 unsafe impl ::core::marker::Sync for ToastNotifier {}
 #[doc = "*Required features: 'UI_Notifications'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ToastTemplateType(pub i32);
 impl ToastTemplateType {
     pub const ToastImageAndText01: Self = Self(0i32);
@@ -5949,12 +5890,6 @@ impl ::core::clone::Clone for ToastTemplateType {
 unsafe impl ::windows::core::Abi for ToastTemplateType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ToastTemplateType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ToastTemplateType {}
 impl ::core::fmt::Debug for ToastTemplateType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ToastTemplateType").field(&self.0).finish()
@@ -6164,6 +6099,7 @@ unsafe impl ::core::marker::Send for UserNotificationChangedEventArgs {}
 unsafe impl ::core::marker::Sync for UserNotificationChangedEventArgs {}
 #[doc = "*Required features: 'UI_Notifications'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserNotificationChangedKind(pub i32);
 impl UserNotificationChangedKind {
     pub const Added: Self = Self(0i32);
@@ -6178,12 +6114,6 @@ impl ::core::clone::Clone for UserNotificationChangedKind {
 unsafe impl ::windows::core::Abi for UserNotificationChangedKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserNotificationChangedKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserNotificationChangedKind {}
 impl ::core::fmt::Debug for UserNotificationChangedKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserNotificationChangedKind").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Popups/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Popups/mod.rs
@@ -392,6 +392,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Mess
 }
 #[doc = "*Required features: 'UI_Popups'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MessageDialogOptions(pub u32);
 impl MessageDialogOptions {
     pub const None: Self = Self(0u32);
@@ -406,12 +407,6 @@ impl ::core::clone::Clone for MessageDialogOptions {
 unsafe impl ::windows::core::Abi for MessageDialogOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MessageDialogOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MessageDialogOptions {}
 impl ::core::fmt::Debug for MessageDialogOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MessageDialogOptions").field(&self.0).finish()
@@ -453,6 +448,7 @@ impl ::windows::core::DefaultType for MessageDialogOptions {
 }
 #[doc = "*Required features: 'UI_Popups'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct Placement(pub i32);
 impl Placement {
     pub const Default: Self = Self(0i32);
@@ -470,12 +466,6 @@ impl ::core::clone::Clone for Placement {
 unsafe impl ::windows::core::Abi for Placement {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for Placement {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for Placement {}
 impl ::core::fmt::Debug for Placement {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("Placement").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Shell/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Shell/mod.rs
@@ -350,6 +350,7 @@ pub struct ITaskbarManagerStaticsVtbl(
 );
 #[doc = "*Required features: 'UI_Shell'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SecurityAppKind(pub i32);
 impl SecurityAppKind {
     pub const WebProtection: Self = Self(0i32);
@@ -363,12 +364,6 @@ impl ::core::clone::Clone for SecurityAppKind {
 unsafe impl ::windows::core::Abi for SecurityAppKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SecurityAppKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SecurityAppKind {}
 impl ::core::fmt::Debug for SecurityAppKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SecurityAppKind").field(&self.0).finish()
@@ -482,6 +477,7 @@ unsafe impl ::core::marker::Send for SecurityAppManager {}
 unsafe impl ::core::marker::Sync for SecurityAppManager {}
 #[doc = "*Required features: 'UI_Shell'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SecurityAppState(pub i32);
 impl SecurityAppState {
     pub const Disabled: Self = Self(0i32);
@@ -496,12 +492,6 @@ impl ::core::clone::Clone for SecurityAppState {
 unsafe impl ::windows::core::Abi for SecurityAppState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SecurityAppState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SecurityAppState {}
 impl ::core::fmt::Debug for SecurityAppState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SecurityAppState").field(&self.0).finish()
@@ -515,6 +505,7 @@ impl ::windows::core::DefaultType for SecurityAppState {
 }
 #[doc = "*Required features: 'UI_Shell'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SecurityAppSubstatus(pub i32);
 impl SecurityAppSubstatus {
     pub const Undetermined: Self = Self(0i32);
@@ -531,12 +522,6 @@ impl ::core::clone::Clone for SecurityAppSubstatus {
 unsafe impl ::windows::core::Abi for SecurityAppSubstatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SecurityAppSubstatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SecurityAppSubstatus {}
 impl ::core::fmt::Debug for SecurityAppSubstatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SecurityAppSubstatus").field(&self.0).finish()
@@ -550,6 +535,7 @@ impl ::windows::core::DefaultType for SecurityAppSubstatus {
 }
 #[doc = "*Required features: 'UI_Shell'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ShareWindowCommand(pub i32);
 impl ShareWindowCommand {
     pub const None: Self = Self(0i32);
@@ -565,12 +551,6 @@ impl ::core::clone::Clone for ShareWindowCommand {
 unsafe impl ::windows::core::Abi for ShareWindowCommand {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ShareWindowCommand {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ShareWindowCommand {}
 impl ::core::fmt::Debug for ShareWindowCommand {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ShareWindowCommand").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/StartScreen/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/StartScreen/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'UI_StartScreen'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ForegroundText(pub i32);
 impl ForegroundText {
     pub const Dark: Self = Self(0i32);
@@ -15,12 +16,6 @@ impl ::core::clone::Clone for ForegroundText {
 unsafe impl ::windows::core::Abi for ForegroundText {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ForegroundText {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ForegroundText {}
 impl ::core::fmt::Debug for ForegroundText {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ForegroundText").field(&self.0).finish()
@@ -862,6 +857,7 @@ unsafe impl ::core::marker::Send for JumpListItem {}
 unsafe impl ::core::marker::Sync for JumpListItem {}
 #[doc = "*Required features: 'UI_StartScreen'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct JumpListItemKind(pub i32);
 impl JumpListItemKind {
     pub const Arguments: Self = Self(0i32);
@@ -876,12 +872,6 @@ impl ::core::clone::Clone for JumpListItemKind {
 unsafe impl ::windows::core::Abi for JumpListItemKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JumpListItemKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for JumpListItemKind {}
 impl ::core::fmt::Debug for JumpListItemKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("JumpListItemKind").field(&self.0).finish()
@@ -895,6 +885,7 @@ impl ::windows::core::DefaultType for JumpListItemKind {
 }
 #[doc = "*Required features: 'UI_StartScreen'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct JumpListSystemGroupKind(pub i32);
 impl JumpListSystemGroupKind {
     pub const None: Self = Self(0i32);
@@ -910,12 +901,6 @@ impl ::core::clone::Clone for JumpListSystemGroupKind {
 unsafe impl ::windows::core::Abi for JumpListSystemGroupKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for JumpListSystemGroupKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for JumpListSystemGroupKind {}
 impl ::core::fmt::Debug for JumpListSystemGroupKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("JumpListSystemGroupKind").field(&self.0).finish()
@@ -1902,6 +1887,7 @@ unsafe impl ::core::marker::Send for TileMixedRealityModel {}
 unsafe impl ::core::marker::Sync for TileMixedRealityModel {}
 #[doc = "*Required features: 'UI_StartScreen'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TileMixedRealityModelActivationBehavior(pub i32);
 impl TileMixedRealityModelActivationBehavior {
     pub const Default: Self = Self(0i32);
@@ -1916,12 +1902,6 @@ impl ::core::clone::Clone for TileMixedRealityModelActivationBehavior {
 unsafe impl ::windows::core::Abi for TileMixedRealityModelActivationBehavior {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TileMixedRealityModelActivationBehavior {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TileMixedRealityModelActivationBehavior {}
 impl ::core::fmt::Debug for TileMixedRealityModelActivationBehavior {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TileMixedRealityModelActivationBehavior").field(&self.0).finish()
@@ -1935,6 +1915,7 @@ impl ::windows::core::DefaultType for TileMixedRealityModelActivationBehavior {
 }
 #[doc = "*Required features: 'UI_StartScreen'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TileOptions(pub u32);
 impl TileOptions {
     pub const None: Self = Self(0u32);
@@ -1951,12 +1932,6 @@ impl ::core::clone::Clone for TileOptions {
 unsafe impl ::windows::core::Abi for TileOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TileOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TileOptions {}
 impl ::core::fmt::Debug for TileOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TileOptions").field(&self.0).finish()
@@ -1998,6 +1973,7 @@ impl ::windows::core::DefaultType for TileOptions {
 }
 #[doc = "*Required features: 'UI_StartScreen'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TileSize(pub i32);
 impl TileSize {
     pub const Default: Self = Self(0i32);
@@ -2018,12 +1994,6 @@ impl ::core::clone::Clone for TileSize {
 unsafe impl ::windows::core::Abi for TileSize {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TileSize {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TileSize {}
 impl ::core::fmt::Debug for TileSize {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TileSize").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Text/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Text/Core/mod.rs
@@ -734,6 +734,7 @@ unsafe impl ::core::marker::Send for CoreTextFormatUpdatingEventArgs {}
 unsafe impl ::core::marker::Sync for CoreTextFormatUpdatingEventArgs {}
 #[doc = "*Required features: 'UI_Text_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CoreTextFormatUpdatingReason(pub i32);
 impl CoreTextFormatUpdatingReason {
     pub const None: Self = Self(0i32);
@@ -751,12 +752,6 @@ impl ::core::clone::Clone for CoreTextFormatUpdatingReason {
 unsafe impl ::windows::core::Abi for CoreTextFormatUpdatingReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CoreTextFormatUpdatingReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CoreTextFormatUpdatingReason {}
 impl ::core::fmt::Debug for CoreTextFormatUpdatingReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CoreTextFormatUpdatingReason").field(&self.0).finish()
@@ -770,6 +765,7 @@ impl ::windows::core::DefaultType for CoreTextFormatUpdatingReason {
 }
 #[doc = "*Required features: 'UI_Text_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CoreTextFormatUpdatingResult(pub i32);
 impl CoreTextFormatUpdatingResult {
     pub const Succeeded: Self = Self(0i32);
@@ -784,12 +780,6 @@ impl ::core::clone::Clone for CoreTextFormatUpdatingResult {
 unsafe impl ::windows::core::Abi for CoreTextFormatUpdatingResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CoreTextFormatUpdatingResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CoreTextFormatUpdatingResult {}
 impl ::core::fmt::Debug for CoreTextFormatUpdatingResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CoreTextFormatUpdatingResult").field(&self.0).finish()
@@ -803,6 +793,7 @@ impl ::windows::core::DefaultType for CoreTextFormatUpdatingResult {
 }
 #[doc = "*Required features: 'UI_Text_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CoreTextInputPaneDisplayPolicy(pub i32);
 impl CoreTextInputPaneDisplayPolicy {
     pub const Automatic: Self = Self(0i32);
@@ -817,12 +808,6 @@ impl ::core::clone::Clone for CoreTextInputPaneDisplayPolicy {
 unsafe impl ::windows::core::Abi for CoreTextInputPaneDisplayPolicy {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CoreTextInputPaneDisplayPolicy {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CoreTextInputPaneDisplayPolicy {}
 impl ::core::fmt::Debug for CoreTextInputPaneDisplayPolicy {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CoreTextInputPaneDisplayPolicy").field(&self.0).finish()
@@ -836,6 +821,7 @@ impl ::windows::core::DefaultType for CoreTextInputPaneDisplayPolicy {
 }
 #[doc = "*Required features: 'UI_Text_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CoreTextInputScope(pub i32);
 impl CoreTextInputScope {
     pub const Default: Self = Self(0i32);
@@ -915,12 +901,6 @@ impl ::core::clone::Clone for CoreTextInputScope {
 unsafe impl ::windows::core::Abi for CoreTextInputScope {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CoreTextInputScope {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CoreTextInputScope {}
 impl ::core::fmt::Debug for CoreTextInputScope {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CoreTextInputScope").field(&self.0).finish()
@@ -1564,6 +1544,7 @@ unsafe impl ::core::marker::Send for CoreTextSelectionUpdatingEventArgs {}
 unsafe impl ::core::marker::Sync for CoreTextSelectionUpdatingEventArgs {}
 #[doc = "*Required features: 'UI_Text_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CoreTextSelectionUpdatingResult(pub i32);
 impl CoreTextSelectionUpdatingResult {
     pub const Succeeded: Self = Self(0i32);
@@ -1578,12 +1559,6 @@ impl ::core::clone::Clone for CoreTextSelectionUpdatingResult {
 unsafe impl ::windows::core::Abi for CoreTextSelectionUpdatingResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CoreTextSelectionUpdatingResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CoreTextSelectionUpdatingResult {}
 impl ::core::fmt::Debug for CoreTextSelectionUpdatingResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CoreTextSelectionUpdatingResult").field(&self.0).finish()
@@ -2061,6 +2036,7 @@ unsafe impl ::core::marker::Send for CoreTextTextUpdatingEventArgs {}
 unsafe impl ::core::marker::Sync for CoreTextTextUpdatingEventArgs {}
 #[doc = "*Required features: 'UI_Text_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CoreTextTextUpdatingResult(pub i32);
 impl CoreTextTextUpdatingResult {
     pub const Succeeded: Self = Self(0i32);
@@ -2075,12 +2051,6 @@ impl ::core::clone::Clone for CoreTextTextUpdatingResult {
 unsafe impl ::windows::core::Abi for CoreTextTextUpdatingResult {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CoreTextTextUpdatingResult {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CoreTextTextUpdatingResult {}
 impl ::core::fmt::Debug for CoreTextTextUpdatingResult {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CoreTextTextUpdatingResult").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Text/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Text/mod.rs
@@ -3,6 +3,7 @@
 pub mod Core;
 #[doc = "*Required features: 'UI_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CaretType(pub i32);
 impl CaretType {
     pub const Normal: Self = Self(0i32);
@@ -17,12 +18,6 @@ impl ::core::clone::Clone for CaretType {
 unsafe impl ::windows::core::Abi for CaretType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CaretType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CaretType {}
 impl ::core::fmt::Debug for CaretType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CaretType").field(&self.0).finish()
@@ -183,6 +178,7 @@ unsafe impl ::core::marker::Send for ContentLinkInfo {}
 unsafe impl ::core::marker::Sync for ContentLinkInfo {}
 #[doc = "*Required features: 'UI_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FindOptions(pub u32);
 impl FindOptions {
     pub const None: Self = Self(0u32);
@@ -198,12 +194,6 @@ impl ::core::clone::Clone for FindOptions {
 unsafe impl ::windows::core::Abi for FindOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FindOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FindOptions {}
 impl ::core::fmt::Debug for FindOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FindOptions").field(&self.0).finish()
@@ -245,6 +235,7 @@ impl ::windows::core::DefaultType for FindOptions {
 }
 #[doc = "*Required features: 'UI_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FontStretch(pub i32);
 impl FontStretch {
     pub const Undefined: Self = Self(0i32);
@@ -267,12 +258,6 @@ impl ::core::clone::Clone for FontStretch {
 unsafe impl ::windows::core::Abi for FontStretch {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FontStretch {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FontStretch {}
 impl ::core::fmt::Debug for FontStretch {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FontStretch").field(&self.0).finish()
@@ -286,6 +271,7 @@ impl ::windows::core::DefaultType for FontStretch {
 }
 #[doc = "*Required features: 'UI_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FontStyle(pub i32);
 impl FontStyle {
     pub const Normal: Self = Self(0i32);
@@ -301,12 +287,6 @@ impl ::core::clone::Clone for FontStyle {
 unsafe impl ::windows::core::Abi for FontStyle {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FontStyle {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FontStyle {}
 impl ::core::fmt::Debug for FontStyle {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FontStyle").field(&self.0).finish()
@@ -511,6 +491,7 @@ unsafe impl ::core::marker::Send for FontWeights {}
 unsafe impl ::core::marker::Sync for FontWeights {}
 #[doc = "*Required features: 'UI_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FormatEffect(pub i32);
 impl FormatEffect {
     pub const Off: Self = Self(0i32);
@@ -527,12 +508,6 @@ impl ::core::clone::Clone for FormatEffect {
 unsafe impl ::windows::core::Abi for FormatEffect {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FormatEffect {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FormatEffect {}
 impl ::core::fmt::Debug for FormatEffect {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FormatEffect").field(&self.0).finish()
@@ -546,6 +521,7 @@ impl ::windows::core::DefaultType for FormatEffect {
 }
 #[doc = "*Required features: 'UI_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HorizontalCharacterAlignment(pub i32);
 impl HorizontalCharacterAlignment {
     pub const Left: Self = Self(0i32);
@@ -561,12 +537,6 @@ impl ::core::clone::Clone for HorizontalCharacterAlignment {
 unsafe impl ::windows::core::Abi for HorizontalCharacterAlignment {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HorizontalCharacterAlignment {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HorizontalCharacterAlignment {}
 impl ::core::fmt::Debug for HorizontalCharacterAlignment {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HorizontalCharacterAlignment").field(&self.0).finish()
@@ -2941,6 +2911,7 @@ pub struct ITextSelectionVtbl(
 );
 #[doc = "*Required features: 'UI_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LetterCase(pub i32);
 impl LetterCase {
     pub const Lower: Self = Self(0i32);
@@ -2955,12 +2926,6 @@ impl ::core::clone::Clone for LetterCase {
 unsafe impl ::windows::core::Abi for LetterCase {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LetterCase {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LetterCase {}
 impl ::core::fmt::Debug for LetterCase {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LetterCase").field(&self.0).finish()
@@ -2974,6 +2939,7 @@ impl ::windows::core::DefaultType for LetterCase {
 }
 #[doc = "*Required features: 'UI_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LineSpacingRule(pub i32);
 impl LineSpacingRule {
     pub const Undefined: Self = Self(0i32);
@@ -2994,12 +2960,6 @@ impl ::core::clone::Clone for LineSpacingRule {
 unsafe impl ::windows::core::Abi for LineSpacingRule {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LineSpacingRule {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LineSpacingRule {}
 impl ::core::fmt::Debug for LineSpacingRule {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LineSpacingRule").field(&self.0).finish()
@@ -3013,6 +2973,7 @@ impl ::windows::core::DefaultType for LineSpacingRule {
 }
 #[doc = "*Required features: 'UI_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LinkType(pub i32);
 impl LinkType {
     pub const Undefined: Self = Self(0i32);
@@ -3034,12 +2995,6 @@ impl ::core::clone::Clone for LinkType {
 unsafe impl ::windows::core::Abi for LinkType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LinkType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LinkType {}
 impl ::core::fmt::Debug for LinkType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LinkType").field(&self.0).finish()
@@ -3053,6 +3008,7 @@ impl ::windows::core::DefaultType for LinkType {
 }
 #[doc = "*Required features: 'UI_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MarkerAlignment(pub i32);
 impl MarkerAlignment {
     pub const Undefined: Self = Self(0i32);
@@ -3069,12 +3025,6 @@ impl ::core::clone::Clone for MarkerAlignment {
 unsafe impl ::windows::core::Abi for MarkerAlignment {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MarkerAlignment {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MarkerAlignment {}
 impl ::core::fmt::Debug for MarkerAlignment {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MarkerAlignment").field(&self.0).finish()
@@ -3088,6 +3038,7 @@ impl ::windows::core::DefaultType for MarkerAlignment {
 }
 #[doc = "*Required features: 'UI_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MarkerStyle(pub i32);
 impl MarkerStyle {
     pub const Undefined: Self = Self(0i32);
@@ -3107,12 +3058,6 @@ impl ::core::clone::Clone for MarkerStyle {
 unsafe impl ::windows::core::Abi for MarkerStyle {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MarkerStyle {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MarkerStyle {}
 impl ::core::fmt::Debug for MarkerStyle {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MarkerStyle").field(&self.0).finish()
@@ -3126,6 +3071,7 @@ impl ::windows::core::DefaultType for MarkerStyle {
 }
 #[doc = "*Required features: 'UI_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MarkerType(pub i32);
 impl MarkerType {
     pub const Undefined: Self = Self(0i32);
@@ -3163,12 +3109,6 @@ impl ::core::clone::Clone for MarkerType {
 unsafe impl ::windows::core::Abi for MarkerType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MarkerType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MarkerType {}
 impl ::core::fmt::Debug for MarkerType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MarkerType").field(&self.0).finish()
@@ -3182,6 +3122,7 @@ impl ::windows::core::DefaultType for MarkerType {
 }
 #[doc = "*Required features: 'UI_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ParagraphAlignment(pub i32);
 impl ParagraphAlignment {
     pub const Undefined: Self = Self(0i32);
@@ -3199,12 +3140,6 @@ impl ::core::clone::Clone for ParagraphAlignment {
 unsafe impl ::windows::core::Abi for ParagraphAlignment {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ParagraphAlignment {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ParagraphAlignment {}
 impl ::core::fmt::Debug for ParagraphAlignment {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ParagraphAlignment").field(&self.0).finish()
@@ -3218,6 +3153,7 @@ impl ::windows::core::DefaultType for ParagraphAlignment {
 }
 #[doc = "*Required features: 'UI_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ParagraphStyle(pub i32);
 impl ParagraphStyle {
     pub const Undefined: Self = Self(0i32);
@@ -3242,12 +3178,6 @@ impl ::core::clone::Clone for ParagraphStyle {
 unsafe impl ::windows::core::Abi for ParagraphStyle {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ParagraphStyle {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ParagraphStyle {}
 impl ::core::fmt::Debug for ParagraphStyle {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ParagraphStyle").field(&self.0).finish()
@@ -3261,6 +3191,7 @@ impl ::windows::core::DefaultType for ParagraphStyle {
 }
 #[doc = "*Required features: 'UI_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PointOptions(pub u32);
 impl PointOptions {
     pub const None: Self = Self(0u32);
@@ -3281,12 +3212,6 @@ impl ::core::clone::Clone for PointOptions {
 unsafe impl ::windows::core::Abi for PointOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PointOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PointOptions {}
 impl ::core::fmt::Debug for PointOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PointOptions").field(&self.0).finish()
@@ -3328,6 +3253,7 @@ impl ::windows::core::DefaultType for PointOptions {
 }
 #[doc = "*Required features: 'UI_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RangeGravity(pub i32);
 impl RangeGravity {
     pub const UIBehavior: Self = Self(0i32);
@@ -3345,12 +3271,6 @@ impl ::core::clone::Clone for RangeGravity {
 unsafe impl ::windows::core::Abi for RangeGravity {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RangeGravity {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RangeGravity {}
 impl ::core::fmt::Debug for RangeGravity {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RangeGravity").field(&self.0).finish()
@@ -3364,6 +3284,7 @@ impl ::windows::core::DefaultType for RangeGravity {
 }
 #[doc = "*Required features: 'UI_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RichEditMathMode(pub i32);
 impl RichEditMathMode {
     pub const NoMath: Self = Self(0i32);
@@ -3378,12 +3299,6 @@ impl ::core::clone::Clone for RichEditMathMode {
 unsafe impl ::windows::core::Abi for RichEditMathMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RichEditMathMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RichEditMathMode {}
 impl ::core::fmt::Debug for RichEditMathMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RichEditMathMode").field(&self.0).finish()
@@ -4167,6 +4082,7 @@ unsafe impl ::core::marker::Send for RichEditTextRange {}
 unsafe impl ::core::marker::Sync for RichEditTextRange {}
 #[doc = "*Required features: 'UI_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SelectionOptions(pub u32);
 impl SelectionOptions {
     pub const StartActive: Self = Self(1u32);
@@ -4184,12 +4100,6 @@ impl ::core::clone::Clone for SelectionOptions {
 unsafe impl ::windows::core::Abi for SelectionOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SelectionOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SelectionOptions {}
 impl ::core::fmt::Debug for SelectionOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SelectionOptions").field(&self.0).finish()
@@ -4231,6 +4141,7 @@ impl ::windows::core::DefaultType for SelectionOptions {
 }
 #[doc = "*Required features: 'UI_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SelectionType(pub i32);
 impl SelectionType {
     pub const None: Self = Self(0i32);
@@ -4248,12 +4159,6 @@ impl ::core::clone::Clone for SelectionType {
 unsafe impl ::windows::core::Abi for SelectionType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SelectionType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SelectionType {}
 impl ::core::fmt::Debug for SelectionType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SelectionType").field(&self.0).finish()
@@ -4267,6 +4172,7 @@ impl ::windows::core::DefaultType for SelectionType {
 }
 #[doc = "*Required features: 'UI_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TabAlignment(pub i32);
 impl TabAlignment {
     pub const Left: Self = Self(0i32);
@@ -4284,12 +4190,6 @@ impl ::core::clone::Clone for TabAlignment {
 unsafe impl ::windows::core::Abi for TabAlignment {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TabAlignment {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TabAlignment {}
 impl ::core::fmt::Debug for TabAlignment {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TabAlignment").field(&self.0).finish()
@@ -4303,6 +4203,7 @@ impl ::windows::core::DefaultType for TabAlignment {
 }
 #[doc = "*Required features: 'UI_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TabLeader(pub i32);
 impl TabLeader {
     pub const Spaces: Self = Self(0i32);
@@ -4321,12 +4222,6 @@ impl ::core::clone::Clone for TabLeader {
 unsafe impl ::windows::core::Abi for TabLeader {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TabLeader {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TabLeader {}
 impl ::core::fmt::Debug for TabLeader {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TabLeader").field(&self.0).finish()
@@ -4408,6 +4303,7 @@ impl ::windows::core::RuntimeName for TextConstants {
 }
 #[doc = "*Required features: 'UI_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TextDecorations(pub u32);
 impl TextDecorations {
     pub const None: Self = Self(0u32);
@@ -4423,12 +4319,6 @@ impl ::core::clone::Clone for TextDecorations {
 unsafe impl ::windows::core::Abi for TextDecorations {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TextDecorations {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TextDecorations {}
 impl ::core::fmt::Debug for TextDecorations {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TextDecorations").field(&self.0).finish()
@@ -4470,6 +4360,7 @@ impl ::windows::core::DefaultType for TextDecorations {
 }
 #[doc = "*Required features: 'UI_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TextGetOptions(pub u32);
 impl TextGetOptions {
     pub const None: Self = Self(0u32);
@@ -4491,12 +4382,6 @@ impl ::core::clone::Clone for TextGetOptions {
 unsafe impl ::windows::core::Abi for TextGetOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TextGetOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TextGetOptions {}
 impl ::core::fmt::Debug for TextGetOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TextGetOptions").field(&self.0).finish()
@@ -4538,6 +4423,7 @@ impl ::windows::core::DefaultType for TextGetOptions {
 }
 #[doc = "*Required features: 'UI_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TextRangeUnit(pub i32);
 impl TextRangeUnit {
     pub const Character: Self = Self(0i32);
@@ -4583,12 +4469,6 @@ impl ::core::clone::Clone for TextRangeUnit {
 unsafe impl ::windows::core::Abi for TextRangeUnit {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TextRangeUnit {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TextRangeUnit {}
 impl ::core::fmt::Debug for TextRangeUnit {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TextRangeUnit").field(&self.0).finish()
@@ -4602,6 +4482,7 @@ impl ::windows::core::DefaultType for TextRangeUnit {
 }
 #[doc = "*Required features: 'UI_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TextScript(pub i32);
 impl TextScript {
     pub const Undefined: Self = Self(0i32);
@@ -4678,12 +4559,6 @@ impl ::core::clone::Clone for TextScript {
 unsafe impl ::windows::core::Abi for TextScript {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TextScript {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TextScript {}
 impl ::core::fmt::Debug for TextScript {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TextScript").field(&self.0).finish()
@@ -4697,6 +4572,7 @@ impl ::windows::core::DefaultType for TextScript {
 }
 #[doc = "*Required features: 'UI_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TextSetOptions(pub u32);
 impl TextSetOptions {
     pub const None: Self = Self(0u32);
@@ -4716,12 +4592,6 @@ impl ::core::clone::Clone for TextSetOptions {
 unsafe impl ::windows::core::Abi for TextSetOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TextSetOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TextSetOptions {}
 impl ::core::fmt::Debug for TextSetOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TextSetOptions").field(&self.0).finish()
@@ -4763,6 +4633,7 @@ impl ::windows::core::DefaultType for TextSetOptions {
 }
 #[doc = "*Required features: 'UI_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UnderlineType(pub i32);
 impl UnderlineType {
     pub const Undefined: Self = Self(0i32);
@@ -4795,12 +4666,6 @@ impl ::core::clone::Clone for UnderlineType {
 unsafe impl ::windows::core::Abi for UnderlineType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UnderlineType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UnderlineType {}
 impl ::core::fmt::Debug for UnderlineType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UnderlineType").field(&self.0).finish()
@@ -4814,6 +4679,7 @@ impl ::windows::core::DefaultType for UnderlineType {
 }
 #[doc = "*Required features: 'UI_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VerticalCharacterAlignment(pub i32);
 impl VerticalCharacterAlignment {
     pub const Top: Self = Self(0i32);
@@ -4829,12 +4695,6 @@ impl ::core::clone::Clone for VerticalCharacterAlignment {
 unsafe impl ::windows::core::Abi for VerticalCharacterAlignment {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VerticalCharacterAlignment {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VerticalCharacterAlignment {}
 impl ::core::fmt::Debug for VerticalCharacterAlignment {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VerticalCharacterAlignment").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/UIAutomation/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/UIAutomation/Core/mod.rs
@@ -186,6 +186,7 @@ unsafe impl ::core::marker::Send for AutomationRemoteOperationResult {}
 unsafe impl ::core::marker::Sync for AutomationRemoteOperationResult {}
 #[doc = "*Required features: 'UI_UIAutomation_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AutomationRemoteOperationStatus(pub i32);
 impl AutomationRemoteOperationStatus {
     pub const Success: Self = Self(0i32);
@@ -203,12 +204,6 @@ impl ::core::clone::Clone for AutomationRemoteOperationStatus {
 unsafe impl ::windows::core::Abi for AutomationRemoteOperationStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AutomationRemoteOperationStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AutomationRemoteOperationStatus {}
 impl ::core::fmt::Debug for AutomationRemoteOperationStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AutomationRemoteOperationStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/ViewManagement/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/ViewManagement/Core/mod.rs
@@ -765,6 +765,7 @@ unsafe impl ::core::marker::Send for CoreInputViewHidingEventArgs {}
 unsafe impl ::core::marker::Sync for CoreInputViewHidingEventArgs {}
 #[doc = "*Required features: 'UI_ViewManagement_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CoreInputViewKind(pub i32);
 impl CoreInputViewKind {
     pub const Default: Self = Self(0i32);
@@ -784,12 +785,6 @@ impl ::core::clone::Clone for CoreInputViewKind {
 unsafe impl ::windows::core::Abi for CoreInputViewKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CoreInputViewKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CoreInputViewKind {}
 impl ::core::fmt::Debug for CoreInputViewKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CoreInputViewKind").field(&self.0).finish()
@@ -893,6 +888,7 @@ unsafe impl ::core::marker::Send for CoreInputViewOcclusion {}
 unsafe impl ::core::marker::Sync for CoreInputViewOcclusion {}
 #[doc = "*Required features: 'UI_ViewManagement_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CoreInputViewOcclusionKind(pub i32);
 impl CoreInputViewOcclusionKind {
     pub const Docked: Self = Self(0i32);
@@ -908,12 +904,6 @@ impl ::core::clone::Clone for CoreInputViewOcclusionKind {
 unsafe impl ::windows::core::Abi for CoreInputViewOcclusionKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CoreInputViewOcclusionKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CoreInputViewOcclusionKind {}
 impl ::core::fmt::Debug for CoreInputViewOcclusionKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CoreInputViewOcclusionKind").field(&self.0).finish()
@@ -1219,6 +1209,7 @@ unsafe impl ::core::marker::Send for CoreInputViewTransferringXYFocusEventArgs {
 unsafe impl ::core::marker::Sync for CoreInputViewTransferringXYFocusEventArgs {}
 #[doc = "*Required features: 'UI_ViewManagement_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CoreInputViewXYFocusTransferDirection(pub i32);
 impl CoreInputViewXYFocusTransferDirection {
     pub const Up: Self = Self(0i32);
@@ -1235,12 +1226,6 @@ impl ::core::clone::Clone for CoreInputViewXYFocusTransferDirection {
 unsafe impl ::windows::core::Abi for CoreInputViewXYFocusTransferDirection {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CoreInputViewXYFocusTransferDirection {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CoreInputViewXYFocusTransferDirection {}
 impl ::core::fmt::Debug for CoreInputViewXYFocusTransferDirection {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CoreInputViewXYFocusTransferDirection").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/ViewManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/ViewManagement/mod.rs
@@ -689,6 +689,7 @@ unsafe impl ::core::marker::Send for ApplicationView {}
 unsafe impl ::core::marker::Sync for ApplicationView {}
 #[doc = "*Required features: 'UI_ViewManagement'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ApplicationViewBoundsMode(pub i32);
 impl ApplicationViewBoundsMode {
     pub const UseVisible: Self = Self(0i32);
@@ -703,12 +704,6 @@ impl ::core::clone::Clone for ApplicationViewBoundsMode {
 unsafe impl ::windows::core::Abi for ApplicationViewBoundsMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ApplicationViewBoundsMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ApplicationViewBoundsMode {}
 impl ::core::fmt::Debug for ApplicationViewBoundsMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ApplicationViewBoundsMode").field(&self.0).finish()
@@ -811,6 +806,7 @@ unsafe impl ::core::marker::Send for ApplicationViewConsolidatedEventArgs {}
 unsafe impl ::core::marker::Sync for ApplicationViewConsolidatedEventArgs {}
 #[doc = "*Required features: 'UI_ViewManagement'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ApplicationViewMode(pub i32);
 impl ApplicationViewMode {
     pub const Default: Self = Self(0i32);
@@ -825,12 +821,6 @@ impl ::core::clone::Clone for ApplicationViewMode {
 unsafe impl ::windows::core::Abi for ApplicationViewMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ApplicationViewMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ApplicationViewMode {}
 impl ::core::fmt::Debug for ApplicationViewMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ApplicationViewMode").field(&self.0).finish()
@@ -844,6 +834,7 @@ impl ::windows::core::DefaultType for ApplicationViewMode {
 }
 #[doc = "*Required features: 'UI_ViewManagement'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ApplicationViewOrientation(pub i32);
 impl ApplicationViewOrientation {
     pub const Landscape: Self = Self(0i32);
@@ -858,12 +849,6 @@ impl ::core::clone::Clone for ApplicationViewOrientation {
 unsafe impl ::windows::core::Abi for ApplicationViewOrientation {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ApplicationViewOrientation {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ApplicationViewOrientation {}
 impl ::core::fmt::Debug for ApplicationViewOrientation {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ApplicationViewOrientation").field(&self.0).finish()
@@ -968,6 +953,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Appl
 #[doc = "*Required features: 'UI_ViewManagement', 'deprecated'*"]
 #[cfg(feature = "deprecated")]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ApplicationViewState(pub i32);
 #[cfg(feature = "deprecated")]
 impl ApplicationViewState {
@@ -988,14 +974,6 @@ impl ::core::clone::Clone for ApplicationViewState {
 unsafe impl ::windows::core::Abi for ApplicationViewState {
     type Abi = Self;
 }
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::PartialEq for ApplicationViewState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-#[cfg(feature = "deprecated")]
-impl ::core::cmp::Eq for ApplicationViewState {}
 #[cfg(feature = "deprecated")]
 impl ::core::fmt::Debug for ApplicationViewState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
@@ -1114,6 +1092,7 @@ impl ::windows::core::RuntimeName for ApplicationViewSwitcher {
 }
 #[doc = "*Required features: 'UI_ViewManagement'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ApplicationViewSwitchingOptions(pub u32);
 impl ApplicationViewSwitchingOptions {
     pub const Default: Self = Self(0u32);
@@ -1129,12 +1108,6 @@ impl ::core::clone::Clone for ApplicationViewSwitchingOptions {
 unsafe impl ::windows::core::Abi for ApplicationViewSwitchingOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ApplicationViewSwitchingOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ApplicationViewSwitchingOptions {}
 impl ::core::fmt::Debug for ApplicationViewSwitchingOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ApplicationViewSwitchingOptions").field(&self.0).finish()
@@ -1532,6 +1505,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &Appl
 }
 #[doc = "*Required features: 'UI_ViewManagement'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ApplicationViewWindowingMode(pub i32);
 impl ApplicationViewWindowingMode {
     pub const Auto: Self = Self(0i32);
@@ -1549,12 +1523,6 @@ impl ::core::clone::Clone for ApplicationViewWindowingMode {
 unsafe impl ::windows::core::Abi for ApplicationViewWindowingMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ApplicationViewWindowingMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ApplicationViewWindowingMode {}
 impl ::core::fmt::Debug for ApplicationViewWindowingMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ApplicationViewWindowingMode").field(&self.0).finish()
@@ -1568,6 +1536,7 @@ impl ::windows::core::DefaultType for ApplicationViewWindowingMode {
 }
 #[doc = "*Required features: 'UI_ViewManagement'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FullScreenSystemOverlayMode(pub i32);
 impl FullScreenSystemOverlayMode {
     pub const Standard: Self = Self(0i32);
@@ -1582,12 +1551,6 @@ impl ::core::clone::Clone for FullScreenSystemOverlayMode {
 unsafe impl ::windows::core::Abi for FullScreenSystemOverlayMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FullScreenSystemOverlayMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FullScreenSystemOverlayMode {}
 impl ::core::fmt::Debug for FullScreenSystemOverlayMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FullScreenSystemOverlayMode").field(&self.0).finish()
@@ -1601,6 +1564,7 @@ impl ::windows::core::DefaultType for FullScreenSystemOverlayMode {
 }
 #[doc = "*Required features: 'UI_ViewManagement'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HandPreference(pub i32);
 impl HandPreference {
     pub const LeftHanded: Self = Self(0i32);
@@ -1615,12 +1579,6 @@ impl ::core::clone::Clone for HandPreference {
 unsafe impl ::windows::core::Abi for HandPreference {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HandPreference {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HandPreference {}
 impl ::core::fmt::Debug for HandPreference {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HandPreference").field(&self.0).finish()
@@ -3419,6 +3377,7 @@ unsafe impl ::core::marker::Send for StatusBarProgressIndicator {}
 unsafe impl ::core::marker::Sync for StatusBarProgressIndicator {}
 #[doc = "*Required features: 'UI_ViewManagement'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UIColorType(pub i32);
 impl UIColorType {
     pub const Background: Self = Self(0i32);
@@ -3441,12 +3400,6 @@ impl ::core::clone::Clone for UIColorType {
 unsafe impl ::windows::core::Abi for UIColorType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UIColorType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UIColorType {}
 impl ::core::fmt::Debug for UIColorType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UIColorType").field(&self.0).finish()
@@ -3460,6 +3413,7 @@ impl ::windows::core::DefaultType for UIColorType {
 }
 #[doc = "*Required features: 'UI_ViewManagement'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UIElementType(pub i32);
 impl UIElementType {
     pub const ActiveCaption: Self = Self(0i32);
@@ -3498,12 +3452,6 @@ impl ::core::clone::Clone for UIElementType {
 unsafe impl ::windows::core::Abi for UIElementType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UIElementType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UIElementType {}
 impl ::core::fmt::Debug for UIElementType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UIElementType").field(&self.0).finish()
@@ -4136,6 +4084,7 @@ unsafe impl ::core::marker::Send for UIViewSettings {}
 unsafe impl ::core::marker::Sync for UIViewSettings {}
 #[doc = "*Required features: 'UI_ViewManagement'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UserInteractionMode(pub i32);
 impl UserInteractionMode {
     pub const Mouse: Self = Self(0i32);
@@ -4150,12 +4099,6 @@ impl ::core::clone::Clone for UserInteractionMode {
 unsafe impl ::windows::core::Abi for UserInteractionMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UserInteractionMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UserInteractionMode {}
 impl ::core::fmt::Debug for UserInteractionMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UserInteractionMode").field(&self.0).finish()
@@ -4280,6 +4223,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &View
 }
 #[doc = "*Required features: 'UI_ViewManagement'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ViewSizePreference(pub i32);
 impl ViewSizePreference {
     pub const Default: Self = Self(0i32);
@@ -4299,12 +4243,6 @@ impl ::core::clone::Clone for ViewSizePreference {
 unsafe impl ::windows::core::Abi for ViewSizePreference {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ViewSizePreference {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ViewSizePreference {}
 impl ::core::fmt::Debug for ViewSizePreference {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ViewSizePreference").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/WebUI/Core/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/WebUI/Core/mod.rs
@@ -978,6 +978,7 @@ unsafe impl ::core::marker::Send for WebUICommandBarBitmapIcon {}
 unsafe impl ::core::marker::Sync for WebUICommandBarBitmapIcon {}
 #[doc = "*Required features: 'UI_WebUI_Core'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WebUICommandBarClosedDisplayMode(pub i32);
 impl WebUICommandBarClosedDisplayMode {
     pub const Default: Self = Self(0i32);
@@ -993,12 +994,6 @@ impl ::core::clone::Clone for WebUICommandBarClosedDisplayMode {
 unsafe impl ::windows::core::Abi for WebUICommandBarClosedDisplayMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WebUICommandBarClosedDisplayMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WebUICommandBarClosedDisplayMode {}
 impl ::core::fmt::Debug for WebUICommandBarClosedDisplayMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WebUICommandBarClosedDisplayMode").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/WebUI/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/WebUI/mod.rs
@@ -1911,6 +1911,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &NewW
 }
 #[doc = "*Required features: 'UI_WebUI'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PrintContent(pub i32);
 impl PrintContent {
     pub const AllPages: Self = Self(0i32);
@@ -1927,12 +1928,6 @@ impl ::core::clone::Clone for PrintContent {
 unsafe impl ::windows::core::Abi for PrintContent {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PrintContent {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PrintContent {}
 impl ::core::fmt::Debug for PrintContent {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PrintContent").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/WindowManagement/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/WindowManagement/mod.rs
@@ -620,6 +620,7 @@ unsafe impl ::core::marker::Send for AppWindowClosedEventArgs {}
 unsafe impl ::core::marker::Sync for AppWindowClosedEventArgs {}
 #[doc = "*Required features: 'UI_WindowManagement'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppWindowClosedReason(pub i32);
 impl AppWindowClosedReason {
     pub const Other: Self = Self(0i32);
@@ -635,12 +636,6 @@ impl ::core::clone::Clone for AppWindowClosedReason {
 unsafe impl ::windows::core::Abi for AppWindowClosedReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppWindowClosedReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppWindowClosedReason {}
 impl ::core::fmt::Debug for AppWindowClosedReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppWindowClosedReason").field(&self.0).finish()
@@ -749,6 +744,7 @@ unsafe impl ::core::marker::Send for AppWindowFrame {}
 unsafe impl ::core::marker::Sync for AppWindowFrame {}
 #[doc = "*Required features: 'UI_WindowManagement'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppWindowFrameStyle(pub i32);
 impl AppWindowFrameStyle {
     pub const Default: Self = Self(0i32);
@@ -763,12 +759,6 @@ impl ::core::clone::Clone for AppWindowFrameStyle {
 unsafe impl ::windows::core::Abi for AppWindowFrameStyle {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppWindowFrameStyle {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppWindowFrameStyle {}
 impl ::core::fmt::Debug for AppWindowFrameStyle {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppWindowFrameStyle").field(&self.0).finish()
@@ -962,6 +952,7 @@ unsafe impl ::core::marker::Send for AppWindowPresentationConfiguration {}
 unsafe impl ::core::marker::Sync for AppWindowPresentationConfiguration {}
 #[doc = "*Required features: 'UI_WindowManagement'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppWindowPresentationKind(pub i32);
 impl AppWindowPresentationKind {
     pub const Default: Self = Self(0i32);
@@ -977,12 +968,6 @@ impl ::core::clone::Clone for AppWindowPresentationKind {
 unsafe impl ::windows::core::Abi for AppWindowPresentationKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppWindowPresentationKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppWindowPresentationKind {}
 impl ::core::fmt::Debug for AppWindowPresentationKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppWindowPresentationKind").field(&self.0).finish()
@@ -1479,6 +1464,7 @@ unsafe impl ::core::marker::Send for AppWindowTitleBarOcclusion {}
 unsafe impl ::core::marker::Sync for AppWindowTitleBarOcclusion {}
 #[doc = "*Required features: 'UI_WindowManagement'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AppWindowTitleBarVisibility(pub i32);
 impl AppWindowTitleBarVisibility {
     pub const Default: Self = Self(0i32);
@@ -1493,12 +1479,6 @@ impl ::core::clone::Clone for AppWindowTitleBarVisibility {
 unsafe impl ::windows::core::Abi for AppWindowTitleBarVisibility {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AppWindowTitleBarVisibility {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AppWindowTitleBarVisibility {}
 impl ::core::fmt::Debug for AppWindowTitleBarVisibility {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AppWindowTitleBarVisibility").field(&self.0).finish()
@@ -2854,6 +2834,7 @@ unsafe impl ::core::marker::Send for WindowingEnvironmentChangedEventArgs {}
 unsafe impl ::core::marker::Sync for WindowingEnvironmentChangedEventArgs {}
 #[doc = "*Required features: 'UI_WindowManagement'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WindowingEnvironmentKind(pub i32);
 impl WindowingEnvironmentKind {
     pub const Unknown: Self = Self(0i32);
@@ -2869,12 +2850,6 @@ impl ::core::clone::Clone for WindowingEnvironmentKind {
 unsafe impl ::windows::core::Abi for WindowingEnvironmentKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WindowingEnvironmentKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WindowingEnvironmentKind {}
 impl ::core::fmt::Debug for WindowingEnvironmentKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WindowingEnvironmentKind").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Xaml/Automation/Peers/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/Automation/Peers/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'UI_Xaml_Automation_Peers'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AccessibilityView(pub i32);
 impl AccessibilityView {
     pub const Raw: Self = Self(0i32);
@@ -16,12 +17,6 @@ impl ::core::clone::Clone for AccessibilityView {
 unsafe impl ::windows::core::Abi for AccessibilityView {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AccessibilityView {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AccessibilityView {}
 impl ::core::fmt::Debug for AccessibilityView {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AccessibilityView").field(&self.0).finish()
@@ -1019,6 +1014,7 @@ unsafe impl ::core::marker::Send for AutoSuggestBoxAutomationPeer {}
 unsafe impl ::core::marker::Sync for AutoSuggestBoxAutomationPeer {}
 #[doc = "*Required features: 'UI_Xaml_Automation_Peers'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AutomationControlType(pub i32);
 impl AutomationControlType {
     pub const Button: Self = Self(0i32);
@@ -1072,12 +1068,6 @@ impl ::core::clone::Clone for AutomationControlType {
 unsafe impl ::windows::core::Abi for AutomationControlType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AutomationControlType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AutomationControlType {}
 impl ::core::fmt::Debug for AutomationControlType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AutomationControlType").field(&self.0).finish()
@@ -1091,6 +1081,7 @@ impl ::windows::core::DefaultType for AutomationControlType {
 }
 #[doc = "*Required features: 'UI_Xaml_Automation_Peers'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AutomationEvents(pub i32);
 impl AutomationEvents {
     pub const ToolTipOpened: Self = Self(0i32);
@@ -1133,12 +1124,6 @@ impl ::core::clone::Clone for AutomationEvents {
 unsafe impl ::windows::core::Abi for AutomationEvents {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AutomationEvents {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AutomationEvents {}
 impl ::core::fmt::Debug for AutomationEvents {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AutomationEvents").field(&self.0).finish()
@@ -1152,6 +1137,7 @@ impl ::windows::core::DefaultType for AutomationEvents {
 }
 #[doc = "*Required features: 'UI_Xaml_Automation_Peers'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AutomationHeadingLevel(pub i32);
 impl AutomationHeadingLevel {
     pub const None: Self = Self(0i32);
@@ -1174,12 +1160,6 @@ impl ::core::clone::Clone for AutomationHeadingLevel {
 unsafe impl ::windows::core::Abi for AutomationHeadingLevel {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AutomationHeadingLevel {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AutomationHeadingLevel {}
 impl ::core::fmt::Debug for AutomationHeadingLevel {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AutomationHeadingLevel").field(&self.0).finish()
@@ -1193,6 +1173,7 @@ impl ::windows::core::DefaultType for AutomationHeadingLevel {
 }
 #[doc = "*Required features: 'UI_Xaml_Automation_Peers'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AutomationLandmarkType(pub i32);
 impl AutomationLandmarkType {
     pub const None: Self = Self(0i32);
@@ -1211,12 +1192,6 @@ impl ::core::clone::Clone for AutomationLandmarkType {
 unsafe impl ::windows::core::Abi for AutomationLandmarkType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AutomationLandmarkType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AutomationLandmarkType {}
 impl ::core::fmt::Debug for AutomationLandmarkType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AutomationLandmarkType").field(&self.0).finish()
@@ -1230,6 +1205,7 @@ impl ::windows::core::DefaultType for AutomationLandmarkType {
 }
 #[doc = "*Required features: 'UI_Xaml_Automation_Peers'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AutomationLiveSetting(pub i32);
 impl AutomationLiveSetting {
     pub const Off: Self = Self(0i32);
@@ -1245,12 +1221,6 @@ impl ::core::clone::Clone for AutomationLiveSetting {
 unsafe impl ::windows::core::Abi for AutomationLiveSetting {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AutomationLiveSetting {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AutomationLiveSetting {}
 impl ::core::fmt::Debug for AutomationLiveSetting {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AutomationLiveSetting").field(&self.0).finish()
@@ -1264,6 +1234,7 @@ impl ::windows::core::DefaultType for AutomationLiveSetting {
 }
 #[doc = "*Required features: 'UI_Xaml_Automation_Peers'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AutomationNavigationDirection(pub i32);
 impl AutomationNavigationDirection {
     pub const Parent: Self = Self(0i32);
@@ -1281,12 +1252,6 @@ impl ::core::clone::Clone for AutomationNavigationDirection {
 unsafe impl ::windows::core::Abi for AutomationNavigationDirection {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AutomationNavigationDirection {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AutomationNavigationDirection {}
 impl ::core::fmt::Debug for AutomationNavigationDirection {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AutomationNavigationDirection").field(&self.0).finish()
@@ -1300,6 +1265,7 @@ impl ::windows::core::DefaultType for AutomationNavigationDirection {
 }
 #[doc = "*Required features: 'UI_Xaml_Automation_Peers'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AutomationNotificationKind(pub i32);
 impl AutomationNotificationKind {
     pub const ItemAdded: Self = Self(0i32);
@@ -1317,12 +1283,6 @@ impl ::core::clone::Clone for AutomationNotificationKind {
 unsafe impl ::windows::core::Abi for AutomationNotificationKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AutomationNotificationKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AutomationNotificationKind {}
 impl ::core::fmt::Debug for AutomationNotificationKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AutomationNotificationKind").field(&self.0).finish()
@@ -1336,6 +1296,7 @@ impl ::windows::core::DefaultType for AutomationNotificationKind {
 }
 #[doc = "*Required features: 'UI_Xaml_Automation_Peers'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AutomationNotificationProcessing(pub i32);
 impl AutomationNotificationProcessing {
     pub const ImportantAll: Self = Self(0i32);
@@ -1353,12 +1314,6 @@ impl ::core::clone::Clone for AutomationNotificationProcessing {
 unsafe impl ::windows::core::Abi for AutomationNotificationProcessing {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AutomationNotificationProcessing {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AutomationNotificationProcessing {}
 impl ::core::fmt::Debug for AutomationNotificationProcessing {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AutomationNotificationProcessing").field(&self.0).finish()
@@ -1372,6 +1327,7 @@ impl ::windows::core::DefaultType for AutomationNotificationProcessing {
 }
 #[doc = "*Required features: 'UI_Xaml_Automation_Peers'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AutomationOrientation(pub i32);
 impl AutomationOrientation {
     pub const None: Self = Self(0i32);
@@ -1387,12 +1343,6 @@ impl ::core::clone::Clone for AutomationOrientation {
 unsafe impl ::windows::core::Abi for AutomationOrientation {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AutomationOrientation {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AutomationOrientation {}
 impl ::core::fmt::Debug for AutomationOrientation {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AutomationOrientation").field(&self.0).finish()
@@ -2116,6 +2066,7 @@ unsafe impl ::core::marker::Send for AutomationPeerAnnotation {}
 unsafe impl ::core::marker::Sync for AutomationPeerAnnotation {}
 #[doc = "*Required features: 'UI_Xaml_Automation_Peers'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AutomationStructureChangeType(pub i32);
 impl AutomationStructureChangeType {
     pub const ChildAdded: Self = Self(0i32);
@@ -2134,12 +2085,6 @@ impl ::core::clone::Clone for AutomationStructureChangeType {
 unsafe impl ::windows::core::Abi for AutomationStructureChangeType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AutomationStructureChangeType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AutomationStructureChangeType {}
 impl ::core::fmt::Debug for AutomationStructureChangeType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AutomationStructureChangeType").field(&self.0).finish()
@@ -15826,6 +15771,7 @@ unsafe impl ::core::marker::Send for PasswordBoxAutomationPeer {}
 unsafe impl ::core::marker::Sync for PasswordBoxAutomationPeer {}
 #[doc = "*Required features: 'UI_Xaml_Automation_Peers'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PatternInterface(pub i32);
 impl PatternInterface {
     pub const Invoke: Self = Self(0i32);
@@ -15872,12 +15818,6 @@ impl ::core::clone::Clone for PatternInterface {
 unsafe impl ::windows::core::Abi for PatternInterface {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PatternInterface {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PatternInterface {}
 impl ::core::fmt::Debug for PatternInterface {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PatternInterface").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Xaml/Automation/Text/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/Automation/Text/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'UI_Xaml_Automation_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TextPatternRangeEndpoint(pub i32);
 impl TextPatternRangeEndpoint {
     pub const Start: Self = Self(0i32);
@@ -15,12 +16,6 @@ impl ::core::clone::Clone for TextPatternRangeEndpoint {
 unsafe impl ::windows::core::Abi for TextPatternRangeEndpoint {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TextPatternRangeEndpoint {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TextPatternRangeEndpoint {}
 impl ::core::fmt::Debug for TextPatternRangeEndpoint {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TextPatternRangeEndpoint").field(&self.0).finish()
@@ -34,6 +29,7 @@ impl ::windows::core::DefaultType for TextPatternRangeEndpoint {
 }
 #[doc = "*Required features: 'UI_Xaml_Automation_Text'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TextUnit(pub i32);
 impl TextUnit {
     pub const Character: Self = Self(0i32);
@@ -53,12 +49,6 @@ impl ::core::clone::Clone for TextUnit {
 unsafe impl ::windows::core::Abi for TextUnit {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TextUnit {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TextUnit {}
 impl ::core::fmt::Debug for TextUnit {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TextUnit").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Xaml/Automation/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/Automation/mod.rs
@@ -120,6 +120,7 @@ unsafe impl ::core::marker::Send for AnnotationPatternIdentifiers {}
 unsafe impl ::core::marker::Sync for AnnotationPatternIdentifiers {}
 #[doc = "*Required features: 'UI_Xaml_Automation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AnnotationType(pub i32);
 impl AnnotationType {
     pub const Unknown: Self = Self(60000i32);
@@ -155,12 +156,6 @@ impl ::core::clone::Clone for AnnotationType {
 unsafe impl ::windows::core::Abi for AnnotationType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AnnotationType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AnnotationType {}
 impl ::core::fmt::Debug for AnnotationType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AnnotationType").field(&self.0).finish()
@@ -174,6 +169,7 @@ impl ::windows::core::DefaultType for AnnotationType {
 }
 #[doc = "*Required features: 'UI_Xaml_Automation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AutomationActiveEnd(pub i32);
 impl AutomationActiveEnd {
     pub const None: Self = Self(0i32);
@@ -189,12 +185,6 @@ impl ::core::clone::Clone for AutomationActiveEnd {
 unsafe impl ::windows::core::Abi for AutomationActiveEnd {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AutomationActiveEnd {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AutomationActiveEnd {}
 impl ::core::fmt::Debug for AutomationActiveEnd {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AutomationActiveEnd").field(&self.0).finish()
@@ -208,6 +198,7 @@ impl ::windows::core::DefaultType for AutomationActiveEnd {
 }
 #[doc = "*Required features: 'UI_Xaml_Automation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AutomationAnimationStyle(pub i32);
 impl AutomationAnimationStyle {
     pub const None: Self = Self(0i32);
@@ -228,12 +219,6 @@ impl ::core::clone::Clone for AutomationAnimationStyle {
 unsafe impl ::windows::core::Abi for AutomationAnimationStyle {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AutomationAnimationStyle {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AutomationAnimationStyle {}
 impl ::core::fmt::Debug for AutomationAnimationStyle {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AutomationAnimationStyle").field(&self.0).finish()
@@ -411,6 +396,7 @@ unsafe impl ::core::marker::Send for AutomationAnnotation {}
 unsafe impl ::core::marker::Sync for AutomationAnnotation {}
 #[doc = "*Required features: 'UI_Xaml_Automation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AutomationBulletStyle(pub i32);
 impl AutomationBulletStyle {
     pub const None: Self = Self(0i32);
@@ -430,12 +416,6 @@ impl ::core::clone::Clone for AutomationBulletStyle {
 unsafe impl ::windows::core::Abi for AutomationBulletStyle {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AutomationBulletStyle {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AutomationBulletStyle {}
 impl ::core::fmt::Debug for AutomationBulletStyle {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AutomationBulletStyle").field(&self.0).finish()
@@ -449,6 +429,7 @@ impl ::windows::core::DefaultType for AutomationBulletStyle {
 }
 #[doc = "*Required features: 'UI_Xaml_Automation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AutomationCaretBidiMode(pub i32);
 impl AutomationCaretBidiMode {
     pub const LTR: Self = Self(0i32);
@@ -463,12 +444,6 @@ impl ::core::clone::Clone for AutomationCaretBidiMode {
 unsafe impl ::windows::core::Abi for AutomationCaretBidiMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AutomationCaretBidiMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AutomationCaretBidiMode {}
 impl ::core::fmt::Debug for AutomationCaretBidiMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AutomationCaretBidiMode").field(&self.0).finish()
@@ -482,6 +457,7 @@ impl ::windows::core::DefaultType for AutomationCaretBidiMode {
 }
 #[doc = "*Required features: 'UI_Xaml_Automation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AutomationCaretPosition(pub i32);
 impl AutomationCaretPosition {
     pub const Unknown: Self = Self(0i32);
@@ -497,12 +473,6 @@ impl ::core::clone::Clone for AutomationCaretPosition {
 unsafe impl ::windows::core::Abi for AutomationCaretPosition {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AutomationCaretPosition {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AutomationCaretPosition {}
 impl ::core::fmt::Debug for AutomationCaretPosition {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AutomationCaretPosition").field(&self.0).finish()
@@ -902,6 +872,7 @@ unsafe impl ::core::marker::Send for AutomationElementIdentifiers {}
 unsafe impl ::core::marker::Sync for AutomationElementIdentifiers {}
 #[doc = "*Required features: 'UI_Xaml_Automation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AutomationFlowDirections(pub i32);
 impl AutomationFlowDirections {
     pub const Default: Self = Self(0i32);
@@ -918,12 +889,6 @@ impl ::core::clone::Clone for AutomationFlowDirections {
 unsafe impl ::windows::core::Abi for AutomationFlowDirections {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AutomationFlowDirections {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AutomationFlowDirections {}
 impl ::core::fmt::Debug for AutomationFlowDirections {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AutomationFlowDirections").field(&self.0).finish()
@@ -937,6 +902,7 @@ impl ::windows::core::DefaultType for AutomationFlowDirections {
 }
 #[doc = "*Required features: 'UI_Xaml_Automation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AutomationOutlineStyles(pub i32);
 impl AutomationOutlineStyles {
     pub const None: Self = Self(0i32);
@@ -954,12 +920,6 @@ impl ::core::clone::Clone for AutomationOutlineStyles {
 unsafe impl ::windows::core::Abi for AutomationOutlineStyles {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AutomationOutlineStyles {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AutomationOutlineStyles {}
 impl ::core::fmt::Debug for AutomationOutlineStyles {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AutomationOutlineStyles").field(&self.0).finish()
@@ -1680,6 +1640,7 @@ unsafe impl ::core::marker::Send for AutomationProperty {}
 unsafe impl ::core::marker::Sync for AutomationProperty {}
 #[doc = "*Required features: 'UI_Xaml_Automation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AutomationStyleId(pub i32);
 impl AutomationStyleId {
     pub const Heading1: Self = Self(70001i32);
@@ -1707,12 +1668,6 @@ impl ::core::clone::Clone for AutomationStyleId {
 unsafe impl ::windows::core::Abi for AutomationStyleId {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AutomationStyleId {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AutomationStyleId {}
 impl ::core::fmt::Debug for AutomationStyleId {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AutomationStyleId").field(&self.0).finish()
@@ -1726,6 +1681,7 @@ impl ::windows::core::DefaultType for AutomationStyleId {
 }
 #[doc = "*Required features: 'UI_Xaml_Automation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AutomationTextDecorationLineStyle(pub i32);
 impl AutomationTextDecorationLineStyle {
     pub const None: Self = Self(0i32);
@@ -1757,12 +1713,6 @@ impl ::core::clone::Clone for AutomationTextDecorationLineStyle {
 unsafe impl ::windows::core::Abi for AutomationTextDecorationLineStyle {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AutomationTextDecorationLineStyle {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AutomationTextDecorationLineStyle {}
 impl ::core::fmt::Debug for AutomationTextDecorationLineStyle {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AutomationTextDecorationLineStyle").field(&self.0).finish()
@@ -1776,6 +1726,7 @@ impl ::windows::core::DefaultType for AutomationTextDecorationLineStyle {
 }
 #[doc = "*Required features: 'UI_Xaml_Automation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AutomationTextEditChangeType(pub i32);
 impl AutomationTextEditChangeType {
     pub const None: Self = Self(0i32);
@@ -1792,12 +1743,6 @@ impl ::core::clone::Clone for AutomationTextEditChangeType {
 unsafe impl ::windows::core::Abi for AutomationTextEditChangeType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AutomationTextEditChangeType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AutomationTextEditChangeType {}
 impl ::core::fmt::Debug for AutomationTextEditChangeType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AutomationTextEditChangeType").field(&self.0).finish()
@@ -1896,6 +1841,7 @@ unsafe impl ::core::marker::Send for DockPatternIdentifiers {}
 unsafe impl ::core::marker::Sync for DockPatternIdentifiers {}
 #[doc = "*Required features: 'UI_Xaml_Automation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DockPosition(pub i32);
 impl DockPosition {
     pub const Top: Self = Self(0i32);
@@ -1914,12 +1860,6 @@ impl ::core::clone::Clone for DockPosition {
 unsafe impl ::windows::core::Abi for DockPosition {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DockPosition {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DockPosition {}
 impl ::core::fmt::Debug for DockPosition {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DockPosition").field(&self.0).finish()
@@ -2216,6 +2156,7 @@ unsafe impl ::core::marker::Send for ExpandCollapsePatternIdentifiers {}
 unsafe impl ::core::marker::Sync for ExpandCollapsePatternIdentifiers {}
 #[doc = "*Required features: 'UI_Xaml_Automation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ExpandCollapseState(pub i32);
 impl ExpandCollapseState {
     pub const Collapsed: Self = Self(0i32);
@@ -2232,12 +2173,6 @@ impl ::core::clone::Clone for ExpandCollapseState {
 unsafe impl ::windows::core::Abi for ExpandCollapseState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ExpandCollapseState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ExpandCollapseState {}
 impl ::core::fmt::Debug for ExpandCollapseState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ExpandCollapseState").field(&self.0).finish()
@@ -3986,6 +3921,7 @@ unsafe impl ::core::marker::Send for RangeValuePatternIdentifiers {}
 unsafe impl ::core::marker::Sync for RangeValuePatternIdentifiers {}
 #[doc = "*Required features: 'UI_Xaml_Automation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RowOrColumnMajor(pub i32);
 impl RowOrColumnMajor {
     pub const RowMajor: Self = Self(0i32);
@@ -4001,12 +3937,6 @@ impl ::core::clone::Clone for RowOrColumnMajor {
 unsafe impl ::windows::core::Abi for RowOrColumnMajor {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RowOrColumnMajor {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RowOrColumnMajor {}
 impl ::core::fmt::Debug for RowOrColumnMajor {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RowOrColumnMajor").field(&self.0).finish()
@@ -4020,6 +3950,7 @@ impl ::windows::core::DefaultType for RowOrColumnMajor {
 }
 #[doc = "*Required features: 'UI_Xaml_Automation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ScrollAmount(pub i32);
 impl ScrollAmount {
     pub const LargeDecrement: Self = Self(0i32);
@@ -4037,12 +3968,6 @@ impl ::core::clone::Clone for ScrollAmount {
 unsafe impl ::windows::core::Abi for ScrollAmount {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ScrollAmount {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ScrollAmount {}
 impl ::core::fmt::Debug for ScrollAmount {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ScrollAmount").field(&self.0).finish()
@@ -4586,6 +4511,7 @@ unsafe impl ::core::marker::Send for StylesPatternIdentifiers {}
 unsafe impl ::core::marker::Sync for StylesPatternIdentifiers {}
 #[doc = "*Required features: 'UI_Xaml_Automation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SupportedTextSelection(pub i32);
 impl SupportedTextSelection {
     pub const None: Self = Self(0i32);
@@ -4601,12 +4527,6 @@ impl ::core::clone::Clone for SupportedTextSelection {
 unsafe impl ::windows::core::Abi for SupportedTextSelection {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SupportedTextSelection {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SupportedTextSelection {}
 impl ::core::fmt::Debug for SupportedTextSelection {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SupportedTextSelection").field(&self.0).finish()
@@ -4620,6 +4540,7 @@ impl ::windows::core::DefaultType for SupportedTextSelection {
 }
 #[doc = "*Required features: 'UI_Xaml_Automation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SynchronizedInputType(pub i32);
 impl SynchronizedInputType {
     pub const KeyUp: Self = Self(1i32);
@@ -4638,12 +4559,6 @@ impl ::core::clone::Clone for SynchronizedInputType {
 unsafe impl ::windows::core::Abi for SynchronizedInputType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SynchronizedInputType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SynchronizedInputType {}
 impl ::core::fmt::Debug for SynchronizedInputType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SynchronizedInputType").field(&self.0).finish()
@@ -4933,6 +4848,7 @@ unsafe impl ::core::marker::Send for TogglePatternIdentifiers {}
 unsafe impl ::core::marker::Sync for TogglePatternIdentifiers {}
 #[doc = "*Required features: 'UI_Xaml_Automation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ToggleState(pub i32);
 impl ToggleState {
     pub const Off: Self = Self(0i32);
@@ -4948,12 +4864,6 @@ impl ::core::clone::Clone for ToggleState {
 unsafe impl ::windows::core::Abi for ToggleState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ToggleState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ToggleState {}
 impl ::core::fmt::Debug for ToggleState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ToggleState").field(&self.0).finish()
@@ -5264,6 +5174,7 @@ unsafe impl ::core::marker::Send for ValuePatternIdentifiers {}
 unsafe impl ::core::marker::Sync for ValuePatternIdentifiers {}
 #[doc = "*Required features: 'UI_Xaml_Automation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WindowInteractionState(pub i32);
 impl WindowInteractionState {
     pub const Running: Self = Self(0i32);
@@ -5281,12 +5192,6 @@ impl ::core::clone::Clone for WindowInteractionState {
 unsafe impl ::windows::core::Abi for WindowInteractionState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WindowInteractionState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WindowInteractionState {}
 impl ::core::fmt::Debug for WindowInteractionState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WindowInteractionState").field(&self.0).finish()
@@ -5420,6 +5325,7 @@ unsafe impl ::core::marker::Send for WindowPatternIdentifiers {}
 unsafe impl ::core::marker::Sync for WindowPatternIdentifiers {}
 #[doc = "*Required features: 'UI_Xaml_Automation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WindowVisualState(pub i32);
 impl WindowVisualState {
     pub const Normal: Self = Self(0i32);
@@ -5435,12 +5341,6 @@ impl ::core::clone::Clone for WindowVisualState {
 unsafe impl ::windows::core::Abi for WindowVisualState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WindowVisualState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WindowVisualState {}
 impl ::core::fmt::Debug for WindowVisualState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WindowVisualState").field(&self.0).finish()
@@ -5454,6 +5354,7 @@ impl ::windows::core::DefaultType for WindowVisualState {
 }
 #[doc = "*Required features: 'UI_Xaml_Automation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ZoomUnit(pub i32);
 impl ZoomUnit {
     pub const NoAmount: Self = Self(0i32);
@@ -5471,12 +5372,6 @@ impl ::core::clone::Clone for ZoomUnit {
 unsafe impl ::windows::core::Abi for ZoomUnit {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ZoomUnit {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ZoomUnit {}
 impl ::core::fmt::Debug for ZoomUnit {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ZoomUnit").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Xaml/Controls/Maps/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/Controls/Maps/mod.rs
@@ -3401,6 +3401,7 @@ unsafe impl ::core::marker::Send for MapActualCameraChangingEventArgs {}
 unsafe impl ::core::marker::Sync for MapActualCameraChangingEventArgs {}
 #[doc = "*Required features: 'UI_Xaml_Controls_Maps'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MapAnimationKind(pub i32);
 impl MapAnimationKind {
     pub const Default: Self = Self(0i32);
@@ -3417,12 +3418,6 @@ impl ::core::clone::Clone for MapAnimationKind {
 unsafe impl ::windows::core::Abi for MapAnimationKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MapAnimationKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MapAnimationKind {}
 impl ::core::fmt::Debug for MapAnimationKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MapAnimationKind").field(&self.0).finish()
@@ -3850,6 +3845,7 @@ unsafe impl ::core::marker::Send for MapCamera {}
 unsafe impl ::core::marker::Sync for MapCamera {}
 #[doc = "*Required features: 'UI_Xaml_Controls_Maps'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MapCameraChangeReason(pub i32);
 impl MapCameraChangeReason {
     pub const System: Self = Self(0i32);
@@ -3865,12 +3861,6 @@ impl ::core::clone::Clone for MapCameraChangeReason {
 unsafe impl ::windows::core::Abi for MapCameraChangeReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MapCameraChangeReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MapCameraChangeReason {}
 impl ::core::fmt::Debug for MapCameraChangeReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MapCameraChangeReason").field(&self.0).finish()
@@ -3884,6 +3874,7 @@ impl ::windows::core::DefaultType for MapCameraChangeReason {
 }
 #[doc = "*Required features: 'UI_Xaml_Controls_Maps'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MapColorScheme(pub i32);
 impl MapColorScheme {
     pub const Light: Self = Self(0i32);
@@ -3898,12 +3889,6 @@ impl ::core::clone::Clone for MapColorScheme {
 unsafe impl ::windows::core::Abi for MapColorScheme {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MapColorScheme {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MapColorScheme {}
 impl ::core::fmt::Debug for MapColorScheme {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MapColorScheme").field(&self.0).finish()
@@ -7405,6 +7390,7 @@ unsafe impl ::core::marker::Send for MapElementClickEventArgs {}
 unsafe impl ::core::marker::Sync for MapElementClickEventArgs {}
 #[doc = "*Required features: 'UI_Xaml_Controls_Maps'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MapElementCollisionBehavior(pub i32);
 impl MapElementCollisionBehavior {
     pub const Hide: Self = Self(0i32);
@@ -7419,12 +7405,6 @@ impl ::core::clone::Clone for MapElementCollisionBehavior {
 unsafe impl ::windows::core::Abi for MapElementCollisionBehavior {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MapElementCollisionBehavior {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MapElementCollisionBehavior {}
 impl ::core::fmt::Debug for MapElementCollisionBehavior {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MapElementCollisionBehavior").field(&self.0).finish()
@@ -8630,6 +8610,7 @@ unsafe impl ::core::marker::Send for MapInputEventArgs {}
 unsafe impl ::core::marker::Sync for MapInputEventArgs {}
 #[doc = "*Required features: 'UI_Xaml_Controls_Maps'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MapInteractionMode(pub i32);
 impl MapInteractionMode {
     pub const Auto: Self = Self(0i32);
@@ -8650,12 +8631,6 @@ impl ::core::clone::Clone for MapInteractionMode {
 unsafe impl ::windows::core::Abi for MapInteractionMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MapInteractionMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MapInteractionMode {}
 impl ::core::fmt::Debug for MapInteractionMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MapInteractionMode").field(&self.0).finish()
@@ -9000,6 +8975,7 @@ unsafe impl ::core::marker::Send for MapLayer {}
 unsafe impl ::core::marker::Sync for MapLayer {}
 #[doc = "*Required features: 'UI_Xaml_Controls_Maps'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MapLoadingStatus(pub i32);
 impl MapLoadingStatus {
     pub const Loading: Self = Self(0i32);
@@ -9016,12 +8992,6 @@ impl ::core::clone::Clone for MapLoadingStatus {
 unsafe impl ::windows::core::Abi for MapLoadingStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MapLoadingStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MapLoadingStatus {}
 impl ::core::fmt::Debug for MapLoadingStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MapLoadingStatus").field(&self.0).finish()
@@ -9161,6 +9131,7 @@ unsafe impl ::core::marker::Send for MapModel3D {}
 unsafe impl ::core::marker::Sync for MapModel3D {}
 #[doc = "*Required features: 'UI_Xaml_Controls_Maps'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MapModel3DShadingOption(pub i32);
 impl MapModel3DShadingOption {
     pub const Default: Self = Self(0i32);
@@ -9176,12 +9147,6 @@ impl ::core::clone::Clone for MapModel3DShadingOption {
 unsafe impl ::windows::core::Abi for MapModel3DShadingOption {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MapModel3DShadingOption {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MapModel3DShadingOption {}
 impl ::core::fmt::Debug for MapModel3DShadingOption {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MapModel3DShadingOption").field(&self.0).finish()
@@ -9195,6 +9160,7 @@ impl ::windows::core::DefaultType for MapModel3DShadingOption {
 }
 #[doc = "*Required features: 'UI_Xaml_Controls_Maps'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MapPanInteractionMode(pub i32);
 impl MapPanInteractionMode {
     pub const Auto: Self = Self(0i32);
@@ -9209,12 +9175,6 @@ impl ::core::clone::Clone for MapPanInteractionMode {
 unsafe impl ::windows::core::Abi for MapPanInteractionMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MapPanInteractionMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MapPanInteractionMode {}
 impl ::core::fmt::Debug for MapPanInteractionMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MapPanInteractionMode").field(&self.0).finish()
@@ -9643,6 +9603,7 @@ unsafe impl ::core::marker::Send for MapPolyline {}
 unsafe impl ::core::marker::Sync for MapPolyline {}
 #[doc = "*Required features: 'UI_Xaml_Controls_Maps'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MapProjection(pub i32);
 impl MapProjection {
     pub const WebMercator: Self = Self(0i32);
@@ -9657,12 +9618,6 @@ impl ::core::clone::Clone for MapProjection {
 unsafe impl ::windows::core::Abi for MapProjection {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MapProjection {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MapProjection {}
 impl ::core::fmt::Debug for MapProjection {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MapProjection").field(&self.0).finish()
@@ -10107,6 +10062,7 @@ unsafe impl ::core::marker::Send for MapScene {}
 unsafe impl ::core::marker::Sync for MapScene {}
 #[doc = "*Required features: 'UI_Xaml_Controls_Maps'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MapStyle(pub i32);
 impl MapStyle {
     pub const None: Self = Self(0i32);
@@ -10127,12 +10083,6 @@ impl ::core::clone::Clone for MapStyle {
 unsafe impl ::windows::core::Abi for MapStyle {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MapStyle {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MapStyle {}
 impl ::core::fmt::Debug for MapStyle {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MapStyle").field(&self.0).finish()
@@ -10897,6 +10847,7 @@ unsafe impl ::core::marker::Send for MapTargetCameraChangedEventArgs {}
 unsafe impl ::core::marker::Sync for MapTargetCameraChangedEventArgs {}
 #[doc = "*Required features: 'UI_Xaml_Controls_Maps'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MapTileAnimationState(pub i32);
 impl MapTileAnimationState {
     pub const Stopped: Self = Self(0i32);
@@ -10912,12 +10863,6 @@ impl ::core::clone::Clone for MapTileAnimationState {
 unsafe impl ::windows::core::Abi for MapTileAnimationState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MapTileAnimationState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MapTileAnimationState {}
 impl ::core::fmt::Debug for MapTileAnimationState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MapTileAnimationState").field(&self.0).finish()
@@ -11344,6 +11289,7 @@ unsafe impl ::core::marker::Send for MapTileDataSource {}
 unsafe impl ::core::marker::Sync for MapTileDataSource {}
 #[doc = "*Required features: 'UI_Xaml_Controls_Maps'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MapTileLayer(pub i32);
 impl MapTileLayer {
     pub const LabelOverlay: Self = Self(0i32);
@@ -11361,12 +11307,6 @@ impl ::core::clone::Clone for MapTileLayer {
 unsafe impl ::windows::core::Abi for MapTileLayer {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MapTileLayer {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MapTileLayer {}
 impl ::core::fmt::Debug for MapTileLayer {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MapTileLayer").field(&self.0).finish()
@@ -12147,6 +12087,7 @@ unsafe impl ::core::marker::Send for MapTileUriRequestedEventArgs {}
 unsafe impl ::core::marker::Sync for MapTileUriRequestedEventArgs {}
 #[doc = "*Required features: 'UI_Xaml_Controls_Maps'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MapVisibleRegionKind(pub i32);
 impl MapVisibleRegionKind {
     pub const Near: Self = Self(0i32);
@@ -12161,12 +12102,6 @@ impl ::core::clone::Clone for MapVisibleRegionKind {
 unsafe impl ::windows::core::Abi for MapVisibleRegionKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MapVisibleRegionKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MapVisibleRegionKind {}
 impl ::core::fmt::Debug for MapVisibleRegionKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MapVisibleRegionKind").field(&self.0).finish()
@@ -12180,6 +12115,7 @@ impl ::windows::core::DefaultType for MapVisibleRegionKind {
 }
 #[doc = "*Required features: 'UI_Xaml_Controls_Maps'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MapWatermarkMode(pub i32);
 impl MapWatermarkMode {
     pub const Automatic: Self = Self(0i32);
@@ -12194,12 +12130,6 @@ impl ::core::clone::Clone for MapWatermarkMode {
 unsafe impl ::windows::core::Abi for MapWatermarkMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MapWatermarkMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MapWatermarkMode {}
 impl ::core::fmt::Debug for MapWatermarkMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MapWatermarkMode").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Xaml/Controls/Primitives/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/Controls/Primitives/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'UI_Xaml_Controls_Primitives'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AnimationDirection(pub i32);
 impl AnimationDirection {
     pub const Left: Self = Self(0i32);
@@ -17,12 +18,6 @@ impl ::core::clone::Clone for AnimationDirection {
 unsafe impl ::windows::core::Abi for AnimationDirection {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AnimationDirection {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AnimationDirection {}
 impl ::core::fmt::Debug for AnimationDirection {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AnimationDirection").field(&self.0).finish()
@@ -3247,6 +3242,7 @@ unsafe impl ::core::marker::Send for CommandBarTemplateSettings {}
 unsafe impl ::core::marker::Sync for CommandBarTemplateSettings {}
 #[doc = "*Required features: 'UI_Xaml_Controls_Primitives'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ComponentResourceLocation(pub i32);
 impl ComponentResourceLocation {
     pub const Application: Self = Self(0i32);
@@ -3261,12 +3257,6 @@ impl ::core::clone::Clone for ComponentResourceLocation {
 unsafe impl ::windows::core::Abi for ComponentResourceLocation {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ComponentResourceLocation {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ComponentResourceLocation {}
 impl ::core::fmt::Debug for ComponentResourceLocation {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ComponentResourceLocation").field(&self.0).finish()
@@ -3876,6 +3866,7 @@ unsafe impl ::windows::core::RuntimeType for DragStartedEventHandler {
 pub struct DragStartedEventHandlerVtbl(pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, e: ::windows::core::RawPtr) -> ::windows::core::HRESULT);
 #[doc = "*Required features: 'UI_Xaml_Controls_Primitives'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EdgeTransitionLocation(pub i32);
 impl EdgeTransitionLocation {
     pub const Left: Self = Self(0i32);
@@ -3892,12 +3883,6 @@ impl ::core::clone::Clone for EdgeTransitionLocation {
 unsafe impl ::windows::core::Abi for EdgeTransitionLocation {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EdgeTransitionLocation {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EdgeTransitionLocation {}
 impl ::core::fmt::Debug for EdgeTransitionLocation {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EdgeTransitionLocation").field(&self.0).finish()
@@ -4464,6 +4449,7 @@ unsafe impl ::core::marker::Send for FlyoutBaseClosingEventArgs {}
 unsafe impl ::core::marker::Sync for FlyoutBaseClosingEventArgs {}
 #[doc = "*Required features: 'UI_Xaml_Controls_Primitives'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FlyoutPlacementMode(pub i32);
 impl FlyoutPlacementMode {
     pub const Top: Self = Self(0i32);
@@ -4490,12 +4476,6 @@ impl ::core::clone::Clone for FlyoutPlacementMode {
 unsafe impl ::windows::core::Abi for FlyoutPlacementMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FlyoutPlacementMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FlyoutPlacementMode {}
 impl ::core::fmt::Debug for FlyoutPlacementMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FlyoutPlacementMode").field(&self.0).finish()
@@ -4509,6 +4489,7 @@ impl ::windows::core::DefaultType for FlyoutPlacementMode {
 }
 #[doc = "*Required features: 'UI_Xaml_Controls_Primitives'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FlyoutShowMode(pub i32);
 impl FlyoutShowMode {
     pub const Auto: Self = Self(0i32);
@@ -4525,12 +4506,6 @@ impl ::core::clone::Clone for FlyoutShowMode {
 unsafe impl ::windows::core::Abi for FlyoutShowMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FlyoutShowMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FlyoutShowMode {}
 impl ::core::fmt::Debug for FlyoutShowMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FlyoutShowMode").field(&self.0).finish()
@@ -4685,6 +4660,7 @@ unsafe impl ::core::marker::Send for FlyoutShowOptions {}
 unsafe impl ::core::marker::Sync for FlyoutShowOptions {}
 #[doc = "*Required features: 'UI_Xaml_Controls_Primitives'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GeneratorDirection(pub i32);
 impl GeneratorDirection {
     pub const Forward: Self = Self(0i32);
@@ -4699,12 +4675,6 @@ impl ::core::clone::Clone for GeneratorDirection {
 unsafe impl ::windows::core::Abi for GeneratorDirection {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GeneratorDirection {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GeneratorDirection {}
 impl ::core::fmt::Debug for GeneratorDirection {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GeneratorDirection").field(&self.0).finish()
@@ -5636,6 +5606,7 @@ unsafe impl ::core::marker::Send for GridViewItemTemplateSettings {}
 unsafe impl ::core::marker::Sync for GridViewItemTemplateSettings {}
 #[doc = "*Required features: 'UI_Xaml_Controls_Primitives'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GroupHeaderPlacement(pub i32);
 impl GroupHeaderPlacement {
     pub const Top: Self = Self(0i32);
@@ -5650,12 +5621,6 @@ impl ::core::clone::Clone for GroupHeaderPlacement {
 unsafe impl ::windows::core::Abi for GroupHeaderPlacement {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GroupHeaderPlacement {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GroupHeaderPlacement {}
 impl ::core::fmt::Debug for GroupHeaderPlacement {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GroupHeaderPlacement").field(&self.0).finish()
@@ -11143,6 +11108,7 @@ unsafe impl ::core::marker::Send for ListViewItemPresenter {}
 unsafe impl ::core::marker::Sync for ListViewItemPresenter {}
 #[doc = "*Required features: 'UI_Xaml_Controls_Primitives'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ListViewItemPresenterCheckMode(pub i32);
 impl ListViewItemPresenterCheckMode {
     pub const Inline: Self = Self(0i32);
@@ -11157,12 +11123,6 @@ impl ::core::clone::Clone for ListViewItemPresenterCheckMode {
 unsafe impl ::windows::core::Abi for ListViewItemPresenterCheckMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ListViewItemPresenterCheckMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ListViewItemPresenterCheckMode {}
 impl ::core::fmt::Debug for ListViewItemPresenterCheckMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ListViewItemPresenterCheckMode").field(&self.0).finish()
@@ -11176,6 +11136,7 @@ impl ::windows::core::DefaultType for ListViewItemPresenterCheckMode {
 }
 #[doc = "*Required features: 'UI_Xaml_Controls_Primitives'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ListViewItemPresenterSelectionIndicatorMode(pub i32);
 impl ListViewItemPresenterSelectionIndicatorMode {
     pub const Inline: Self = Self(0i32);
@@ -11190,12 +11151,6 @@ impl ::core::clone::Clone for ListViewItemPresenterSelectionIndicatorMode {
 unsafe impl ::windows::core::Abi for ListViewItemPresenterSelectionIndicatorMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ListViewItemPresenterSelectionIndicatorMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ListViewItemPresenterSelectionIndicatorMode {}
 impl ::core::fmt::Debug for ListViewItemPresenterSelectionIndicatorMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ListViewItemPresenterSelectionIndicatorMode").field(&self.0).finish()
@@ -14081,6 +14036,7 @@ unsafe impl ::core::marker::Send for PivotPanel {}
 unsafe impl ::core::marker::Sync for PivotPanel {}
 #[doc = "*Required features: 'UI_Xaml_Controls_Primitives'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PlacementMode(pub i32);
 impl PlacementMode {
     pub const Bottom: Self = Self(2i32);
@@ -14098,12 +14054,6 @@ impl ::core::clone::Clone for PlacementMode {
 unsafe impl ::windows::core::Abi for PlacementMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PlacementMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PlacementMode {}
 impl ::core::fmt::Debug for PlacementMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PlacementMode").field(&self.0).finish()
@@ -14592,6 +14542,7 @@ unsafe impl ::core::marker::Send for Popup {}
 unsafe impl ::core::marker::Sync for Popup {}
 #[doc = "*Required features: 'UI_Xaml_Controls_Primitives'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PopupPlacementMode(pub i32);
 impl PopupPlacementMode {
     pub const Auto: Self = Self(0i32);
@@ -14617,12 +14568,6 @@ impl ::core::clone::Clone for PopupPlacementMode {
 unsafe impl ::windows::core::Abi for PopupPlacementMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PopupPlacementMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PopupPlacementMode {}
 impl ::core::fmt::Debug for PopupPlacementMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PopupPlacementMode").field(&self.0).finish()
@@ -16211,6 +16156,7 @@ unsafe impl ::windows::core::RuntimeType for ScrollEventHandler {
 pub struct ScrollEventHandlerVtbl(pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, e: ::windows::core::RawPtr) -> ::windows::core::HRESULT);
 #[doc = "*Required features: 'UI_Xaml_Controls_Primitives'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ScrollEventType(pub i32);
 impl ScrollEventType {
     pub const SmallDecrement: Self = Self(0i32);
@@ -16232,12 +16178,6 @@ impl ::core::clone::Clone for ScrollEventType {
 unsafe impl ::windows::core::Abi for ScrollEventType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ScrollEventType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ScrollEventType {}
 impl ::core::fmt::Debug for ScrollEventType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ScrollEventType").field(&self.0).finish()
@@ -16251,6 +16191,7 @@ impl ::windows::core::DefaultType for ScrollEventType {
 }
 #[doc = "*Required features: 'UI_Xaml_Controls_Primitives'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ScrollingIndicatorMode(pub i32);
 impl ScrollingIndicatorMode {
     pub const None: Self = Self(0i32);
@@ -16266,12 +16207,6 @@ impl ::core::clone::Clone for ScrollingIndicatorMode {
 unsafe impl ::windows::core::Abi for ScrollingIndicatorMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ScrollingIndicatorMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ScrollingIndicatorMode {}
 impl ::core::fmt::Debug for ScrollingIndicatorMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ScrollingIndicatorMode").field(&self.0).finish()
@@ -17057,6 +16992,7 @@ unsafe impl ::core::marker::Send for SettingsFlyoutTemplateSettings {}
 unsafe impl ::core::marker::Sync for SettingsFlyoutTemplateSettings {}
 #[doc = "*Required features: 'UI_Xaml_Controls_Primitives'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SliderSnapsTo(pub i32);
 impl SliderSnapsTo {
     pub const StepValues: Self = Self(0i32);
@@ -17071,12 +17007,6 @@ impl ::core::clone::Clone for SliderSnapsTo {
 unsafe impl ::windows::core::Abi for SliderSnapsTo {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SliderSnapsTo {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SliderSnapsTo {}
 impl ::core::fmt::Debug for SliderSnapsTo {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SliderSnapsTo").field(&self.0).finish()
@@ -17090,6 +17020,7 @@ impl ::windows::core::DefaultType for SliderSnapsTo {
 }
 #[doc = "*Required features: 'UI_Xaml_Controls_Primitives'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SnapPointsAlignment(pub i32);
 impl SnapPointsAlignment {
     pub const Near: Self = Self(0i32);
@@ -17105,12 +17036,6 @@ impl ::core::clone::Clone for SnapPointsAlignment {
 unsafe impl ::windows::core::Abi for SnapPointsAlignment {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SnapPointsAlignment {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SnapPointsAlignment {}
 impl ::core::fmt::Debug for SnapPointsAlignment {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SnapPointsAlignment").field(&self.0).finish()
@@ -17766,6 +17691,7 @@ unsafe impl ::core::marker::Send for TickBar {}
 unsafe impl ::core::marker::Sync for TickBar {}
 #[doc = "*Required features: 'UI_Xaml_Controls_Primitives'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TickPlacement(pub i32);
 impl TickPlacement {
     pub const None: Self = Self(0i32);
@@ -17783,12 +17709,6 @@ impl ::core::clone::Clone for TickPlacement {
 unsafe impl ::windows::core::Abi for TickPlacement {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TickPlacement {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TickPlacement {}
 impl ::core::fmt::Debug for TickPlacement {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TickPlacement").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Xaml/Core/Direct/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/Core/Direct/mod.rs
@@ -617,6 +617,7 @@ unsafe impl ::core::marker::Send for XamlDirect {}
 unsafe impl ::core::marker::Sync for XamlDirect {}
 #[doc = "*Required features: 'UI_Xaml_Core_Direct'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct XamlEventIndex(pub i32);
 impl XamlEventIndex {
     pub const FrameworkElement_DataContextChanged: Self = Self(16i32);
@@ -767,12 +768,6 @@ impl ::core::clone::Clone for XamlEventIndex {
 unsafe impl ::windows::core::Abi for XamlEventIndex {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XamlEventIndex {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for XamlEventIndex {}
 impl ::core::fmt::Debug for XamlEventIndex {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("XamlEventIndex").field(&self.0).finish()
@@ -786,6 +781,7 @@ impl ::windows::core::DefaultType for XamlEventIndex {
 }
 #[doc = "*Required features: 'UI_Xaml_Core_Direct'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct XamlPropertyIndex(pub i32);
 impl XamlPropertyIndex {
     pub const AutomationProperties_AcceleratorKey: Self = Self(5i32);
@@ -2467,12 +2463,6 @@ impl ::core::clone::Clone for XamlPropertyIndex {
 unsafe impl ::windows::core::Abi for XamlPropertyIndex {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XamlPropertyIndex {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for XamlPropertyIndex {}
 impl ::core::fmt::Debug for XamlPropertyIndex {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("XamlPropertyIndex").field(&self.0).finish()
@@ -2486,6 +2476,7 @@ impl ::windows::core::DefaultType for XamlPropertyIndex {
 }
 #[doc = "*Required features: 'UI_Xaml_Core_Direct'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct XamlTypeIndex(pub i32);
 impl XamlTypeIndex {
     pub const AutoSuggestBoxSuggestionChosenEventArgs: Self = Self(34i32);
@@ -2748,12 +2739,6 @@ impl ::core::clone::Clone for XamlTypeIndex {
 unsafe impl ::windows::core::Abi for XamlTypeIndex {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XamlTypeIndex {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for XamlTypeIndex {}
 impl ::core::fmt::Debug for XamlTypeIndex {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("XamlTypeIndex").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Xaml/Data/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/Data/mod.rs
@@ -560,6 +560,7 @@ unsafe impl ::core::marker::Send for BindingExpressionBase {}
 unsafe impl ::core::marker::Sync for BindingExpressionBase {}
 #[doc = "*Required features: 'UI_Xaml_Data'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BindingMode(pub i32);
 impl BindingMode {
     pub const OneWay: Self = Self(1i32);
@@ -575,12 +576,6 @@ impl ::core::clone::Clone for BindingMode {
 unsafe impl ::windows::core::Abi for BindingMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BindingMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BindingMode {}
 impl ::core::fmt::Debug for BindingMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BindingMode").field(&self.0).finish()
@@ -3299,6 +3294,7 @@ unsafe impl ::core::marker::Send for RelativeSource {}
 unsafe impl ::core::marker::Sync for RelativeSource {}
 #[doc = "*Required features: 'UI_Xaml_Data'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RelativeSourceMode(pub i32);
 impl RelativeSourceMode {
     pub const None: Self = Self(0i32);
@@ -3314,12 +3310,6 @@ impl ::core::clone::Clone for RelativeSourceMode {
 unsafe impl ::windows::core::Abi for RelativeSourceMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RelativeSourceMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RelativeSourceMode {}
 impl ::core::fmt::Debug for RelativeSourceMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RelativeSourceMode").field(&self.0).finish()
@@ -3333,6 +3323,7 @@ impl ::windows::core::DefaultType for RelativeSourceMode {
 }
 #[doc = "*Required features: 'UI_Xaml_Data'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UpdateSourceTrigger(pub i32);
 impl UpdateSourceTrigger {
     pub const Default: Self = Self(0i32);
@@ -3349,12 +3340,6 @@ impl ::core::clone::Clone for UpdateSourceTrigger {
 unsafe impl ::windows::core::Abi for UpdateSourceTrigger {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UpdateSourceTrigger {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UpdateSourceTrigger {}
 impl ::core::fmt::Debug for UpdateSourceTrigger {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UpdateSourceTrigger").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Xaml/Documents/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/Documents/mod.rs
@@ -5002,6 +5002,7 @@ unsafe impl ::core::marker::Send for LineBreak {}
 unsafe impl ::core::marker::Sync for LineBreak {}
 #[doc = "*Required features: 'UI_Xaml_Documents'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LogicalDirection(pub i32);
 impl LogicalDirection {
     pub const Backward: Self = Self(0i32);
@@ -5016,12 +5017,6 @@ impl ::core::clone::Clone for LogicalDirection {
 unsafe impl ::windows::core::Abi for LogicalDirection {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LogicalDirection {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LogicalDirection {}
 impl ::core::fmt::Debug for LogicalDirection {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LogicalDirection").field(&self.0).finish()
@@ -7666,6 +7661,7 @@ unsafe impl ::core::marker::Send for Underline {}
 unsafe impl ::core::marker::Sync for Underline {}
 #[doc = "*Required features: 'UI_Xaml_Documents'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct UnderlineStyle(pub i32);
 impl UnderlineStyle {
     pub const None: Self = Self(0i32);
@@ -7680,12 +7676,6 @@ impl ::core::clone::Clone for UnderlineStyle {
 unsafe impl ::windows::core::Abi for UnderlineStyle {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for UnderlineStyle {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for UnderlineStyle {}
 impl ::core::fmt::Debug for UnderlineStyle {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("UnderlineStyle").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Xaml/Hosting/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/Hosting/mod.rs
@@ -387,6 +387,7 @@ unsafe impl ::core::marker::Send for DesignerAppView {}
 unsafe impl ::core::marker::Sync for DesignerAppView {}
 #[doc = "*Required features: 'UI_Xaml_Hosting'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DesignerAppViewState(pub i32);
 impl DesignerAppViewState {
     pub const Visible: Self = Self(0i32);
@@ -401,12 +402,6 @@ impl ::core::clone::Clone for DesignerAppViewState {
 unsafe impl ::windows::core::Abi for DesignerAppViewState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DesignerAppViewState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DesignerAppViewState {}
 impl ::core::fmt::Debug for DesignerAppViewState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DesignerAppViewState").field(&self.0).finish()
@@ -1726,6 +1721,7 @@ unsafe impl ::core::marker::Send for WindowsXamlManager {}
 unsafe impl ::core::marker::Sync for WindowsXamlManager {}
 #[doc = "*Required features: 'UI_Xaml_Hosting'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct XamlSourceFocusNavigationReason(pub i32);
 impl XamlSourceFocusNavigationReason {
     pub const Programmatic: Self = Self(0i32);
@@ -1746,12 +1742,6 @@ impl ::core::clone::Clone for XamlSourceFocusNavigationReason {
 unsafe impl ::windows::core::Abi for XamlSourceFocusNavigationReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XamlSourceFocusNavigationReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for XamlSourceFocusNavigationReason {}
 impl ::core::fmt::Debug for XamlSourceFocusNavigationReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("XamlSourceFocusNavigationReason").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Xaml/Input/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/Input/mod.rs
@@ -1142,6 +1142,7 @@ unsafe impl ::core::marker::Send for FindNextElementOptions {}
 unsafe impl ::core::marker::Sync for FindNextElementOptions {}
 #[doc = "*Required features: 'UI_Xaml_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FocusInputDeviceKind(pub i32);
 impl FocusInputDeviceKind {
     pub const None: Self = Self(0i32);
@@ -1160,12 +1161,6 @@ impl ::core::clone::Clone for FocusInputDeviceKind {
 unsafe impl ::windows::core::Abi for FocusInputDeviceKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FocusInputDeviceKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FocusInputDeviceKind {}
 impl ::core::fmt::Debug for FocusInputDeviceKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FocusInputDeviceKind").field(&self.0).finish()
@@ -1693,6 +1688,7 @@ unsafe impl ::core::marker::Send for FocusMovementResult {}
 unsafe impl ::core::marker::Sync for FocusMovementResult {}
 #[doc = "*Required features: 'UI_Xaml_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FocusNavigationDirection(pub i32);
 impl FocusNavigationDirection {
     pub const Next: Self = Self(0i32);
@@ -1712,12 +1708,6 @@ impl ::core::clone::Clone for FocusNavigationDirection {
 unsafe impl ::windows::core::Abi for FocusNavigationDirection {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FocusNavigationDirection {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FocusNavigationDirection {}
 impl ::core::fmt::Debug for FocusNavigationDirection {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FocusNavigationDirection").field(&self.0).finish()
@@ -4207,6 +4197,7 @@ unsafe impl ::core::marker::Send for InputScopeName {}
 unsafe impl ::core::marker::Sync for InputScopeName {}
 #[doc = "*Required features: 'UI_Xaml_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct InputScopeNameValue(pub i32);
 impl InputScopeNameValue {
     pub const Default: Self = Self(0i32);
@@ -4263,12 +4254,6 @@ impl ::core::clone::Clone for InputScopeNameValue {
 unsafe impl ::windows::core::Abi for InputScopeNameValue {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for InputScopeNameValue {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for InputScopeNameValue {}
 impl ::core::fmt::Debug for InputScopeNameValue {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("InputScopeNameValue").field(&self.0).finish()
@@ -4498,6 +4483,7 @@ unsafe impl ::core::marker::Send for KeyRoutedEventArgs {}
 unsafe impl ::core::marker::Sync for KeyRoutedEventArgs {}
 #[doc = "*Required features: 'UI_Xaml_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct KeyTipPlacementMode(pub i32);
 impl KeyTipPlacementMode {
     pub const Auto: Self = Self(0i32);
@@ -4517,12 +4503,6 @@ impl ::core::clone::Clone for KeyTipPlacementMode {
 unsafe impl ::windows::core::Abi for KeyTipPlacementMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KeyTipPlacementMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for KeyTipPlacementMode {}
 impl ::core::fmt::Debug for KeyTipPlacementMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("KeyTipPlacementMode").field(&self.0).finish()
@@ -4847,6 +4827,7 @@ unsafe impl ::core::marker::Send for KeyboardAcceleratorInvokedEventArgs {}
 unsafe impl ::core::marker::Sync for KeyboardAcceleratorInvokedEventArgs {}
 #[doc = "*Required features: 'UI_Xaml_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct KeyboardAcceleratorPlacementMode(pub i32);
 impl KeyboardAcceleratorPlacementMode {
     pub const Auto: Self = Self(0i32);
@@ -4861,12 +4842,6 @@ impl ::core::clone::Clone for KeyboardAcceleratorPlacementMode {
 unsafe impl ::windows::core::Abi for KeyboardAcceleratorPlacementMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KeyboardAcceleratorPlacementMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for KeyboardAcceleratorPlacementMode {}
 impl ::core::fmt::Debug for KeyboardAcceleratorPlacementMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("KeyboardAcceleratorPlacementMode").field(&self.0).finish()
@@ -4880,6 +4855,7 @@ impl ::windows::core::DefaultType for KeyboardAcceleratorPlacementMode {
 }
 #[doc = "*Required features: 'UI_Xaml_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct KeyboardNavigationMode(pub i32);
 impl KeyboardNavigationMode {
     pub const Local: Self = Self(0i32);
@@ -4895,12 +4871,6 @@ impl ::core::clone::Clone for KeyboardNavigationMode {
 unsafe impl ::windows::core::Abi for KeyboardNavigationMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for KeyboardNavigationMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for KeyboardNavigationMode {}
 impl ::core::fmt::Debug for KeyboardNavigationMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("KeyboardNavigationMode").field(&self.0).finish()
@@ -5867,6 +5837,7 @@ unsafe impl ::core::marker::Send for ManipulationInertiaStartingRoutedEventArgs 
 unsafe impl ::core::marker::Sync for ManipulationInertiaStartingRoutedEventArgs {}
 #[doc = "*Required features: 'UI_Xaml_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ManipulationModes(pub u32);
 impl ManipulationModes {
     pub const None: Self = Self(0u32);
@@ -5891,12 +5862,6 @@ impl ::core::clone::Clone for ManipulationModes {
 unsafe impl ::windows::core::Abi for ManipulationModes {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ManipulationModes {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ManipulationModes {}
 impl ::core::fmt::Debug for ManipulationModes {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ManipulationModes").field(&self.0).finish()
@@ -7460,6 +7425,7 @@ unsafe impl ::core::marker::Send for StandardUICommand {}
 unsafe impl ::core::marker::Sync for StandardUICommand {}
 #[doc = "*Required features: 'UI_Xaml_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StandardUICommandKind(pub i32);
 impl StandardUICommandKind {
     pub const None: Self = Self(0i32);
@@ -7489,12 +7455,6 @@ impl ::core::clone::Clone for StandardUICommandKind {
 unsafe impl ::windows::core::Abi for StandardUICommandKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StandardUICommandKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StandardUICommandKind {}
 impl ::core::fmt::Debug for StandardUICommandKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StandardUICommandKind").field(&self.0).finish()
@@ -7714,6 +7674,7 @@ unsafe impl ::core::marker::Send for TappedRoutedEventArgs {}
 unsafe impl ::core::marker::Sync for TappedRoutedEventArgs {}
 #[doc = "*Required features: 'UI_Xaml_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct XYFocusKeyboardNavigationMode(pub i32);
 impl XYFocusKeyboardNavigationMode {
     pub const Auto: Self = Self(0i32);
@@ -7729,12 +7690,6 @@ impl ::core::clone::Clone for XYFocusKeyboardNavigationMode {
 unsafe impl ::windows::core::Abi for XYFocusKeyboardNavigationMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XYFocusKeyboardNavigationMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for XYFocusKeyboardNavigationMode {}
 impl ::core::fmt::Debug for XYFocusKeyboardNavigationMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("XYFocusKeyboardNavigationMode").field(&self.0).finish()
@@ -7748,6 +7703,7 @@ impl ::windows::core::DefaultType for XYFocusKeyboardNavigationMode {
 }
 #[doc = "*Required features: 'UI_Xaml_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct XYFocusNavigationStrategy(pub i32);
 impl XYFocusNavigationStrategy {
     pub const Auto: Self = Self(0i32);
@@ -7764,12 +7720,6 @@ impl ::core::clone::Clone for XYFocusNavigationStrategy {
 unsafe impl ::windows::core::Abi for XYFocusNavigationStrategy {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XYFocusNavigationStrategy {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for XYFocusNavigationStrategy {}
 impl ::core::fmt::Debug for XYFocusNavigationStrategy {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("XYFocusNavigationStrategy").field(&self.0).finish()
@@ -7783,6 +7733,7 @@ impl ::windows::core::DefaultType for XYFocusNavigationStrategy {
 }
 #[doc = "*Required features: 'UI_Xaml_Input'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct XYFocusNavigationStrategyOverride(pub i32);
 impl XYFocusNavigationStrategyOverride {
     pub const None: Self = Self(0i32);
@@ -7800,12 +7751,6 @@ impl ::core::clone::Clone for XYFocusNavigationStrategyOverride {
 unsafe impl ::windows::core::Abi for XYFocusNavigationStrategyOverride {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for XYFocusNavigationStrategyOverride {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for XYFocusNavigationStrategyOverride {}
 impl ::core::fmt::Debug for XYFocusNavigationStrategyOverride {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("XYFocusNavigationStrategyOverride").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Xaml/Interop/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/Interop/mod.rs
@@ -931,6 +931,7 @@ pub struct INotifyCollectionChangedEventArgsFactoryVtbl(
 );
 #[doc = "*Required features: 'UI_Xaml_Interop'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct NotifyCollectionChangedAction(pub i32);
 impl NotifyCollectionChangedAction {
     pub const Add: Self = Self(0i32);
@@ -948,12 +949,6 @@ impl ::core::clone::Clone for NotifyCollectionChangedAction {
 unsafe impl ::windows::core::Abi for NotifyCollectionChangedAction {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NotifyCollectionChangedAction {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for NotifyCollectionChangedAction {}
 impl ::core::fmt::Debug for NotifyCollectionChangedAction {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NotifyCollectionChangedAction").field(&self.0).finish()
@@ -1167,6 +1162,7 @@ unsafe impl ::windows::core::RuntimeType for NotifyCollectionChangedEventHandler
 pub struct NotifyCollectionChangedEventHandlerVtbl(pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, e: ::windows::core::RawPtr) -> ::windows::core::HRESULT);
 #[doc = "*Required features: 'UI_Xaml_Interop'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TypeKind(pub i32);
 impl TypeKind {
     pub const Primitive: Self = Self(0i32);
@@ -1182,12 +1178,6 @@ impl ::core::clone::Clone for TypeKind {
 unsafe impl ::windows::core::Abi for TypeKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TypeKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TypeKind {}
 impl ::core::fmt::Debug for TypeKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TypeKind").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Xaml/Media/Animation/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/Media/Animation/mod.rs
@@ -801,6 +801,7 @@ unsafe impl ::core::marker::Send for CircleEase {}
 unsafe impl ::core::marker::Sync for CircleEase {}
 #[doc = "*Required features: 'UI_Xaml_Media_Animation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ClockState(pub i32);
 impl ClockState {
     pub const Active: Self = Self(0i32);
@@ -816,12 +817,6 @@ impl ::core::clone::Clone for ClockState {
 unsafe impl ::windows::core::Abi for ClockState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ClockState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ClockState {}
 impl ::core::fmt::Debug for ClockState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ClockState").field(&self.0).finish()
@@ -1928,6 +1923,7 @@ unsafe impl ::core::marker::Send for ConnectedAnimation {}
 unsafe impl ::core::marker::Sync for ConnectedAnimation {}
 #[doc = "*Required features: 'UI_Xaml_Media_Animation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ConnectedAnimationComponent(pub i32);
 impl ConnectedAnimationComponent {
     pub const OffsetX: Self = Self(0i32);
@@ -1944,12 +1940,6 @@ impl ::core::clone::Clone for ConnectedAnimationComponent {
 unsafe impl ::windows::core::Abi for ConnectedAnimationComponent {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ConnectedAnimationComponent {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ConnectedAnimationComponent {}
 impl ::core::fmt::Debug for ConnectedAnimationComponent {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ConnectedAnimationComponent").field(&self.0).finish()
@@ -5448,6 +5438,7 @@ unsafe impl ::core::marker::Send for EasingFunctionBase {}
 unsafe impl ::core::marker::Sync for EasingFunctionBase {}
 #[doc = "*Required features: 'UI_Xaml_Media_Animation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct EasingMode(pub i32);
 impl EasingMode {
     pub const EaseOut: Self = Self(0i32);
@@ -5463,12 +5454,6 @@ impl ::core::clone::Clone for EasingMode {
 unsafe impl ::windows::core::Abi for EasingMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for EasingMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for EasingMode {}
 impl ::core::fmt::Debug for EasingMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("EasingMode").field(&self.0).finish()
@@ -6702,6 +6687,7 @@ unsafe impl ::core::marker::Send for FadeOutThemeAnimation {}
 unsafe impl ::core::marker::Sync for FadeOutThemeAnimation {}
 #[doc = "*Required features: 'UI_Xaml_Media_Animation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FillBehavior(pub i32);
 impl FillBehavior {
     pub const HoldEnd: Self = Self(0i32);
@@ -6716,12 +6702,6 @@ impl ::core::clone::Clone for FillBehavior {
 unsafe impl ::windows::core::Abi for FillBehavior {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FillBehavior {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FillBehavior {}
 impl ::core::fmt::Debug for FillBehavior {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FillBehavior").field(&self.0).finish()
@@ -13924,6 +13904,7 @@ unsafe impl ::core::marker::Send for RepeatBehaviorHelper {}
 unsafe impl ::core::marker::Sync for RepeatBehaviorHelper {}
 #[doc = "*Required features: 'UI_Xaml_Media_Animation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RepeatBehaviorType(pub i32);
 impl RepeatBehaviorType {
     pub const Count: Self = Self(0i32);
@@ -13939,12 +13920,6 @@ impl ::core::clone::Clone for RepeatBehaviorType {
 unsafe impl ::windows::core::Abi for RepeatBehaviorType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RepeatBehaviorType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RepeatBehaviorType {}
 impl ::core::fmt::Debug for RepeatBehaviorType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RepeatBehaviorType").field(&self.0).finish()
@@ -14408,6 +14383,7 @@ unsafe impl ::core::marker::Send for SineEase {}
 unsafe impl ::core::marker::Sync for SineEase {}
 #[doc = "*Required features: 'UI_Xaml_Media_Animation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SlideNavigationTransitionEffect(pub i32);
 impl SlideNavigationTransitionEffect {
     pub const FromBottom: Self = Self(0i32);
@@ -14423,12 +14399,6 @@ impl ::core::clone::Clone for SlideNavigationTransitionEffect {
 unsafe impl ::windows::core::Abi for SlideNavigationTransitionEffect {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SlideNavigationTransitionEffect {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SlideNavigationTransitionEffect {}
 impl ::core::fmt::Debug for SlideNavigationTransitionEffect {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SlideNavigationTransitionEffect").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Xaml/Media/Imaging/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/Media/Imaging/mod.rs
@@ -1,6 +1,7 @@
 #![allow(non_snake_case, non_camel_case_types, non_upper_case_globals, clashing_extern_declarations, clippy::all)]
 #[doc = "*Required features: 'UI_Xaml_Media_Imaging'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BitmapCreateOptions(pub u32);
 impl BitmapCreateOptions {
     pub const None: Self = Self(0u32);
@@ -15,12 +16,6 @@ impl ::core::clone::Clone for BitmapCreateOptions {
 unsafe impl ::windows::core::Abi for BitmapCreateOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BitmapCreateOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BitmapCreateOptions {}
 impl ::core::fmt::Debug for BitmapCreateOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BitmapCreateOptions").field(&self.0).finish()
@@ -600,6 +595,7 @@ unsafe impl ::core::marker::Send for BitmapSource {}
 unsafe impl ::core::marker::Sync for BitmapSource {}
 #[doc = "*Required features: 'UI_Xaml_Media_Imaging'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DecodePixelType(pub i32);
 impl DecodePixelType {
     pub const Physical: Self = Self(0i32);
@@ -614,12 +610,6 @@ impl ::core::clone::Clone for DecodePixelType {
 unsafe impl ::windows::core::Abi for DecodePixelType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DecodePixelType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DecodePixelType {}
 impl ::core::fmt::Debug for DecodePixelType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DecodePixelType").field(&self.0).finish()
@@ -2164,6 +2154,7 @@ unsafe impl ::core::marker::Send for SvgImageSourceFailedEventArgs {}
 unsafe impl ::core::marker::Sync for SvgImageSourceFailedEventArgs {}
 #[doc = "*Required features: 'UI_Xaml_Media_Imaging'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SvgImageSourceLoadStatus(pub i32);
 impl SvgImageSourceLoadStatus {
     pub const Success: Self = Self(0i32);
@@ -2180,12 +2171,6 @@ impl ::core::clone::Clone for SvgImageSourceLoadStatus {
 unsafe impl ::windows::core::Abi for SvgImageSourceLoadStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SvgImageSourceLoadStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SvgImageSourceLoadStatus {}
 impl ::core::fmt::Debug for SvgImageSourceLoadStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SvgImageSourceLoadStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Xaml/Media/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/Media/mod.rs
@@ -7,6 +7,7 @@ pub mod Imaging;
 pub mod Media3D;
 #[doc = "*Required features: 'UI_Xaml_Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AcrylicBackgroundSource(pub i32);
 impl AcrylicBackgroundSource {
     pub const HostBackdrop: Self = Self(0i32);
@@ -21,12 +22,6 @@ impl ::core::clone::Clone for AcrylicBackgroundSource {
 unsafe impl ::windows::core::Abi for AcrylicBackgroundSource {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AcrylicBackgroundSource {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AcrylicBackgroundSource {}
 impl ::core::fmt::Debug for AcrylicBackgroundSource {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AcrylicBackgroundSource").field(&self.0).finish()
@@ -345,6 +340,7 @@ unsafe impl ::core::marker::Send for AcrylicBrush {}
 unsafe impl ::core::marker::Sync for AcrylicBrush {}
 #[doc = "*Required features: 'UI_Xaml_Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AlignmentX(pub i32);
 impl AlignmentX {
     pub const Left: Self = Self(0i32);
@@ -360,12 +356,6 @@ impl ::core::clone::Clone for AlignmentX {
 unsafe impl ::windows::core::Abi for AlignmentX {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AlignmentX {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AlignmentX {}
 impl ::core::fmt::Debug for AlignmentX {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AlignmentX").field(&self.0).finish()
@@ -379,6 +369,7 @@ impl ::windows::core::DefaultType for AlignmentX {
 }
 #[doc = "*Required features: 'UI_Xaml_Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AlignmentY(pub i32);
 impl AlignmentY {
     pub const Top: Self = Self(0i32);
@@ -394,12 +385,6 @@ impl ::core::clone::Clone for AlignmentY {
 unsafe impl ::windows::core::Abi for AlignmentY {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AlignmentY {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AlignmentY {}
 impl ::core::fmt::Debug for AlignmentY {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AlignmentY").field(&self.0).finish()
@@ -642,6 +627,7 @@ unsafe impl ::core::marker::Send for ArcSegment {}
 unsafe impl ::core::marker::Sync for ArcSegment {}
 #[doc = "*Required features: 'UI_Xaml_Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AudioCategory(pub i32);
 impl AudioCategory {
     pub const Other: Self = Self(0i32);
@@ -666,12 +652,6 @@ impl ::core::clone::Clone for AudioCategory {
 unsafe impl ::windows::core::Abi for AudioCategory {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AudioCategory {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AudioCategory {}
 impl ::core::fmt::Debug for AudioCategory {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AudioCategory").field(&self.0).finish()
@@ -685,6 +665,7 @@ impl ::windows::core::DefaultType for AudioCategory {
 }
 #[doc = "*Required features: 'UI_Xaml_Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AudioDeviceType(pub i32);
 impl AudioDeviceType {
     pub const Console: Self = Self(0i32);
@@ -700,12 +681,6 @@ impl ::core::clone::Clone for AudioDeviceType {
 unsafe impl ::windows::core::Abi for AudioDeviceType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AudioDeviceType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AudioDeviceType {}
 impl ::core::fmt::Debug for AudioDeviceType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AudioDeviceType").field(&self.0).finish()
@@ -1483,6 +1458,7 @@ unsafe impl ::core::marker::Send for BrushCollection {}
 unsafe impl ::core::marker::Sync for BrushCollection {}
 #[doc = "*Required features: 'UI_Xaml_Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct BrushMappingMode(pub i32);
 impl BrushMappingMode {
     pub const Absolute: Self = Self(0i32);
@@ -1497,12 +1473,6 @@ impl ::core::clone::Clone for BrushMappingMode {
 unsafe impl ::windows::core::Abi for BrushMappingMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for BrushMappingMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for BrushMappingMode {}
 impl ::core::fmt::Debug for BrushMappingMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("BrushMappingMode").field(&self.0).finish()
@@ -1608,6 +1578,7 @@ unsafe impl ::core::marker::Send for CacheMode {}
 unsafe impl ::core::marker::Sync for CacheMode {}
 #[doc = "*Required features: 'UI_Xaml_Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ColorInterpolationMode(pub i32);
 impl ColorInterpolationMode {
     pub const ScRgbLinearInterpolation: Self = Self(0i32);
@@ -1622,12 +1593,6 @@ impl ::core::clone::Clone for ColorInterpolationMode {
 unsafe impl ::windows::core::Abi for ColorInterpolationMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ColorInterpolationMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ColorInterpolationMode {}
 impl ::core::fmt::Debug for ColorInterpolationMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ColorInterpolationMode").field(&self.0).finish()
@@ -2351,6 +2316,7 @@ unsafe impl ::core::marker::Send for DoubleCollection {}
 unsafe impl ::core::marker::Sync for DoubleCollection {}
 #[doc = "*Required features: 'UI_Xaml_Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ElementCompositeMode(pub i32);
 impl ElementCompositeMode {
     pub const Inherit: Self = Self(0i32);
@@ -2366,12 +2332,6 @@ impl ::core::clone::Clone for ElementCompositeMode {
 unsafe impl ::windows::core::Abi for ElementCompositeMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ElementCompositeMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ElementCompositeMode {}
 impl ::core::fmt::Debug for ElementCompositeMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ElementCompositeMode").field(&self.0).finish()
@@ -2572,6 +2532,7 @@ unsafe impl ::core::marker::Send for EllipseGeometry {}
 unsafe impl ::core::marker::Sync for EllipseGeometry {}
 #[doc = "*Required features: 'UI_Xaml_Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FastPlayFallbackBehaviour(pub i32);
 impl FastPlayFallbackBehaviour {
     pub const Skip: Self = Self(0i32);
@@ -2587,12 +2548,6 @@ impl ::core::clone::Clone for FastPlayFallbackBehaviour {
 unsafe impl ::windows::core::Abi for FastPlayFallbackBehaviour {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FastPlayFallbackBehaviour {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FastPlayFallbackBehaviour {}
 impl ::core::fmt::Debug for FastPlayFallbackBehaviour {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FastPlayFallbackBehaviour").field(&self.0).finish()
@@ -2606,6 +2561,7 @@ impl ::windows::core::DefaultType for FastPlayFallbackBehaviour {
 }
 #[doc = "*Required features: 'UI_Xaml_Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FillRule(pub i32);
 impl FillRule {
     pub const EvenOdd: Self = Self(0i32);
@@ -2620,12 +2576,6 @@ impl ::core::clone::Clone for FillRule {
 unsafe impl ::windows::core::Abi for FillRule {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FillRule {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FillRule {}
 impl ::core::fmt::Debug for FillRule {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FillRule").field(&self.0).finish()
@@ -3669,6 +3619,7 @@ unsafe impl ::core::marker::Send for GradientBrush {}
 unsafe impl ::core::marker::Sync for GradientBrush {}
 #[doc = "*Required features: 'UI_Xaml_Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GradientSpreadMethod(pub i32);
 impl GradientSpreadMethod {
     pub const Pad: Self = Self(0i32);
@@ -3684,12 +3635,6 @@ impl ::core::clone::Clone for GradientSpreadMethod {
 unsafe impl ::windows::core::Abi for GradientSpreadMethod {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GradientSpreadMethod {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GradientSpreadMethod {}
 impl ::core::fmt::Debug for GradientSpreadMethod {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GradientSpreadMethod").field(&self.0).finish()
@@ -7750,6 +7695,7 @@ unsafe impl ::core::marker::Send for LoadedImageSourceLoadCompletedEventArgs {}
 unsafe impl ::core::marker::Sync for LoadedImageSourceLoadCompletedEventArgs {}
 #[doc = "*Required features: 'UI_Xaml_Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LoadedImageSourceLoadStatus(pub i32);
 impl LoadedImageSourceLoadStatus {
     pub const Success: Self = Self(0i32);
@@ -7766,12 +7712,6 @@ impl ::core::clone::Clone for LoadedImageSourceLoadStatus {
 unsafe impl ::windows::core::Abi for LoadedImageSourceLoadStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LoadedImageSourceLoadStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LoadedImageSourceLoadStatus {}
 impl ::core::fmt::Debug for LoadedImageSourceLoadStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LoadedImageSourceLoadStatus").field(&self.0).finish()
@@ -8455,6 +8395,7 @@ unsafe impl ::core::marker::Send for MatrixTransform {}
 unsafe impl ::core::marker::Sync for MatrixTransform {}
 #[doc = "*Required features: 'UI_Xaml_Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaCanPlayResponse(pub i32);
 impl MediaCanPlayResponse {
     pub const NotSupported: Self = Self(0i32);
@@ -8470,12 +8411,6 @@ impl ::core::clone::Clone for MediaCanPlayResponse {
 unsafe impl ::windows::core::Abi for MediaCanPlayResponse {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaCanPlayResponse {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaCanPlayResponse {}
 impl ::core::fmt::Debug for MediaCanPlayResponse {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaCanPlayResponse").field(&self.0).finish()
@@ -8489,6 +8424,7 @@ impl ::windows::core::DefaultType for MediaCanPlayResponse {
 }
 #[doc = "*Required features: 'UI_Xaml_Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MediaElementState(pub i32);
 impl MediaElementState {
     pub const Closed: Self = Self(0i32);
@@ -8507,12 +8443,6 @@ impl ::core::clone::Clone for MediaElementState {
 unsafe impl ::windows::core::Abi for MediaElementState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MediaElementState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MediaElementState {}
 impl ::core::fmt::Debug for MediaElementState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MediaElementState").field(&self.0).finish()
@@ -9685,6 +9615,7 @@ unsafe impl ::core::marker::Send for PathSegmentCollection {}
 unsafe impl ::core::marker::Sync for PathSegmentCollection {}
 #[doc = "*Required features: 'UI_Xaml_Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PenLineCap(pub i32);
 impl PenLineCap {
     pub const Flat: Self = Self(0i32);
@@ -9701,12 +9632,6 @@ impl ::core::clone::Clone for PenLineCap {
 unsafe impl ::windows::core::Abi for PenLineCap {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PenLineCap {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PenLineCap {}
 impl ::core::fmt::Debug for PenLineCap {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PenLineCap").field(&self.0).finish()
@@ -9720,6 +9645,7 @@ impl ::windows::core::DefaultType for PenLineCap {
 }
 #[doc = "*Required features: 'UI_Xaml_Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PenLineJoin(pub i32);
 impl PenLineJoin {
     pub const Miter: Self = Self(0i32);
@@ -9735,12 +9661,6 @@ impl ::core::clone::Clone for PenLineJoin {
 unsafe impl ::windows::core::Abi for PenLineJoin {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PenLineJoin {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PenLineJoin {}
 impl ::core::fmt::Debug for PenLineJoin {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PenLineJoin").field(&self.0).finish()
@@ -12210,6 +12130,7 @@ unsafe impl ::core::marker::Send for RevealBrush {}
 unsafe impl ::core::marker::Sync for RevealBrush {}
 #[doc = "*Required features: 'UI_Xaml_Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct RevealBrushState(pub i32);
 impl RevealBrushState {
     pub const Normal: Self = Self(0i32);
@@ -12225,12 +12146,6 @@ impl ::core::clone::Clone for RevealBrushState {
 unsafe impl ::windows::core::Abi for RevealBrushState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for RevealBrushState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for RevealBrushState {}
 impl ::core::fmt::Debug for RevealBrushState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("RevealBrushState").field(&self.0).finish()
@@ -13174,6 +13089,7 @@ unsafe impl ::core::marker::Send for SolidColorBrush {}
 unsafe impl ::core::marker::Sync for SolidColorBrush {}
 #[doc = "*Required features: 'UI_Xaml_Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct Stereo3DVideoPackingMode(pub i32);
 impl Stereo3DVideoPackingMode {
     pub const None: Self = Self(0i32);
@@ -13189,12 +13105,6 @@ impl ::core::clone::Clone for Stereo3DVideoPackingMode {
 unsafe impl ::windows::core::Abi for Stereo3DVideoPackingMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for Stereo3DVideoPackingMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for Stereo3DVideoPackingMode {}
 impl ::core::fmt::Debug for Stereo3DVideoPackingMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("Stereo3DVideoPackingMode").field(&self.0).finish()
@@ -13208,6 +13118,7 @@ impl ::windows::core::DefaultType for Stereo3DVideoPackingMode {
 }
 #[doc = "*Required features: 'UI_Xaml_Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct Stereo3DVideoRenderMode(pub i32);
 impl Stereo3DVideoRenderMode {
     pub const Mono: Self = Self(0i32);
@@ -13222,12 +13133,6 @@ impl ::core::clone::Clone for Stereo3DVideoRenderMode {
 unsafe impl ::windows::core::Abi for Stereo3DVideoRenderMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for Stereo3DVideoRenderMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for Stereo3DVideoRenderMode {}
 impl ::core::fmt::Debug for Stereo3DVideoRenderMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("Stereo3DVideoRenderMode").field(&self.0).finish()
@@ -13241,6 +13146,7 @@ impl ::windows::core::DefaultType for Stereo3DVideoRenderMode {
 }
 #[doc = "*Required features: 'UI_Xaml_Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct Stretch(pub i32);
 impl Stretch {
     pub const None: Self = Self(0i32);
@@ -13257,12 +13163,6 @@ impl ::core::clone::Clone for Stretch {
 unsafe impl ::windows::core::Abi for Stretch {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for Stretch {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for Stretch {}
 impl ::core::fmt::Debug for Stretch {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("Stretch").field(&self.0).finish()
@@ -13276,6 +13176,7 @@ impl ::windows::core::DefaultType for Stretch {
 }
 #[doc = "*Required features: 'UI_Xaml_Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct StyleSimulations(pub i32);
 impl StyleSimulations {
     pub const None: Self = Self(0i32);
@@ -13292,12 +13193,6 @@ impl ::core::clone::Clone for StyleSimulations {
 unsafe impl ::windows::core::Abi for StyleSimulations {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for StyleSimulations {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for StyleSimulations {}
 impl ::core::fmt::Debug for StyleSimulations {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("StyleSimulations").field(&self.0).finish()
@@ -13311,6 +13206,7 @@ impl ::windows::core::DefaultType for StyleSimulations {
 }
 #[doc = "*Required features: 'UI_Xaml_Media'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SweepDirection(pub i32);
 impl SweepDirection {
     pub const Counterclockwise: Self = Self(0i32);
@@ -13325,12 +13221,6 @@ impl ::core::clone::Clone for SweepDirection {
 unsafe impl ::windows::core::Abi for SweepDirection {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SweepDirection {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SweepDirection {}
 impl ::core::fmt::Debug for SweepDirection {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SweepDirection").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Xaml/Navigation/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/Navigation/mod.rs
@@ -668,6 +668,7 @@ unsafe impl ::windows::core::RuntimeType for NavigatingCancelEventHandler {
 pub struct NavigatingCancelEventHandlerVtbl(pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, e: ::windows::core::RawPtr) -> ::windows::core::HRESULT);
 #[doc = "*Required features: 'UI_Xaml_Navigation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct NavigationCacheMode(pub i32);
 impl NavigationCacheMode {
     pub const Disabled: Self = Self(0i32);
@@ -683,12 +684,6 @@ impl ::core::clone::Clone for NavigationCacheMode {
 unsafe impl ::windows::core::Abi for NavigationCacheMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NavigationCacheMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for NavigationCacheMode {}
 impl ::core::fmt::Debug for NavigationCacheMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NavigationCacheMode").field(&self.0).finish()
@@ -1010,6 +1005,7 @@ unsafe impl ::windows::core::RuntimeType for NavigationFailedEventHandler {
 pub struct NavigationFailedEventHandlerVtbl(pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, e: ::windows::core::RawPtr) -> ::windows::core::HRESULT);
 #[doc = "*Required features: 'UI_Xaml_Navigation'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct NavigationMode(pub i32);
 impl NavigationMode {
     pub const New: Self = Self(0i32);
@@ -1026,12 +1022,6 @@ impl ::core::clone::Clone for NavigationMode {
 unsafe impl ::windows::core::Abi for NavigationMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for NavigationMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for NavigationMode {}
 impl ::core::fmt::Debug for NavigationMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("NavigationMode").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Xaml/Printing/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/Printing/mod.rs
@@ -629,6 +629,7 @@ unsafe impl ::windows::core::RuntimeType for PaginateEventHandler {
 pub struct PaginateEventHandlerVtbl(pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, e: ::windows::core::RawPtr) -> ::windows::core::HRESULT);
 #[doc = "*Required features: 'UI_Xaml_Printing'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PreviewPageCountType(pub i32);
 impl PreviewPageCountType {
     pub const Final: Self = Self(0i32);
@@ -643,12 +644,6 @@ impl ::core::clone::Clone for PreviewPageCountType {
 unsafe impl ::windows::core::Abi for PreviewPageCountType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PreviewPageCountType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PreviewPageCountType {}
 impl ::core::fmt::Debug for PreviewPageCountType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PreviewPageCountType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/UI/Xaml/mod.rs
+++ b/crates/libs/windows/src/Windows/UI/Xaml/mod.rs
@@ -463,6 +463,7 @@ unsafe impl ::core::marker::Send for Application {}
 unsafe impl ::core::marker::Sync for Application {}
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ApplicationHighContrastAdjustment(pub u32);
 impl ApplicationHighContrastAdjustment {
     pub const None: Self = Self(0u32);
@@ -477,12 +478,6 @@ impl ::core::clone::Clone for ApplicationHighContrastAdjustment {
 unsafe impl ::windows::core::Abi for ApplicationHighContrastAdjustment {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ApplicationHighContrastAdjustment {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ApplicationHighContrastAdjustment {}
 impl ::core::fmt::Debug for ApplicationHighContrastAdjustment {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ApplicationHighContrastAdjustment").field(&self.0).finish()
@@ -671,6 +666,7 @@ unsafe impl ::core::marker::Send for ApplicationInitializationCallbackParams {}
 unsafe impl ::core::marker::Sync for ApplicationInitializationCallbackParams {}
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ApplicationRequiresPointerMode(pub i32);
 impl ApplicationRequiresPointerMode {
     pub const Auto: Self = Self(0i32);
@@ -685,12 +681,6 @@ impl ::core::clone::Clone for ApplicationRequiresPointerMode {
 unsafe impl ::windows::core::Abi for ApplicationRequiresPointerMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ApplicationRequiresPointerMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ApplicationRequiresPointerMode {}
 impl ::core::fmt::Debug for ApplicationRequiresPointerMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ApplicationRequiresPointerMode").field(&self.0).finish()
@@ -704,6 +694,7 @@ impl ::windows::core::DefaultType for ApplicationRequiresPointerMode {
 }
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ApplicationTheme(pub i32);
 impl ApplicationTheme {
     pub const Light: Self = Self(0i32);
@@ -718,12 +709,6 @@ impl ::core::clone::Clone for ApplicationTheme {
 unsafe impl ::windows::core::Abi for ApplicationTheme {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ApplicationTheme {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ApplicationTheme {}
 impl ::core::fmt::Debug for ApplicationTheme {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ApplicationTheme").field(&self.0).finish()
@@ -737,6 +722,7 @@ impl ::windows::core::DefaultType for ApplicationTheme {
 }
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct AutomationTextAttributesEnum(pub i32);
 impl AutomationTextAttributesEnum {
     pub const AnimationStyleAttribute: Self = Self(40000i32);
@@ -789,12 +775,6 @@ impl ::core::clone::Clone for AutomationTextAttributesEnum {
 unsafe impl ::windows::core::Abi for AutomationTextAttributesEnum {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for AutomationTextAttributesEnum {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for AutomationTextAttributesEnum {}
 impl ::core::fmt::Debug for AutomationTextAttributesEnum {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("AutomationTextAttributesEnum").field(&self.0).finish()
@@ -4845,6 +4825,7 @@ unsafe impl ::core::marker::Send for DurationHelper {}
 unsafe impl ::core::marker::Sync for DurationHelper {}
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct DurationType(pub i32);
 impl DurationType {
     pub const Automatic: Self = Self(0i32);
@@ -4860,12 +4841,6 @@ impl ::core::clone::Clone for DurationType {
 unsafe impl ::windows::core::Abi for DurationType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for DurationType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for DurationType {}
 impl ::core::fmt::Debug for DurationType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("DurationType").field(&self.0).finish()
@@ -5208,6 +5183,7 @@ unsafe impl ::core::marker::Send for ElementFactoryRecycleArgs {}
 unsafe impl ::core::marker::Sync for ElementFactoryRecycleArgs {}
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ElementHighContrastAdjustment(pub u32);
 impl ElementHighContrastAdjustment {
     pub const None: Self = Self(0u32);
@@ -5223,12 +5199,6 @@ impl ::core::clone::Clone for ElementHighContrastAdjustment {
 unsafe impl ::windows::core::Abi for ElementHighContrastAdjustment {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ElementHighContrastAdjustment {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ElementHighContrastAdjustment {}
 impl ::core::fmt::Debug for ElementHighContrastAdjustment {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ElementHighContrastAdjustment").field(&self.0).finish()
@@ -5270,6 +5240,7 @@ impl ::windows::core::DefaultType for ElementHighContrastAdjustment {
 }
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ElementSoundKind(pub i32);
 impl ElementSoundKind {
     pub const Focus: Self = Self(0i32);
@@ -5289,12 +5260,6 @@ impl ::core::clone::Clone for ElementSoundKind {
 unsafe impl ::windows::core::Abi for ElementSoundKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ElementSoundKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ElementSoundKind {}
 impl ::core::fmt::Debug for ElementSoundKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ElementSoundKind").field(&self.0).finish()
@@ -5308,6 +5273,7 @@ impl ::windows::core::DefaultType for ElementSoundKind {
 }
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ElementSoundMode(pub i32);
 impl ElementSoundMode {
     pub const Default: Self = Self(0i32);
@@ -5323,12 +5289,6 @@ impl ::core::clone::Clone for ElementSoundMode {
 unsafe impl ::windows::core::Abi for ElementSoundMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ElementSoundMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ElementSoundMode {}
 impl ::core::fmt::Debug for ElementSoundMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ElementSoundMode").field(&self.0).finish()
@@ -5462,6 +5422,7 @@ unsafe impl ::core::marker::Send for ElementSoundPlayer {}
 unsafe impl ::core::marker::Sync for ElementSoundPlayer {}
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ElementSoundPlayerState(pub i32);
 impl ElementSoundPlayerState {
     pub const Auto: Self = Self(0i32);
@@ -5477,12 +5438,6 @@ impl ::core::clone::Clone for ElementSoundPlayerState {
 unsafe impl ::windows::core::Abi for ElementSoundPlayerState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ElementSoundPlayerState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ElementSoundPlayerState {}
 impl ::core::fmt::Debug for ElementSoundPlayerState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ElementSoundPlayerState").field(&self.0).finish()
@@ -5496,6 +5451,7 @@ impl ::windows::core::DefaultType for ElementSoundPlayerState {
 }
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ElementSpatialAudioMode(pub i32);
 impl ElementSpatialAudioMode {
     pub const Auto: Self = Self(0i32);
@@ -5511,12 +5467,6 @@ impl ::core::clone::Clone for ElementSpatialAudioMode {
 unsafe impl ::windows::core::Abi for ElementSpatialAudioMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ElementSpatialAudioMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ElementSpatialAudioMode {}
 impl ::core::fmt::Debug for ElementSpatialAudioMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ElementSpatialAudioMode").field(&self.0).finish()
@@ -5530,6 +5480,7 @@ impl ::windows::core::DefaultType for ElementSpatialAudioMode {
 }
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ElementTheme(pub i32);
 impl ElementTheme {
     pub const Default: Self = Self(0i32);
@@ -5545,12 +5496,6 @@ impl ::core::clone::Clone for ElementTheme {
 unsafe impl ::windows::core::Abi for ElementTheme {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ElementTheme {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ElementTheme {}
 impl ::core::fmt::Debug for ElementTheme {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ElementTheme").field(&self.0).finish()
@@ -5975,6 +5920,7 @@ unsafe impl ::windows::core::RuntimeType for ExceptionRoutedEventHandler {
 pub struct ExceptionRoutedEventHandlerVtbl(pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void, iid: &::windows::core::GUID, interface: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void) -> u32, pub unsafe extern "system" fn(this: *mut ::core::ffi::c_void, sender: *mut ::core::ffi::c_void, e: ::windows::core::RawPtr) -> ::windows::core::HRESULT);
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FlowDirection(pub i32);
 impl FlowDirection {
     pub const LeftToRight: Self = Self(0i32);
@@ -5989,12 +5935,6 @@ impl ::core::clone::Clone for FlowDirection {
 unsafe impl ::windows::core::Abi for FlowDirection {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FlowDirection {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FlowDirection {}
 impl ::core::fmt::Debug for FlowDirection {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FlowDirection").field(&self.0).finish()
@@ -6008,6 +5948,7 @@ impl ::windows::core::DefaultType for FlowDirection {
 }
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FocusState(pub i32);
 impl FocusState {
     pub const Unfocused: Self = Self(0i32);
@@ -6024,12 +5965,6 @@ impl ::core::clone::Clone for FocusState {
 unsafe impl ::windows::core::Abi for FocusState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FocusState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FocusState {}
 impl ::core::fmt::Debug for FocusState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FocusState").field(&self.0).finish()
@@ -6043,6 +5978,7 @@ impl ::windows::core::DefaultType for FocusState {
 }
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FocusVisualKind(pub i32);
 impl FocusVisualKind {
     pub const DottedLine: Self = Self(0i32);
@@ -6058,12 +5994,6 @@ impl ::core::clone::Clone for FocusVisualKind {
 unsafe impl ::windows::core::Abi for FocusVisualKind {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FocusVisualKind {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FocusVisualKind {}
 impl ::core::fmt::Debug for FocusVisualKind {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FocusVisualKind").field(&self.0).finish()
@@ -6077,6 +6007,7 @@ impl ::windows::core::DefaultType for FocusVisualKind {
 }
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FontCapitals(pub i32);
 impl FontCapitals {
     pub const Normal: Self = Self(0i32);
@@ -6096,12 +6027,6 @@ impl ::core::clone::Clone for FontCapitals {
 unsafe impl ::windows::core::Abi for FontCapitals {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FontCapitals {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FontCapitals {}
 impl ::core::fmt::Debug for FontCapitals {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FontCapitals").field(&self.0).finish()
@@ -6115,6 +6040,7 @@ impl ::windows::core::DefaultType for FontCapitals {
 }
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FontEastAsianLanguage(pub i32);
 impl FontEastAsianLanguage {
     pub const Normal: Self = Self(0i32);
@@ -6137,12 +6063,6 @@ impl ::core::clone::Clone for FontEastAsianLanguage {
 unsafe impl ::windows::core::Abi for FontEastAsianLanguage {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FontEastAsianLanguage {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FontEastAsianLanguage {}
 impl ::core::fmt::Debug for FontEastAsianLanguage {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FontEastAsianLanguage").field(&self.0).finish()
@@ -6156,6 +6076,7 @@ impl ::windows::core::DefaultType for FontEastAsianLanguage {
 }
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FontEastAsianWidths(pub i32);
 impl FontEastAsianWidths {
     pub const Normal: Self = Self(0i32);
@@ -6174,12 +6095,6 @@ impl ::core::clone::Clone for FontEastAsianWidths {
 unsafe impl ::windows::core::Abi for FontEastAsianWidths {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FontEastAsianWidths {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FontEastAsianWidths {}
 impl ::core::fmt::Debug for FontEastAsianWidths {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FontEastAsianWidths").field(&self.0).finish()
@@ -6193,6 +6108,7 @@ impl ::windows::core::DefaultType for FontEastAsianWidths {
 }
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FontFraction(pub i32);
 impl FontFraction {
     pub const Normal: Self = Self(0i32);
@@ -6208,12 +6124,6 @@ impl ::core::clone::Clone for FontFraction {
 unsafe impl ::windows::core::Abi for FontFraction {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FontFraction {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FontFraction {}
 impl ::core::fmt::Debug for FontFraction {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FontFraction").field(&self.0).finish()
@@ -6227,6 +6137,7 @@ impl ::windows::core::DefaultType for FontFraction {
 }
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FontNumeralAlignment(pub i32);
 impl FontNumeralAlignment {
     pub const Normal: Self = Self(0i32);
@@ -6242,12 +6153,6 @@ impl ::core::clone::Clone for FontNumeralAlignment {
 unsafe impl ::windows::core::Abi for FontNumeralAlignment {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FontNumeralAlignment {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FontNumeralAlignment {}
 impl ::core::fmt::Debug for FontNumeralAlignment {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FontNumeralAlignment").field(&self.0).finish()
@@ -6261,6 +6166,7 @@ impl ::windows::core::DefaultType for FontNumeralAlignment {
 }
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FontNumeralStyle(pub i32);
 impl FontNumeralStyle {
     pub const Normal: Self = Self(0i32);
@@ -6276,12 +6182,6 @@ impl ::core::clone::Clone for FontNumeralStyle {
 unsafe impl ::windows::core::Abi for FontNumeralStyle {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FontNumeralStyle {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FontNumeralStyle {}
 impl ::core::fmt::Debug for FontNumeralStyle {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FontNumeralStyle").field(&self.0).finish()
@@ -6295,6 +6195,7 @@ impl ::windows::core::DefaultType for FontNumeralStyle {
 }
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct FontVariants(pub i32);
 impl FontVariants {
     pub const Normal: Self = Self(0i32);
@@ -6313,12 +6214,6 @@ impl ::core::clone::Clone for FontVariants {
 unsafe impl ::windows::core::Abi for FontVariants {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for FontVariants {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for FontVariants {}
 impl ::core::fmt::Debug for FontVariants {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("FontVariants").field(&self.0).finish()
@@ -7737,6 +7632,7 @@ unsafe impl ::core::marker::Send for GridLengthHelper {}
 unsafe impl ::core::marker::Sync for GridLengthHelper {}
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct GridUnitType(pub i32);
 impl GridUnitType {
     pub const Auto: Self = Self(0i32);
@@ -7752,12 +7648,6 @@ impl ::core::clone::Clone for GridUnitType {
 unsafe impl ::windows::core::Abi for GridUnitType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for GridUnitType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for GridUnitType {}
 impl ::core::fmt::Debug for GridUnitType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("GridUnitType").field(&self.0).finish()
@@ -7771,6 +7661,7 @@ impl ::windows::core::DefaultType for GridUnitType {
 }
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HorizontalAlignment(pub i32);
 impl HorizontalAlignment {
     pub const Left: Self = Self(0i32);
@@ -7787,12 +7678,6 @@ impl ::core::clone::Clone for HorizontalAlignment {
 unsafe impl ::windows::core::Abi for HorizontalAlignment {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HorizontalAlignment {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HorizontalAlignment {}
 impl ::core::fmt::Debug for HorizontalAlignment {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HorizontalAlignment").field(&self.0).finish()
@@ -12196,6 +12081,7 @@ pub struct LeavingBackgroundEventHandlerVtbl(
 );
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct LineStackingStrategy(pub i32);
 impl LineStackingStrategy {
     pub const MaxHeight: Self = Self(0i32);
@@ -12211,12 +12097,6 @@ impl ::core::clone::Clone for LineStackingStrategy {
 unsafe impl ::windows::core::Abi for LineStackingStrategy {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for LineStackingStrategy {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for LineStackingStrategy {}
 impl ::core::fmt::Debug for LineStackingStrategy {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("LineStackingStrategy").field(&self.0).finish()
@@ -12351,6 +12231,7 @@ unsafe impl ::core::marker::Send for MediaFailedRoutedEventArgs {}
 unsafe impl ::core::marker::Sync for MediaFailedRoutedEventArgs {}
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct OpticalMarginAlignment(pub i32);
 impl OpticalMarginAlignment {
     pub const None: Self = Self(0i32);
@@ -12365,12 +12246,6 @@ impl ::core::clone::Clone for OpticalMarginAlignment {
 unsafe impl ::windows::core::Abi for OpticalMarginAlignment {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for OpticalMarginAlignment {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for OpticalMarginAlignment {}
 impl ::core::fmt::Debug for OpticalMarginAlignment {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("OpticalMarginAlignment").field(&self.0).finish()
@@ -15037,6 +14912,7 @@ unsafe impl ::core::marker::Send for TargetPropertyPath {}
 unsafe impl ::core::marker::Sync for TargetPropertyPath {}
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TextAlignment(pub i32);
 impl TextAlignment {
     pub const Center: Self = Self(0i32);
@@ -15056,12 +14932,6 @@ impl ::core::clone::Clone for TextAlignment {
 unsafe impl ::windows::core::Abi for TextAlignment {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TextAlignment {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TextAlignment {}
 impl ::core::fmt::Debug for TextAlignment {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TextAlignment").field(&self.0).finish()
@@ -15075,6 +14945,7 @@ impl ::windows::core::DefaultType for TextAlignment {
 }
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TextLineBounds(pub i32);
 impl TextLineBounds {
     pub const Full: Self = Self(0i32);
@@ -15091,12 +14962,6 @@ impl ::core::clone::Clone for TextLineBounds {
 unsafe impl ::windows::core::Abi for TextLineBounds {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TextLineBounds {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TextLineBounds {}
 impl ::core::fmt::Debug for TextLineBounds {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TextLineBounds").field(&self.0).finish()
@@ -15110,6 +14975,7 @@ impl ::windows::core::DefaultType for TextLineBounds {
 }
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TextReadingOrder(pub i32);
 impl TextReadingOrder {
     pub const Default: Self = Self(0i32);
@@ -15125,12 +14991,6 @@ impl ::core::clone::Clone for TextReadingOrder {
 unsafe impl ::windows::core::Abi for TextReadingOrder {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TextReadingOrder {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TextReadingOrder {}
 impl ::core::fmt::Debug for TextReadingOrder {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TextReadingOrder").field(&self.0).finish()
@@ -15144,6 +15004,7 @@ impl ::windows::core::DefaultType for TextReadingOrder {
 }
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TextTrimming(pub i32);
 impl TextTrimming {
     pub const None: Self = Self(0i32);
@@ -15160,12 +15021,6 @@ impl ::core::clone::Clone for TextTrimming {
 unsafe impl ::windows::core::Abi for TextTrimming {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TextTrimming {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TextTrimming {}
 impl ::core::fmt::Debug for TextTrimming {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TextTrimming").field(&self.0).finish()
@@ -15179,6 +15034,7 @@ impl ::windows::core::DefaultType for TextTrimming {
 }
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct TextWrapping(pub i32);
 impl TextWrapping {
     pub const NoWrap: Self = Self(1i32);
@@ -15194,12 +15050,6 @@ impl ::core::clone::Clone for TextWrapping {
 unsafe impl ::windows::core::Abi for TextWrapping {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for TextWrapping {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for TextWrapping {}
 impl ::core::fmt::Debug for TextWrapping {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("TextWrapping").field(&self.0).finish()
@@ -18783,6 +18633,7 @@ unsafe impl ::core::marker::Send for Vector3Transition {}
 unsafe impl ::core::marker::Sync for Vector3Transition {}
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct Vector3TransitionComponents(pub u32);
 impl Vector3TransitionComponents {
     pub const X: Self = Self(1u32);
@@ -18798,12 +18649,6 @@ impl ::core::clone::Clone for Vector3TransitionComponents {
 unsafe impl ::windows::core::Abi for Vector3TransitionComponents {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for Vector3TransitionComponents {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for Vector3TransitionComponents {}
 impl ::core::fmt::Debug for Vector3TransitionComponents {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("Vector3TransitionComponents").field(&self.0).finish()
@@ -18845,6 +18690,7 @@ impl ::windows::core::DefaultType for Vector3TransitionComponents {
 }
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct VerticalAlignment(pub i32);
 impl VerticalAlignment {
     pub const Top: Self = Self(0i32);
@@ -18861,12 +18707,6 @@ impl ::core::clone::Clone for VerticalAlignment {
 unsafe impl ::windows::core::Abi for VerticalAlignment {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for VerticalAlignment {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for VerticalAlignment {}
 impl ::core::fmt::Debug for VerticalAlignment {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("VerticalAlignment").field(&self.0).finish()
@@ -18880,6 +18720,7 @@ impl ::windows::core::DefaultType for VerticalAlignment {
 }
 #[doc = "*Required features: 'UI_Xaml'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct Visibility(pub i32);
 impl Visibility {
     pub const Visible: Self = Self(0i32);
@@ -18894,12 +18735,6 @@ impl ::core::clone::Clone for Visibility {
 unsafe impl ::windows::core::Abi for Visibility {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for Visibility {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for Visibility {}
 impl ::core::fmt::Debug for Visibility {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("Visibility").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Web/Http/Diagnostics/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/Http/Diagnostics/mod.rs
@@ -656,6 +656,7 @@ unsafe impl ::core::marker::Send for HttpDiagnosticProviderResponseReceivedEvent
 unsafe impl ::core::marker::Sync for HttpDiagnosticProviderResponseReceivedEventArgs {}
 #[doc = "*Required features: 'Web_Http_Diagnostics'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HttpDiagnosticRequestInitiator(pub i32);
 impl HttpDiagnosticRequestInitiator {
     pub const ParsedElement: Self = Self(0i32);
@@ -681,12 +682,6 @@ impl ::core::clone::Clone for HttpDiagnosticRequestInitiator {
 unsafe impl ::windows::core::Abi for HttpDiagnosticRequestInitiator {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HttpDiagnosticRequestInitiator {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HttpDiagnosticRequestInitiator {}
 impl ::core::fmt::Debug for HttpDiagnosticRequestInitiator {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HttpDiagnosticRequestInitiator").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Web/Http/Filters/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/Http/Filters/mod.rs
@@ -446,6 +446,7 @@ unsafe impl ::core::marker::Send for HttpCacheControl {}
 unsafe impl ::core::marker::Sync for HttpCacheControl {}
 #[doc = "*Required features: 'Web_Http_Filters'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HttpCacheReadBehavior(pub i32);
 impl HttpCacheReadBehavior {
     pub const Default: Self = Self(0i32);
@@ -462,12 +463,6 @@ impl ::core::clone::Clone for HttpCacheReadBehavior {
 unsafe impl ::windows::core::Abi for HttpCacheReadBehavior {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HttpCacheReadBehavior {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HttpCacheReadBehavior {}
 impl ::core::fmt::Debug for HttpCacheReadBehavior {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HttpCacheReadBehavior").field(&self.0).finish()
@@ -481,6 +476,7 @@ impl ::windows::core::DefaultType for HttpCacheReadBehavior {
 }
 #[doc = "*Required features: 'Web_Http_Filters'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HttpCacheWriteBehavior(pub i32);
 impl HttpCacheWriteBehavior {
     pub const Default: Self = Self(0i32);
@@ -495,12 +491,6 @@ impl ::core::clone::Clone for HttpCacheWriteBehavior {
 unsafe impl ::windows::core::Abi for HttpCacheWriteBehavior {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HttpCacheWriteBehavior {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HttpCacheWriteBehavior {}
 impl ::core::fmt::Debug for HttpCacheWriteBehavior {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HttpCacheWriteBehavior").field(&self.0).finish()
@@ -514,6 +504,7 @@ impl ::windows::core::DefaultType for HttpCacheWriteBehavior {
 }
 #[doc = "*Required features: 'Web_Http_Filters'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HttpCookieUsageBehavior(pub i32);
 impl HttpCookieUsageBehavior {
     pub const Default: Self = Self(0i32);
@@ -528,12 +519,6 @@ impl ::core::clone::Clone for HttpCookieUsageBehavior {
 unsafe impl ::windows::core::Abi for HttpCookieUsageBehavior {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HttpCookieUsageBehavior {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HttpCookieUsageBehavior {}
 impl ::core::fmt::Debug for HttpCookieUsageBehavior {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HttpCookieUsageBehavior").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Web/Http/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/Http/mod.rs
@@ -601,6 +601,7 @@ unsafe impl ::core::marker::Send for HttpClient {}
 unsafe impl ::core::marker::Sync for HttpClient {}
 #[doc = "*Required features: 'Web_Http'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HttpCompletionOption(pub i32);
 impl HttpCompletionOption {
     pub const ResponseContentRead: Self = Self(0i32);
@@ -615,12 +616,6 @@ impl ::core::clone::Clone for HttpCompletionOption {
 unsafe impl ::windows::core::Abi for HttpCompletionOption {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HttpCompletionOption {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HttpCompletionOption {}
 impl ::core::fmt::Debug for HttpCompletionOption {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HttpCompletionOption").field(&self.0).finish()
@@ -2772,6 +2767,7 @@ impl ::core::default::Default for HttpProgress {
 }
 #[doc = "*Required features: 'Web_Http'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HttpProgressStage(pub i32);
 impl HttpProgressStage {
     pub const None: Self = Self(0i32);
@@ -2794,12 +2790,6 @@ impl ::core::clone::Clone for HttpProgressStage {
 unsafe impl ::windows::core::Abi for HttpProgressStage {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HttpProgressStage {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HttpProgressStage {}
 impl ::core::fmt::Debug for HttpProgressStage {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HttpProgressStage").field(&self.0).finish()
@@ -3474,6 +3464,7 @@ unsafe impl ::core::marker::Send for HttpResponseMessage {}
 unsafe impl ::core::marker::Sync for HttpResponseMessage {}
 #[doc = "*Required features: 'Web_Http'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HttpResponseMessageSource(pub i32);
 impl HttpResponseMessageSource {
     pub const None: Self = Self(0i32);
@@ -3489,12 +3480,6 @@ impl ::core::clone::Clone for HttpResponseMessageSource {
 unsafe impl ::windows::core::Abi for HttpResponseMessageSource {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HttpResponseMessageSource {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HttpResponseMessageSource {}
 impl ::core::fmt::Debug for HttpResponseMessageSource {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HttpResponseMessageSource").field(&self.0).finish()
@@ -3508,6 +3493,7 @@ impl ::windows::core::DefaultType for HttpResponseMessageSource {
 }
 #[doc = "*Required features: 'Web_Http'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HttpStatusCode(pub i32);
 impl HttpStatusCode {
     pub const None: Self = Self(0i32);
@@ -3578,12 +3564,6 @@ impl ::core::clone::Clone for HttpStatusCode {
 unsafe impl ::windows::core::Abi for HttpStatusCode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HttpStatusCode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HttpStatusCode {}
 impl ::core::fmt::Debug for HttpStatusCode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HttpStatusCode").field(&self.0).finish()
@@ -4230,6 +4210,7 @@ unsafe impl ::core::marker::Send for HttpTransportInformation {}
 unsafe impl ::core::marker::Sync for HttpTransportInformation {}
 #[doc = "*Required features: 'Web_Http'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HttpVersion(pub i32);
 impl HttpVersion {
     pub const None: Self = Self(0i32);
@@ -4246,12 +4227,6 @@ impl ::core::clone::Clone for HttpVersion {
 unsafe impl ::windows::core::Abi for HttpVersion {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HttpVersion {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HttpVersion {}
 impl ::core::fmt::Debug for HttpVersion {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HttpVersion").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Web/Syndication/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/Syndication/mod.rs
@@ -2041,6 +2041,7 @@ impl ::windows::core::RuntimeName for SyndicationError {
 }
 #[doc = "*Required features: 'Web_Syndication'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SyndicationErrorStatus(pub i32);
 impl SyndicationErrorStatus {
     pub const Unknown: Self = Self(0i32);
@@ -2059,12 +2060,6 @@ impl ::core::clone::Clone for SyndicationErrorStatus {
 unsafe impl ::windows::core::Abi for SyndicationErrorStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SyndicationErrorStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SyndicationErrorStatus {}
 impl ::core::fmt::Debug for SyndicationErrorStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SyndicationErrorStatus").field(&self.0).finish()
@@ -2497,6 +2492,7 @@ unsafe impl ::core::marker::Send for SyndicationFeed {}
 unsafe impl ::core::marker::Sync for SyndicationFeed {}
 #[doc = "*Required features: 'Web_Syndication'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SyndicationFormat(pub i32);
 impl SyndicationFormat {
     pub const Atom10: Self = Self(0i32);
@@ -2515,12 +2511,6 @@ impl ::core::clone::Clone for SyndicationFormat {
 unsafe impl ::windows::core::Abi for SyndicationFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SyndicationFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SyndicationFormat {}
 impl ::core::fmt::Debug for SyndicationFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SyndicationFormat").field(&self.0).finish()
@@ -4237,6 +4227,7 @@ unsafe impl ::core::marker::Send for SyndicationText {}
 unsafe impl ::core::marker::Sync for SyndicationText {}
 #[doc = "*Required features: 'Web_Syndication'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SyndicationTextType(pub i32);
 impl SyndicationTextType {
     pub const Text: Self = Self(0i32);
@@ -4252,12 +4243,6 @@ impl ::core::clone::Clone for SyndicationTextType {
 unsafe impl ::windows::core::Abi for SyndicationTextType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SyndicationTextType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SyndicationTextType {}
 impl ::core::fmt::Debug for SyndicationTextType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SyndicationTextType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Web/UI/Interop/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/UI/Interop/mod.rs
@@ -950,6 +950,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &WebV
 }
 #[doc = "*Required features: 'Web_UI_Interop'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WebViewControlAcceleratorKeyRoutingStage(pub i32);
 impl WebViewControlAcceleratorKeyRoutingStage {
     pub const Tunneling: Self = Self(0i32);
@@ -964,12 +965,6 @@ impl ::core::clone::Clone for WebViewControlAcceleratorKeyRoutingStage {
 unsafe impl ::windows::core::Abi for WebViewControlAcceleratorKeyRoutingStage {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WebViewControlAcceleratorKeyRoutingStage {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WebViewControlAcceleratorKeyRoutingStage {}
 impl ::core::fmt::Debug for WebViewControlAcceleratorKeyRoutingStage {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WebViewControlAcceleratorKeyRoutingStage").field(&self.0).finish()
@@ -983,6 +978,7 @@ impl ::windows::core::DefaultType for WebViewControlAcceleratorKeyRoutingStage {
 }
 #[doc = "*Required features: 'Web_UI_Interop'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WebViewControlMoveFocusReason(pub i32);
 impl WebViewControlMoveFocusReason {
     pub const Programmatic: Self = Self(0i32);
@@ -998,12 +994,6 @@ impl ::core::clone::Clone for WebViewControlMoveFocusReason {
 unsafe impl ::windows::core::Abi for WebViewControlMoveFocusReason {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WebViewControlMoveFocusReason {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WebViewControlMoveFocusReason {}
 impl ::core::fmt::Debug for WebViewControlMoveFocusReason {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WebViewControlMoveFocusReason").field(&self.0).finish()
@@ -1248,6 +1238,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &WebV
 }
 #[doc = "*Required features: 'Web_UI_Interop'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WebViewControlProcessCapabilityState(pub i32);
 impl WebViewControlProcessCapabilityState {
     pub const Default: Self = Self(0i32);
@@ -1263,12 +1254,6 @@ impl ::core::clone::Clone for WebViewControlProcessCapabilityState {
 unsafe impl ::windows::core::Abi for WebViewControlProcessCapabilityState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WebViewControlProcessCapabilityState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WebViewControlProcessCapabilityState {}
 impl ::core::fmt::Debug for WebViewControlProcessCapabilityState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WebViewControlProcessCapabilityState").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Web/UI/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/UI/mod.rs
@@ -1878,6 +1878,7 @@ impl<'a> ::windows::core::IntoParam<'a, ::windows::core::IInspectable> for &WebV
 }
 #[doc = "*Required features: 'Web_UI'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WebViewControlPermissionState(pub i32);
 impl WebViewControlPermissionState {
     pub const Unknown: Self = Self(0i32);
@@ -1894,12 +1895,6 @@ impl ::core::clone::Clone for WebViewControlPermissionState {
 unsafe impl ::windows::core::Abi for WebViewControlPermissionState {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WebViewControlPermissionState {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WebViewControlPermissionState {}
 impl ::core::fmt::Debug for WebViewControlPermissionState {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WebViewControlPermissionState").field(&self.0).finish()
@@ -1913,6 +1908,7 @@ impl ::windows::core::DefaultType for WebViewControlPermissionState {
 }
 #[doc = "*Required features: 'Web_UI'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WebViewControlPermissionType(pub i32);
 impl WebViewControlPermissionType {
     pub const Geolocation: Self = Self(0i32);
@@ -1932,12 +1928,6 @@ impl ::core::clone::Clone for WebViewControlPermissionType {
 unsafe impl ::windows::core::Abi for WebViewControlPermissionType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WebViewControlPermissionType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WebViewControlPermissionType {}
 impl ::core::fmt::Debug for WebViewControlPermissionType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WebViewControlPermissionType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Web/mod.rs
+++ b/crates/libs/windows/src/Windows/Web/mod.rs
@@ -135,6 +135,7 @@ impl ::windows::core::RuntimeName for WebError {
 }
 #[doc = "*Required features: 'Web'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct WebErrorStatus(pub i32);
 impl WebErrorStatus {
     pub const Unknown: Self = Self(0i32);
@@ -202,12 +203,6 @@ impl ::core::clone::Clone for WebErrorStatus {
 unsafe impl ::windows::core::Abi for WebErrorStatus {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for WebErrorStatus {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for WebErrorStatus {}
 impl ::core::fmt::Debug for WebErrorStatus {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("WebErrorStatus").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/WinML/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/AI/MachineLearning/WinML/mod.rs
@@ -1438,6 +1438,7 @@ impl ::core::default::Default for MLOperatorAttributeNameValue_0 {
 }
 #[doc = "*Required features: 'Win32_AI_MachineLearning_WinML'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MLOperatorAttributeType(pub u32);
 impl MLOperatorAttributeType {
     pub const Undefined: Self = Self(0u32);
@@ -1457,12 +1458,6 @@ impl ::core::clone::Clone for MLOperatorAttributeType {
 unsafe impl ::windows::core::Abi for MLOperatorAttributeType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MLOperatorAttributeType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MLOperatorAttributeType {}
 impl ::core::fmt::Debug for MLOperatorAttributeType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MLOperatorAttributeType").field(&self.0).finish()
@@ -1550,6 +1545,7 @@ impl ::core::default::Default for MLOperatorEdgeDescription_0 {
 }
 #[doc = "*Required features: 'Win32_AI_MachineLearning_WinML'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MLOperatorEdgeType(pub u32);
 impl MLOperatorEdgeType {
     pub const Undefined: Self = Self(0u32);
@@ -1564,12 +1560,6 @@ impl ::core::clone::Clone for MLOperatorEdgeType {
 unsafe impl ::windows::core::Abi for MLOperatorEdgeType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MLOperatorEdgeType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MLOperatorEdgeType {}
 impl ::core::fmt::Debug for MLOperatorEdgeType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MLOperatorEdgeType").field(&self.0).finish()
@@ -1645,6 +1635,7 @@ impl ::core::default::Default for MLOperatorEdgeTypeConstraint {
 }
 #[doc = "*Required features: 'Win32_AI_MachineLearning_WinML'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MLOperatorExecutionType(pub u32);
 impl MLOperatorExecutionType {
     pub const Undefined: Self = Self(0u32);
@@ -1660,12 +1651,6 @@ impl ::core::clone::Clone for MLOperatorExecutionType {
 unsafe impl ::windows::core::Abi for MLOperatorExecutionType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MLOperatorExecutionType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MLOperatorExecutionType {}
 impl ::core::fmt::Debug for MLOperatorExecutionType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MLOperatorExecutionType").field(&self.0).finish()
@@ -1759,6 +1744,7 @@ impl ::core::default::Default for MLOperatorKernelDescription {
 }
 #[doc = "*Required features: 'Win32_AI_MachineLearning_WinML'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MLOperatorKernelOptions(pub u32);
 impl MLOperatorKernelOptions {
     pub const None: Self = Self(0u32);
@@ -1773,12 +1759,6 @@ impl ::core::clone::Clone for MLOperatorKernelOptions {
 unsafe impl ::windows::core::Abi for MLOperatorKernelOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MLOperatorKernelOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MLOperatorKernelOptions {}
 impl ::core::fmt::Debug for MLOperatorKernelOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MLOperatorKernelOptions").field(&self.0).finish()
@@ -1814,6 +1794,7 @@ impl ::core::ops::Not for MLOperatorKernelOptions {
 }
 #[doc = "*Required features: 'Win32_AI_MachineLearning_WinML'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MLOperatorParameterOptions(pub u32);
 impl MLOperatorParameterOptions {
     pub const Single: Self = Self(0u32);
@@ -1829,12 +1810,6 @@ impl ::core::clone::Clone for MLOperatorParameterOptions {
 unsafe impl ::windows::core::Abi for MLOperatorParameterOptions {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MLOperatorParameterOptions {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MLOperatorParameterOptions {}
 impl ::core::fmt::Debug for MLOperatorParameterOptions {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MLOperatorParameterOptions").field(&self.0).finish()
@@ -2000,6 +1975,7 @@ impl ::core::default::Default for MLOperatorSchemaEdgeDescription_0 {
 }
 #[doc = "*Required features: 'Win32_AI_MachineLearning_WinML'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MLOperatorSchemaEdgeTypeFormat(pub i32);
 impl MLOperatorSchemaEdgeTypeFormat {
     pub const EdgeDescription: Self = Self(0i32);
@@ -2014,12 +1990,6 @@ impl ::core::clone::Clone for MLOperatorSchemaEdgeTypeFormat {
 unsafe impl ::windows::core::Abi for MLOperatorSchemaEdgeTypeFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MLOperatorSchemaEdgeTypeFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MLOperatorSchemaEdgeTypeFormat {}
 impl ::core::fmt::Debug for MLOperatorSchemaEdgeTypeFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MLOperatorSchemaEdgeTypeFormat").field(&self.0).finish()
@@ -2066,6 +2036,7 @@ impl ::core::default::Default for MLOperatorSetId {
 }
 #[doc = "*Required features: 'Win32_AI_MachineLearning_WinML'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MLOperatorTensorDataType(pub u32);
 impl MLOperatorTensorDataType {
     pub const Undefined: Self = Self(0u32);
@@ -2094,12 +2065,6 @@ impl ::core::clone::Clone for MLOperatorTensorDataType {
 unsafe impl ::windows::core::Abi for MLOperatorTensorDataType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MLOperatorTensorDataType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MLOperatorTensorDataType {}
 impl ::core::fmt::Debug for MLOperatorTensorDataType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MLOperatorTensorDataType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Win32/Media/Audio/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Audio/mod.rs
@@ -1805,6 +1805,7 @@ pub unsafe fn CoRegisterMessageFilter<'a, Param0: ::windows::core::IntoParam<'a,
 }
 #[doc = "*Required features: 'Win32_Media_Audio'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct ConnectorType(pub i32);
 impl ConnectorType {
     pub const Unknown_Connector: Self = Self(0i32);
@@ -1823,12 +1824,6 @@ impl ::core::clone::Clone for ConnectorType {
 unsafe impl ::windows::core::Abi for ConnectorType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for ConnectorType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for ConnectorType {}
 impl ::core::fmt::Debug for ConnectorType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("ConnectorType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/mod.rs
@@ -12695,6 +12695,7 @@ impl ::core::default::Default for SECURITY_LOGON_SESSION_DATA {
 }
 #[doc = "*Required features: 'Win32_Security_Authentication_Identity'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct SECURITY_LOGON_TYPE(pub i32);
 impl SECURITY_LOGON_TYPE {
     pub const UndefinedLogonType: Self = Self(0i32);
@@ -12720,12 +12721,6 @@ impl ::core::clone::Clone for SECURITY_LOGON_TYPE {
 unsafe impl ::windows::core::Abi for SECURITY_LOGON_TYPE {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for SECURITY_LOGON_TYPE {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for SECURITY_LOGON_TYPE {}
 impl ::core::fmt::Debug for SECURITY_LOGON_TYPE {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("SECURITY_LOGON_TYPE").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/mod.rs
@@ -21964,6 +21964,7 @@ impl ::core::default::Default for HTTPSPolicyCallbackData_0 {
 }
 #[doc = "*Required features: 'Win32_Security_Cryptography'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct HandleType(pub i32);
 impl HandleType {
     pub const Asymmetric: Self = Self(1i32);
@@ -21980,12 +21981,6 @@ impl ::core::clone::Clone for HandleType {
 unsafe impl ::windows::core::Abi for HandleType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for HandleType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for HandleType {}
 impl ::core::fmt::Debug for HandleType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("HandleType").field(&self.0).finish()
@@ -26423,6 +26418,7 @@ impl ::core::default::Default for PUBLICKEYSTRUC {
 }
 #[doc = "*Required features: 'Win32_Security_Cryptography'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PaddingMode(pub i32);
 impl PaddingMode {
     pub const None: Self = Self(1i32);
@@ -26440,12 +26436,6 @@ impl ::core::clone::Clone for PaddingMode {
 unsafe impl ::windows::core::Abi for PaddingMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PaddingMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PaddingMode {}
 impl ::core::fmt::Debug for PaddingMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PaddingMode").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Win32/System/WindowsProgramming/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WindowsProgramming/mod.rs
@@ -647,6 +647,7 @@ impl ::core::default::Default for CUSTOM_SYSTEM_EVENT_TRIGGER_CONFIG {
 pub const CameraUIControl: ::windows::core::GUID = ::windows::core::GUID::from_u128(0x16d5a2be_b1c5_47b3_8eae_ccbcf452c7e8);
 #[doc = "*Required features: 'Win32_System_WindowsProgramming'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CameraUIControlCaptureMode(pub i32);
 impl CameraUIControlCaptureMode {
     pub const PhotoOrVideo: Self = Self(0i32);
@@ -662,12 +663,6 @@ impl ::core::clone::Clone for CameraUIControlCaptureMode {
 unsafe impl ::windows::core::Abi for CameraUIControlCaptureMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CameraUIControlCaptureMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CameraUIControlCaptureMode {}
 impl ::core::fmt::Debug for CameraUIControlCaptureMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CameraUIControlCaptureMode").field(&self.0).finish()
@@ -675,6 +670,7 @@ impl ::core::fmt::Debug for CameraUIControlCaptureMode {
 }
 #[doc = "*Required features: 'Win32_System_WindowsProgramming'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CameraUIControlLinearSelectionMode(pub i32);
 impl CameraUIControlLinearSelectionMode {
     pub const Single: Self = Self(0i32);
@@ -689,12 +685,6 @@ impl ::core::clone::Clone for CameraUIControlLinearSelectionMode {
 unsafe impl ::windows::core::Abi for CameraUIControlLinearSelectionMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CameraUIControlLinearSelectionMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CameraUIControlLinearSelectionMode {}
 impl ::core::fmt::Debug for CameraUIControlLinearSelectionMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CameraUIControlLinearSelectionMode").field(&self.0).finish()
@@ -702,6 +692,7 @@ impl ::core::fmt::Debug for CameraUIControlLinearSelectionMode {
 }
 #[doc = "*Required features: 'Win32_System_WindowsProgramming'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CameraUIControlMode(pub i32);
 impl CameraUIControlMode {
     pub const Browse: Self = Self(0i32);
@@ -716,12 +707,6 @@ impl ::core::clone::Clone for CameraUIControlMode {
 unsafe impl ::windows::core::Abi for CameraUIControlMode {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CameraUIControlMode {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CameraUIControlMode {}
 impl ::core::fmt::Debug for CameraUIControlMode {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CameraUIControlMode").field(&self.0).finish()
@@ -729,6 +714,7 @@ impl ::core::fmt::Debug for CameraUIControlMode {
 }
 #[doc = "*Required features: 'Win32_System_WindowsProgramming'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CameraUIControlPhotoFormat(pub i32);
 impl CameraUIControlPhotoFormat {
     pub const Jpeg: Self = Self(0i32);
@@ -744,12 +730,6 @@ impl ::core::clone::Clone for CameraUIControlPhotoFormat {
 unsafe impl ::windows::core::Abi for CameraUIControlPhotoFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CameraUIControlPhotoFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CameraUIControlPhotoFormat {}
 impl ::core::fmt::Debug for CameraUIControlPhotoFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CameraUIControlPhotoFormat").field(&self.0).finish()
@@ -757,6 +737,7 @@ impl ::core::fmt::Debug for CameraUIControlPhotoFormat {
 }
 #[doc = "*Required features: 'Win32_System_WindowsProgramming'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CameraUIControlVideoFormat(pub i32);
 impl CameraUIControlVideoFormat {
     pub const Mp4: Self = Self(0i32);
@@ -771,12 +752,6 @@ impl ::core::clone::Clone for CameraUIControlVideoFormat {
 unsafe impl ::windows::core::Abi for CameraUIControlVideoFormat {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CameraUIControlVideoFormat {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CameraUIControlVideoFormat {}
 impl ::core::fmt::Debug for CameraUIControlVideoFormat {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CameraUIControlVideoFormat").field(&self.0).finish()
@@ -784,6 +759,7 @@ impl ::core::fmt::Debug for CameraUIControlVideoFormat {
 }
 #[doc = "*Required features: 'Win32_System_WindowsProgramming'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct CameraUIControlViewType(pub i32);
 impl CameraUIControlViewType {
     pub const SingleItem: Self = Self(0i32);
@@ -798,12 +774,6 @@ impl ::core::clone::Clone for CameraUIControlViewType {
 unsafe impl ::windows::core::Abi for CameraUIControlViewType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for CameraUIControlViewType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for CameraUIControlViewType {}
 impl ::core::fmt::Debug for CameraUIControlViewType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("CameraUIControlViewType").field(&self.0).finish()

--- a/crates/libs/windows/src/Windows/Win32/UI/Xaml/Diagnostics/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Xaml/Diagnostics/mod.rs
@@ -1011,6 +1011,7 @@ pub unsafe fn InitializeXamlDiagnosticsEx<'a, Param0: ::windows::core::IntoParam
 }
 #[doc = "*Required features: 'Win32_UI_Xaml_Diagnostics'*"]
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct MetadataBit(pub i32);
 impl MetadataBit {
     pub const None: Self = Self(0i32);
@@ -1031,12 +1032,6 @@ impl ::core::clone::Clone for MetadataBit {
 unsafe impl ::windows::core::Abi for MetadataBit {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for MetadataBit {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for MetadataBit {}
 impl ::core::fmt::Debug for MetadataBit {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("MetadataBit").field(&self.0).finish()

--- a/crates/libs/windows/src/core/bindings.rs
+++ b/crates/libs/windows/src/core/bindings.rs
@@ -656,6 +656,7 @@ impl ::core::default::Default for Point {
     }
 }
 #[repr(transparent)]
+#[derive(:: core :: cmp :: PartialEq, :: core :: cmp :: Eq)]
 pub struct PropertyType(pub i32);
 impl PropertyType {
     pub const Empty: Self = Self(0i32);
@@ -709,12 +710,6 @@ impl ::core::clone::Clone for PropertyType {
 unsafe impl ::windows::core::Abi for PropertyType {
     type Abi = Self;
 }
-impl ::core::cmp::PartialEq for PropertyType {
-    fn eq(&self, other: &Self) -> bool {
-        self.0 == other.0
-    }
-}
-impl ::core::cmp::Eq for PropertyType {}
 impl ::core::fmt::Debug for PropertyType {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
         f.debug_tuple("PropertyType").field(&self.0).finish()

--- a/crates/tests/enums/tests/tests.rs
+++ b/crates/tests/enums/tests/tests.rs
@@ -18,3 +18,11 @@ fn nested() {
     options &= InputStreamOptions::ReadAhead;
     assert!(options.0 == 2);
 }
+
+#[test]
+fn const_pattern() {
+    match InputStreamOptions::ReadAhead {
+        InputStreamOptions::ReadAhead => assert!(true),
+        _ => assert!(false),
+    }
+}

--- a/crates/tests/handles/Cargo.toml
+++ b/crates/tests/handles/Cargo.toml
@@ -9,6 +9,7 @@ path = "../../libs/windows"
 features = [
     "Win32_Foundation",
     "Win32_Graphics_Gdi",
+    "Win32_System_Registry",
 ]
 
 [dependencies.windows-sys]

--- a/crates/tests/handles/tests/win.rs
+++ b/crates/tests/handles/tests/win.rs
@@ -1,4 +1,4 @@
-use windows::{Win32::Foundation::*, Win32::Graphics::Gdi::*};
+use windows::{Win32::Foundation::*, Win32::Graphics::Gdi::*, Win32::System::Registry::*};
 
 #[test]
 fn boolean() {
@@ -28,5 +28,13 @@ fn hfont() {
 
         assert!(!DeleteObject(font).as_bool());
         assert!(!DeleteObject(object).as_bool());
+    }
+}
+
+#[test]
+fn const_pattern() {
+    match HKEY_CLASSES_ROOT {
+        HKEY_CLASSES_ROOT => assert!(true),
+        _ => assert!(false),
     }
 }


### PR DESCRIPTION
Fixes #1437
