### PR TITLE
doc: expose Interface trait and Weak object in documentation

### DIFF
--- a/crates/libs/windows/src/core/interface.rs
+++ b/crates/libs/windows/src/core/interface.rs
@@ -3,8 +3,9 @@ use bindings::*;
 
 /// Provides low-level access to a COM interface.
 ///
-/// This trait is automatically used by the generated bindings and should not be
-/// used directly.
+/// This trait is automatically implemented by the generated bindings and should not be
+/// implemented manually.
+///
 /// # Safety
 pub unsafe trait Interface: Sized {
     #[doc(hidden)]

--- a/crates/libs/windows/src/core/mod.rs
+++ b/crates/libs/windows/src/core/mod.rs
@@ -47,7 +47,6 @@ pub use heap::*;
 pub use hresult::*;
 pub use hstring::*;
 pub use inspectable::*;
-#[doc(hidden)]
 pub use interface::*;
 #[doc(hidden)]
 pub use into_param::*;
@@ -70,7 +69,6 @@ pub use to_impl::*;
 pub use unknown::*;
 #[doc(hidden)]
 pub use waiter::*;
-#[doc(hidden)]
 pub use weak::*;
 #[doc(hidden)]
 pub use weak_ref_count::*;


### PR DESCRIPTION
The Interface trait exposes two public functions that are quite useful
when using COM objects.

The Weak struct is also returned by the downgrade function, so expose it
as well.

Closes #1502 