### PR TITLE
Simpler error interop

### DIFF
--- a/crates/libs/bindgen/src/extensions/win32_error.rs
+++ b/crates/libs/bindgen/src/extensions/win32_error.rs
@@ -4,7 +4,7 @@ pub fn gen() -> TokenStream {
     quote! {
         impl ::core::convert::From<WIN32_ERROR> for ::windows::core::HRESULT {
             fn from(value: WIN32_ERROR) -> Self {
-                Self::from_win32(value.0)
+                Self(if value.0 as i32 <= 0 { value.0 } else { (value.0 & 0x0000_FFFF) | (7 << 16) | 0x8000_0000 } as _)
             }
         }
     }

--- a/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
@@ -20844,7 +20844,7 @@ impl ::core::fmt::Debug for WIN32_ERROR {
 }
 impl ::core::convert::From<WIN32_ERROR> for ::windows::core::HRESULT {
     fn from(value: WIN32_ERROR) -> Self {
-        Self::from_win32(value.0)
+        Self(if value.0 as i32 <= 0 { value.0 } else { (value.0 & 0x0000_FFFF) | (7 << 16) | 0x8000_0000 } as _)
     }
 }
 #[doc = "*Required features: 'Win32_Foundation'*"]

--- a/crates/libs/windows/src/core/bindings.rs
+++ b/crates/libs/windows/src/core/bindings.rs
@@ -1588,7 +1588,7 @@ impl ::core::fmt::Debug for WIN32_ERROR {
 }
 impl ::core::convert::From<WIN32_ERROR> for ::windows::core::HRESULT {
     fn from(value: WIN32_ERROR) -> Self {
-        Self::from_win32(value.0)
+        Self(if value.0 as i32 <= 0 { value.0 } else { (value.0 & 0x0000_FFFF) | (7 << 16) | 0x8000_0000 } as _)
     }
 }
 #[repr(C)]

--- a/crates/libs/windows/src/core/error.rs
+++ b/crates/libs/windows/src/core/error.rs
@@ -130,11 +130,7 @@ impl core::convert::From<HRESULT> for Error {
 impl core::fmt::Debug for Error {
     fn fmt(&self, fmt: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         let mut debug = fmt.debug_struct("Error");
-        debug.field("code", &format_args!("{:#010X}", self.code.0)).field("message", &self.message());
-        if let Some(win32) = self.win32_error() {
-            debug.field("win32_error", &format_args!("{}", win32.0));
-        }
-        debug.finish()
+        debug.field("code", &format_args!("{:#010X}", self.code.0)).field("message", &self.message()).finish()
     }
 }
 

--- a/crates/libs/windows/src/core/error.rs
+++ b/crates/libs/windows/src/core/error.rs
@@ -71,10 +71,11 @@ impl Error {
     }
 
     /// Returns the win32 error code if the underlying HRESULT's facility is win32
-    pub fn win32_error(&self) -> Option<u32> {
+    #[cfg(feature = "Win32_Foundation")]
+    pub fn win32_error(&self) -> Option<crate::Win32::Foundation::WIN32_ERROR> {
         let hresult = self.code.0 as u32;
         if ((hresult >> 16) & 0x7FF) == 7 {
-            Some(hresult & 0xFFFF)
+            Some(crate::Win32::Foundation::WIN32_ERROR(hresult & 0xFFFF))
         } else {
             None
         }
@@ -131,7 +132,7 @@ impl core::fmt::Debug for Error {
         let mut debug = fmt.debug_struct("Error");
         debug.field("code", &format_args!("{:#010X}", self.code.0)).field("message", &self.message());
         if let Some(win32) = self.win32_error() {
-            debug.field("win32_error", &format_args!("{}", win32));
+            debug.field("win32_error", &format_args!("{}", win32.0));
         }
         debug.finish()
     }

--- a/crates/libs/windows/src/core/hresult.rs
+++ b/crates/libs/windows/src/core/hresult.rs
@@ -9,10 +9,6 @@ use bindings::*;
 pub struct HRESULT(pub i32);
 
 impl HRESULT {
-    pub fn from_win32(value: u32) -> HRESULT {
-        Self(if value as i32 <= 0 { value } else { (value & 0x0000_FFFF) | (7 << 16) | 0x8000_0000 } as _)
-    }
-
     /// Returns [`true`] if `self` is a success code.
     #[inline]
     pub const fn is_ok(self) -> bool {

--- a/crates/tests/enums/tests/win.rs
+++ b/crates/tests/enums/tests/win.rs
@@ -36,7 +36,7 @@ fn win32_error() {
     assert!("WIN32_ERROR(5)" == format!("{:?}", e));
 
     let e: Error = h.into();
-    assert_eq!("Error { code: 0x80070005, message: Access is denied.\r\n, win32_error: 5 }", format!("{:?}", e));
+    assert_eq!("Error { code: 0x80070005, message: Access is denied.\r\n }", format!("{:?}", e));
     let e: WIN32_ERROR = e.win32_error().unwrap();
     assert!(e == ERROR_ACCESS_DENIED);
 }

--- a/crates/tests/enums/tests/win.rs
+++ b/crates/tests/enums/tests/win.rs
@@ -34,6 +34,11 @@ fn win32_error() {
     let h: HRESULT = ERROR_ACCESS_DENIED.into();
     assert!(h.is_err());
     assert!("WIN32_ERROR(5)" == format!("{:?}", e));
+
+    let e: Error = h.into();
+    assert_eq!("Error { code: 0x80070005, message: Access is denied.\r\n, win32_error: 5 }", format!("{:?}", e));
+    let e: WIN32_ERROR = e.win32_error().unwrap();
+    assert!(e == ERROR_ACCESS_DENIED);
 }
 
 #[test]

--- a/crates/tests/handles/tests/legacy.rs
+++ b/crates/tests/handles/tests/legacy.rs
@@ -1,4 +1,3 @@
-use windows::core::HRESULT;
 use windows::Win32::Foundation::*;
 use windows::Win32::System::Registry::*;
 
@@ -15,11 +14,9 @@ fn handle() {
     assert!(HANDLE(1).ok().unwrap() == HANDLE(1));
 
     unsafe { SetLastError(ERROR_INVALID_WINDOW_HANDLE) };
-    assert!(HANDLE(0).ok().err().unwrap().code() == HRESULT::from_win32(ERROR_INVALID_WINDOW_HANDLE.0));
     assert!(HANDLE(0).ok().err().unwrap().code() == ERROR_INVALID_WINDOW_HANDLE.into());
 
     unsafe { SetLastError(ERROR_FILE_NOT_FOUND) };
-    assert!(HANDLE(-1).ok().err().unwrap().code() == HRESULT::from_win32(ERROR_FILE_NOT_FOUND.0));
     assert!(HANDLE(-1).ok().err().unwrap().code() == ERROR_FILE_NOT_FOUND.into());
 
     assert!(core::mem::size_of::<HANDLE>() == core::mem::size_of::<usize>());


### PR DESCRIPTION
Now that we have pre-generated bindings, the `Error` type can refer to the `WIN32_ERROR` type using a feature.

Fixes #1370