### PR TITLE
Make NTSTATUS::ok a const fn

### DIFF
--- a/crates/libs/bindgen/src/replacements/ntstatus.rs
+++ b/crates/libs/bindgen/src/replacements/ntstatus.rs
@@ -21,7 +21,7 @@ pub fn gen() -> TokenStream {
             }
 
             #[inline]
-            pub fn ok(self) -> ::windows::core::Result<()> {
+            pub const fn ok(self) -> ::windows::core::Result<()> {
                 if self.is_ok() {
                     Ok(())
                 } else {

--- a/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
@@ -5118,7 +5118,7 @@ impl NTSTATUS {
         ::windows::core::HRESULT(self.0 | 0x1000_0000)
     }
     #[inline]
-    pub fn ok(self) -> ::windows::core::Result<()> {
+    pub const fn ok(self) -> ::windows::core::Result<()> {
         if self.is_ok() {
             Ok(())
         } else {


### PR DESCRIPTION
is_ok, to_hresult and fast_error are all const fn, so `ok` should be a fine candidate for const-ification.