### PR TITLE
Remove nightly features that are no longer required

### DIFF
--- a/crates/libs/windows/src/lib.rs
+++ b/crates/libs/windows/src/lib.rs
@@ -2,8 +2,6 @@
 Learn more about Rust for Windows here: <https://github.com/microsoft/windows-rs>
 */
 
-#![cfg_attr(feature = "implement", feature(const_fn_fn_ptr_basics))]
-#![cfg_attr(feature = "implement", feature(const_fn_trait_bound))]
 #![doc(html_no_source)]
 #![allow(non_snake_case, non_upper_case_globals, non_camel_case_types, dead_code, unused_variables)]
 

--- a/crates/tests/nightly_interface/tests/com.rs
+++ b/crates/tests/nightly_interface/tests/com.rs
@@ -1,6 +1,4 @@
 #![allow(non_snake_case)]
-#![feature(const_fn_trait_bound)]
-#![feature(const_fn_fn_ptr_basics)]
 
 use windows::{core::*, Win32::Foundation::*, Win32::System::Com::*};
 


### PR DESCRIPTION
These are no longer required now that 1.61 made it to the nightly version. 