### PR TITLE
`Type::GenericParam` can store a static `str`

### DIFF
--- a/crates/libs/bindgen/src/names.rs
+++ b/crates/libs/bindgen/src/names.rs
@@ -165,7 +165,7 @@ pub fn gen_element_name(def: &Type, gen: &Gen) -> TokenStream {
             let len = Literal::u32_unsuffixed(*len);
             quote! { [#name; #len] }
         }
-        Type::GenericParam(generic) => generic.into(),
+        Type::GenericParam(generic) => (*generic).into(),
         Type::MethodDef(def) => def.name().into(),
         Type::Field(field) => field.name().into(),
         Type::TypeDef(t) => gen_type_name(t, gen),

--- a/crates/libs/metadata/src/tables/type_def.rs
+++ b/crates/libs/metadata/src/tables/type_def.rs
@@ -16,7 +16,7 @@ impl From<Row> for TypeDef {
 impl TypeDef {
     #[must_use]
     pub fn with_generics(mut self) -> Self {
-        self.generics = self.generic_params().map(|generic| Type::GenericParam(generic.name().to_string())).collect();
+        self.generics = self.generic_params().map(|generic| Type::GenericParam(generic.name())).collect();
         self
     }
 

--- a/crates/libs/metadata/src/type.rs
+++ b/crates/libs/metadata/src/type.rs
@@ -22,8 +22,8 @@ pub enum Type {
     IUnknown,
     IInspectable,
     HRESULT,
-    TypeName,             // Used for parsing attribute blobs
-    GenericParam(String), // TODO: can be &'static str?
+    TypeName, // Used for parsing attribute blobs
+    GenericParam(&'static str),
     MethodDef(MethodDef),
     Field(Field),
     TypeDef(TypeDef),


### PR DESCRIPTION
This is a holdover from the old `implement` macro that needed to make `GenericParam` values from tokens.