### PR TITLE
0.31.0

### DIFF
--- a/.github/readme.md
+++ b/.github/readme.md
@@ -15,7 +15,7 @@ Start by adding the following to your Cargo.toml file:
 
 ```toml
 [dependencies.windows]
-version = "0.30.0"
+version = "0.31.0"
 features = [
     "alloc",
     "Data_Xml_Dom",
@@ -63,7 +63,7 @@ Start by adding the following to your Cargo.toml file:
 
 ```toml
 [dependencies.windows-sys]
-version = "0.30.0"
+version = "0.31.0"
 features = [
     "Win32_Foundation",
     "Win32_Security",

--- a/crates/libs/bindgen/Cargo.toml
+++ b/crates/libs/bindgen/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-bindgen"
-version = "0.30.0"
+version = "0.31.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -8,5 +8,5 @@ description = "Code gen support for the windows crate"
 repository = "https://github.com/microsoft/windows-rs"
 
 [dependencies]
-tokens = { package = "windows-tokens", path = "../tokens", version = "0.30.0" }
-metadata = { package = "windows-metadata", path = "../metadata", version = "0.30.0" }
+tokens = { package = "windows-tokens", path = "../tokens", version = "0.31.0" }
+metadata = { package = "windows-metadata", path = "../metadata", version = "0.31.0" }

--- a/crates/libs/implement/Cargo.toml
+++ b/crates/libs/implement/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-implement"
-version = "0.30.0"
+version = "0.31.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -12,4 +12,4 @@ proc-macro = true
 
 [dependencies]
 syn = { version = "1.0", default-features = false, features = ["parsing", "proc-macro", "printing", "full", "derive"] }
-tokens = { package = "windows-tokens", path = "../tokens", version = "0.30.0" }
+tokens = { package = "windows-tokens", path = "../tokens", version = "0.31.0" }

--- a/crates/libs/metadata/Cargo.toml
+++ b/crates/libs/metadata/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-metadata"
-version = "0.30.0"
+version = "0.31.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/libs/sys/Cargo.toml
+++ b/crates/libs/sys/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "windows-sys"
-version = "0.30.0"
+version = "0.31.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -14,34 +14,34 @@ default-target = "x86_64-pc-windows-msvc"
 all-features = true
 
 [target.i686-pc-windows-msvc.dependencies]
-windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.30.0" }
+windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.31.0" }
 
 [target.i686-uwp-windows-msvc.dependencies]
-windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.30.0" }
+windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.31.0" }
 
 [target.x86_64-pc-windows-msvc.dependencies]
-windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.30.0" }
+windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.31.0" }
 
 [target.x86_64-uwp-windows-msvc.dependencies]
-windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.30.0" }
+windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.31.0" }
 
 [target.aarch64-pc-windows-msvc.dependencies]
-windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.30.0" }
+windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.31.0" }
 
 [target.aarch64-uwp-windows-msvc.dependencies]
-windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.30.0" }
+windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.31.0" }
 
 [target.i686-pc-windows-gnu.dependencies]
-windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.30.0" }
+windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.31.0" }
 
 [target.i686-uwp-windows-gnu.dependencies]
-windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.30.0" }
+windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.31.0" }
 
 [target.x86_64-pc-windows-gnu.dependencies]
-windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.30.0" }
+windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.31.0" }
 
 [target.x86_64-uwp-windows-gnu.dependencies]
-windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.30.0" }
+windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.31.0" }
 
 [features]
 default = []

--- a/crates/libs/tokens/Cargo.toml
+++ b/crates/libs/tokens/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows-tokens"
-version = "0.30.0"
+version = "0.31.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/libs/windows/Cargo.toml
+++ b/crates/libs/windows/Cargo.toml
@@ -1,7 +1,7 @@
 
 [package]
 name = "windows"
-version = "0.30.0"
+version = "0.31.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -15,37 +15,37 @@ default-target = "x86_64-pc-windows-msvc"
 targets = []
 
 [target.i686-pc-windows-msvc.dependencies]
-windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.30.0" }
+windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.31.0" }
 
 [target.i686-uwp-windows-msvc.dependencies]
-windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.30.0" }
+windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.31.0" }
 
 [target.x86_64-pc-windows-msvc.dependencies]
-windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.30.0" }
+windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.31.0" }
 
 [target.x86_64-uwp-windows-msvc.dependencies]
-windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.30.0" }
+windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.31.0" }
 
 [target.aarch64-pc-windows-msvc.dependencies]
-windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.30.0" }
+windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.31.0" }
 
 [target.aarch64-uwp-windows-msvc.dependencies]
-windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.30.0" }
+windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.31.0" }
 
 [target.i686-pc-windows-gnu.dependencies]
-windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.30.0" }
+windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.31.0" }
 
 [target.i686-uwp-windows-gnu.dependencies]
-windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.30.0" }
+windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.31.0" }
 
 [target.x86_64-pc-windows-gnu.dependencies]
-windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.30.0" }
+windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.31.0" }
 
 [target.x86_64-uwp-windows-gnu.dependencies]
-windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.30.0" }
+windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.31.0" }
 
 [dependencies]
-windows-implement = { path = "../implement",  version = "0.30.0", optional = true }
+windows-implement = { path = "../implement",  version = "0.31.0", optional = true }
 
 [features]
 default = []

--- a/crates/targets/aarch64_msvc/Cargo.toml
+++ b/crates/targets/aarch64_msvc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_aarch64_msvc"
-version = "0.30.0"
+version = "0.31.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/i686_gnu/Cargo.toml
+++ b/crates/targets/i686_gnu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_i686_gnu"
-version = "0.30.0"
+version = "0.31.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/i686_msvc/Cargo.toml
+++ b/crates/targets/i686_msvc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_i686_msvc"
-version = "0.30.0"
+version = "0.31.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/x86_64_gnu/Cargo.toml
+++ b/crates/targets/x86_64_gnu/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_x86_64_gnu"
-version = "0.30.0"
+version = "0.31.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/targets/x86_64_msvc/Cargo.toml
+++ b/crates/targets/x86_64_msvc/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "windows_x86_64_msvc"
-version = "0.30.0"
+version = "0.31.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"

--- a/crates/tools/bindings/Cargo.toml
+++ b/crates/tools/bindings/Cargo.toml
@@ -5,5 +5,5 @@ edition = "2018"
 publish = false
 
 [dependencies]
-metadata = { package = "windows-metadata", path = "../../libs/metadata", version = "0.30.0" }
-bindgen = { package = "windows-bindgen", path = "../../libs/bindgen", version = "0.30.0" }
+metadata = { package = "windows-metadata", path = "../../libs/metadata", version = "0.31.0" }
+bindgen = { package = "windows-bindgen", path = "../../libs/bindgen", version = "0.31.0" }

--- a/crates/tools/gnu/Cargo.toml
+++ b/crates/tools/gnu/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2018"
 publish = false
 
 [dependencies]
-metadata = { package = "windows-metadata", path = "../../libs/metadata", version = "0.30.0" }
+metadata = { package = "windows-metadata", path = "../../libs/metadata", version = "0.31.0" }

--- a/crates/tools/msvc/Cargo.toml
+++ b/crates/tools/msvc/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2018"
 publish = false
 
 [dependencies]
-metadata = { package = "windows-metadata", path = "../../libs/metadata", version = "0.30.0" }
+metadata = { package = "windows-metadata", path = "../../libs/metadata", version = "0.31.0" }

--- a/crates/tools/sys/Cargo.toml
+++ b/crates/tools/sys/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2018"
 publish = false
 
 [dependencies]
-metadata = { package = "windows-metadata", path = "../../libs/metadata", version = "0.30.0" }
-bindgen = { package = "windows-bindgen", path = "../../libs/bindgen", version = "0.30.0" }
+metadata = { package = "windows-metadata", path = "../../libs/metadata", version = "0.31.0" }
+bindgen = { package = "windows-bindgen", path = "../../libs/bindgen", version = "0.31.0" }
 rayon = "1.5.1"

--- a/crates/tools/sys/src/main.rs
+++ b/crates/tools/sys/src/main.rs
@@ -25,7 +25,7 @@ fn main() {
         r#"
 [package]
 name = "windows-sys"
-version = "0.30.0"
+version = "0.31.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -38,34 +38,34 @@ default-target = "x86_64-pc-windows-msvc"
 all-features = true
 
 [target.i686-pc-windows-msvc.dependencies]
-windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.30.0" }
+windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.31.0" }
 
 [target.i686-uwp-windows-msvc.dependencies]
-windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.30.0" }
+windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.31.0" }
 
 [target.x86_64-pc-windows-msvc.dependencies]
-windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.30.0" }
+windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.31.0" }
 
 [target.x86_64-uwp-windows-msvc.dependencies]
-windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.30.0" }
+windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.31.0" }
 
 [target.aarch64-pc-windows-msvc.dependencies]
-windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.30.0" }
+windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.31.0" }
 
 [target.aarch64-uwp-windows-msvc.dependencies]
-windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.30.0" }
+windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.31.0" }
 
 [target.i686-pc-windows-gnu.dependencies]
-windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.30.0" }
+windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.31.0" }
 
 [target.i686-uwp-windows-gnu.dependencies]
-windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.30.0" }
+windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.31.0" }
 
 [target.x86_64-pc-windows-gnu.dependencies]
-windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.30.0" }
+windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.31.0" }
 
 [target.x86_64-uwp-windows-gnu.dependencies]
-windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.30.0" }
+windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.31.0" }
 
 [features]
 default = []

--- a/crates/tools/windows/Cargo.toml
+++ b/crates/tools/windows/Cargo.toml
@@ -5,6 +5,6 @@ edition = "2018"
 publish = false
 
 [dependencies]
-metadata = { package = "windows-metadata", path = "../../libs/metadata", version = "0.30.0" }
-bindgen = { package = "windows-bindgen", path = "../../libs/bindgen", version = "0.30.0" }
+metadata = { package = "windows-metadata", path = "../../libs/metadata", version = "0.31.0" }
+bindgen = { package = "windows-bindgen", path = "../../libs/bindgen", version = "0.31.0" }
 rayon = "1.5.1"

--- a/crates/tools/windows/src/main.rs
+++ b/crates/tools/windows/src/main.rs
@@ -25,7 +25,7 @@ fn main() {
         r#"
 [package]
 name = "windows"
-version = "0.30.0"
+version = "0.31.0"
 authors = ["Microsoft"]
 edition = "2018"
 license = "MIT OR Apache-2.0"
@@ -39,37 +39,37 @@ default-target = "x86_64-pc-windows-msvc"
 targets = []
 
 [target.i686-pc-windows-msvc.dependencies]
-windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.30.0" }
+windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.31.0" }
 
 [target.i686-uwp-windows-msvc.dependencies]
-windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.30.0" }
+windows_i686_msvc = { path = "../../targets/i686_msvc", version = "0.31.0" }
 
 [target.x86_64-pc-windows-msvc.dependencies]
-windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.30.0" }
+windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.31.0" }
 
 [target.x86_64-uwp-windows-msvc.dependencies]
-windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.30.0" }
+windows_x86_64_msvc = { path = "../../targets/x86_64_msvc", version = "0.31.0" }
 
 [target.aarch64-pc-windows-msvc.dependencies]
-windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.30.0" }
+windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.31.0" }
 
 [target.aarch64-uwp-windows-msvc.dependencies]
-windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.30.0" }
+windows_aarch64_msvc = { path = "../../targets/aarch64_msvc", version = "0.31.0" }
 
 [target.i686-pc-windows-gnu.dependencies]
-windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.30.0" }
+windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.31.0" }
 
 [target.i686-uwp-windows-gnu.dependencies]
-windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.30.0" }
+windows_i686_gnu = { path = "../../targets/i686_gnu", version = "0.31.0" }
 
 [target.x86_64-pc-windows-gnu.dependencies]
-windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.30.0" }
+windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.31.0" }
 
 [target.x86_64-uwp-windows-gnu.dependencies]
-windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.30.0" }
+windows_x86_64_gnu = { path = "../../targets/x86_64_gnu", version = "0.31.0" }
 
 [dependencies]
-windows-implement = { path = "../implement",  version = "0.30.0", optional = true }
+windows-implement = { path = "../implement",  version = "0.31.0", optional = true }
 
 [features]
 default = []

--- a/crates/tools/yml/Cargo.toml
+++ b/crates/tools/yml/Cargo.toml
@@ -5,4 +5,4 @@ edition = "2018"
 publish = false
 
 [dependencies]
-metadata = { package = "windows-metadata", path = "../../libs/metadata", version = "0.30.0" }
+metadata = { package = "windows-metadata", path = "../../libs/metadata", version = "0.31.0" }


### PR DESCRIPTION
These is the list of changes going into `0.31.0`, due to be released on Thursday. Thanks!

cc/ @kennykerr feel free to move things around in case they've not been categorized right.

---

<!-- Latest as of 3c3c5b92d90e3995b6b53b44b4d77d2edafd6778 -->

## Added
* Derive `PartialEq` and `Eq` for scoped enums to support constant patterns by @kennykerr in https://github.com/microsoft/windows-rs/pull/1438
* Make handle fields `const` by @kennykerr in https://github.com/microsoft/windows-rs/pull/1468
* Make applicable fields `const` by @kennykerr in https://github.com/microsoft/windows-rs/pull/1470
* Support functions that don't return by @kennykerr in https://github.com/microsoft/windows-rs/pull/1485

## Changed
* Trait-based `implement` macro by @kennykerr in https://github.com/microsoft/windows-rs/pull/1450
* Test samples by @kennykerr in https://github.com/microsoft/windows-rs/pull/1456
* Simpler error interop by @kennykerr in https://github.com/microsoft/windows-rs/pull/1462
* Improve core/xaml app sample ergonomics by @riverar in https://github.com/microsoft/windows-rs/pull/1463
* Improve enum code gen by @kennykerr in https://github.com/microsoft/windows-rs/pull/1457
* Update Win32 metadata to 17.0.9 by @kennykerr in https://github.com/microsoft/windows-rs/pull/1482
* Split clippy into separate build runner by @kennykerr in https://github.com/microsoft/windows-rs/pull/1487
* Update target lib files by @kennykerr, @riverar in https://github.com/microsoft/windows-rs/pull/1488

## Fixed
* Use correct lib for internal bindings by @kennykerr in https://github.com/microsoft/windows-rs/pull/1432
* Require delegates to be `Send` by @kennykerr in https://github.com/microsoft/windows-rs/pull/1458
* Adds test to confirm fix by @kennykerr in https://github.com/microsoft/windows-rs/pull/1461
* Remove dead code by @kennykerr in https://github.com/microsoft/windows-rs/pull/1467
* Avoid generating invalid `Debug` traits by @kennykerr in https://github.com/microsoft/windows-rs/pull/1473
* Reliably handle Unicode string literals by @kennykerr in https://github.com/microsoft/windows-rs/pull/1480

## Other
* Document how to build docs + release order by @yoshuawuyts in https://github.com/microsoft/windows-rs/pull/1430
* Check windows-sys with 1.46 as MSRV by @kennykerr in https://github.com/microsoft/windows-rs/pull/1460
* Improve crate naming and build validation by @kennykerr in https://github.com/microsoft/windows-rs/pull/1469
* Improve tests on CI by @kennykerr in https://github.com/microsoft/windows-rs/pull/1452, https://github.com/microsoft/windows-rs/pull/1453, https://github.com/microsoft/windows-rs/pull/1455


**Full Changelog**: https://github.com/microsoft/windows-rs/compare/0.30.0...0.31.0