### PR TITLE
Improve core/xaml app sample ergonomics

### DIFF
--- a/crates/samples/core_app/Cargo.toml
+++ b/crates/samples/core_app/Cargo.toml
@@ -6,8 +6,12 @@ edition = "2018"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
+    "alloc",
     "implement",
     "ApplicationModel_Core",
     "UI_Core",
+    "Win32_Foundation",
+    "Win32_Storage_Packaging_Appx",
     "Win32_System_Com",
+    "Win32_UI_WindowsAndMessaging"
 ]

--- a/crates/samples/core_app/appx/AppxManifest.xml
+++ b/crates/samples/core_app/appx/AppxManifest.xml
@@ -19,7 +19,7 @@
     <Resource Language="en-us" />
   </Resources>
   <Applications>
-    <Application Id="App" Executable="sample.exe" EntryPoint="CoreApp.App">
+    <Application Id="App" Executable="core_app.exe" EntryPoint="CoreApp.App">
       <uap:VisualElements DisplayName="Rust CoreApp" Description="Description"
         Square150x150Logo="Square150x150Logo.png" Square44x44Logo="Square44x44Logo.png" BackgroundColor="transparent">
         <uap:SplashScreen Image="SplashScreen.png" />

--- a/crates/samples/core_app/register.cmd
+++ b/crates/samples/core_app/register.cmd
@@ -1,5 +1,6 @@
 cargo build
-copy appx\* target\debug
-cd target\debug
+copy appx\* ..\..\..\target\debug
+cd ..\..\..\target\debug
+powershell -command "Get-AppxPackage *0f8c5510-182f-4208-a48e-4215050a0453* | Remove-AppxPackage"
 powershell -command "Add-AppxPackage -Register AppxManifest.xml"
-cd ..\..\
+cd ..\..\crates\samples\core_app

--- a/crates/samples/core_app/src/main.rs
+++ b/crates/samples/core_app/src/main.rs
@@ -1,6 +1,14 @@
 #![windows_subsystem = "windows"]
 
-use windows::{core::*, ApplicationModel::Core::*, Win32::System::Com::*, UI::Core::*};
+use windows::{
+    core::*,
+    ApplicationModel::{Core::*, Package},
+    Win32::{
+        System::Com::*,
+        UI::WindowsAndMessaging::{MessageBoxW, MB_ICONSTOP, MB_OK}, Foundation::HWND,
+    },
+    UI::Core::*,
+};
 
 #[implement(IFrameworkViewSource)]
 struct CoreApp();
@@ -48,6 +56,11 @@ impl IFrameworkView_Impl for CoreAppView {
 fn main() -> Result<()> {
     unsafe {
         CoInitializeEx(std::ptr::null_mut(), COINIT_MULTITHREADED)?;
+
+        if let Err(result) = Package::Current() {
+            MessageBoxW(HWND::default(), "This sample must be registered (via register.cmd) and launched from Start.", "Error", MB_ICONSTOP | MB_OK);
+            return Err(result);
+        }
     }
 
     let app: IFrameworkViewSource = CoreApp().into();

--- a/crates/samples/core_app/src/main.rs
+++ b/crates/samples/core_app/src/main.rs
@@ -4,8 +4,9 @@ use windows::{
     core::*,
     ApplicationModel::{Core::*, Package},
     Win32::{
+        Foundation::HWND,
         System::Com::*,
-        UI::WindowsAndMessaging::{MessageBoxW, MB_ICONSTOP, MB_OK}, Foundation::HWND,
+        UI::WindowsAndMessaging::{MessageBoxW, MB_ICONSTOP, MB_OK},
     },
     UI::Core::*,
 };

--- a/crates/samples/xaml_app/Cargo.toml
+++ b/crates/samples/xaml_app/Cargo.toml
@@ -6,9 +6,13 @@ edition = "2018"
 [dependencies.windows]
 path = "../../libs/windows"
 features = [
+    "alloc",
     "implement",
     "ApplicationModel_Activation",
-    "Win32_System_Com",
     "UI_Xaml_Controls",
     "UI_Xaml",
+    "Win32_Foundation",
+    "Win32_Storage_Packaging_Appx",
+    "Win32_System_Com",
+    "Win32_UI_WindowsAndMessaging",
 ]

--- a/crates/samples/xaml_app/register.cmd
+++ b/crates/samples/xaml_app/register.cmd
@@ -1,6 +1,6 @@
 cargo build
 copy appx\* ..\..\..\target\debug
 cd ..\..\..\target\debug
-powershell -command "Get-AppxPackage *942b16b2* | Remove-AppxPackage"
+powershell -command "Get-AppxPackage *942b16b2-c2af-4092-ba34-e4f0c2df308b* | Remove-AppxPackage"
 powershell -command "Add-AppxPackage -Register AppxManifest.xml"
 cd ..\..\crates\samples\xaml_app

--- a/crates/samples/xaml_app/src/main.rs
+++ b/crates/samples/xaml_app/src/main.rs
@@ -1,7 +1,17 @@
 #![windows_subsystem = "windows"]
 #![allow(non_snake_case)]
 
-use windows::{core::*, ApplicationModel::Activation::*, Win32::System::Com::*, UI::Xaml::Controls::*, UI::Xaml::*};
+use windows::{
+    core::*,
+    ApplicationModel::{Activation::LaunchActivatedEventArgs, Package},
+    Win32::System::Com::*,
+    Win32::{
+        Foundation::HWND,
+        UI::WindowsAndMessaging::{MessageBoxW, MB_ICONSTOP, MB_OK},
+    },
+    UI::Xaml::Controls::*,
+    UI::Xaml::*,
+};
 
 #[implement(IApplicationOverrides)]
 struct MyApp();
@@ -17,7 +27,13 @@ impl IApplicationOverrides_Impl for MyApp {
 fn main() -> Result<()> {
     unsafe {
         CoInitializeEx(std::ptr::null_mut(), COINIT_MULTITHREADED)?;
+
+        if let Err(result) = Package::Current() {
+            MessageBoxW(HWND::default(), "This sample must be registered (via register.cmd) and launched from Start.", "Error", MB_ICONSTOP | MB_OK);
+            return Err(result);
+        }
     }
+
     Application::Start(ApplicationInitializationCallback::new(|_| {
         Application::compose(MyApp())?;
         Ok(())


### PR DESCRIPTION
Adds an identity check to core/xaml app samples to head off a common pitfall. Also fixes up core_app sample to behave similarly to its peer.