### PR TITLE
Remove bthprops special handling

### DIFF
--- a/crates/tools/msvc/src/main.rs
+++ b/crates/tools/msvc/src/main.rs
@@ -83,9 +83,7 @@ fn build_library(output: &std::path::Path, library: &str, functions: &BTreeMap<&
 LIBRARY {}
 EXPORTS
 "#,
-            // DllImportAttribute dllName not explicitly specified for bthprops.cpl #714
-            // https://github.com/microsoft/win32metadata/issues/714
-            if library == "bthprops" { "bthprops.cpl" } else { library }
+            library
         )
         .as_bytes(),
     )


### PR DESCRIPTION
Removes bthprops special handling (#1257) that is no longer needed. Metadata now explicitly emits extensions for non `.dll` libs.

Closes: #1521 
See also: microsoft/win32metadata#777