### PR TITLE
Fix bug in multi arg COM methods and allow all types in interface methods

### DIFF
--- a/crates/libs/interface/src/lib.rs
+++ b/crates/libs/interface/src/lib.rs
@@ -102,9 +102,6 @@ impl Interface {
                 let vis = &m.visibility;
                 let name = &m.name;
 
-                if m.args.iter().any(|a| !a.pass_through) {
-                    panic!("TODO: handle methods with non-pass through arguments");
-                }
                 let args = m.gen_args();
                 let params = &m
                     .args
@@ -115,8 +112,8 @@ impl Interface {
                     })
                     .collect::<Vec<_>>();
                 quote! {
-                    #vis unsafe fn #name(&self, #(#args)*) -> ::windows::core::HRESULT {
-                        (::windows::core::Interface::vtable(self).#name)(::core::mem::transmute_copy(self), #(#params)*)
+                    #vis unsafe fn #name(&self, #(#args),*) -> ::windows::core::HRESULT {
+                        (::windows::core::Interface::vtable(self).#name)(::core::mem::transmute_copy(self), #(#params),*)
                     }
                 }
             })
@@ -137,13 +134,10 @@ impl Interface {
             .map(|m| {
                 let name = &m.name;
                 let docs = &m.docs;
-                if m.args.iter().any(|a| !a.pass_through) {
-                    panic!("TODO: handle methods with non-pass through arguments");
-                }
                 let args = m.gen_args();
                 quote! {
                     #(#docs)*
-                    unsafe fn #name(&self, #(#args)*) -> ::windows::core::HRESULT;
+                    unsafe fn #name(&self, #(#args),*) -> ::windows::core::HRESULT;
                 }
             })
             .collect::<Vec<_>>();
@@ -166,9 +160,6 @@ impl Interface {
             .map(|m| {
                 let name = &m.name;
                 let ret = &m.ret;
-                if m.args.iter().any(|a| !a.pass_through) {
-                    panic!("TODO: handle methods with non-pass through arguments");
-                }
                 let args = m.gen_args();
                 quote! {
                     pub #name: unsafe extern "system" fn(this: *mut ::core::ffi::c_void, #(#args),*) #ret,
@@ -442,11 +433,7 @@ impl syn::parse::Parse for InterfaceMethod {
                 syn::FnArg::Receiver(_) => None,
                 syn::FnArg::Typed(p) => Some(p),
             })
-            .map(|p| {
-                let pass_through = matches!(&*p.ty, syn::Type::Ptr(_));
-
-                Ok(InterfaceMethodArg { ty: p.ty, pat: p.pat, pass_through })
-            })
+            .map(|p| Ok(InterfaceMethodArg { ty: p.ty, pat: p.pat }))
             .collect::<Result<Vec<InterfaceMethodArg>, syn::Error>>()?;
 
         let ret = sig.output;
@@ -460,6 +447,4 @@ struct InterfaceMethodArg {
     pub ty: Box<syn::Type>,
     /// The name of the argument
     pub pat: Box<syn::Pat>,
-    /// Whether the argument needs transformation before crossing an FFI boundary
-    pub pass_through: bool,
 }

--- a/crates/tests/nightly_interface/tests/com.rs
+++ b/crates/tests/nightly_interface/tests/com.rs
@@ -5,9 +5,9 @@ use windows::{core::*, Win32::Foundation::*, Win32::System::Com::*};
 /// A custom declaration of implementation of `IUri`
 #[interface("a39ee748-6a27-4817-a6f2-13914bef5890")]
 pub unsafe trait ICustomUri: IUnknown {
-    unsafe fn GetPropertyBSTR(&self) -> HRESULT;
+    unsafe fn GetPropertyBSTR(&self, property: Uri_PROPERTY, value: *mut BSTR, flags: u32) -> HRESULT;
     unsafe fn GetPropertyLength(&self) -> HRESULT;
-    unsafe fn GetPropertyDWORD(&self) -> HRESULT;
+    unsafe fn GetPropertyDWORD(&self, property: Uri_PROPERTY, value: *mut u32, flags: u32) -> HRESULT;
     unsafe fn HasProperty(&self) -> HRESULT;
     unsafe fn GetAbsoluteUri(&self) -> HRESULT;
     unsafe fn GetAuthority(&self) -> HRESULT;
@@ -20,14 +20,20 @@ pub unsafe trait ICustomUri: IUnknown {
 struct CustomUri;
 
 impl ICustomUri_Impl for CustomUri {
-    unsafe fn GetPropertyBSTR(&self) -> HRESULT {
-        todo!()
+    unsafe fn GetPropertyBSTR(&self, property: Uri_PROPERTY, value: *mut BSTR, flags: u32) -> HRESULT {
+        assert!(flags == 0);
+        assert!(property == Uri_PROPERTY_DOMAIN);
+        *value = "property".into();
+        S_OK
     }
     unsafe fn GetPropertyLength(&self) -> HRESULT {
         todo!()
     }
-    unsafe fn GetPropertyDWORD(&self) -> HRESULT {
-        todo!()
+    unsafe fn GetPropertyDWORD(&self, property: Uri_PROPERTY, value: *mut u32, flags: u32) -> HRESULT {
+        assert!(flags == 0);
+        assert!(property == Uri_PROPERTY_PORT);
+        *value = 123;
+        S_OK
     }
     unsafe fn HasProperty(&self) -> HRESULT {
         todo!()
@@ -54,12 +60,24 @@ fn test_custom_interface() -> windows::core::Result<()> {
         let a: IUri = CreateUri("http://kennykerr.ca", Default::default(), 0)?;
         let domain = a.GetDomain()?;
         assert_eq!(domain, "kennykerr.ca");
+        let mut property = BSTR::new();
+        a.GetPropertyBSTR(Uri_PROPERTY_DOMAIN, &mut property, 0)?;
+        assert_eq!(property, "kennykerr.ca");
+        let mut property = 0;
+        a.GetPropertyDWORD(Uri_PROPERTY_PORT, &mut property, 0)?;
+        assert_eq!(property, 80);
 
         // Call the OS implementation through the custom interface
         let b: ICustomUri = a.cast()?;
         let mut domain = BSTR::new();
         b.GetDomain(&mut domain).ok()?;
         assert_eq!(domain, "kennykerr.ca");
+        let mut property = BSTR::new();
+        a.GetPropertyBSTR(Uri_PROPERTY_DOMAIN, &mut property, 0)?;
+        assert_eq!(property, "kennykerr.ca");
+        let mut property = 0;
+        a.GetPropertyDWORD(Uri_PROPERTY_PORT, &mut property, 0)?;
+        assert_eq!(property, 80);
 
         // Use the custom implementation through the OS interface
         let c: ICustomUri = CustomUri.into();
@@ -67,12 +85,24 @@ fn test_custom_interface() -> windows::core::Result<()> {
         let c: IUri = c.cast()?;
         let domain = c.GetDomain()?;
         assert_eq!(domain, "kennykerr.ca");
+        let mut property = BSTR::new();
+        c.GetPropertyBSTR(Uri_PROPERTY_DOMAIN, &mut property, 0)?;
+        assert_eq!(property, "property");
+        let mut property = 0;
+        c.GetPropertyDWORD(Uri_PROPERTY_PORT, &mut property, 0)?;
+        assert_eq!(property, 123);
 
         // Call the custom implementation through the custom interface
         let d: ICustomUri = c.cast()?;
         let mut domain = BSTR::new();
         d.GetDomain(&mut domain).ok()?;
         assert_eq!(domain, "kennykerr.ca");
+        let mut property = BSTR::new();
+        d.GetPropertyBSTR(Uri_PROPERTY_DOMAIN, &mut property, 0).ok()?;
+        assert_eq!(property, "property");
+        let mut property = 0;
+        d.GetPropertyDWORD(Uri_PROPERTY_PORT, &mut property, 0).ok()?;
+        assert_eq!(property, 123);
 
         Ok(())
     }


### PR DESCRIPTION
This fixes a bug that did not allow multiple arguments in a COM method.

It also removes an restriction on which types are allowed as COM method params. This means the user might be careful that the types passed across the FFI boundary are FFI safe. 