### PR TITLE
Fix bug where the `interface` feature could not be used without the `implement` feature

### DIFF
--- a/crates/libs/windows/src/core/unknown.rs
+++ b/crates/libs/windows/src/core/unknown.rs
@@ -66,7 +66,7 @@ pub trait IUnknownImpl {
     fn Release(&mut self) -> u32;
 }
 
-#[cfg(feature = "implement")]
+#[cfg(any(feature = "interface", feature = "implement"))]
 impl IUnknownVtbl {
     pub const fn new<T: IUnknownImpl, const OFFSET: isize>() -> Self {
         unsafe extern "system" fn QueryInterface<T: IUnknownImpl, const OFFSET: isize>(this: RawPtr, iid: &GUID, interface: *mut RawPtr) -> HRESULT {


### PR DESCRIPTION
Fixes another issue in https://github.com/microsoft/windows-rs/issues/1486 where the `implement` feature needed to be enabled in order to be able to use the `interface` macro. 