### PR TITLE
Include Win32 "retval" signatures in transformation

### DIFF
--- a/crates/libs/metadata/src/signature.rs
+++ b/crates/libs/metadata/src/signature.rs
@@ -66,7 +66,12 @@ impl Signature {
 
 impl MethodParam {
     fn is_retval(&self) -> bool {
-        // TODO: why aren't we just using the retval flag? This is super brittle.
+        // The Win32 metadata uses `RetValAttribute` to call out retval methods but it is employed
+        // very sparingly, so this heuristic is used to apply the transformation more uniformly.
+
+        if self.def.is_retval() {
+            return true;
+        }
 
         if !self.ty.is_pointer() {
             return false;

--- a/crates/libs/metadata/src/tables/param.rs
+++ b/crates/libs/metadata/src/tables/param.rs
@@ -32,4 +32,8 @@ impl Param {
         // TODO: replace bool return with actual array info from attribute
         self.has_attribute("NativeArrayInfoAttribute")
     }
+
+    pub fn is_retval(&self) -> bool {
+        self.has_attribute("RetValAttribute")
+    }
 }

--- a/crates/libs/windows/src/Windows/Win32/Graphics/CompositionSwapchain/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/CompositionSwapchain/impl.rs
@@ -238,7 +238,7 @@ pub trait IPresentationManager_Impl: Sized {
     fn SetPreferredPresentDuration(&self, preferredduration: &SystemInterruptTime, deviationtolerance: &SystemInterruptTime) -> ::windows::core::Result<()>;
     fn ForceVSyncInterrupt(&self, forcevsyncinterrupt: u8) -> ::windows::core::Result<()>;
     fn Present(&self) -> ::windows::core::Result<()>;
-    fn GetPresentRetiringFence(&self, riid: *const ::windows::core::GUID, fence: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
+    fn GetPresentRetiringFence(&self, riid: *const ::windows::core::GUID) -> ::windows::core::Result<*mut ::core::ffi::c_void>;
     fn CancelPresentsFrom(&self, presentidtocancelfrom: u64) -> ::windows::core::Result<()>;
     fn GetLostEvent(&self) -> ::windows::core::Result<super::super::Foundation::HANDLE>;
     fn GetPresentStatisticsAvailableEvent(&self) -> ::windows::core::Result<super::super::Foundation::HANDLE>;
@@ -298,7 +298,13 @@ impl IPresentationManager_Vtbl {
         unsafe extern "system" fn GetPresentRetiringFence<Identity: ::windows::core::IUnknownImpl, Impl: IPresentationManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, riid: *const ::windows::core::GUID, fence: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
             let this = (this as *mut ::windows::core::RawPtr).offset(OFFSET) as *mut Identity;
             let this = (*this).get_impl() as *mut Impl;
-            (*this).GetPresentRetiringFence(::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&fence)).into()
+            match (*this).GetPresentRetiringFence(::core::mem::transmute_copy(&riid)) {
+                ::core::result::Result::Ok(ok__) => {
+                    *fence = ::core::mem::transmute(ok__);
+                    ::windows::core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn CancelPresentsFrom<Identity: ::windows::core::IUnknownImpl, Impl: IPresentationManager_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, presentidtocancelfrom: u64) -> ::windows::core::HRESULT {
             let this = (this as *mut ::windows::core::RawPtr).offset(OFFSET) as *mut Identity;

--- a/crates/libs/windows/src/Windows/Win32/Graphics/CompositionSwapchain/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/CompositionSwapchain/mod.rs
@@ -668,8 +668,9 @@ impl IPresentationManager {
         (::windows::core::Interface::vtable(self).Present)(::core::mem::transmute_copy(self)).ok()
     }
     #[doc = "*Required features: 'Win32_Graphics_CompositionSwapchain'*"]
-    pub unsafe fn GetPresentRetiringFence(&self, riid: *const ::windows::core::GUID, fence: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).GetPresentRetiringFence)(::core::mem::transmute_copy(self), ::core::mem::transmute(riid), ::core::mem::transmute(fence)).ok()
+    pub unsafe fn GetPresentRetiringFence(&self, riid: *const ::windows::core::GUID) -> ::windows::core::Result<*mut ::core::ffi::c_void> {
+        let mut result__: *mut ::core::ffi::c_void = ::core::mem::zeroed();
+        (::windows::core::Interface::vtable(self).GetPresentRetiringFence)(::core::mem::transmute_copy(self), ::core::mem::transmute(riid), ::core::mem::transmute(&mut result__)).from_abi::<*mut ::core::ffi::c_void>(result__)
     }
     #[doc = "*Required features: 'Win32_Graphics_CompositionSwapchain'*"]
     pub unsafe fn CancelPresentsFrom(&self, presentidtocancelfrom: u64) -> ::windows::core::Result<()> {

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/impl.rs
@@ -1,6 +1,6 @@
 pub trait ITraceEvent_Impl: Sized {
     fn Clone(&self) -> ::windows::core::Result<ITraceEvent>;
-    fn GetUserContext(&self, usercontext: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
+    fn GetUserContext(&self) -> ::windows::core::Result<*mut ::core::ffi::c_void>;
     fn GetEventRecord(&self) -> ::windows::core::Result<*mut EVENT_RECORD>;
     fn SetPayload(&self, payload: *const u8, payloadsize: u32) -> ::windows::core::Result<()>;
     fn SetEventDescriptor(&self, eventdescriptor: *const EVENT_DESCRIPTOR) -> ::windows::core::Result<()>;
@@ -28,7 +28,13 @@ impl ITraceEvent_Vtbl {
         unsafe extern "system" fn GetUserContext<Identity: ::windows::core::IUnknownImpl, Impl: ITraceEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, usercontext: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
             let this = (this as *mut ::windows::core::RawPtr).offset(OFFSET) as *mut Identity;
             let this = (*this).get_impl() as *mut Impl;
-            (*this).GetUserContext(::core::mem::transmute_copy(&usercontext)).into()
+            match (*this).GetUserContext() {
+                ::core::result::Result::Ok(ok__) => {
+                    *usercontext = ::core::mem::transmute(ok__);
+                    ::windows::core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn GetEventRecord<Identity: ::windows::core::IUnknownImpl, Impl: ITraceEvent_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, eventrecord: *mut *mut EVENT_RECORD) -> ::windows::core::HRESULT {
             let this = (this as *mut ::windows::core::RawPtr).offset(OFFSET) as *mut Identity;

--- a/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Diagnostics/Etw/mod.rs
@@ -4019,8 +4019,9 @@ impl ITraceEvent {
         (::windows::core::Interface::vtable(self).Clone)(::core::mem::transmute_copy(self), ::core::mem::transmute(&mut result__)).from_abi::<ITraceEvent>(result__)
     }
     #[doc = "*Required features: 'Win32_System_Diagnostics_Etw'*"]
-    pub unsafe fn GetUserContext(&self, usercontext: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).GetUserContext)(::core::mem::transmute_copy(self), ::core::mem::transmute(usercontext)).ok()
+    pub unsafe fn GetUserContext(&self) -> ::windows::core::Result<*mut ::core::ffi::c_void> {
+        let mut result__: *mut ::core::ffi::c_void = ::core::mem::zeroed();
+        (::windows::core::Interface::vtable(self).GetUserContext)(::core::mem::transmute_copy(self), ::core::mem::transmute(&mut result__)).from_abi::<*mut ::core::ffi::c_void>(result__)
     }
     #[doc = "*Required features: 'Win32_System_Diagnostics_Etw'*"]
     pub unsafe fn GetEventRecord(&self) -> ::windows::core::Result<*mut EVENT_RECORD> {

--- a/crates/libs/windows/src/Windows/Win32/System/SettingsManagementInfrastructure/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SettingsManagementInfrastructure/impl.rs
@@ -50,7 +50,7 @@ pub trait ISettingsContext_Impl: Sized {
     fn Serialize(&self, pstream: &::core::option::Option<super::Com::IStream>, ptarget: &::core::option::Option<ITargetInfo>) -> ::windows::core::Result<()>;
     fn Deserialize(&self, pstream: &::core::option::Option<super::Com::IStream>, ptarget: &::core::option::Option<ITargetInfo>, pppresults: *mut *mut ::core::option::Option<ISettingsResult>, pcresultcount: *mut usize) -> ::windows::core::Result<()>;
     fn SetUserData(&self, puserdata: *const ::core::ffi::c_void) -> ::windows::core::Result<()>;
-    fn GetUserData(&self, puserdata: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
+    fn GetUserData(&self) -> ::windows::core::Result<*mut ::core::ffi::c_void>;
     fn GetNamespaces(&self) -> ::windows::core::Result<IItemEnumerator>;
     fn GetStoredSettings(&self, pidentity: &::core::option::Option<ISettingsIdentity>, ppaddedsettings: *mut ::core::option::Option<IItemEnumerator>, ppmodifiedsettings: *mut ::core::option::Option<IItemEnumerator>, ppdeletedsettings: *mut ::core::option::Option<IItemEnumerator>) -> ::windows::core::Result<()>;
     fn RevertSetting(&self, pidentity: &::core::option::Option<ISettingsIdentity>, pwzsetting: super::super::Foundation::PWSTR) -> ::windows::core::Result<()>;
@@ -76,7 +76,13 @@ impl ISettingsContext_Vtbl {
         unsafe extern "system" fn GetUserData<Identity: ::windows::core::IUnknownImpl, Impl: ISettingsContext_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, puserdata: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
             let this = (this as *mut ::windows::core::RawPtr).offset(OFFSET) as *mut Identity;
             let this = (*this).get_impl() as *mut Impl;
-            (*this).GetUserData(::core::mem::transmute_copy(&puserdata)).into()
+            match (*this).GetUserData() {
+                ::core::result::Result::Ok(ok__) => {
+                    *puserdata = ::core::mem::transmute(ok__);
+                    ::windows::core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         unsafe extern "system" fn GetNamespaces<Identity: ::windows::core::IUnknownImpl, Impl: ISettingsContext_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, ppnamespaceids: *mut ::windows::core::RawPtr) -> ::windows::core::HRESULT {
             let this = (this as *mut ::windows::core::RawPtr).offset(OFFSET) as *mut Identity;

--- a/crates/libs/windows/src/Windows/Win32/System/SettingsManagementInfrastructure/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/SettingsManagementInfrastructure/mod.rs
@@ -93,8 +93,9 @@ impl ISettingsContext {
         (::windows::core::Interface::vtable(self).SetUserData)(::core::mem::transmute_copy(self), ::core::mem::transmute(puserdata)).ok()
     }
     #[doc = "*Required features: 'Win32_System_SettingsManagementInfrastructure'*"]
-    pub unsafe fn GetUserData(&self, puserdata: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).GetUserData)(::core::mem::transmute_copy(self), ::core::mem::transmute(puserdata)).ok()
+    pub unsafe fn GetUserData(&self) -> ::windows::core::Result<*mut ::core::ffi::c_void> {
+        let mut result__: *mut ::core::ffi::c_void = ::core::mem::zeroed();
+        (::windows::core::Interface::vtable(self).GetUserData)(::core::mem::transmute_copy(self), ::core::mem::transmute(&mut result__)).from_abi::<*mut ::core::ffi::c_void>(result__)
     }
     #[doc = "*Required features: 'Win32_System_SettingsManagementInfrastructure'*"]
     pub unsafe fn GetNamespaces(&self) -> ::windows::core::Result<IItemEnumerator> {

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Display/impl.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Display/impl.rs
@@ -1,7 +1,7 @@
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 pub trait IDisplayDeviceInterop_Impl: Sized {
     fn CreateSharedHandle(&self, pobject: &::core::option::Option<::windows::core::IInspectable>, psecurityattributes: *const super::super::super::Security::SECURITY_ATTRIBUTES, access: u32, name: &::windows::core::HSTRING) -> ::windows::core::Result<super::super::super::Foundation::HANDLE>;
-    fn OpenSharedHandle(&self, nthandle: super::super::super::Foundation::HANDLE, riid: &::windows::core::GUID, ppvobj: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()>;
+    fn OpenSharedHandle(&self, nthandle: super::super::super::Foundation::HANDLE, riid: &::windows::core::GUID) -> ::windows::core::Result<*mut ::core::ffi::c_void>;
 }
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Security"))]
 impl IDisplayDeviceInterop_Vtbl {
@@ -20,7 +20,13 @@ impl IDisplayDeviceInterop_Vtbl {
         unsafe extern "system" fn OpenSharedHandle<Identity: ::windows::core::IUnknownImpl, Impl: IDisplayDeviceInterop_Impl, const OFFSET: isize>(this: *mut ::core::ffi::c_void, nthandle: super::super::super::Foundation::HANDLE, riid: ::windows::core::GUID, ppvobj: *mut *mut ::core::ffi::c_void) -> ::windows::core::HRESULT {
             let this = (this as *mut ::windows::core::RawPtr).offset(OFFSET) as *mut Identity;
             let this = (*this).get_impl() as *mut Impl;
-            (*this).OpenSharedHandle(::core::mem::transmute_copy(&nthandle), ::core::mem::transmute_copy(&riid), ::core::mem::transmute_copy(&ppvobj)).into()
+            match (*this).OpenSharedHandle(::core::mem::transmute_copy(&nthandle), ::core::mem::transmute_copy(&riid)) {
+                ::core::result::Result::Ok(ok__) => {
+                    *ppvobj = ::core::mem::transmute(ok__);
+                    ::windows::core::HRESULT(0)
+                }
+                ::core::result::Result::Err(err) => err.into(),
+            }
         }
         Self {
             base: ::windows::core::IUnknownVtbl::new::<Identity, OFFSET>(),

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/Display/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/Display/mod.rs
@@ -11,8 +11,9 @@ impl IDisplayDeviceInterop {
     }
     #[doc = "*Required features: 'Win32_System_WinRT_Display', 'Win32_Foundation'*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn OpenSharedHandle<'a, Param0: ::windows::core::IntoParam<'a, super::super::super::Foundation::HANDLE>, Param1: ::windows::core::IntoParam<'a, ::windows::core::GUID>>(&self, nthandle: Param0, riid: Param1, ppvobj: *mut *mut ::core::ffi::c_void) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).OpenSharedHandle)(::core::mem::transmute_copy(self), nthandle.into_param().abi(), riid.into_param().abi(), ::core::mem::transmute(ppvobj)).ok()
+    pub unsafe fn OpenSharedHandle<'a, Param0: ::windows::core::IntoParam<'a, super::super::super::Foundation::HANDLE>, Param1: ::windows::core::IntoParam<'a, ::windows::core::GUID>>(&self, nthandle: Param0, riid: Param1) -> ::windows::core::Result<*mut ::core::ffi::c_void> {
+        let mut result__: *mut ::core::ffi::c_void = ::core::mem::zeroed();
+        (::windows::core::Interface::vtable(self).OpenSharedHandle)(::core::mem::transmute_copy(self), nthandle.into_param().abi(), riid.into_param().abi(), ::core::mem::transmute(&mut result__)).from_abi::<*mut ::core::ffi::c_void>(result__)
     }
 }
 impl ::core::convert::From<IDisplayDeviceInterop> for ::windows::core::IUnknown {


### PR DESCRIPTION
Clarifies how `retval` signatures are transformed.
