### PR TITLE
Re-enable clippy during build validation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,3 +57,16 @@ jobs:
       run: rustup update --no-self-update ${{ matrix.rust }} && rustup default ${{ matrix.rust }}
     - name: Run cargo check
       run: cargo check -p windows-sys --all-features
+
+  cargo_clippy:
+    name: Check cargo clippy
+    runs-on: windows-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v2
+    - name: Switch to nightly
+      run: rustup update --no-self-update nightly && rustup default nightly
+    - name: Install clippy
+      run: rustup component add clippy
+    - name: Run clippy
+      run: cargo clippy --all -- -D warnings


### PR DESCRIPTION
This is tricky because `clippy` will only work with `nightly` due to the use of non-stable features by the `implement` feature. 