### PR TITLE
Restore ability to codegen with windows as dep crate

### DIFF
--- a/crates/libs/bindgen/src/gen.rs
+++ b/crates/libs/bindgen/src/gen.rs
@@ -17,6 +17,7 @@ impl Gen<'_> {
         if self.flatten || namespace == self.namespace {
             quote! {}
         } else {
+            let is_windows_extern = namespace.starts_with("Windows.") && !self.namespace.starts_with("Windows");
             let mut relative = self.namespace.split('.').peekable();
             let mut namespace = namespace.split('.').peekable();
 
@@ -30,8 +31,13 @@ impl Gen<'_> {
 
             let mut tokens = TokenStream::new();
 
-            for _ in 0..relative.count() {
-                tokens.push_str("super::");
+            if is_windows_extern {
+                tokens.push_str("::windows::");
+                namespace.next();
+            } else {
+                for _ in 0..relative.count() {
+                    tokens.push_str("super::");
+                }
             }
 
             for namespace in namespace {


### PR DESCRIPTION
Adds a flag to treat `windows` crate as self or external. Tweaks feature doc/cfg emission so that `windows` features get expressed correctly in non-windows crates (e.g. `windows/Win32.Foundation`).

See also: #1278 