### PR TITLE
Double quote features in documentation for easier consumption

### DIFF
--- a/crates/libs/bindgen/src/gen.rs
+++ b/crates/libs/bindgen/src/gen.rs
@@ -54,14 +54,14 @@ impl Gen<'_> {
         if !self.doc {
             quote! {}
         } else {
-            let mut tokens = format!("'{}'", to_feature(self.namespace));
+            let mut tokens = format!(r#"\"{}\""#, to_feature(self.namespace));
 
             let mut features = cfg.features(self.namespace);
             if self.windows_extern {
                 features = features.into_iter().filter(|f| !f.starts_with("Windows.")).collect();
             }
             for features in features {
-                tokens.push_str(&format!(", '{}'", to_feature(features)));
+                tokens.push_str(&format!(r#", \"{}\""#, to_feature(features)));
             }
 
             format!(r#"#[doc = "*Required features: {}*"]"#, tokens).into()


### PR DESCRIPTION
Double quotes feature names for easier cut/paste into Cargo.toml.

Closes #1597.