### PR TITLE
Add reproducible example fields to bug report form

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -26,10 +26,19 @@ body:
       description: >
         Please provide a short summary of the bug, along with any information
         you feel relevant to replicating the bug.
-      value: |
-        ```rust
-        <code>
-        ```
+  - type: textarea
+    attributes:
+      label: Reproducible example
+      description: >
+        Please provide all code needed to reproduce the issue.
+      render: toml
+  - type: textarea
+    attributes:
+      label: Your crate manifest
+      description: >
+        Please provide a manifest (`Cargo.toml`) that corresponds
+        to the reproducible example.
+      render: toml
   - type: textarea
     attributes:
       label: Expected behavior


### PR DESCRIPTION
Adds two text areas:
1. for reproducible example code (rendered as Rust code)
2. for a Cargo manfiest (Cargo.toml) that corresponds to that example

This will shorten bug triage loops considerably as feature lookups won't need to occur.

Demo: https://github.com/riverar/windows-rs/issues/new?assignees=&labels=bug&template=bug_report.yml&title=Bug%3A
(feel free to create issues, I will clean it up after merge)

[no ci]