### PR TITLE
Support richer COM interface hierarchies

### DIFF
--- a/crates/libs/interface/src/lib.rs
+++ b/crates/libs/interface/src/lib.rs
@@ -127,7 +127,7 @@ impl Interface {
     }
 
     fn get_com_trait(&self) -> proc_macro2::TokenStream {
-        let name = quote::format_ident!("{}Impl", self.name);
+        let name = quote::format_ident!("{}_Impl", self.name);
         let vis = &self.visibility;
         let methods = self
             .methods
@@ -170,7 +170,7 @@ impl Interface {
                 }
             })
             .collect::<Vec<_>>();
-        let trait_name = quote::format_ident!("{}Impl", name);
+        let trait_name = quote::format_ident!("{}_Impl", name);
         let functions = self
             .methods
             .iter()
@@ -295,7 +295,7 @@ impl Interface {
         if i == "IUnknown" {
             return quote!();
         }
-        let i = quote::format_ident!("{}Impl", i);
+        let i = quote::format_ident!("{}_Impl", i);
         quote!(#i +)
     }
 }

--- a/crates/libs/interface/src/lib.rs
+++ b/crates/libs/interface/src/lib.rs
@@ -292,7 +292,7 @@ impl Interface {
     /// Gets the parent trait constrait which is nothing if the parent is IUnknown
     fn parent_trait_constraint(&self) -> proc_macro2::TokenStream {
         let i = self.parent_ident();
-        if i.clone().to_string() == "IUnknown" {
+        if i == "IUnknown" {
             return quote!();
         }
         let i = quote::format_ident!("{}Impl", i);

--- a/crates/libs/windows/src/core/interface.rs
+++ b/crates/libs/windows/src/core/interface.rs
@@ -22,7 +22,7 @@ pub unsafe trait Interface: Sized {
     #[doc(hidden)]
     unsafe fn assume_vtable<T: Interface>(&self) -> &T::Vtable {
         let this: RawPtr = core::mem::transmute_copy(self);
-        &(*(*(this as *mut *mut _) as *mut _))
+        &**(this as *mut *mut T::Vtable)
     }
 
     #[doc(hidden)]

--- a/crates/tests/nightly_interface/tests/com.rs
+++ b/crates/tests/nightly_interface/tests/com.rs
@@ -19,7 +19,7 @@ pub unsafe trait ICustomUri: IUnknown {
 #[implement(ICustomUri)]
 struct CustomUri;
 
-impl ICustomUri_Impl for CustomUri {
+impl ICustomUriImpl for CustomUri {
     unsafe fn GetPropertyBSTR(&self, property: Uri_PROPERTY, value: *mut BSTR, flags: u32) -> HRESULT {
         assert!(flags == 0);
         assert!(property == Uri_PROPERTY_DOMAIN);
@@ -138,19 +138,19 @@ impl HouseCat {
     }
 }
 
-impl ICat_Impl for HouseCat {
+impl ICatImpl for HouseCat {
     unsafe fn IgnoreHumans(&self) -> HRESULT {
         S_OK
     }
 }
 
-impl IDomesticAnimal_Impl for HouseCat {
+impl IDomesticAnimalImpl for HouseCat {
     unsafe fn Train(&self) -> HRESULT {
         S_OK
     }
 }
 
-impl IAnimal_Impl for HouseCat {
+impl IAnimalImpl for HouseCat {
     unsafe fn Eat(&self, food: *const Food) -> HRESULT {
         let h = self.0.get();
         let h = h + (*food).deliciousness;

--- a/crates/tests/nightly_interface/tests/com.rs
+++ b/crates/tests/nightly_interface/tests/com.rs
@@ -16,39 +16,90 @@ pub unsafe trait ICustomUri: IUnknown {
     // etc
 }
 
-#[implement(ICustomUri)]
-struct CustomUri;
+/// A custom declaration of implementation of `IPersist`
+#[interface("0000010c-0000-0000-C000-000000000046")]
+pub unsafe trait ICustomPersist: IUnknown {
+    unsafe fn GetClassID(&self, clsid: *mut GUID) -> HRESULT;
+}
 
-impl ICustomUriImpl for CustomUri {
-    unsafe fn GetPropertyBSTR(&self, property: Uri_PROPERTY, value: *mut BSTR, flags: u32) -> HRESULT {
-        assert!(flags == 0);
-        assert!(property == Uri_PROPERTY_DOMAIN);
-        *value = "property".into();
+/// A custom declaration of implementation of `IPersistMemory`
+#[interface("BD1AE5E0-A6AE-11CE-BD37-504200C10000")]
+pub unsafe trait ICustomPersistMemory: ICustomPersist {
+    unsafe fn IsDirty(&self) -> HRESULT;
+    unsafe fn Load(&self, input: *const core::ffi::c_void, size: u32) -> HRESULT;
+    unsafe fn Save(&self, output: *mut core::ffi::c_void, clear_dirty: BOOL, size: u32) -> HRESULT;
+    unsafe fn GetSizeMax(&self, len: *mut u32) -> HRESULT;
+    unsafe fn InitNew(&self) -> HRESULT;
+}
+
+/// A custom in-memory store
+#[implement(ICustomPersistMemory, ICustomPersist)]
+#[derive(Default)]
+struct Persist(std::sync::RwLock<PersistState>);
+
+impl Persist {
+    fn new() -> Self {
+        Self(std::sync::RwLock::new(PersistState::default()))
+    }
+}
+
+#[derive(Default)]
+struct PersistState {
+    memory: [u8; 10],
+    dirty: bool,
+}
+
+impl ICustomPersist_Impl for Persist {
+    unsafe fn GetClassID(&self, clsid: *mut GUID) -> HRESULT {
+        *clsid = "117fb826-2155-483a-b50d-bc99a2c7cca3".into();
         S_OK
     }
-    unsafe fn GetPropertyLength(&self) -> HRESULT {
-        todo!()
+}
+
+impl ICustomPersistMemory_Impl for Persist {
+    unsafe fn IsDirty(&self) -> HRESULT {
+        let reader = self.0.read().unwrap();
+        if reader.dirty {
+            S_OK
+        } else {
+            S_FALSE
+        }
     }
-    unsafe fn GetPropertyDWORD(&self, property: Uri_PROPERTY, value: *mut u32, flags: u32) -> HRESULT {
-        assert!(flags == 0);
-        assert!(property == Uri_PROPERTY_PORT);
-        *value = 123;
+
+    unsafe fn Load(&self, input: *const core::ffi::c_void, size: u32) -> HRESULT {
+        let mut writer = self.0.write().unwrap();
+        if size <= writer.memory.len() as _ {
+            std::ptr::copy(input, writer.memory.as_mut_ptr() as _, size as _);
+            writer.dirty = true;
+            S_OK
+        } else {
+            E_OUTOFMEMORY
+        }
+    }
+
+    unsafe fn Save(&self, output: *mut core::ffi::c_void, clear_dirty: BOOL, size: u32) -> HRESULT {
+        let mut writer = self.0.write().unwrap();
+        if size <= writer.memory.len() as _ {
+            std::ptr::copy(writer.memory.as_mut_ptr() as _, output, size as _);
+            if clear_dirty.as_bool() {
+                writer.dirty = false;
+            }
+            S_OK
+        } else {
+            E_OUTOFMEMORY
+        }
+    }
+
+    unsafe fn GetSizeMax(&self, len: *mut u32) -> HRESULT {
+        let reader = self.0.read().unwrap();
+        *len = reader.memory.len() as _;
         S_OK
     }
-    unsafe fn HasProperty(&self) {
-        todo!()
-    }
-    unsafe fn GetAbsoluteUri(&self) -> HRESULT {
-        todo!()
-    }
-    unsafe fn GetAuthority(&self) -> HRESULT {
-        todo!()
-    }
-    unsafe fn GetDisplayUri(&self) -> i32 {
-        todo!()
-    }
-    unsafe fn GetDomain(&self, value: *mut BSTR) -> HRESULT {
-        *value = "kennykerr.ca".into();
+
+    unsafe fn InitNew(&self) -> HRESULT {
+        let mut writer = self.0.write().unwrap();
+        writer.memory = Default::default();
+        writer.dirty = false;
         S_OK
     }
 }
@@ -56,18 +107,8 @@ impl ICustomUriImpl for CustomUri {
 #[test]
 fn test_custom_interface() -> windows::core::Result<()> {
     unsafe {
-        // Use the OS implementation through the OS interface
+        // Use the OS implementation of Uri through the custom `ICustomUri` interface
         let a: IUri = CreateUri("http://kennykerr.ca", Default::default(), 0)?;
-        let domain = a.GetDomain()?;
-        assert_eq!(domain, "kennykerr.ca");
-        let mut property = BSTR::new();
-        a.GetPropertyBSTR(Uri_PROPERTY_DOMAIN, &mut property, 0)?;
-        assert_eq!(property, "kennykerr.ca");
-        let mut property = 0;
-        a.GetPropertyDWORD(Uri_PROPERTY_PORT, &mut property, 0)?;
-        assert_eq!(property, 80);
-
-        // Call the OS implementation through the custom interface
         let b: ICustomUri = a.cast()?;
         let mut domain = BSTR::new();
         b.GetDomain(&mut domain).ok()?;
@@ -79,97 +120,36 @@ fn test_custom_interface() -> windows::core::Result<()> {
         a.GetPropertyDWORD(Uri_PROPERTY_PORT, &mut property, 0)?;
         assert_eq!(property, 80);
 
-        // Use the custom implementation through the OS interface
-        let c: ICustomUri = CustomUri.into();
-        // This works because `ICustomUri` and `IUri` share the same guid
-        let c: IUri = c.cast()?;
-        let domain = c.GetDomain()?;
-        assert_eq!(domain, "kennykerr.ca");
-        let mut property = BSTR::new();
-        c.GetPropertyBSTR(Uri_PROPERTY_DOMAIN, &mut property, 0)?;
-        assert_eq!(property, "property");
-        let mut property = 0;
-        c.GetPropertyDWORD(Uri_PROPERTY_PORT, &mut property, 0)?;
-        assert_eq!(property, 123);
+        // Use the custom implementation of `Persist` through the OS `IPersistMemory` interface
+        let p: ICustomPersistMemory = Persist::new().into();
+        // This works because `ICustomPersistMemory` and `IPersistMemory` share the same guid
+        let p: IPersistMemory = p.cast()?;
+        assert_eq!(p.GetClassID()?, "117fb826-2155-483a-b50d-bc99a2c7cca3".into());
+        // TODO: can't test IsDirty until this is fixed: https://github.com/microsoft/win32metadata/issues/838
+        assert_eq!(p.GetSizeMax()?, 10);
+        p.Load(&[0xAAu8, 0xBB, 0xCC])?;
+        let mut memory = [0x00u8, 0x00, 0x00, 0x00];
+        p.Save(&mut memory, true)?;
+        assert_eq!(memory, [0xAAu8, 0xBB, 0xCC, 0x00]);
 
-        // Call the custom implementation through the custom interface
-        let d: ICustomUri = c.cast()?;
-        let mut domain = BSTR::new();
-        d.GetDomain(&mut domain).ok()?;
-        assert_eq!(domain, "kennykerr.ca");
-        let mut property = BSTR::new();
-        d.GetPropertyBSTR(Uri_PROPERTY_DOMAIN, &mut property, 0).ok()?;
-        assert_eq!(property, "property");
-        let mut property = 0;
-        d.GetPropertyDWORD(Uri_PROPERTY_PORT, &mut property, 0).ok()?;
-        assert_eq!(property, 123);
+        // Use the custom implementation of `Persist` through the custom interface of `ICustomPersist`
+        let p: ICustomPersistMemory = p.cast()?;
+        let mut size = 0;
+        p.GetSizeMax(&mut size).ok()?;
+        assert_eq!(size, 10);
+        assert_eq!(p.IsDirty(), S_FALSE);
+        p.Load(&[0xAAu8, 0xBB, 0xCC] as *const _ as *const _, 3).ok()?;
+        assert_eq!(p.IsDirty(), S_OK);
+        let mut memory = [0x00u8, 0x00, 0x00, 0x00];
+        p.Save(&mut memory as *mut _ as *mut _, true.into(), 4).ok()?;
+        assert_eq!(p.IsDirty(), S_FALSE);
+        assert_eq!(memory, [0xAAu8, 0xBB, 0xCC, 0x00]);
+
+        let p: ICustomPersist = p.cast()?;
+        let mut b = GUID::default();
+        p.GetClassID(&mut b).ok()?;
+        assert_eq!(b, "117fb826-2155-483a-b50d-bc99a2c7cca3".into());
 
         Ok(())
     }
-}
-
-#[repr(C)]
-pub struct Food {
-    deliciousness: usize,
-}
-
-#[interface("EFF8970E-C50F-45E0-9284-291CE5A6F771")]
-pub unsafe trait IAnimal: IUnknown {
-    unsafe fn Eat(&self, food: *const Food) -> HRESULT;
-    unsafe fn Happiness(&self) -> usize;
-}
-
-#[interface("F5353C58-CFD9-4204-8D92-D274C7578B53")]
-pub unsafe trait ICat: IAnimal {
-    unsafe fn IgnoreHumans(&self) -> HRESULT;
-}
-
-#[interface("C22425DF-EFB2-4B85-933E-9CF7B23459E8")]
-pub unsafe trait IDomesticAnimal: IAnimal {
-    unsafe fn Train(&self) -> HRESULT;
-}
-
-#[implement(ICat, IDomesticAnimal, IAnimal)]
-struct HouseCat(std::cell::Cell<usize>);
-
-impl HouseCat {
-    fn new() -> Self {
-        Self(std::cell::Cell::new(0))
-    }
-}
-
-impl ICatImpl for HouseCat {
-    unsafe fn IgnoreHumans(&self) -> HRESULT {
-        S_OK
-    }
-}
-
-impl IDomesticAnimalImpl for HouseCat {
-    unsafe fn Train(&self) -> HRESULT {
-        S_OK
-    }
-}
-
-impl IAnimalImpl for HouseCat {
-    unsafe fn Eat(&self, food: *const Food) -> HRESULT {
-        let h = self.0.get();
-        let h = h + (*food).deliciousness;
-        self.0.set(h);
-
-        S_OK
-    }
-
-    unsafe fn Happiness(&self) -> usize {
-        self.0.get()
-    }
-}
-
-#[test]
-fn test_rich_interface_hierarchy() -> windows::core::Result<()> {
-    let animal: IAnimal = HouseCat::new().into();
-    assert_eq!(unsafe { animal.Happiness() }, 0);
-    unsafe { animal.Eat(&Food { deliciousness: 10 }).ok()? };
-    assert_eq!(unsafe { animal.Happiness() }, 10);
-
-    Ok(())
 }


### PR DESCRIPTION
As part of #1486, this allows for COM interfaces that inherit from something other than `IUnknown`. 

This also adds a test with a simple but rich COM hierarchy. 