### PR TITLE
Explicit parameter direction

### DIFF
--- a/crates/libs/bindgen/src/helpers.rs
+++ b/crates/libs/bindgen/src/helpers.rs
@@ -124,7 +124,7 @@ pub fn gen_vtbl_signature(def: &TypeDef, method: &MethodDef, gen: &Gen) -> Token
             let abi = gen_abi_element_name(&p.ty, gen);
             let abi_size_name = gen_ident(&format!("{}_array_size", p.def.name()));
 
-            if p.def.is_input() {
+            if p.def.flags().input() {
                 if p.ty.is_winrt_array() {
                     quote! { #abi_size_name: u32, #name: *const #abi, }
                 } else if p.ty.is_winrt_const_ref() {
@@ -411,7 +411,7 @@ fn gen_winrt_invoke_arg(param: &MethodParam) -> TokenStream {
     let name = gen_param_name(&param.def);
     let abi_size_name: TokenStream = format!("{}_array_size", param.def.name()).into();
 
-    if param.def.is_input() {
+    if param.def.flags().input() {
         if param.ty.is_winrt_array() {
             quote! { ::core::slice::from_raw_parts(::core::mem::transmute_copy(&#name), #abi_size_name as _) }
         } else if param.ty.is_primitive() {
@@ -490,7 +490,7 @@ fn gen_win32_produce_type(param: &MethodParam, gen: &Gen) -> TokenStream {
     let name = gen_param_name(&param.def);
     let kind = gen_default_type(&param.ty, gen);
 
-    if param.def.is_input() && !param.ty.is_primitive() {
+    if param.def.flags().input() && !param.ty.is_primitive() {
         quote! { #name: &#kind, }
     } else {
         quote! { #name: #kind, }
@@ -516,7 +516,7 @@ pub fn gen_default_type(def: &Type, gen: &Gen) -> TokenStream {
 fn gen_winrt_produce_type(param: &MethodParam, include_param_names: bool, gen: &Gen) -> TokenStream {
     let default_type = gen_default_type(&param.ty, gen);
 
-    let sig = if param.def.is_input() {
+    let sig = if param.def.flags().input() {
         if param.ty.is_winrt_array() {
             quote! { &[#default_type] }
         } else if param.ty.is_primitive() {

--- a/crates/libs/bindgen/src/methods.rs
+++ b/crates/libs/bindgen/src/methods.rs
@@ -262,7 +262,7 @@ pub fn gen_winrt_params(params: &[MethodParam], gen: &Gen) -> TokenStream {
         let kind = gen_element_name(&param.ty, gen);
         let default_type = gen_default_type(&param.ty, gen);
 
-        if param.def.is_input() {
+        if param.def.flags().input() {
             if param.ty.is_winrt_array() {
                 result.combine(&quote! { #name: &[#default_type], });
             } else if param.is_convertible() {
@@ -296,7 +296,7 @@ pub fn gen_win32_abi_arg(param: &MethodParam) -> TokenStream {
 pub fn gen_winrt_abi_arg(param: &MethodParam) -> TokenStream {
     let name = gen_param_name(&param.def);
 
-    if param.def.is_input() {
+    if param.def.flags().input() {
         if param.ty.is_winrt_array() {
             quote! { #name.len() as u32, ::core::mem::transmute(#name.as_ptr()) }
         } else if param.is_convertible() {

--- a/crates/libs/metadata/src/signature.rs
+++ b/crates/libs/metadata/src/signature.rs
@@ -27,7 +27,7 @@ impl Signature {
                         let object = &self.params[self.params.len() - 1];
 
                         if guid.ty == Type::ConstPtr((Box::new(Type::GUID), 1)) && !guid.def.flags().output() && object.ty == Type::MutPtr((Box::new(Type::Void), 2)) && object.def.is_com_out_ptr() {
-                            if object.def.is_optional() {
+                            if object.def.flags().optional() {
                                 return SignatureKind::QueryOptional;
                             } else {
                                 return SignatureKind::Query;
@@ -88,6 +88,6 @@ impl MethodParam {
     }
 
     pub fn is_convertible(&self) -> bool {
-        self.def.is_input() && !self.ty.is_winrt_array() && !self.ty.is_pointer() && self.ty.is_convertible()
+        self.def.flags().input() && !self.ty.is_winrt_array() && !self.ty.is_pointer() && self.ty.is_convertible()
     }
 }

--- a/crates/libs/metadata/src/tables/method_def.rs
+++ b/crates/libs/metadata/src/tables/method_def.rs
@@ -111,10 +111,7 @@ impl MethodDef {
                     None
                 } else {
                     let ty = reader.type_from_blob(&mut blob, None, generics).expect("MethodDef");
-
-                    // TODO: why not def.is_input
                     let ty = if !def.flags().output() { ty.to_const() } else { ty };
-
                     Some(MethodParam { def, ty })
                 }
             })

--- a/crates/libs/metadata/src/tables/param.rs
+++ b/crates/libs/metadata/src/tables/param.rs
@@ -24,14 +24,6 @@ impl Param {
         self.attributes().any(|attribute| attribute.name() == name)
     }
 
-    pub fn is_input(&self) -> bool {
-        // TODO: this needs to be !output test.
-        self.flags().input()
-    }
-
-    pub fn is_optional(&self) -> bool {
-        self.flags().optional()
-    }
 
     pub fn is_com_out_ptr(&self) -> bool {
         self.has_attribute("ComOutPtrAttribute")

--- a/crates/libs/metadata/src/tables/param.rs
+++ b/crates/libs/metadata/src/tables/param.rs
@@ -24,7 +24,6 @@ impl Param {
         self.attributes().any(|attribute| attribute.name() == name)
     }
 
-
     pub fn is_com_out_ptr(&self) -> bool {
         self.has_attribute("ComOutPtrAttribute")
     }


### PR DESCRIPTION
I was hoping to fix some API signatures thanks to the enhanced signature parsing I introduced (#1530) but that led to the discovery of incorrect metadata (https://github.com/microsoft/win32metadata/issues/803), so here I'm just being more explicit about parameter flag handling until the metadata is fixed. 