### PR TITLE
Provide hex output for `Debug` impl of `HRESULT` and `NTSTATUS`

### DIFF
--- a/crates/libs/bindgen/src/replacements/ntstatus.rs
+++ b/crates/libs/bindgen/src/replacements/ntstatus.rs
@@ -55,7 +55,7 @@ pub fn gen() -> TokenStream {
         impl ::core::cmp::Eq for NTSTATUS {}
         impl ::core::fmt::Debug for NTSTATUS {
             fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-                f.debug_tuple("NTSTATUS").field(&self.0).finish()
+                f.write_fmt(format_args!("NTSTATUS(0x{:08X})", self.0))
             }
         }
         unsafe impl ::windows::core::Abi for NTSTATUS {

--- a/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
@@ -5155,7 +5155,7 @@ impl ::core::cmp::PartialEq for NTSTATUS {
 impl ::core::cmp::Eq for NTSTATUS {}
 impl ::core::fmt::Debug for NTSTATUS {
     fn fmt(&self, f: &mut ::core::fmt::Formatter<'_>) -> ::core::fmt::Result {
-        f.debug_tuple("NTSTATUS").field(&self.0).finish()
+        f.write_fmt(format_args!("NTSTATUS(0x{:08X})", self.0))
     }
 }
 unsafe impl ::windows::core::Abi for NTSTATUS {

--- a/crates/libs/windows/src/core/hresult.rs
+++ b/crates/libs/windows/src/core/hresult.rs
@@ -3,7 +3,7 @@ use bindings::*;
 
 /// An error code value returned by most COM functions.
 #[repr(transparent)]
-#[derive(Copy, Clone, Default, Debug, Eq, PartialEq)]
+#[derive(Copy, Clone, Default, Eq, PartialEq)]
 #[must_use]
 #[allow(non_camel_case_types)]
 pub struct HRESULT(pub i32);
@@ -107,6 +107,12 @@ impl<T> core::convert::From<Result<T>> for HRESULT {
         }
 
         HRESULT(0)
+    }
+}
+
+impl core::fmt::Debug for HRESULT {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.write_fmt(format_args!("HRESULT(0x{:08X})", self.0))
     }
 }
 

--- a/crates/tests/error/tests/test.rs
+++ b/crates/tests/error/tests/test.rs
@@ -12,6 +12,9 @@ fn hresult() -> Result<()> {
     assert_eq!(S_OK.is_ok(), true);
     assert_eq!(S_OK.is_err(), false);
 
+    assert_eq!(format!("{:?}", S_OK), "HRESULT(0x00000000)");
+    assert_eq!(format!("{:?}", E_INVALIDARG), "HRESULT(0x80070057)");
+
     S_OK.ok()
 }
 
@@ -29,6 +32,9 @@ fn win32_error() -> Result<()> {
     assert_eq!(ERROR_SUCCESS.is_ok(), true);
     assert_eq!(ERROR_SUCCESS.is_err(), false);
 
+    assert_eq!(format!("{:?}", ERROR_SUCCESS), "WIN32_ERROR(0)");
+    assert_eq!(format!("{:?}", ERROR_BAD_ARGUMENTS), "WIN32_ERROR(160)");
+
     ERROR_SUCCESS.ok()
 }
 
@@ -44,6 +50,9 @@ fn ntstatus() -> Result<()> {
     assert_eq!(STATUS_NOT_FOUND.is_err(), true);
     assert_eq!(STATUS_SUCCESS.is_ok(), true);
     assert_eq!(STATUS_SUCCESS.is_err(), false);
+
+    assert_eq!(format!("{:?}", STATUS_SUCCESS), "NTSTATUS(0x00000000)");
+    assert_eq!(format!("{:?}", STATUS_NOT_FOUND), "NTSTATUS(0xC0000225)");
 
     STATUS_SUCCESS.ok()
 }


### PR DESCRIPTION
This should now be consistent with most documented `HRESULT` and `NTSTATUS` values. 

Fixes #1588