### PR TITLE
Allow for non-HRESULT return types in COM

### DIFF
--- a/crates/libs/interface/src/lib.rs
+++ b/crates/libs/interface/src/lib.rs
@@ -114,8 +114,9 @@ impl Interface {
                         quote! { #pat }
                     })
                     .collect::<Vec<_>>();
+                let ret = &m.ret;
                 quote! {
-                    #vis unsafe fn #name(&self, #(#args)*) -> ::windows::core::HRESULT {
+                    #vis unsafe fn #name(&self, #(#args)*) #ret {
                         (::windows::core::Interface::vtable(self).#name)(::core::mem::transmute_copy(self), #(#params)*)
                     }
                 }
@@ -141,9 +142,10 @@ impl Interface {
                     panic!("TODO: handle methods with non-pass through arguments");
                 }
                 let args = m.gen_args();
+                let ret = &m.ret;
                 quote! {
                     #(#docs)*
-                    unsafe fn #name(&self, #(#args)*) -> ::windows::core::HRESULT;
+                    unsafe fn #name(&self, #(#args)*) #ret;
                 }
             })
             .collect::<Vec<_>>();
@@ -190,8 +192,9 @@ impl Interface {
                         quote! { #pat }
                     })
                     .collect::<Vec<_>>();
+                let ret = &m.ret;
                 quote! {
-                    unsafe extern "system" fn #name<Identity: ::windows::core::IUnknownImpl, Impl: #trait_name, const OFFSET: isize>(this: *mut ::core::ffi::c_void, #(#args),*) -> ::windows::core::HRESULT {
+                    unsafe extern "system" fn #name<Identity: ::windows::core::IUnknownImpl, Impl: #trait_name, const OFFSET: isize>(this: *mut ::core::ffi::c_void, #(#args),*) #ret {
                         let this = (this as *mut ::windows::core::RawPtr).offset(OFFSET) as *mut Identity;
                         let this = (*this).get_impl() as *mut Impl;
                         (*this).#name(#(#params),*).into()

--- a/crates/tests/nightly_interface/tests/com.rs
+++ b/crates/tests/nightly_interface/tests/com.rs
@@ -11,7 +11,7 @@ pub unsafe trait ICustomUri: IUnknown {
     unsafe fn HasProperty(&self) -> HRESULT;
     unsafe fn GetAbsoluteUri(&self) -> HRESULT;
     unsafe fn GetAuthority(&self) -> HRESULT;
-    unsafe fn GetDisplayUri(&self) -> HRESULT;
+    unsafe fn GetDisplayUri(&self) -> i32;
     unsafe fn GetDomain(&self, value: *mut BSTR) -> HRESULT;
     // etc
 }
@@ -38,7 +38,7 @@ impl ICustomUri_Impl for CustomUri {
     unsafe fn GetAuthority(&self) -> HRESULT {
         todo!()
     }
-    unsafe fn GetDisplayUri(&self) -> HRESULT {
+    unsafe fn GetDisplayUri(&self) -> i32 {
         todo!()
     }
     unsafe fn GetDomain(&self, value: *mut BSTR) -> HRESULT {


### PR DESCRIPTION
This allows for return types in COM interfaces that are not `HRESULT`