### PR TITLE
Limit win32 array params to non-shared length params

### DIFF
--- a/crates/libs/bindgen/src/methods.rs
+++ b/crates/libs/bindgen/src/methods.rs
@@ -344,13 +344,8 @@ pub fn gen_win32_args(params: &[MethodParam]) -> TokenStream {
         }
 
         if let Some(ArrayInfo::RelativePtr(relative)) = param.array_info {
-            if let Some(relative) = relative {
-                let name = gen_param_name(&params[relative].def);
-                tokens.combine(&quote! { #name.len() as _, });
-            } else {
-                let len: TokenStream = format!("PARAM{}", position).into();
-                tokens.combine(&quote! { #len as _, });
-            }
+            let name = gen_param_name(&params[relative].def);
+            tokens.combine(&quote! { #name.len() as _, });
             continue;
         }
 

--- a/crates/libs/bindgen/src/methods.rs
+++ b/crates/libs/bindgen/src/methods.rs
@@ -283,7 +283,7 @@ pub fn gen_win32_params(params: &[MethodParam], gen: &Gen) -> TokenStream {
             }
         }
 
-        if let Some(ArrayInfo::RelativeLen(len)) = param.array_info {
+        if let Some(ArrayInfo::RelativeLen(_)) = param.array_info {
             let ty = param.ty.deref();
             let ty = gen_default_type(&ty, gen);
             let ty = if param.def.flags().output() {
@@ -316,7 +316,7 @@ pub fn gen_win32_params(params: &[MethodParam], gen: &Gen) -> TokenStream {
 pub fn gen_win32_args(params: &[MethodParam]) -> TokenStream {
     let mut tokens = quote! {};
 
-    for (position, param) in params.iter().enumerate() {
+    for param in params {
         let name = gen_param_name(&param.def);
 
         if let Some(ArrayInfo::Fixed(fixed)) = param.array_info {

--- a/crates/libs/bindgen/src/methods.rs
+++ b/crates/libs/bindgen/src/methods.rs
@@ -286,19 +286,10 @@ pub fn gen_win32_params(params: &[MethodParam], gen: &Gen) -> TokenStream {
         if let Some(ArrayInfo::RelativeLen(len)) = param.array_info {
             let ty = param.ty.deref();
             let ty = gen_default_type(&ty, gen);
-            let ty = if let Some(ArrayInfo::RelativePtr(Some(_))) = params[len].array_info {
-                if param.def.flags().output() {
-                    quote! { &mut [#ty] }
-                } else {
-                    quote! { &[#ty] }
-                }
+            let ty = if param.def.flags().output() {
+                quote! { &mut [#ty] }
             } else {
-                let len: TokenStream = format!("PARAM{}", len).into();
-                if param.def.flags().output() {
-                    quote! { &mut [#ty; #len] }
-                } else {
-                    quote! { &[#ty; #len] }
-                }
+                quote! { &[#ty] }
             };
 
             tokens.combine(&quote! { #name: #ty, });

--- a/crates/libs/bindgen/src/signatures.rs
+++ b/crates/libs/bindgen/src/signatures.rs
@@ -14,10 +14,7 @@ pub fn gen_param_constraints(params: &[MethodParam], gen: &Gen) -> TokenStream {
     let mut tokens = quote! {};
 
     for (position, param) in params.iter().enumerate() {
-        if let Some(ArrayInfo::RelativePtr(None)) = param.array_info {
-            let name: TokenStream = format!("PARAM{}", position).into();
-            tokens.combine(&quote! { const #name: usize, });
-        } else if param.is_convertible() {
+        if param.is_convertible() {
             let name: TokenStream = format!("Param{}", position).into();
             let into = gen_element_name(&param.ty, gen);
             tokens.combine(&quote! { #name: ::windows::core::IntoParam<'a, #into>, });

--- a/crates/libs/metadata/src/reader/array_info.rs
+++ b/crates/libs/metadata/src/reader/array_info.rs
@@ -2,5 +2,5 @@
 pub enum ArrayInfo {
     Fixed(usize),
     RelativeLen(usize),
-    RelativePtr(Option<usize>),
+    RelativePtr(usize),
 }

--- a/crates/libs/metadata/src/reader/tables/method_def.rs
+++ b/crates/libs/metadata/src/reader/tables/method_def.rs
@@ -124,11 +124,7 @@ impl MethodDef {
                 // The len params must be input only.
                 // TODO: workaround for https://github.com/microsoft/win32metadata/issues/813
                 if !params[relative].def.flags().output() && position != relative {
-                    if params[relative].array_info.is_none() {
-                        params[relative].array_info = Some(ArrayInfo::RelativePtr(Some(position)));
-                    } else {
-                        params[relative].array_info = Some(ArrayInfo::RelativePtr(None));
-                    }
+                    params[relative].array_info = Some(ArrayInfo::RelativePtr(position));
                 } else {
                     params[position].array_info = None;
                 }

--- a/crates/libs/metadata/src/reader/tables/method_def.rs
+++ b/crates/libs/metadata/src/reader/tables/method_def.rs
@@ -146,7 +146,7 @@ impl MethodDef {
 
         // Remove any sets that have optional ptr params.
         for (len, ptrs) in sets {
-            if ptrs.len() > 1 && ptrs.iter().any(|ptr| params[*ptr].def.flags().optional()) {
+            if ptrs.len() > 1 {
                 params[len].array_info = None;
                 for ptr in ptrs {
                     params[ptr].array_info = None;

--- a/crates/libs/metadata/src/reader/tables/method_def.rs
+++ b/crates/libs/metadata/src/reader/tables/method_def.rs
@@ -140,7 +140,7 @@ impl MethodDef {
             }
         }
 
-        // Remove any sets that have optional ptr params.
+        // Remove all sets.
         for (len, ptrs) in sets {
             if ptrs.len() > 1 {
                 params[len].array_info = None;

--- a/crates/libs/windows/src/Windows/Win32/Devices/HumanInterfaceDevice/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/HumanInterfaceDevice/mod.rs
@@ -8820,14 +8820,14 @@ pub unsafe fn HidP_UnsetUsages<'a, Param6: ::windows::core::IntoParam<'a, ::wind
 #[doc = "*Required features: `\"Win32_Devices_HumanInterfaceDevice\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
-pub unsafe fn HidP_UsageListDifference<'a, const PARAM4: usize>(previoususagelist: &[u16; PARAM4], currentusagelist: &[u16; PARAM4], breakusagelist: &mut [u16; PARAM4], makeusagelist: &mut [u16; PARAM4]) -> ::windows::core::Result<()> {
+pub unsafe fn HidP_UsageListDifference(previoususagelist: *const u16, currentusagelist: *const u16, breakusagelist: *mut u16, makeusagelist: *mut u16, usagelistlength: u32) -> ::windows::core::Result<()> {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn HidP_UsageListDifference(previoususagelist: *const u16, currentusagelist: *const u16, breakusagelist: *mut u16, makeusagelist: *mut u16, usagelistlength: u32) -> super::super::Foundation::NTSTATUS;
         }
-        HidP_UsageListDifference(::core::mem::transmute(::windows::core::as_ptr_or_null(previoususagelist)), ::core::mem::transmute(::windows::core::as_ptr_or_null(currentusagelist)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(breakusagelist)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(makeusagelist)), PARAM4 as _).ok()
+        HidP_UsageListDifference(::core::mem::transmute(previoususagelist), ::core::mem::transmute(currentusagelist), ::core::mem::transmute(breakusagelist), ::core::mem::transmute(makeusagelist), ::core::mem::transmute(usagelistlength)).ok()
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");

--- a/crates/libs/windows/src/Windows/Win32/Devices/ImageAcquisition/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/ImageAcquisition/mod.rs
@@ -2519,8 +2519,8 @@ pub struct IWiaPropertyStorage(::windows::core::IUnknown);
 impl IWiaPropertyStorage {
     #[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
-    pub unsafe fn ReadMultiple<'a, const PARAM0: usize>(&self, rgpspec: &[super::super::System::Com::StructuredStorage::PROPSPEC; PARAM0], rgpropvar: &mut [super::super::System::Com::StructuredStorage::PROPVARIANT; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).ReadMultiple)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(rgpspec)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(rgpropvar))).ok()
+    pub unsafe fn ReadMultiple(&self, cpspec: u32, rgpspec: *const super::super::System::Com::StructuredStorage::PROPSPEC, rgpropvar: *mut super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).ReadMultiple)(::core::mem::transmute_copy(self), ::core::mem::transmute(cpspec), ::core::mem::transmute(rgpspec), ::core::mem::transmute(rgpropvar)).ok()
     }
     #[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
@@ -2533,12 +2533,12 @@ impl IWiaPropertyStorage {
         (::windows::core::Interface::vtable(self).DeleteMultiple)(::core::mem::transmute_copy(self), rgpspec.len() as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(rgpspec))).ok()
     }
     #[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`*"]
-    pub unsafe fn ReadPropertyNames<'a, const PARAM0: usize>(&self, rgpropid: &[u32; PARAM0], rglpwstrname: &mut [::windows::core::PWSTR; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).ReadPropertyNames)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(rgpropid)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(rglpwstrname))).ok()
+    pub unsafe fn ReadPropertyNames(&self, cpropid: u32, rgpropid: *const u32, rglpwstrname: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).ReadPropertyNames)(::core::mem::transmute_copy(self), ::core::mem::transmute(cpropid), ::core::mem::transmute(rgpropid), ::core::mem::transmute(rglpwstrname)).ok()
     }
     #[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`*"]
-    pub unsafe fn WritePropertyNames<'a, const PARAM0: usize>(&self, rgpropid: &[u32; PARAM0], rglpwstrname: &[::windows::core::PWSTR; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).WritePropertyNames)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(rgpropid)), ::core::mem::transmute(::windows::core::as_ptr_or_null(rglpwstrname))).ok()
+    pub unsafe fn WritePropertyNames(&self, cpropid: u32, rgpropid: *const u32, rglpwstrname: *const ::windows::core::PWSTR) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).WritePropertyNames)(::core::mem::transmute_copy(self), ::core::mem::transmute(cpropid), ::core::mem::transmute(rgpropid), ::core::mem::transmute(rglpwstrname)).ok()
     }
     #[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`*"]
     pub unsafe fn DeletePropertyNames(&self, rgpropid: &[u32]) -> ::windows::core::Result<()> {
@@ -2575,8 +2575,8 @@ impl IWiaPropertyStorage {
     }
     #[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
-    pub unsafe fn GetPropertyAttributes<'a, const PARAM0: usize>(&self, rgpspec: &[super::super::System::Com::StructuredStorage::PROPSPEC; PARAM0], rgflags: &mut [u32; PARAM0], rgpropvar: &mut [super::super::System::Com::StructuredStorage::PROPVARIANT; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).GetPropertyAttributes)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(rgpspec)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(rgflags)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(rgpropvar))).ok()
+    pub unsafe fn GetPropertyAttributes(&self, cpspec: u32, rgpspec: *const super::super::System::Com::StructuredStorage::PROPSPEC, rgflags: *mut u32, rgpropvar: *mut super::super::System::Com::StructuredStorage::PROPVARIANT) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).GetPropertyAttributes)(::core::mem::transmute_copy(self), ::core::mem::transmute(cpspec), ::core::mem::transmute(rgpspec), ::core::mem::transmute(rgflags), ::core::mem::transmute(rgpropvar)).ok()
     }
     #[doc = "*Required features: `\"Win32_Devices_ImageAcquisition\"`*"]
     pub unsafe fn GetCount(&self) -> ::windows::core::Result<u32> {

--- a/crates/libs/windows/src/Windows/Win32/Globalization/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Globalization/mod.rs
@@ -2274,14 +2274,14 @@ pub unsafe fn GetStringTypeA(locale: u32, dwinfotype: u32, lpsrcstr: &[u8], lpch
 #[doc = "*Required features: `\"Win32_Globalization\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
-pub unsafe fn GetStringTypeExA<'a, const PARAM3: usize>(locale: u32, dwinfotype: u32, lpsrcstr: &[u8; PARAM3], lpchartype: &mut [u16; PARAM3]) -> super::Foundation::BOOL {
+pub unsafe fn GetStringTypeExA(locale: u32, dwinfotype: u32, lpsrcstr: ::windows::core::PCSTR, cchsrc: i32, lpchartype: *mut u16) -> super::Foundation::BOOL {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn GetStringTypeExA(locale: u32, dwinfotype: u32, lpsrcstr: ::windows::core::PCSTR, cchsrc: i32, lpchartype: *mut u16) -> super::Foundation::BOOL;
         }
-        ::core::mem::transmute(GetStringTypeExA(::core::mem::transmute(locale), ::core::mem::transmute(dwinfotype), ::core::mem::transmute(::windows::core::as_ptr_or_null(lpsrcstr)), PARAM3 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(lpchartype))))
+        ::core::mem::transmute(GetStringTypeExA(::core::mem::transmute(locale), ::core::mem::transmute(dwinfotype), ::core::mem::transmute(lpsrcstr), ::core::mem::transmute(cchsrc), ::core::mem::transmute(lpchartype)))
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
@@ -2289,14 +2289,14 @@ pub unsafe fn GetStringTypeExA<'a, const PARAM3: usize>(locale: u32, dwinfotype:
 #[doc = "*Required features: `\"Win32_Globalization\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
-pub unsafe fn GetStringTypeExW<'a, const PARAM3: usize>(locale: u32, dwinfotype: u32, lpsrcstr: &[u16; PARAM3], lpchartype: &mut [u16; PARAM3]) -> super::Foundation::BOOL {
+pub unsafe fn GetStringTypeExW(locale: u32, dwinfotype: u32, lpsrcstr: ::windows::core::PCWSTR, cchsrc: i32, lpchartype: *mut u16) -> super::Foundation::BOOL {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn GetStringTypeExW(locale: u32, dwinfotype: u32, lpsrcstr: ::windows::core::PCWSTR, cchsrc: i32, lpchartype: *mut u16) -> super::Foundation::BOOL;
         }
-        ::core::mem::transmute(GetStringTypeExW(::core::mem::transmute(locale), ::core::mem::transmute(dwinfotype), ::core::mem::transmute(::windows::core::as_ptr_or_null(lpsrcstr)), PARAM3 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(lpchartype))))
+        ::core::mem::transmute(GetStringTypeExW(::core::mem::transmute(locale), ::core::mem::transmute(dwinfotype), ::core::mem::transmute(lpsrcstr), ::core::mem::transmute(cchsrc), ::core::mem::transmute(lpchartype)))
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
@@ -8133,14 +8133,14 @@ pub unsafe fn ScriptApplyDigitSubstitution(psds: *const SCRIPT_DIGITSUBSTITUTE, 
 #[doc = "*Required features: `\"Win32_Globalization\"`, `\"Win32_Graphics_Gdi\"`*"]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[inline]
-pub unsafe fn ScriptApplyLogicalWidth<'a, const PARAM1: usize, const PARAM2: usize>(pidx: &[i32; PARAM1], pwlogclust: &[u16; PARAM1], psva: &[SCRIPT_VISATTR; PARAM2], piadvance: &[i32; PARAM2], psa: *const SCRIPT_ANALYSIS, pabc: *mut super::Graphics::Gdi::ABC, pijustify: *mut i32) -> ::windows::core::Result<()> {
+pub unsafe fn ScriptApplyLogicalWidth(pidx: *const i32, cchars: i32, cglyphs: i32, pwlogclust: *const u16, psva: *const SCRIPT_VISATTR, piadvance: *const i32, psa: *const SCRIPT_ANALYSIS, pabc: *mut super::Graphics::Gdi::ABC, pijustify: *mut i32) -> ::windows::core::Result<()> {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn ScriptApplyLogicalWidth(pidx: *const i32, cchars: i32, cglyphs: i32, pwlogclust: *const u16, psva: *const SCRIPT_VISATTR, piadvance: *const i32, psa: *const SCRIPT_ANALYSIS, pabc: *mut super::Graphics::Gdi::ABC, pijustify: *mut i32) -> ::windows::core::HRESULT;
         }
-        ScriptApplyLogicalWidth(::core::mem::transmute(::windows::core::as_ptr_or_null(pidx)), PARAM1 as _, PARAM2 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(pwlogclust)), ::core::mem::transmute(::windows::core::as_ptr_or_null(psva)), ::core::mem::transmute(::windows::core::as_ptr_or_null(piadvance)), ::core::mem::transmute(psa), ::core::mem::transmute(pabc), ::core::mem::transmute(pijustify)).ok()
+        ScriptApplyLogicalWidth(::core::mem::transmute(pidx), ::core::mem::transmute(cchars), ::core::mem::transmute(cglyphs), ::core::mem::transmute(pwlogclust), ::core::mem::transmute(psva), ::core::mem::transmute(piadvance), ::core::mem::transmute(psa), ::core::mem::transmute(pabc), ::core::mem::transmute(pijustify)).ok()
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
@@ -8163,14 +8163,14 @@ pub unsafe fn ScriptBreak(pwcchars: &[u16], psa: *const SCRIPT_ANALYSIS) -> ::wi
 #[doc = "*Required features: `\"Win32_Globalization\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
-pub unsafe fn ScriptCPtoX<'a, Param1: ::windows::core::IntoParam<'a, super::Foundation::BOOL>, const PARAM3: usize>(icp: i32, ftrailing: Param1, pwlogclust: &[u16], psva: &[SCRIPT_VISATTR; PARAM3], piadvance: &[i32; PARAM3], psa: *const SCRIPT_ANALYSIS, pix: *mut i32) -> ::windows::core::Result<()> {
+pub unsafe fn ScriptCPtoX<'a, Param1: ::windows::core::IntoParam<'a, super::Foundation::BOOL>>(icp: i32, ftrailing: Param1, cglyphs: i32, pwlogclust: &[u16], psva: *const SCRIPT_VISATTR, piadvance: *const i32, psa: *const SCRIPT_ANALYSIS, pix: *mut i32) -> ::windows::core::Result<()> {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn ScriptCPtoX(icp: i32, ftrailing: super::Foundation::BOOL, cchars: i32, cglyphs: i32, pwlogclust: *const u16, psva: *const SCRIPT_VISATTR, piadvance: *const i32, psa: *const SCRIPT_ANALYSIS, pix: *mut i32) -> ::windows::core::HRESULT;
         }
-        ScriptCPtoX(::core::mem::transmute(icp), ftrailing.into_param().abi(), pwlogclust.len() as _, PARAM3 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(pwlogclust)), ::core::mem::transmute(::windows::core::as_ptr_or_null(psva)), ::core::mem::transmute(::windows::core::as_ptr_or_null(piadvance)), ::core::mem::transmute(psa), ::core::mem::transmute(pix)).ok()
+        ScriptCPtoX(::core::mem::transmute(icp), ftrailing.into_param().abi(), pwlogclust.len() as _, ::core::mem::transmute(cglyphs), ::core::mem::transmute(::windows::core::as_ptr_or_null(pwlogclust)), ::core::mem::transmute(psva), ::core::mem::transmute(piadvance), ::core::mem::transmute(psa), ::core::mem::transmute(pix)).ok()
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
@@ -8207,14 +8207,14 @@ pub unsafe fn ScriptFreeCache(psc: *mut *mut ::core::ffi::c_void) -> ::windows::
 #[doc = "*Required features: `\"Win32_Globalization\"`, `\"Win32_Graphics_Gdi\"`*"]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[inline]
-pub unsafe fn ScriptGetCMap<'a, Param0: ::windows::core::IntoParam<'a, super::Graphics::Gdi::HDC>, const PARAM3: usize>(hdc: Param0, psc: *mut *mut ::core::ffi::c_void, pwcinchars: &[u16; PARAM3], dwflags: u32, pwoutglyphs: &mut [u16; PARAM3]) -> ::windows::core::Result<()> {
+pub unsafe fn ScriptGetCMap<'a, Param0: ::windows::core::IntoParam<'a, super::Graphics::Gdi::HDC>>(hdc: Param0, psc: *mut *mut ::core::ffi::c_void, pwcinchars: ::windows::core::PCWSTR, cchars: i32, dwflags: u32, pwoutglyphs: *mut u16) -> ::windows::core::Result<()> {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn ScriptGetCMap(hdc: super::Graphics::Gdi::HDC, psc: *mut *mut ::core::ffi::c_void, pwcinchars: ::windows::core::PCWSTR, cchars: i32, dwflags: u32, pwoutglyphs: *mut u16) -> ::windows::core::HRESULT;
         }
-        ScriptGetCMap(hdc.into_param().abi(), ::core::mem::transmute(psc), ::core::mem::transmute(::windows::core::as_ptr_or_null(pwcinchars)), PARAM3 as _, ::core::mem::transmute(dwflags), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(pwoutglyphs))).ok()
+        ScriptGetCMap(hdc.into_param().abi(), ::core::mem::transmute(psc), ::core::mem::transmute(pwcinchars), ::core::mem::transmute(cchars), ::core::mem::transmute(dwflags), ::core::mem::transmute(pwoutglyphs)).ok()
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
@@ -8311,14 +8311,14 @@ pub unsafe fn ScriptGetGlyphABCWidth<'a, Param0: ::windows::core::IntoParam<'a, 
 }
 #[doc = "*Required features: `\"Win32_Globalization\"`*"]
 #[inline]
-pub unsafe fn ScriptGetLogicalWidths<'a, const PARAM1: usize, const PARAM2: usize>(psa: *const SCRIPT_ANALYSIS, piglyphwidth: &[i32; PARAM2], pwlogclust: &[u16; PARAM1], psva: &[SCRIPT_VISATTR; PARAM2], pidx: &[i32; PARAM1]) -> ::windows::core::Result<()> {
+pub unsafe fn ScriptGetLogicalWidths(psa: *const SCRIPT_ANALYSIS, cchars: i32, cglyphs: i32, piglyphwidth: *const i32, pwlogclust: *const u16, psva: *const SCRIPT_VISATTR, pidx: *const i32) -> ::windows::core::Result<()> {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn ScriptGetLogicalWidths(psa: *const SCRIPT_ANALYSIS, cchars: i32, cglyphs: i32, piglyphwidth: *const i32, pwlogclust: *const u16, psva: *const SCRIPT_VISATTR, pidx: *const i32) -> ::windows::core::HRESULT;
         }
-        ScriptGetLogicalWidths(::core::mem::transmute(psa), PARAM1 as _, PARAM2 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(piglyphwidth)), ::core::mem::transmute(::windows::core::as_ptr_or_null(pwlogclust)), ::core::mem::transmute(::windows::core::as_ptr_or_null(psva)), ::core::mem::transmute(::windows::core::as_ptr_or_null(pidx))).ok()
+        ScriptGetLogicalWidths(::core::mem::transmute(psa), ::core::mem::transmute(cchars), ::core::mem::transmute(cglyphs), ::core::mem::transmute(piglyphwidth), ::core::mem::transmute(pwlogclust), ::core::mem::transmute(psva), ::core::mem::transmute(pidx)).ok()
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
@@ -8367,21 +8367,21 @@ pub unsafe fn ScriptItemize(pwcinchars: &[u16], pscontrol: *const SCRIPT_CONTROL
 }
 #[doc = "*Required features: `\"Win32_Globalization\"`*"]
 #[inline]
-pub unsafe fn ScriptItemizeOpenType<'a, const PARAM2: usize>(pwcinchars: &[u16], pscontrol: *const SCRIPT_CONTROL, psstate: *const SCRIPT_STATE, pitems: &mut [SCRIPT_ITEM; PARAM2], pscripttags: &mut [u32; PARAM2], pcitems: *mut i32) -> ::windows::core::Result<()> {
+pub unsafe fn ScriptItemizeOpenType(pwcinchars: &[u16], cmaxitems: i32, pscontrol: *const SCRIPT_CONTROL, psstate: *const SCRIPT_STATE, pitems: *mut SCRIPT_ITEM, pscripttags: *mut u32, pcitems: *mut i32) -> ::windows::core::Result<()> {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn ScriptItemizeOpenType(pwcinchars: ::windows::core::PCWSTR, cinchars: i32, cmaxitems: i32, pscontrol: *const SCRIPT_CONTROL, psstate: *const SCRIPT_STATE, pitems: *mut SCRIPT_ITEM, pscripttags: *mut u32, pcitems: *mut i32) -> ::windows::core::HRESULT;
         }
-        ScriptItemizeOpenType(::core::mem::transmute(::windows::core::as_ptr_or_null(pwcinchars)), pwcinchars.len() as _, PARAM2 as _, ::core::mem::transmute(pscontrol), ::core::mem::transmute(psstate), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(pitems)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(pscripttags)), ::core::mem::transmute(pcitems)).ok()
+        ScriptItemizeOpenType(::core::mem::transmute(::windows::core::as_ptr_or_null(pwcinchars)), pwcinchars.len() as _, ::core::mem::transmute(cmaxitems), ::core::mem::transmute(pscontrol), ::core::mem::transmute(psstate), ::core::mem::transmute(pitems), ::core::mem::transmute(pscripttags), ::core::mem::transmute(pcitems)).ok()
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
 }
 #[doc = "*Required features: `\"Win32_Globalization\"`*"]
 #[inline]
-pub unsafe fn ScriptJustify<'a, const PARAM2: usize>(psva: &[SCRIPT_VISATTR; PARAM2], piadvance: &[i32; PARAM2], idx: i32, iminkashida: i32) -> ::windows::core::Result<i32> {
+pub unsafe fn ScriptJustify(psva: *const SCRIPT_VISATTR, piadvance: *const i32, cglyphs: i32, idx: i32, iminkashida: i32) -> ::windows::core::Result<i32> {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
@@ -8389,7 +8389,7 @@ pub unsafe fn ScriptJustify<'a, const PARAM2: usize>(psva: &[SCRIPT_VISATTR; PAR
             fn ScriptJustify(psva: *const SCRIPT_VISATTR, piadvance: *const i32, cglyphs: i32, idx: i32, iminkashida: i32, pijustify: *mut i32) -> ::windows::core::HRESULT;
         }
         let mut result__: i32 = ::core::mem::zeroed();
-        ScriptJustify(::core::mem::transmute(::windows::core::as_ptr_or_null(psva)), ::core::mem::transmute(::windows::core::as_ptr_or_null(piadvance)), PARAM2 as _, ::core::mem::transmute(idx), ::core::mem::transmute(iminkashida), ::core::mem::transmute(&mut result__)).from_abi::<i32>(result__)
+        ScriptJustify(::core::mem::transmute(psva), ::core::mem::transmute(piadvance), ::core::mem::transmute(cglyphs), ::core::mem::transmute(idx), ::core::mem::transmute(iminkashida), ::core::mem::transmute(&mut result__)).from_abi::<i32>(result__)
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
@@ -8411,14 +8411,14 @@ pub unsafe fn ScriptLayout(pblevel: &[u8], pivisualtological: *mut i32, pilogica
 #[doc = "*Required features: `\"Win32_Globalization\"`, `\"Win32_Graphics_Gdi\"`*"]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[inline]
-pub unsafe fn ScriptPlace<'a, Param0: ::windows::core::IntoParam<'a, super::Graphics::Gdi::HDC>, const PARAM3: usize>(hdc: Param0, psc: *mut *mut ::core::ffi::c_void, pwglyphs: &[u16; PARAM3], psva: &[SCRIPT_VISATTR; PARAM3], psa: *mut SCRIPT_ANALYSIS, piadvance: *mut i32, pgoffset: *mut GOFFSET, pabc: *mut super::Graphics::Gdi::ABC) -> ::windows::core::Result<()> {
+pub unsafe fn ScriptPlace<'a, Param0: ::windows::core::IntoParam<'a, super::Graphics::Gdi::HDC>>(hdc: Param0, psc: *mut *mut ::core::ffi::c_void, pwglyphs: *const u16, cglyphs: i32, psva: *const SCRIPT_VISATTR, psa: *mut SCRIPT_ANALYSIS, piadvance: *mut i32, pgoffset: *mut GOFFSET, pabc: *mut super::Graphics::Gdi::ABC) -> ::windows::core::Result<()> {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn ScriptPlace(hdc: super::Graphics::Gdi::HDC, psc: *mut *mut ::core::ffi::c_void, pwglyphs: *const u16, cglyphs: i32, psva: *const SCRIPT_VISATTR, psa: *mut SCRIPT_ANALYSIS, piadvance: *mut i32, pgoffset: *mut GOFFSET, pabc: *mut super::Graphics::Gdi::ABC) -> ::windows::core::HRESULT;
         }
-        ScriptPlace(hdc.into_param().abi(), ::core::mem::transmute(psc), ::core::mem::transmute(::windows::core::as_ptr_or_null(pwglyphs)), PARAM3 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(psva)), ::core::mem::transmute(psa), ::core::mem::transmute(piadvance), ::core::mem::transmute(pgoffset), ::core::mem::transmute(pabc)).ok()
+        ScriptPlace(hdc.into_param().abi(), ::core::mem::transmute(psc), ::core::mem::transmute(pwglyphs), ::core::mem::transmute(cglyphs), ::core::mem::transmute(psva), ::core::mem::transmute(psa), ::core::mem::transmute(piadvance), ::core::mem::transmute(pgoffset), ::core::mem::transmute(pabc)).ok()
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
@@ -8426,7 +8426,7 @@ pub unsafe fn ScriptPlace<'a, Param0: ::windows::core::IntoParam<'a, super::Grap
 #[doc = "*Required features: `\"Win32_Globalization\"`, `\"Win32_Graphics_Gdi\"`*"]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[inline]
-pub unsafe fn ScriptPlaceOpenType<'a, Param0: ::windows::core::IntoParam<'a, super::Graphics::Gdi::HDC>, const PARAM11: usize, const PARAM14: usize>(hdc: Param0, psc: *mut *mut ::core::ffi::c_void, psa: *mut SCRIPT_ANALYSIS, tagscript: u32, taglangsys: u32, rcrangechars: *const i32, rprangeproperties: *const *const textrange_properties, cranges: i32, pwcchars: &[u16; PARAM11], pwlogclust: &[u16; PARAM11], pcharprops: &[script_charprop; PARAM11], pwglyphs: &[u16; PARAM14], pglyphprops: &[script_glyphprop; PARAM14], piadvance: *mut i32, pgoffset: *mut GOFFSET, pabc: *mut super::Graphics::Gdi::ABC) -> ::windows::core::Result<()> {
+pub unsafe fn ScriptPlaceOpenType<'a, Param0: ::windows::core::IntoParam<'a, super::Graphics::Gdi::HDC>>(hdc: Param0, psc: *mut *mut ::core::ffi::c_void, psa: *mut SCRIPT_ANALYSIS, tagscript: u32, taglangsys: u32, rcrangechars: *const i32, rprangeproperties: *const *const textrange_properties, cranges: i32, pwcchars: ::windows::core::PCWSTR, pwlogclust: *const u16, pcharprops: *const script_charprop, cchars: i32, pwglyphs: *const u16, pglyphprops: *const script_glyphprop, cglyphs: i32, piadvance: *mut i32, pgoffset: *mut GOFFSET, pabc: *mut super::Graphics::Gdi::ABC) -> ::windows::core::Result<()> {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
@@ -8442,13 +8442,13 @@ pub unsafe fn ScriptPlaceOpenType<'a, Param0: ::windows::core::IntoParam<'a, sup
             ::core::mem::transmute(rcrangechars),
             ::core::mem::transmute(rprangeproperties),
             ::core::mem::transmute(cranges),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(pwcchars)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(pwlogclust)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(pcharprops)),
-            PARAM11 as _,
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(pwglyphs)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(pglyphprops)),
-            PARAM14 as _,
+            ::core::mem::transmute(pwcchars),
+            ::core::mem::transmute(pwlogclust),
+            ::core::mem::transmute(pcharprops),
+            ::core::mem::transmute(cchars),
+            ::core::mem::transmute(pwglyphs),
+            ::core::mem::transmute(pglyphprops),
+            ::core::mem::transmute(cglyphs),
             ::core::mem::transmute(piadvance),
             ::core::mem::transmute(pgoffset),
             ::core::mem::transmute(pabc),
@@ -8491,14 +8491,14 @@ pub unsafe fn ScriptRecordDigitSubstitution(locale: u32) -> ::windows::core::Res
 #[doc = "*Required features: `\"Win32_Globalization\"`, `\"Win32_Graphics_Gdi\"`*"]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[inline]
-pub unsafe fn ScriptShape<'a, Param0: ::windows::core::IntoParam<'a, super::Graphics::Gdi::HDC>, const PARAM4: usize>(hdc: Param0, psc: *mut *mut ::core::ffi::c_void, pwcchars: &[u16], psa: *mut SCRIPT_ANALYSIS, pwoutglyphs: &mut [u16; PARAM4], pwlogclust: *mut u16, psva: &mut [SCRIPT_VISATTR; PARAM4], pcglyphs: *mut i32) -> ::windows::core::Result<()> {
+pub unsafe fn ScriptShape<'a, Param0: ::windows::core::IntoParam<'a, super::Graphics::Gdi::HDC>>(hdc: Param0, psc: *mut *mut ::core::ffi::c_void, pwcchars: &[u16], cmaxglyphs: i32, psa: *mut SCRIPT_ANALYSIS, pwoutglyphs: *mut u16, pwlogclust: *mut u16, psva: *mut SCRIPT_VISATTR, pcglyphs: *mut i32) -> ::windows::core::Result<()> {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn ScriptShape(hdc: super::Graphics::Gdi::HDC, psc: *mut *mut ::core::ffi::c_void, pwcchars: ::windows::core::PCWSTR, cchars: i32, cmaxglyphs: i32, psa: *mut SCRIPT_ANALYSIS, pwoutglyphs: *mut u16, pwlogclust: *mut u16, psva: *mut SCRIPT_VISATTR, pcglyphs: *mut i32) -> ::windows::core::HRESULT;
         }
-        ScriptShape(hdc.into_param().abi(), ::core::mem::transmute(psc), ::core::mem::transmute(::windows::core::as_ptr_or_null(pwcchars)), pwcchars.len() as _, PARAM4 as _, ::core::mem::transmute(psa), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(pwoutglyphs)), ::core::mem::transmute(pwlogclust), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(psva)), ::core::mem::transmute(pcglyphs)).ok()
+        ScriptShape(hdc.into_param().abi(), ::core::mem::transmute(psc), ::core::mem::transmute(::windows::core::as_ptr_or_null(pwcchars)), pwcchars.len() as _, ::core::mem::transmute(cmaxglyphs), ::core::mem::transmute(psa), ::core::mem::transmute(pwoutglyphs), ::core::mem::transmute(pwlogclust), ::core::mem::transmute(psva), ::core::mem::transmute(pcglyphs)).ok()
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
@@ -8506,7 +8506,7 @@ pub unsafe fn ScriptShape<'a, Param0: ::windows::core::IntoParam<'a, super::Grap
 #[doc = "*Required features: `\"Win32_Globalization\"`, `\"Win32_Graphics_Gdi\"`*"]
 #[cfg(feature = "Win32_Graphics_Gdi")]
 #[inline]
-pub unsafe fn ScriptShapeOpenType<'a, Param0: ::windows::core::IntoParam<'a, super::Graphics::Gdi::HDC>, const PARAM10: usize>(hdc: Param0, psc: *mut *mut ::core::ffi::c_void, psa: *mut SCRIPT_ANALYSIS, tagscript: u32, taglangsys: u32, rcrangechars: *const i32, rprangeproperties: *const *const textrange_properties, cranges: i32, pwcchars: &[u16], pwlogclust: *mut u16, pcharprops: *mut script_charprop, pwoutglyphs: &mut [u16; PARAM10], poutglyphprops: &mut [script_glyphprop; PARAM10], pcglyphs: *mut i32) -> ::windows::core::Result<()> {
+pub unsafe fn ScriptShapeOpenType<'a, Param0: ::windows::core::IntoParam<'a, super::Graphics::Gdi::HDC>>(hdc: Param0, psc: *mut *mut ::core::ffi::c_void, psa: *mut SCRIPT_ANALYSIS, tagscript: u32, taglangsys: u32, rcrangechars: *const i32, rprangeproperties: *const *const textrange_properties, cranges: i32, pwcchars: &[u16], cmaxglyphs: i32, pwlogclust: *mut u16, pcharprops: *mut script_charprop, pwoutglyphs: *mut u16, poutglyphprops: *mut script_glyphprop, pcglyphs: *mut i32) -> ::windows::core::Result<()> {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
@@ -8524,11 +8524,11 @@ pub unsafe fn ScriptShapeOpenType<'a, Param0: ::windows::core::IntoParam<'a, sup
             ::core::mem::transmute(cranges),
             ::core::mem::transmute(::windows::core::as_ptr_or_null(pwcchars)),
             pwcchars.len() as _,
-            PARAM10 as _,
+            ::core::mem::transmute(cmaxglyphs),
             ::core::mem::transmute(pwlogclust),
             ::core::mem::transmute(pcharprops),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(pwoutglyphs)),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(poutglyphprops)),
+            ::core::mem::transmute(pwoutglyphs),
+            ::core::mem::transmute(poutglyphprops),
             ::core::mem::transmute(pcglyphs),
         )
         .ok()
@@ -8727,14 +8727,14 @@ pub unsafe fn ScriptTextOut<'a, Param0: ::windows::core::IntoParam<'a, super::Gr
 }
 #[doc = "*Required features: `\"Win32_Globalization\"`*"]
 #[inline]
-pub unsafe fn ScriptXtoCP<'a, const PARAM2: usize>(ix: i32, pwlogclust: &[u16], psva: &[SCRIPT_VISATTR; PARAM2], piadvance: &[i32; PARAM2], psa: *const SCRIPT_ANALYSIS, picp: *mut i32, pitrailing: *mut i32) -> ::windows::core::Result<()> {
+pub unsafe fn ScriptXtoCP(ix: i32, cglyphs: i32, pwlogclust: &[u16], psva: *const SCRIPT_VISATTR, piadvance: *const i32, psa: *const SCRIPT_ANALYSIS, picp: *mut i32, pitrailing: *mut i32) -> ::windows::core::Result<()> {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn ScriptXtoCP(ix: i32, cchars: i32, cglyphs: i32, pwlogclust: *const u16, psva: *const SCRIPT_VISATTR, piadvance: *const i32, psa: *const SCRIPT_ANALYSIS, picp: *mut i32, pitrailing: *mut i32) -> ::windows::core::HRESULT;
         }
-        ScriptXtoCP(::core::mem::transmute(ix), pwlogclust.len() as _, PARAM2 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(pwlogclust)), ::core::mem::transmute(::windows::core::as_ptr_or_null(psva)), ::core::mem::transmute(::windows::core::as_ptr_or_null(piadvance)), ::core::mem::transmute(psa), ::core::mem::transmute(picp), ::core::mem::transmute(pitrailing)).ok()
+        ScriptXtoCP(::core::mem::transmute(ix), pwlogclust.len() as _, ::core::mem::transmute(cglyphs), ::core::mem::transmute(::windows::core::as_ptr_or_null(pwlogclust)), ::core::mem::transmute(psva), ::core::mem::transmute(piadvance), ::core::mem::transmute(psa), ::core::mem::transmute(picp), ::core::mem::transmute(pitrailing)).ok()
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct2D/mod.rs
@@ -11510,8 +11510,8 @@ impl ID2D1ComputeTransform {
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn MapInputRectsToOutputRect<'a, const PARAM2: usize>(&self, inputrects: &[super::super::Foundation::RECT; PARAM2], inputopaquesubrects: &[super::super::Foundation::RECT; PARAM2], outputrect: *mut super::super::Foundation::RECT, outputopaquesubrect: *mut super::super::Foundation::RECT) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.MapInputRectsToOutputRect)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(inputrects)), ::core::mem::transmute(::windows::core::as_ptr_or_null(inputopaquesubrects)), PARAM2 as _, ::core::mem::transmute(outputrect), ::core::mem::transmute(outputopaquesubrect)).ok()
+    pub unsafe fn MapInputRectsToOutputRect(&self, inputrects: *const super::super::Foundation::RECT, inputopaquesubrects: *const super::super::Foundation::RECT, inputrectcount: u32, outputrect: *mut super::super::Foundation::RECT, outputopaquesubrect: *mut super::super::Foundation::RECT) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.MapInputRectsToOutputRect)(::core::mem::transmute_copy(self), ::core::mem::transmute(inputrects), ::core::mem::transmute(inputopaquesubrects), ::core::mem::transmute(inputrectcount), ::core::mem::transmute(outputrect), ::core::mem::transmute(outputopaquesubrect)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -13859,8 +13859,8 @@ impl ID2D1DeviceContext {
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`*"]
     #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-    pub unsafe fn GetEffectRequiredInputRectangles<'a, Param0: ::windows::core::IntoParam<'a, ID2D1Effect>, const PARAM4: usize>(&self, rendereffect: Param0, renderimagerectangle: *const Common::D2D_RECT_F, inputdescriptions: &[D2D1_EFFECT_INPUT_DESCRIPTION; PARAM4], requiredinputrects: &mut [Common::D2D_RECT_F; PARAM4]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).GetEffectRequiredInputRectangles)(::core::mem::transmute_copy(self), rendereffect.into_param().abi(), ::core::mem::transmute(renderimagerectangle), ::core::mem::transmute(::windows::core::as_ptr_or_null(inputdescriptions)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(requiredinputrects)), PARAM4 as _).ok()
+    pub unsafe fn GetEffectRequiredInputRectangles<'a, Param0: ::windows::core::IntoParam<'a, ID2D1Effect>>(&self, rendereffect: Param0, renderimagerectangle: *const Common::D2D_RECT_F, inputdescriptions: *const D2D1_EFFECT_INPUT_DESCRIPTION, requiredinputrects: *mut Common::D2D_RECT_F, inputcount: u32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).GetEffectRequiredInputRectangles)(::core::mem::transmute_copy(self), rendereffect.into_param().abi(), ::core::mem::transmute(renderimagerectangle), ::core::mem::transmute(inputdescriptions), ::core::mem::transmute(requiredinputrects), ::core::mem::transmute(inputcount)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`*"]
     #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
@@ -14496,8 +14496,8 @@ impl ID2D1DeviceContext1 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`*"]
     #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-    pub unsafe fn GetEffectRequiredInputRectangles<'a, Param0: ::windows::core::IntoParam<'a, ID2D1Effect>, const PARAM4: usize>(&self, rendereffect: Param0, renderimagerectangle: *const Common::D2D_RECT_F, inputdescriptions: &[D2D1_EFFECT_INPUT_DESCRIPTION; PARAM4], requiredinputrects: &mut [Common::D2D_RECT_F; PARAM4]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.GetEffectRequiredInputRectangles)(::core::mem::transmute_copy(self), rendereffect.into_param().abi(), ::core::mem::transmute(renderimagerectangle), ::core::mem::transmute(::windows::core::as_ptr_or_null(inputdescriptions)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(requiredinputrects)), PARAM4 as _).ok()
+    pub unsafe fn GetEffectRequiredInputRectangles<'a, Param0: ::windows::core::IntoParam<'a, ID2D1Effect>>(&self, rendereffect: Param0, renderimagerectangle: *const Common::D2D_RECT_F, inputdescriptions: *const D2D1_EFFECT_INPUT_DESCRIPTION, requiredinputrects: *mut Common::D2D_RECT_F, inputcount: u32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.GetEffectRequiredInputRectangles)(::core::mem::transmute_copy(self), rendereffect.into_param().abi(), ::core::mem::transmute(renderimagerectangle), ::core::mem::transmute(inputdescriptions), ::core::mem::transmute(requiredinputrects), ::core::mem::transmute(inputcount)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`*"]
     #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
@@ -15066,8 +15066,8 @@ impl ID2D1DeviceContext2 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`*"]
     #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-    pub unsafe fn GetEffectRequiredInputRectangles<'a, Param0: ::windows::core::IntoParam<'a, ID2D1Effect>, const PARAM4: usize>(&self, rendereffect: Param0, renderimagerectangle: *const Common::D2D_RECT_F, inputdescriptions: &[D2D1_EFFECT_INPUT_DESCRIPTION; PARAM4], requiredinputrects: &mut [Common::D2D_RECT_F; PARAM4]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.GetEffectRequiredInputRectangles)(::core::mem::transmute_copy(self), rendereffect.into_param().abi(), ::core::mem::transmute(renderimagerectangle), ::core::mem::transmute(::windows::core::as_ptr_or_null(inputdescriptions)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(requiredinputrects)), PARAM4 as _).ok()
+    pub unsafe fn GetEffectRequiredInputRectangles<'a, Param0: ::windows::core::IntoParam<'a, ID2D1Effect>>(&self, rendereffect: Param0, renderimagerectangle: *const Common::D2D_RECT_F, inputdescriptions: *const D2D1_EFFECT_INPUT_DESCRIPTION, requiredinputrects: *mut Common::D2D_RECT_F, inputcount: u32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.GetEffectRequiredInputRectangles)(::core::mem::transmute_copy(self), rendereffect.into_param().abi(), ::core::mem::transmute(renderimagerectangle), ::core::mem::transmute(inputdescriptions), ::core::mem::transmute(requiredinputrects), ::core::mem::transmute(inputcount)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`*"]
     #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
@@ -15740,8 +15740,8 @@ impl ID2D1DeviceContext3 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`*"]
     #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-    pub unsafe fn GetEffectRequiredInputRectangles<'a, Param0: ::windows::core::IntoParam<'a, ID2D1Effect>, const PARAM4: usize>(&self, rendereffect: Param0, renderimagerectangle: *const Common::D2D_RECT_F, inputdescriptions: &[D2D1_EFFECT_INPUT_DESCRIPTION; PARAM4], requiredinputrects: &mut [Common::D2D_RECT_F; PARAM4]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.GetEffectRequiredInputRectangles)(::core::mem::transmute_copy(self), rendereffect.into_param().abi(), ::core::mem::transmute(renderimagerectangle), ::core::mem::transmute(::windows::core::as_ptr_or_null(inputdescriptions)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(requiredinputrects)), PARAM4 as _).ok()
+    pub unsafe fn GetEffectRequiredInputRectangles<'a, Param0: ::windows::core::IntoParam<'a, ID2D1Effect>>(&self, rendereffect: Param0, renderimagerectangle: *const Common::D2D_RECT_F, inputdescriptions: *const D2D1_EFFECT_INPUT_DESCRIPTION, requiredinputrects: *mut Common::D2D_RECT_F, inputcount: u32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.GetEffectRequiredInputRectangles)(::core::mem::transmute_copy(self), rendereffect.into_param().abi(), ::core::mem::transmute(renderimagerectangle), ::core::mem::transmute(inputdescriptions), ::core::mem::transmute(requiredinputrects), ::core::mem::transmute(inputcount)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`*"]
     #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
@@ -16416,8 +16416,8 @@ impl ID2D1DeviceContext4 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`*"]
     #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-    pub unsafe fn GetEffectRequiredInputRectangles<'a, Param0: ::windows::core::IntoParam<'a, ID2D1Effect>, const PARAM4: usize>(&self, rendereffect: Param0, renderimagerectangle: *const Common::D2D_RECT_F, inputdescriptions: &[D2D1_EFFECT_INPUT_DESCRIPTION; PARAM4], requiredinputrects: &mut [Common::D2D_RECT_F; PARAM4]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.GetEffectRequiredInputRectangles)(::core::mem::transmute_copy(self), rendereffect.into_param().abi(), ::core::mem::transmute(renderimagerectangle), ::core::mem::transmute(::windows::core::as_ptr_or_null(inputdescriptions)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(requiredinputrects)), PARAM4 as _).ok()
+    pub unsafe fn GetEffectRequiredInputRectangles<'a, Param0: ::windows::core::IntoParam<'a, ID2D1Effect>>(&self, rendereffect: Param0, renderimagerectangle: *const Common::D2D_RECT_F, inputdescriptions: *const D2D1_EFFECT_INPUT_DESCRIPTION, requiredinputrects: *mut Common::D2D_RECT_F, inputcount: u32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.GetEffectRequiredInputRectangles)(::core::mem::transmute_copy(self), rendereffect.into_param().abi(), ::core::mem::transmute(renderimagerectangle), ::core::mem::transmute(inputdescriptions), ::core::mem::transmute(requiredinputrects), ::core::mem::transmute(inputcount)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`*"]
     #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
@@ -17170,8 +17170,8 @@ impl ID2D1DeviceContext5 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`*"]
     #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-    pub unsafe fn GetEffectRequiredInputRectangles<'a, Param0: ::windows::core::IntoParam<'a, ID2D1Effect>, const PARAM4: usize>(&self, rendereffect: Param0, renderimagerectangle: *const Common::D2D_RECT_F, inputdescriptions: &[D2D1_EFFECT_INPUT_DESCRIPTION; PARAM4], requiredinputrects: &mut [Common::D2D_RECT_F; PARAM4]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.base.GetEffectRequiredInputRectangles)(::core::mem::transmute_copy(self), rendereffect.into_param().abi(), ::core::mem::transmute(renderimagerectangle), ::core::mem::transmute(::windows::core::as_ptr_or_null(inputdescriptions)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(requiredinputrects)), PARAM4 as _).ok()
+    pub unsafe fn GetEffectRequiredInputRectangles<'a, Param0: ::windows::core::IntoParam<'a, ID2D1Effect>>(&self, rendereffect: Param0, renderimagerectangle: *const Common::D2D_RECT_F, inputdescriptions: *const D2D1_EFFECT_INPUT_DESCRIPTION, requiredinputrects: *mut Common::D2D_RECT_F, inputcount: u32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.base.GetEffectRequiredInputRectangles)(::core::mem::transmute_copy(self), rendereffect.into_param().abi(), ::core::mem::transmute(renderimagerectangle), ::core::mem::transmute(inputdescriptions), ::core::mem::transmute(requiredinputrects), ::core::mem::transmute(inputcount)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`*"]
     #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
@@ -17954,8 +17954,8 @@ impl ID2D1DeviceContext6 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`*"]
     #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
-    pub unsafe fn GetEffectRequiredInputRectangles<'a, Param0: ::windows::core::IntoParam<'a, ID2D1Effect>, const PARAM4: usize>(&self, rendereffect: Param0, renderimagerectangle: *const Common::D2D_RECT_F, inputdescriptions: &[D2D1_EFFECT_INPUT_DESCRIPTION; PARAM4], requiredinputrects: &mut [Common::D2D_RECT_F; PARAM4]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.base.base.GetEffectRequiredInputRectangles)(::core::mem::transmute_copy(self), rendereffect.into_param().abi(), ::core::mem::transmute(renderimagerectangle), ::core::mem::transmute(::windows::core::as_ptr_or_null(inputdescriptions)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(requiredinputrects)), PARAM4 as _).ok()
+    pub unsafe fn GetEffectRequiredInputRectangles<'a, Param0: ::windows::core::IntoParam<'a, ID2D1Effect>>(&self, rendereffect: Param0, renderimagerectangle: *const Common::D2D_RECT_F, inputdescriptions: *const D2D1_EFFECT_INPUT_DESCRIPTION, requiredinputrects: *mut Common::D2D_RECT_F, inputcount: u32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.base.base.GetEffectRequiredInputRectangles)(::core::mem::transmute_copy(self), rendereffect.into_param().abi(), ::core::mem::transmute(renderimagerectangle), ::core::mem::transmute(inputdescriptions), ::core::mem::transmute(requiredinputrects), ::core::mem::transmute(inputcount)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Graphics_Direct2D_Common\"`*"]
     #[cfg(feature = "Win32_Graphics_Direct2D_Common")]
@@ -18442,8 +18442,8 @@ impl ID2D1DrawTransform {
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn MapInputRectsToOutputRect<'a, const PARAM2: usize>(&self, inputrects: &[super::super::Foundation::RECT; PARAM2], inputopaquesubrects: &[super::super::Foundation::RECT; PARAM2], outputrect: *mut super::super::Foundation::RECT, outputopaquesubrect: *mut super::super::Foundation::RECT) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.MapInputRectsToOutputRect)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(inputrects)), ::core::mem::transmute(::windows::core::as_ptr_or_null(inputopaquesubrects)), PARAM2 as _, ::core::mem::transmute(outputrect), ::core::mem::transmute(outputopaquesubrect)).ok()
+    pub unsafe fn MapInputRectsToOutputRect(&self, inputrects: *const super::super::Foundation::RECT, inputopaquesubrects: *const super::super::Foundation::RECT, inputrectcount: u32, outputrect: *mut super::super::Foundation::RECT, outputopaquesubrect: *mut super::super::Foundation::RECT) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.MapInputRectsToOutputRect)(::core::mem::transmute_copy(self), ::core::mem::transmute(inputrects), ::core::mem::transmute(inputopaquesubrects), ::core::mem::transmute(inputrectcount), ::core::mem::transmute(outputrect), ::core::mem::transmute(outputopaquesubrect)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -26883,8 +26883,8 @@ impl ID2D1SourceTransform {
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn MapInputRectsToOutputRect<'a, const PARAM2: usize>(&self, inputrects: &[super::super::Foundation::RECT; PARAM2], inputopaquesubrects: &[super::super::Foundation::RECT; PARAM2], outputrect: *mut super::super::Foundation::RECT, outputopaquesubrect: *mut super::super::Foundation::RECT) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.MapInputRectsToOutputRect)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(inputrects)), ::core::mem::transmute(::windows::core::as_ptr_or_null(inputopaquesubrects)), PARAM2 as _, ::core::mem::transmute(outputrect), ::core::mem::transmute(outputopaquesubrect)).ok()
+    pub unsafe fn MapInputRectsToOutputRect(&self, inputrects: *const super::super::Foundation::RECT, inputopaquesubrects: *const super::super::Foundation::RECT, inputrectcount: u32, outputrect: *mut super::super::Foundation::RECT, outputopaquesubrect: *mut super::super::Foundation::RECT) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.MapInputRectsToOutputRect)(::core::mem::transmute_copy(self), ::core::mem::transmute(inputrects), ::core::mem::transmute(inputopaquesubrects), ::core::mem::transmute(inputrectcount), ::core::mem::transmute(outputrect), ::core::mem::transmute(outputopaquesubrect)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -28592,8 +28592,8 @@ impl ID2D1Transform {
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn MapInputRectsToOutputRect<'a, const PARAM2: usize>(&self, inputrects: &[super::super::Foundation::RECT; PARAM2], inputopaquesubrects: &[super::super::Foundation::RECT; PARAM2], outputrect: *mut super::super::Foundation::RECT, outputopaquesubrect: *mut super::super::Foundation::RECT) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).MapInputRectsToOutputRect)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(inputrects)), ::core::mem::transmute(::windows::core::as_ptr_or_null(inputopaquesubrects)), PARAM2 as _, ::core::mem::transmute(outputrect), ::core::mem::transmute(outputopaquesubrect)).ok()
+    pub unsafe fn MapInputRectsToOutputRect(&self, inputrects: *const super::super::Foundation::RECT, inputopaquesubrects: *const super::super::Foundation::RECT, inputrectcount: u32, outputrect: *mut super::super::Foundation::RECT, outputopaquesubrect: *mut super::super::Foundation::RECT) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).MapInputRectsToOutputRect)(::core::mem::transmute_copy(self), ::core::mem::transmute(inputrects), ::core::mem::transmute(inputopaquesubrects), ::core::mem::transmute(inputrectcount), ::core::mem::transmute(outputrect), ::core::mem::transmute(outputopaquesubrect)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct2D\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11on12/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D11on12/mod.rs
@@ -247,8 +247,8 @@ impl ID3D11On12Device2 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D11on12\"`, `\"Win32_Graphics_Direct3D11\"`, `\"Win32_Graphics_Direct3D12\"`*"]
     #[cfg(all(feature = "Win32_Graphics_Direct3D11", feature = "Win32_Graphics_Direct3D12"))]
-    pub unsafe fn ReturnUnderlyingResource<'a, Param0: ::windows::core::IntoParam<'a, super::Direct3D11::ID3D11Resource>, const PARAM1: usize>(&self, presource11: Param0, psignalvalues: &[u64; PARAM1], ppfences: &[::core::option::Option<super::Direct3D12::ID3D12Fence>; PARAM1]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).ReturnUnderlyingResource)(::core::mem::transmute_copy(self), presource11.into_param().abi(), PARAM1 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(psignalvalues)), ::core::mem::transmute(::windows::core::as_ptr_or_null(ppfences))).ok()
+    pub unsafe fn ReturnUnderlyingResource<'a, Param0: ::windows::core::IntoParam<'a, super::Direct3D11::ID3D11Resource>>(&self, presource11: Param0, numsync: u32, psignalvalues: *const u64, ppfences: *const ::core::option::Option<super::Direct3D12::ID3D12Fence>) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).ReturnUnderlyingResource)(::core::mem::transmute_copy(self), presource11.into_param().abi(), ::core::mem::transmute(numsync), ::core::mem::transmute(psignalvalues), ::core::mem::transmute(ppfences)).ok()
     }
 }
 impl ::core::convert::From<ID3D11On12Device2> for ::windows::core::IUnknown {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Direct3D12/mod.rs
@@ -20319,12 +20319,12 @@ impl ID3D12Device1 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn SetEventOnMultipleFenceCompletion<'a, const PARAM2: usize, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::HANDLE>>(&self, ppfences: &[::core::option::Option<ID3D12Fence>; PARAM2], pfencevalues: &[u64; PARAM2], flags: D3D12_MULTIPLE_FENCE_WAIT_FLAGS, hevent: Param4) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).SetEventOnMultipleFenceCompletion)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(ppfences)), ::core::mem::transmute(::windows::core::as_ptr_or_null(pfencevalues)), PARAM2 as _, ::core::mem::transmute(flags), hevent.into_param().abi()).ok()
+    pub unsafe fn SetEventOnMultipleFenceCompletion<'a, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::HANDLE>>(&self, ppfences: *const ::core::option::Option<ID3D12Fence>, pfencevalues: *const u64, numfences: u32, flags: D3D12_MULTIPLE_FENCE_WAIT_FLAGS, hevent: Param4) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).SetEventOnMultipleFenceCompletion)(::core::mem::transmute_copy(self), ::core::mem::transmute(ppfences), ::core::mem::transmute(pfencevalues), ::core::mem::transmute(numfences), ::core::mem::transmute(flags), hevent.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
-    pub unsafe fn SetResidencyPriority<'a, const PARAM0: usize>(&self, ppobjects: &[::core::option::Option<ID3D12Pageable>; PARAM0], ppriorities: &[D3D12_RESIDENCY_PRIORITY; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).SetResidencyPriority)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(ppobjects)), ::core::mem::transmute(::windows::core::as_ptr_or_null(ppriorities))).ok()
+    pub unsafe fn SetResidencyPriority(&self, numobjects: u32, ppobjects: *const ::core::option::Option<ID3D12Pageable>, ppriorities: *const D3D12_RESIDENCY_PRIORITY) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).SetResidencyPriority)(::core::mem::transmute_copy(self), ::core::mem::transmute(numobjects), ::core::mem::transmute(ppobjects), ::core::mem::transmute(ppriorities)).ok()
     }
 }
 impl ::core::convert::From<ID3D12Device1> for ::windows::core::IUnknown {
@@ -20624,12 +20624,12 @@ impl ID3D12Device2 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn SetEventOnMultipleFenceCompletion<'a, const PARAM2: usize, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::HANDLE>>(&self, ppfences: &[::core::option::Option<ID3D12Fence>; PARAM2], pfencevalues: &[u64; PARAM2], flags: D3D12_MULTIPLE_FENCE_WAIT_FLAGS, hevent: Param4) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.SetEventOnMultipleFenceCompletion)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(ppfences)), ::core::mem::transmute(::windows::core::as_ptr_or_null(pfencevalues)), PARAM2 as _, ::core::mem::transmute(flags), hevent.into_param().abi()).ok()
+    pub unsafe fn SetEventOnMultipleFenceCompletion<'a, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::HANDLE>>(&self, ppfences: *const ::core::option::Option<ID3D12Fence>, pfencevalues: *const u64, numfences: u32, flags: D3D12_MULTIPLE_FENCE_WAIT_FLAGS, hevent: Param4) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.SetEventOnMultipleFenceCompletion)(::core::mem::transmute_copy(self), ::core::mem::transmute(ppfences), ::core::mem::transmute(pfencevalues), ::core::mem::transmute(numfences), ::core::mem::transmute(flags), hevent.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
-    pub unsafe fn SetResidencyPriority<'a, const PARAM0: usize>(&self, ppobjects: &[::core::option::Option<ID3D12Pageable>; PARAM0], ppriorities: &[D3D12_RESIDENCY_PRIORITY; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.SetResidencyPriority)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(ppobjects)), ::core::mem::transmute(::windows::core::as_ptr_or_null(ppriorities))).ok()
+    pub unsafe fn SetResidencyPriority(&self, numobjects: u32, ppobjects: *const ::core::option::Option<ID3D12Pageable>, ppriorities: *const D3D12_RESIDENCY_PRIORITY) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.SetResidencyPriority)(::core::mem::transmute_copy(self), ::core::mem::transmute(numobjects), ::core::mem::transmute(ppobjects), ::core::mem::transmute(ppriorities)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
     pub unsafe fn CreatePipelineState<T: ::windows::core::Interface>(&self, pdesc: *const D3D12_PIPELINE_STATE_STREAM_DESC) -> ::windows::core::Result<T> {
@@ -20949,12 +20949,12 @@ impl ID3D12Device3 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn SetEventOnMultipleFenceCompletion<'a, const PARAM2: usize, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::HANDLE>>(&self, ppfences: &[::core::option::Option<ID3D12Fence>; PARAM2], pfencevalues: &[u64; PARAM2], flags: D3D12_MULTIPLE_FENCE_WAIT_FLAGS, hevent: Param4) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.SetEventOnMultipleFenceCompletion)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(ppfences)), ::core::mem::transmute(::windows::core::as_ptr_or_null(pfencevalues)), PARAM2 as _, ::core::mem::transmute(flags), hevent.into_param().abi()).ok()
+    pub unsafe fn SetEventOnMultipleFenceCompletion<'a, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::HANDLE>>(&self, ppfences: *const ::core::option::Option<ID3D12Fence>, pfencevalues: *const u64, numfences: u32, flags: D3D12_MULTIPLE_FENCE_WAIT_FLAGS, hevent: Param4) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.SetEventOnMultipleFenceCompletion)(::core::mem::transmute_copy(self), ::core::mem::transmute(ppfences), ::core::mem::transmute(pfencevalues), ::core::mem::transmute(numfences), ::core::mem::transmute(flags), hevent.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
-    pub unsafe fn SetResidencyPriority<'a, const PARAM0: usize>(&self, ppobjects: &[::core::option::Option<ID3D12Pageable>; PARAM0], ppriorities: &[D3D12_RESIDENCY_PRIORITY; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.SetResidencyPriority)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(ppobjects)), ::core::mem::transmute(::windows::core::as_ptr_or_null(ppriorities))).ok()
+    pub unsafe fn SetResidencyPriority(&self, numobjects: u32, ppobjects: *const ::core::option::Option<ID3D12Pageable>, ppriorities: *const D3D12_RESIDENCY_PRIORITY) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.SetResidencyPriority)(::core::mem::transmute_copy(self), ::core::mem::transmute(numobjects), ::core::mem::transmute(ppobjects), ::core::mem::transmute(ppriorities)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
     pub unsafe fn CreatePipelineState<T: ::windows::core::Interface>(&self, pdesc: *const D3D12_PIPELINE_STATE_STREAM_DESC) -> ::windows::core::Result<T> {
@@ -21314,12 +21314,12 @@ impl ID3D12Device4 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn SetEventOnMultipleFenceCompletion<'a, const PARAM2: usize, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::HANDLE>>(&self, ppfences: &[::core::option::Option<ID3D12Fence>; PARAM2], pfencevalues: &[u64; PARAM2], flags: D3D12_MULTIPLE_FENCE_WAIT_FLAGS, hevent: Param4) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.SetEventOnMultipleFenceCompletion)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(ppfences)), ::core::mem::transmute(::windows::core::as_ptr_or_null(pfencevalues)), PARAM2 as _, ::core::mem::transmute(flags), hevent.into_param().abi()).ok()
+    pub unsafe fn SetEventOnMultipleFenceCompletion<'a, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::HANDLE>>(&self, ppfences: *const ::core::option::Option<ID3D12Fence>, pfencevalues: *const u64, numfences: u32, flags: D3D12_MULTIPLE_FENCE_WAIT_FLAGS, hevent: Param4) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.SetEventOnMultipleFenceCompletion)(::core::mem::transmute_copy(self), ::core::mem::transmute(ppfences), ::core::mem::transmute(pfencevalues), ::core::mem::transmute(numfences), ::core::mem::transmute(flags), hevent.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
-    pub unsafe fn SetResidencyPriority<'a, const PARAM0: usize>(&self, ppobjects: &[::core::option::Option<ID3D12Pageable>; PARAM0], ppriorities: &[D3D12_RESIDENCY_PRIORITY; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.SetResidencyPriority)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(ppobjects)), ::core::mem::transmute(::windows::core::as_ptr_or_null(ppriorities))).ok()
+    pub unsafe fn SetResidencyPriority(&self, numobjects: u32, ppobjects: *const ::core::option::Option<ID3D12Pageable>, ppriorities: *const D3D12_RESIDENCY_PRIORITY) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.SetResidencyPriority)(::core::mem::transmute_copy(self), ::core::mem::transmute(numobjects), ::core::mem::transmute(ppobjects), ::core::mem::transmute(ppriorities)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
     pub unsafe fn CreatePipelineState<T: ::windows::core::Interface>(&self, pdesc: *const D3D12_PIPELINE_STATE_STREAM_DESC) -> ::windows::core::Result<T> {
@@ -21739,12 +21739,12 @@ impl ID3D12Device5 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn SetEventOnMultipleFenceCompletion<'a, const PARAM2: usize, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::HANDLE>>(&self, ppfences: &[::core::option::Option<ID3D12Fence>; PARAM2], pfencevalues: &[u64; PARAM2], flags: D3D12_MULTIPLE_FENCE_WAIT_FLAGS, hevent: Param4) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.SetEventOnMultipleFenceCompletion)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(ppfences)), ::core::mem::transmute(::windows::core::as_ptr_or_null(pfencevalues)), PARAM2 as _, ::core::mem::transmute(flags), hevent.into_param().abi()).ok()
+    pub unsafe fn SetEventOnMultipleFenceCompletion<'a, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::HANDLE>>(&self, ppfences: *const ::core::option::Option<ID3D12Fence>, pfencevalues: *const u64, numfences: u32, flags: D3D12_MULTIPLE_FENCE_WAIT_FLAGS, hevent: Param4) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.SetEventOnMultipleFenceCompletion)(::core::mem::transmute_copy(self), ::core::mem::transmute(ppfences), ::core::mem::transmute(pfencevalues), ::core::mem::transmute(numfences), ::core::mem::transmute(flags), hevent.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
-    pub unsafe fn SetResidencyPriority<'a, const PARAM0: usize>(&self, ppobjects: &[::core::option::Option<ID3D12Pageable>; PARAM0], ppriorities: &[D3D12_RESIDENCY_PRIORITY; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.SetResidencyPriority)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(ppobjects)), ::core::mem::transmute(::windows::core::as_ptr_or_null(ppriorities))).ok()
+    pub unsafe fn SetResidencyPriority(&self, numobjects: u32, ppobjects: *const ::core::option::Option<ID3D12Pageable>, ppriorities: *const D3D12_RESIDENCY_PRIORITY) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.SetResidencyPriority)(::core::mem::transmute_copy(self), ::core::mem::transmute(numobjects), ::core::mem::transmute(ppobjects), ::core::mem::transmute(ppriorities)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
     pub unsafe fn CreatePipelineState<T: ::windows::core::Interface>(&self, pdesc: *const D3D12_PIPELINE_STATE_STREAM_DESC) -> ::windows::core::Result<T> {
@@ -22216,12 +22216,12 @@ impl ID3D12Device6 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn SetEventOnMultipleFenceCompletion<'a, const PARAM2: usize, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::HANDLE>>(&self, ppfences: &[::core::option::Option<ID3D12Fence>; PARAM2], pfencevalues: &[u64; PARAM2], flags: D3D12_MULTIPLE_FENCE_WAIT_FLAGS, hevent: Param4) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.base.SetEventOnMultipleFenceCompletion)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(ppfences)), ::core::mem::transmute(::windows::core::as_ptr_or_null(pfencevalues)), PARAM2 as _, ::core::mem::transmute(flags), hevent.into_param().abi()).ok()
+    pub unsafe fn SetEventOnMultipleFenceCompletion<'a, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::HANDLE>>(&self, ppfences: *const ::core::option::Option<ID3D12Fence>, pfencevalues: *const u64, numfences: u32, flags: D3D12_MULTIPLE_FENCE_WAIT_FLAGS, hevent: Param4) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.base.SetEventOnMultipleFenceCompletion)(::core::mem::transmute_copy(self), ::core::mem::transmute(ppfences), ::core::mem::transmute(pfencevalues), ::core::mem::transmute(numfences), ::core::mem::transmute(flags), hevent.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
-    pub unsafe fn SetResidencyPriority<'a, const PARAM0: usize>(&self, ppobjects: &[::core::option::Option<ID3D12Pageable>; PARAM0], ppriorities: &[D3D12_RESIDENCY_PRIORITY; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.base.SetResidencyPriority)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(ppobjects)), ::core::mem::transmute(::windows::core::as_ptr_or_null(ppriorities))).ok()
+    pub unsafe fn SetResidencyPriority(&self, numobjects: u32, ppobjects: *const ::core::option::Option<ID3D12Pageable>, ppriorities: *const D3D12_RESIDENCY_PRIORITY) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.base.SetResidencyPriority)(::core::mem::transmute_copy(self), ::core::mem::transmute(numobjects), ::core::mem::transmute(ppobjects), ::core::mem::transmute(ppriorities)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
     pub unsafe fn CreatePipelineState<T: ::windows::core::Interface>(&self, pdesc: *const D3D12_PIPELINE_STATE_STREAM_DESC) -> ::windows::core::Result<T> {
@@ -22712,12 +22712,12 @@ impl ID3D12Device7 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn SetEventOnMultipleFenceCompletion<'a, const PARAM2: usize, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::HANDLE>>(&self, ppfences: &[::core::option::Option<ID3D12Fence>; PARAM2], pfencevalues: &[u64; PARAM2], flags: D3D12_MULTIPLE_FENCE_WAIT_FLAGS, hevent: Param4) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.base.base.SetEventOnMultipleFenceCompletion)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(ppfences)), ::core::mem::transmute(::windows::core::as_ptr_or_null(pfencevalues)), PARAM2 as _, ::core::mem::transmute(flags), hevent.into_param().abi()).ok()
+    pub unsafe fn SetEventOnMultipleFenceCompletion<'a, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::HANDLE>>(&self, ppfences: *const ::core::option::Option<ID3D12Fence>, pfencevalues: *const u64, numfences: u32, flags: D3D12_MULTIPLE_FENCE_WAIT_FLAGS, hevent: Param4) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.base.base.SetEventOnMultipleFenceCompletion)(::core::mem::transmute_copy(self), ::core::mem::transmute(ppfences), ::core::mem::transmute(pfencevalues), ::core::mem::transmute(numfences), ::core::mem::transmute(flags), hevent.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
-    pub unsafe fn SetResidencyPriority<'a, const PARAM0: usize>(&self, ppobjects: &[::core::option::Option<ID3D12Pageable>; PARAM0], ppriorities: &[D3D12_RESIDENCY_PRIORITY; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.base.base.SetResidencyPriority)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(ppobjects)), ::core::mem::transmute(::windows::core::as_ptr_or_null(ppriorities))).ok()
+    pub unsafe fn SetResidencyPriority(&self, numobjects: u32, ppobjects: *const ::core::option::Option<ID3D12Pageable>, ppriorities: *const D3D12_RESIDENCY_PRIORITY) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.base.base.SetResidencyPriority)(::core::mem::transmute_copy(self), ::core::mem::transmute(numobjects), ::core::mem::transmute(ppobjects), ::core::mem::transmute(ppriorities)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
     pub unsafe fn CreatePipelineState<T: ::windows::core::Interface>(&self, pdesc: *const D3D12_PIPELINE_STATE_STREAM_DESC) -> ::windows::core::Result<T> {
@@ -23236,12 +23236,12 @@ impl ID3D12Device8 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn SetEventOnMultipleFenceCompletion<'a, const PARAM2: usize, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::HANDLE>>(&self, ppfences: &[::core::option::Option<ID3D12Fence>; PARAM2], pfencevalues: &[u64; PARAM2], flags: D3D12_MULTIPLE_FENCE_WAIT_FLAGS, hevent: Param4) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.base.base.base.SetEventOnMultipleFenceCompletion)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(ppfences)), ::core::mem::transmute(::windows::core::as_ptr_or_null(pfencevalues)), PARAM2 as _, ::core::mem::transmute(flags), hevent.into_param().abi()).ok()
+    pub unsafe fn SetEventOnMultipleFenceCompletion<'a, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::HANDLE>>(&self, ppfences: *const ::core::option::Option<ID3D12Fence>, pfencevalues: *const u64, numfences: u32, flags: D3D12_MULTIPLE_FENCE_WAIT_FLAGS, hevent: Param4) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.base.base.base.SetEventOnMultipleFenceCompletion)(::core::mem::transmute_copy(self), ::core::mem::transmute(ppfences), ::core::mem::transmute(pfencevalues), ::core::mem::transmute(numfences), ::core::mem::transmute(flags), hevent.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
-    pub unsafe fn SetResidencyPriority<'a, const PARAM0: usize>(&self, ppobjects: &[::core::option::Option<ID3D12Pageable>; PARAM0], ppriorities: &[D3D12_RESIDENCY_PRIORITY; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.base.base.base.SetResidencyPriority)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(ppobjects)), ::core::mem::transmute(::windows::core::as_ptr_or_null(ppriorities))).ok()
+    pub unsafe fn SetResidencyPriority(&self, numobjects: u32, ppobjects: *const ::core::option::Option<ID3D12Pageable>, ppriorities: *const D3D12_RESIDENCY_PRIORITY) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.base.base.base.SetResidencyPriority)(::core::mem::transmute_copy(self), ::core::mem::transmute(numobjects), ::core::mem::transmute(ppobjects), ::core::mem::transmute(ppriorities)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
     pub unsafe fn CreatePipelineState<T: ::windows::core::Interface>(&self, pdesc: *const D3D12_PIPELINE_STATE_STREAM_DESC) -> ::windows::core::Result<T> {
@@ -23821,12 +23821,12 @@ impl ID3D12Device9 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn SetEventOnMultipleFenceCompletion<'a, const PARAM2: usize, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::HANDLE>>(&self, ppfences: &[::core::option::Option<ID3D12Fence>; PARAM2], pfencevalues: &[u64; PARAM2], flags: D3D12_MULTIPLE_FENCE_WAIT_FLAGS, hevent: Param4) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.base.base.base.base.SetEventOnMultipleFenceCompletion)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(ppfences)), ::core::mem::transmute(::windows::core::as_ptr_or_null(pfencevalues)), PARAM2 as _, ::core::mem::transmute(flags), hevent.into_param().abi()).ok()
+    pub unsafe fn SetEventOnMultipleFenceCompletion<'a, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::HANDLE>>(&self, ppfences: *const ::core::option::Option<ID3D12Fence>, pfencevalues: *const u64, numfences: u32, flags: D3D12_MULTIPLE_FENCE_WAIT_FLAGS, hevent: Param4) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.base.base.base.base.SetEventOnMultipleFenceCompletion)(::core::mem::transmute_copy(self), ::core::mem::transmute(ppfences), ::core::mem::transmute(pfencevalues), ::core::mem::transmute(numfences), ::core::mem::transmute(flags), hevent.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
-    pub unsafe fn SetResidencyPriority<'a, const PARAM0: usize>(&self, ppobjects: &[::core::option::Option<ID3D12Pageable>; PARAM0], ppriorities: &[D3D12_RESIDENCY_PRIORITY; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.base.base.base.base.SetResidencyPriority)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(ppobjects)), ::core::mem::transmute(::windows::core::as_ptr_or_null(ppriorities))).ok()
+    pub unsafe fn SetResidencyPriority(&self, numobjects: u32, ppobjects: *const ::core::option::Option<ID3D12Pageable>, ppriorities: *const D3D12_RESIDENCY_PRIORITY) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.base.base.base.base.SetResidencyPriority)(::core::mem::transmute_copy(self), ::core::mem::transmute(numobjects), ::core::mem::transmute(ppobjects), ::core::mem::transmute(ppriorities)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
     pub unsafe fn CreatePipelineState<T: ::windows::core::Interface>(&self, pdesc: *const D3D12_PIPELINE_STATE_STREAM_DESC) -> ::windows::core::Result<T> {
@@ -25854,12 +25854,12 @@ impl ID3D12GraphicsCommandList1 {
         (::windows::core::Interface::vtable(self).base.ExecuteIndirect)(::core::mem::transmute_copy(self), pcommandsignature.into_param().abi(), ::core::mem::transmute(maxcommandcount), pargumentbuffer.into_param().abi(), ::core::mem::transmute(argumentbufferoffset), pcountbuffer.into_param().abi(), ::core::mem::transmute(countbufferoffset))
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
-    pub unsafe fn AtomicCopyBufferUINT<'a, Param0: ::windows::core::IntoParam<'a, ID3D12Resource>, Param2: ::windows::core::IntoParam<'a, ID3D12Resource>, const PARAM4: usize>(&self, pdstbuffer: Param0, dstoffset: u64, psrcbuffer: Param2, srcoffset: u64, ppdependentresources: &[::core::option::Option<ID3D12Resource>; PARAM4], pdependentsubresourceranges: &[D3D12_SUBRESOURCE_RANGE_UINT64; PARAM4]) {
-        (::windows::core::Interface::vtable(self).AtomicCopyBufferUINT)(::core::mem::transmute_copy(self), pdstbuffer.into_param().abi(), ::core::mem::transmute(dstoffset), psrcbuffer.into_param().abi(), ::core::mem::transmute(srcoffset), PARAM4 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(ppdependentresources)), ::core::mem::transmute(::windows::core::as_ptr_or_null(pdependentsubresourceranges)))
+    pub unsafe fn AtomicCopyBufferUINT<'a, Param0: ::windows::core::IntoParam<'a, ID3D12Resource>, Param2: ::windows::core::IntoParam<'a, ID3D12Resource>>(&self, pdstbuffer: Param0, dstoffset: u64, psrcbuffer: Param2, srcoffset: u64, dependencies: u32, ppdependentresources: *const ::core::option::Option<ID3D12Resource>, pdependentsubresourceranges: *const D3D12_SUBRESOURCE_RANGE_UINT64) {
+        (::windows::core::Interface::vtable(self).AtomicCopyBufferUINT)(::core::mem::transmute_copy(self), pdstbuffer.into_param().abi(), ::core::mem::transmute(dstoffset), psrcbuffer.into_param().abi(), ::core::mem::transmute(srcoffset), ::core::mem::transmute(dependencies), ::core::mem::transmute(ppdependentresources), ::core::mem::transmute(pdependentsubresourceranges))
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
-    pub unsafe fn AtomicCopyBufferUINT64<'a, Param0: ::windows::core::IntoParam<'a, ID3D12Resource>, Param2: ::windows::core::IntoParam<'a, ID3D12Resource>, const PARAM4: usize>(&self, pdstbuffer: Param0, dstoffset: u64, psrcbuffer: Param2, srcoffset: u64, ppdependentresources: &[::core::option::Option<ID3D12Resource>; PARAM4], pdependentsubresourceranges: &[D3D12_SUBRESOURCE_RANGE_UINT64; PARAM4]) {
-        (::windows::core::Interface::vtable(self).AtomicCopyBufferUINT64)(::core::mem::transmute_copy(self), pdstbuffer.into_param().abi(), ::core::mem::transmute(dstoffset), psrcbuffer.into_param().abi(), ::core::mem::transmute(srcoffset), PARAM4 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(ppdependentresources)), ::core::mem::transmute(::windows::core::as_ptr_or_null(pdependentsubresourceranges)))
+    pub unsafe fn AtomicCopyBufferUINT64<'a, Param0: ::windows::core::IntoParam<'a, ID3D12Resource>, Param2: ::windows::core::IntoParam<'a, ID3D12Resource>>(&self, pdstbuffer: Param0, dstoffset: u64, psrcbuffer: Param2, srcoffset: u64, dependencies: u32, ppdependentresources: *const ::core::option::Option<ID3D12Resource>, pdependentsubresourceranges: *const D3D12_SUBRESOURCE_RANGE_UINT64) {
+        (::windows::core::Interface::vtable(self).AtomicCopyBufferUINT64)(::core::mem::transmute_copy(self), pdstbuffer.into_param().abi(), ::core::mem::transmute(dstoffset), psrcbuffer.into_param().abi(), ::core::mem::transmute(srcoffset), ::core::mem::transmute(dependencies), ::core::mem::transmute(ppdependentresources), ::core::mem::transmute(pdependentsubresourceranges))
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
     pub unsafe fn OMSetDepthBounds(&self, min: f32, max: f32) {
@@ -26258,12 +26258,12 @@ impl ID3D12GraphicsCommandList2 {
         (::windows::core::Interface::vtable(self).base.base.ExecuteIndirect)(::core::mem::transmute_copy(self), pcommandsignature.into_param().abi(), ::core::mem::transmute(maxcommandcount), pargumentbuffer.into_param().abi(), ::core::mem::transmute(argumentbufferoffset), pcountbuffer.into_param().abi(), ::core::mem::transmute(countbufferoffset))
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
-    pub unsafe fn AtomicCopyBufferUINT<'a, Param0: ::windows::core::IntoParam<'a, ID3D12Resource>, Param2: ::windows::core::IntoParam<'a, ID3D12Resource>, const PARAM4: usize>(&self, pdstbuffer: Param0, dstoffset: u64, psrcbuffer: Param2, srcoffset: u64, ppdependentresources: &[::core::option::Option<ID3D12Resource>; PARAM4], pdependentsubresourceranges: &[D3D12_SUBRESOURCE_RANGE_UINT64; PARAM4]) {
-        (::windows::core::Interface::vtable(self).base.AtomicCopyBufferUINT)(::core::mem::transmute_copy(self), pdstbuffer.into_param().abi(), ::core::mem::transmute(dstoffset), psrcbuffer.into_param().abi(), ::core::mem::transmute(srcoffset), PARAM4 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(ppdependentresources)), ::core::mem::transmute(::windows::core::as_ptr_or_null(pdependentsubresourceranges)))
+    pub unsafe fn AtomicCopyBufferUINT<'a, Param0: ::windows::core::IntoParam<'a, ID3D12Resource>, Param2: ::windows::core::IntoParam<'a, ID3D12Resource>>(&self, pdstbuffer: Param0, dstoffset: u64, psrcbuffer: Param2, srcoffset: u64, dependencies: u32, ppdependentresources: *const ::core::option::Option<ID3D12Resource>, pdependentsubresourceranges: *const D3D12_SUBRESOURCE_RANGE_UINT64) {
+        (::windows::core::Interface::vtable(self).base.AtomicCopyBufferUINT)(::core::mem::transmute_copy(self), pdstbuffer.into_param().abi(), ::core::mem::transmute(dstoffset), psrcbuffer.into_param().abi(), ::core::mem::transmute(srcoffset), ::core::mem::transmute(dependencies), ::core::mem::transmute(ppdependentresources), ::core::mem::transmute(pdependentsubresourceranges))
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
-    pub unsafe fn AtomicCopyBufferUINT64<'a, Param0: ::windows::core::IntoParam<'a, ID3D12Resource>, Param2: ::windows::core::IntoParam<'a, ID3D12Resource>, const PARAM4: usize>(&self, pdstbuffer: Param0, dstoffset: u64, psrcbuffer: Param2, srcoffset: u64, ppdependentresources: &[::core::option::Option<ID3D12Resource>; PARAM4], pdependentsubresourceranges: &[D3D12_SUBRESOURCE_RANGE_UINT64; PARAM4]) {
-        (::windows::core::Interface::vtable(self).base.AtomicCopyBufferUINT64)(::core::mem::transmute_copy(self), pdstbuffer.into_param().abi(), ::core::mem::transmute(dstoffset), psrcbuffer.into_param().abi(), ::core::mem::transmute(srcoffset), PARAM4 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(ppdependentresources)), ::core::mem::transmute(::windows::core::as_ptr_or_null(pdependentsubresourceranges)))
+    pub unsafe fn AtomicCopyBufferUINT64<'a, Param0: ::windows::core::IntoParam<'a, ID3D12Resource>, Param2: ::windows::core::IntoParam<'a, ID3D12Resource>>(&self, pdstbuffer: Param0, dstoffset: u64, psrcbuffer: Param2, srcoffset: u64, dependencies: u32, ppdependentresources: *const ::core::option::Option<ID3D12Resource>, pdependentsubresourceranges: *const D3D12_SUBRESOURCE_RANGE_UINT64) {
+        (::windows::core::Interface::vtable(self).base.AtomicCopyBufferUINT64)(::core::mem::transmute_copy(self), pdstbuffer.into_param().abi(), ::core::mem::transmute(dstoffset), psrcbuffer.into_param().abi(), ::core::mem::transmute(srcoffset), ::core::mem::transmute(dependencies), ::core::mem::transmute(ppdependentresources), ::core::mem::transmute(pdependentsubresourceranges))
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
     pub unsafe fn OMSetDepthBounds(&self, min: f32, max: f32) {
@@ -26678,12 +26678,12 @@ impl ID3D12GraphicsCommandList3 {
         (::windows::core::Interface::vtable(self).base.base.base.ExecuteIndirect)(::core::mem::transmute_copy(self), pcommandsignature.into_param().abi(), ::core::mem::transmute(maxcommandcount), pargumentbuffer.into_param().abi(), ::core::mem::transmute(argumentbufferoffset), pcountbuffer.into_param().abi(), ::core::mem::transmute(countbufferoffset))
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
-    pub unsafe fn AtomicCopyBufferUINT<'a, Param0: ::windows::core::IntoParam<'a, ID3D12Resource>, Param2: ::windows::core::IntoParam<'a, ID3D12Resource>, const PARAM4: usize>(&self, pdstbuffer: Param0, dstoffset: u64, psrcbuffer: Param2, srcoffset: u64, ppdependentresources: &[::core::option::Option<ID3D12Resource>; PARAM4], pdependentsubresourceranges: &[D3D12_SUBRESOURCE_RANGE_UINT64; PARAM4]) {
-        (::windows::core::Interface::vtable(self).base.base.AtomicCopyBufferUINT)(::core::mem::transmute_copy(self), pdstbuffer.into_param().abi(), ::core::mem::transmute(dstoffset), psrcbuffer.into_param().abi(), ::core::mem::transmute(srcoffset), PARAM4 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(ppdependentresources)), ::core::mem::transmute(::windows::core::as_ptr_or_null(pdependentsubresourceranges)))
+    pub unsafe fn AtomicCopyBufferUINT<'a, Param0: ::windows::core::IntoParam<'a, ID3D12Resource>, Param2: ::windows::core::IntoParam<'a, ID3D12Resource>>(&self, pdstbuffer: Param0, dstoffset: u64, psrcbuffer: Param2, srcoffset: u64, dependencies: u32, ppdependentresources: *const ::core::option::Option<ID3D12Resource>, pdependentsubresourceranges: *const D3D12_SUBRESOURCE_RANGE_UINT64) {
+        (::windows::core::Interface::vtable(self).base.base.AtomicCopyBufferUINT)(::core::mem::transmute_copy(self), pdstbuffer.into_param().abi(), ::core::mem::transmute(dstoffset), psrcbuffer.into_param().abi(), ::core::mem::transmute(srcoffset), ::core::mem::transmute(dependencies), ::core::mem::transmute(ppdependentresources), ::core::mem::transmute(pdependentsubresourceranges))
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
-    pub unsafe fn AtomicCopyBufferUINT64<'a, Param0: ::windows::core::IntoParam<'a, ID3D12Resource>, Param2: ::windows::core::IntoParam<'a, ID3D12Resource>, const PARAM4: usize>(&self, pdstbuffer: Param0, dstoffset: u64, psrcbuffer: Param2, srcoffset: u64, ppdependentresources: &[::core::option::Option<ID3D12Resource>; PARAM4], pdependentsubresourceranges: &[D3D12_SUBRESOURCE_RANGE_UINT64; PARAM4]) {
-        (::windows::core::Interface::vtable(self).base.base.AtomicCopyBufferUINT64)(::core::mem::transmute_copy(self), pdstbuffer.into_param().abi(), ::core::mem::transmute(dstoffset), psrcbuffer.into_param().abi(), ::core::mem::transmute(srcoffset), PARAM4 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(ppdependentresources)), ::core::mem::transmute(::windows::core::as_ptr_or_null(pdependentsubresourceranges)))
+    pub unsafe fn AtomicCopyBufferUINT64<'a, Param0: ::windows::core::IntoParam<'a, ID3D12Resource>, Param2: ::windows::core::IntoParam<'a, ID3D12Resource>>(&self, pdstbuffer: Param0, dstoffset: u64, psrcbuffer: Param2, srcoffset: u64, dependencies: u32, ppdependentresources: *const ::core::option::Option<ID3D12Resource>, pdependentsubresourceranges: *const D3D12_SUBRESOURCE_RANGE_UINT64) {
+        (::windows::core::Interface::vtable(self).base.base.AtomicCopyBufferUINT64)(::core::mem::transmute_copy(self), pdstbuffer.into_param().abi(), ::core::mem::transmute(dstoffset), psrcbuffer.into_param().abi(), ::core::mem::transmute(srcoffset), ::core::mem::transmute(dependencies), ::core::mem::transmute(ppdependentresources), ::core::mem::transmute(pdependentsubresourceranges))
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
     pub unsafe fn OMSetDepthBounds(&self, min: f32, max: f32) {
@@ -27122,12 +27122,12 @@ impl ID3D12GraphicsCommandList4 {
         (::windows::core::Interface::vtable(self).base.base.base.base.ExecuteIndirect)(::core::mem::transmute_copy(self), pcommandsignature.into_param().abi(), ::core::mem::transmute(maxcommandcount), pargumentbuffer.into_param().abi(), ::core::mem::transmute(argumentbufferoffset), pcountbuffer.into_param().abi(), ::core::mem::transmute(countbufferoffset))
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
-    pub unsafe fn AtomicCopyBufferUINT<'a, Param0: ::windows::core::IntoParam<'a, ID3D12Resource>, Param2: ::windows::core::IntoParam<'a, ID3D12Resource>, const PARAM4: usize>(&self, pdstbuffer: Param0, dstoffset: u64, psrcbuffer: Param2, srcoffset: u64, ppdependentresources: &[::core::option::Option<ID3D12Resource>; PARAM4], pdependentsubresourceranges: &[D3D12_SUBRESOURCE_RANGE_UINT64; PARAM4]) {
-        (::windows::core::Interface::vtable(self).base.base.base.AtomicCopyBufferUINT)(::core::mem::transmute_copy(self), pdstbuffer.into_param().abi(), ::core::mem::transmute(dstoffset), psrcbuffer.into_param().abi(), ::core::mem::transmute(srcoffset), PARAM4 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(ppdependentresources)), ::core::mem::transmute(::windows::core::as_ptr_or_null(pdependentsubresourceranges)))
+    pub unsafe fn AtomicCopyBufferUINT<'a, Param0: ::windows::core::IntoParam<'a, ID3D12Resource>, Param2: ::windows::core::IntoParam<'a, ID3D12Resource>>(&self, pdstbuffer: Param0, dstoffset: u64, psrcbuffer: Param2, srcoffset: u64, dependencies: u32, ppdependentresources: *const ::core::option::Option<ID3D12Resource>, pdependentsubresourceranges: *const D3D12_SUBRESOURCE_RANGE_UINT64) {
+        (::windows::core::Interface::vtable(self).base.base.base.AtomicCopyBufferUINT)(::core::mem::transmute_copy(self), pdstbuffer.into_param().abi(), ::core::mem::transmute(dstoffset), psrcbuffer.into_param().abi(), ::core::mem::transmute(srcoffset), ::core::mem::transmute(dependencies), ::core::mem::transmute(ppdependentresources), ::core::mem::transmute(pdependentsubresourceranges))
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
-    pub unsafe fn AtomicCopyBufferUINT64<'a, Param0: ::windows::core::IntoParam<'a, ID3D12Resource>, Param2: ::windows::core::IntoParam<'a, ID3D12Resource>, const PARAM4: usize>(&self, pdstbuffer: Param0, dstoffset: u64, psrcbuffer: Param2, srcoffset: u64, ppdependentresources: &[::core::option::Option<ID3D12Resource>; PARAM4], pdependentsubresourceranges: &[D3D12_SUBRESOURCE_RANGE_UINT64; PARAM4]) {
-        (::windows::core::Interface::vtable(self).base.base.base.AtomicCopyBufferUINT64)(::core::mem::transmute_copy(self), pdstbuffer.into_param().abi(), ::core::mem::transmute(dstoffset), psrcbuffer.into_param().abi(), ::core::mem::transmute(srcoffset), PARAM4 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(ppdependentresources)), ::core::mem::transmute(::windows::core::as_ptr_or_null(pdependentsubresourceranges)))
+    pub unsafe fn AtomicCopyBufferUINT64<'a, Param0: ::windows::core::IntoParam<'a, ID3D12Resource>, Param2: ::windows::core::IntoParam<'a, ID3D12Resource>>(&self, pdstbuffer: Param0, dstoffset: u64, psrcbuffer: Param2, srcoffset: u64, dependencies: u32, ppdependentresources: *const ::core::option::Option<ID3D12Resource>, pdependentsubresourceranges: *const D3D12_SUBRESOURCE_RANGE_UINT64) {
+        (::windows::core::Interface::vtable(self).base.base.base.AtomicCopyBufferUINT64)(::core::mem::transmute_copy(self), pdstbuffer.into_param().abi(), ::core::mem::transmute(dstoffset), psrcbuffer.into_param().abi(), ::core::mem::transmute(srcoffset), ::core::mem::transmute(dependencies), ::core::mem::transmute(ppdependentresources), ::core::mem::transmute(pdependentsubresourceranges))
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
     pub unsafe fn OMSetDepthBounds(&self, min: f32, max: f32) {
@@ -27638,12 +27638,12 @@ impl ID3D12GraphicsCommandList5 {
         (::windows::core::Interface::vtable(self).base.base.base.base.base.ExecuteIndirect)(::core::mem::transmute_copy(self), pcommandsignature.into_param().abi(), ::core::mem::transmute(maxcommandcount), pargumentbuffer.into_param().abi(), ::core::mem::transmute(argumentbufferoffset), pcountbuffer.into_param().abi(), ::core::mem::transmute(countbufferoffset))
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
-    pub unsafe fn AtomicCopyBufferUINT<'a, Param0: ::windows::core::IntoParam<'a, ID3D12Resource>, Param2: ::windows::core::IntoParam<'a, ID3D12Resource>, const PARAM4: usize>(&self, pdstbuffer: Param0, dstoffset: u64, psrcbuffer: Param2, srcoffset: u64, ppdependentresources: &[::core::option::Option<ID3D12Resource>; PARAM4], pdependentsubresourceranges: &[D3D12_SUBRESOURCE_RANGE_UINT64; PARAM4]) {
-        (::windows::core::Interface::vtable(self).base.base.base.base.AtomicCopyBufferUINT)(::core::mem::transmute_copy(self), pdstbuffer.into_param().abi(), ::core::mem::transmute(dstoffset), psrcbuffer.into_param().abi(), ::core::mem::transmute(srcoffset), PARAM4 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(ppdependentresources)), ::core::mem::transmute(::windows::core::as_ptr_or_null(pdependentsubresourceranges)))
+    pub unsafe fn AtomicCopyBufferUINT<'a, Param0: ::windows::core::IntoParam<'a, ID3D12Resource>, Param2: ::windows::core::IntoParam<'a, ID3D12Resource>>(&self, pdstbuffer: Param0, dstoffset: u64, psrcbuffer: Param2, srcoffset: u64, dependencies: u32, ppdependentresources: *const ::core::option::Option<ID3D12Resource>, pdependentsubresourceranges: *const D3D12_SUBRESOURCE_RANGE_UINT64) {
+        (::windows::core::Interface::vtable(self).base.base.base.base.AtomicCopyBufferUINT)(::core::mem::transmute_copy(self), pdstbuffer.into_param().abi(), ::core::mem::transmute(dstoffset), psrcbuffer.into_param().abi(), ::core::mem::transmute(srcoffset), ::core::mem::transmute(dependencies), ::core::mem::transmute(ppdependentresources), ::core::mem::transmute(pdependentsubresourceranges))
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
-    pub unsafe fn AtomicCopyBufferUINT64<'a, Param0: ::windows::core::IntoParam<'a, ID3D12Resource>, Param2: ::windows::core::IntoParam<'a, ID3D12Resource>, const PARAM4: usize>(&self, pdstbuffer: Param0, dstoffset: u64, psrcbuffer: Param2, srcoffset: u64, ppdependentresources: &[::core::option::Option<ID3D12Resource>; PARAM4], pdependentsubresourceranges: &[D3D12_SUBRESOURCE_RANGE_UINT64; PARAM4]) {
-        (::windows::core::Interface::vtable(self).base.base.base.base.AtomicCopyBufferUINT64)(::core::mem::transmute_copy(self), pdstbuffer.into_param().abi(), ::core::mem::transmute(dstoffset), psrcbuffer.into_param().abi(), ::core::mem::transmute(srcoffset), PARAM4 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(ppdependentresources)), ::core::mem::transmute(::windows::core::as_ptr_or_null(pdependentsubresourceranges)))
+    pub unsafe fn AtomicCopyBufferUINT64<'a, Param0: ::windows::core::IntoParam<'a, ID3D12Resource>, Param2: ::windows::core::IntoParam<'a, ID3D12Resource>>(&self, pdstbuffer: Param0, dstoffset: u64, psrcbuffer: Param2, srcoffset: u64, dependencies: u32, ppdependentresources: *const ::core::option::Option<ID3D12Resource>, pdependentsubresourceranges: *const D3D12_SUBRESOURCE_RANGE_UINT64) {
+        (::windows::core::Interface::vtable(self).base.base.base.base.AtomicCopyBufferUINT64)(::core::mem::transmute_copy(self), pdstbuffer.into_param().abi(), ::core::mem::transmute(dstoffset), psrcbuffer.into_param().abi(), ::core::mem::transmute(srcoffset), ::core::mem::transmute(dependencies), ::core::mem::transmute(ppdependentresources), ::core::mem::transmute(pdependentsubresourceranges))
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
     pub unsafe fn OMSetDepthBounds(&self, min: f32, max: f32) {
@@ -28169,12 +28169,12 @@ impl ID3D12GraphicsCommandList6 {
         (::windows::core::Interface::vtable(self).base.base.base.base.base.base.ExecuteIndirect)(::core::mem::transmute_copy(self), pcommandsignature.into_param().abi(), ::core::mem::transmute(maxcommandcount), pargumentbuffer.into_param().abi(), ::core::mem::transmute(argumentbufferoffset), pcountbuffer.into_param().abi(), ::core::mem::transmute(countbufferoffset))
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
-    pub unsafe fn AtomicCopyBufferUINT<'a, Param0: ::windows::core::IntoParam<'a, ID3D12Resource>, Param2: ::windows::core::IntoParam<'a, ID3D12Resource>, const PARAM4: usize>(&self, pdstbuffer: Param0, dstoffset: u64, psrcbuffer: Param2, srcoffset: u64, ppdependentresources: &[::core::option::Option<ID3D12Resource>; PARAM4], pdependentsubresourceranges: &[D3D12_SUBRESOURCE_RANGE_UINT64; PARAM4]) {
-        (::windows::core::Interface::vtable(self).base.base.base.base.base.AtomicCopyBufferUINT)(::core::mem::transmute_copy(self), pdstbuffer.into_param().abi(), ::core::mem::transmute(dstoffset), psrcbuffer.into_param().abi(), ::core::mem::transmute(srcoffset), PARAM4 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(ppdependentresources)), ::core::mem::transmute(::windows::core::as_ptr_or_null(pdependentsubresourceranges)))
+    pub unsafe fn AtomicCopyBufferUINT<'a, Param0: ::windows::core::IntoParam<'a, ID3D12Resource>, Param2: ::windows::core::IntoParam<'a, ID3D12Resource>>(&self, pdstbuffer: Param0, dstoffset: u64, psrcbuffer: Param2, srcoffset: u64, dependencies: u32, ppdependentresources: *const ::core::option::Option<ID3D12Resource>, pdependentsubresourceranges: *const D3D12_SUBRESOURCE_RANGE_UINT64) {
+        (::windows::core::Interface::vtable(self).base.base.base.base.base.AtomicCopyBufferUINT)(::core::mem::transmute_copy(self), pdstbuffer.into_param().abi(), ::core::mem::transmute(dstoffset), psrcbuffer.into_param().abi(), ::core::mem::transmute(srcoffset), ::core::mem::transmute(dependencies), ::core::mem::transmute(ppdependentresources), ::core::mem::transmute(pdependentsubresourceranges))
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
-    pub unsafe fn AtomicCopyBufferUINT64<'a, Param0: ::windows::core::IntoParam<'a, ID3D12Resource>, Param2: ::windows::core::IntoParam<'a, ID3D12Resource>, const PARAM4: usize>(&self, pdstbuffer: Param0, dstoffset: u64, psrcbuffer: Param2, srcoffset: u64, ppdependentresources: &[::core::option::Option<ID3D12Resource>; PARAM4], pdependentsubresourceranges: &[D3D12_SUBRESOURCE_RANGE_UINT64; PARAM4]) {
-        (::windows::core::Interface::vtable(self).base.base.base.base.base.AtomicCopyBufferUINT64)(::core::mem::transmute_copy(self), pdstbuffer.into_param().abi(), ::core::mem::transmute(dstoffset), psrcbuffer.into_param().abi(), ::core::mem::transmute(srcoffset), PARAM4 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(ppdependentresources)), ::core::mem::transmute(::windows::core::as_ptr_or_null(pdependentsubresourceranges)))
+    pub unsafe fn AtomicCopyBufferUINT64<'a, Param0: ::windows::core::IntoParam<'a, ID3D12Resource>, Param2: ::windows::core::IntoParam<'a, ID3D12Resource>>(&self, pdstbuffer: Param0, dstoffset: u64, psrcbuffer: Param2, srcoffset: u64, dependencies: u32, ppdependentresources: *const ::core::option::Option<ID3D12Resource>, pdependentsubresourceranges: *const D3D12_SUBRESOURCE_RANGE_UINT64) {
+        (::windows::core::Interface::vtable(self).base.base.base.base.base.AtomicCopyBufferUINT64)(::core::mem::transmute_copy(self), pdstbuffer.into_param().abi(), ::core::mem::transmute(dstoffset), psrcbuffer.into_param().abi(), ::core::mem::transmute(srcoffset), ::core::mem::transmute(dependencies), ::core::mem::transmute(ppdependentresources), ::core::mem::transmute(pdependentsubresourceranges))
     }
     #[doc = "*Required features: `\"Win32_Graphics_Direct3D12\"`*"]
     pub unsafe fn OMSetDepthBounds(&self, min: f32, max: f32) {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/DirectWrite/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/DirectWrite/mod.rs
@@ -8867,12 +8867,12 @@ impl IDWriteFontFace {
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetDesignGlyphMetrics<'a, const PARAM1: usize, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, glyphindices: &[u16; PARAM1], glyphmetrics: &mut [DWRITE_GLYPH_METRICS; PARAM1], issideways: Param3) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).GetDesignGlyphMetrics)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), PARAM1 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphmetrics)), issideways.into_param().abi()).ok()
+    pub unsafe fn GetDesignGlyphMetrics<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, glyphindices: *const u16, glyphcount: u32, glyphmetrics: *mut DWRITE_GLYPH_METRICS, issideways: Param3) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).GetDesignGlyphMetrics)(::core::mem::transmute_copy(self), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphmetrics), issideways.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
-    pub unsafe fn GetGlyphIndices<'a, const PARAM1: usize>(&self, codepoints: &[u32; PARAM1], glyphindices: &mut [u16; PARAM1]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).GetGlyphIndices)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(codepoints)), PARAM1 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphindices))).ok()
+    pub unsafe fn GetGlyphIndices(&self, codepoints: *const u32, codepointcount: u32, glyphindices: *mut u16) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).GetGlyphIndices)(::core::mem::transmute_copy(self), ::core::mem::transmute(codepoints), ::core::mem::transmute(codepointcount), ::core::mem::transmute(glyphindices)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -8900,8 +8900,8 @@ impl IDWriteFontFace {
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetGdiCompatibleGlyphMetrics<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, const PARAM5: usize, Param7: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, emsize: f32, pixelsperdip: f32, transform: *const DWRITE_MATRIX, usegdinatural: Param3, glyphindices: &[u16; PARAM5], glyphmetrics: &mut [DWRITE_GLYPH_METRICS; PARAM5], issideways: Param7) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).GetGdiCompatibleGlyphMetrics)(::core::mem::transmute_copy(self), ::core::mem::transmute(emsize), ::core::mem::transmute(pixelsperdip), ::core::mem::transmute(transform), usegdinatural.into_param().abi(), ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), PARAM5 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphmetrics)), issideways.into_param().abi()).ok()
+    pub unsafe fn GetGdiCompatibleGlyphMetrics<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param7: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, emsize: f32, pixelsperdip: f32, transform: *const DWRITE_MATRIX, usegdinatural: Param3, glyphindices: *const u16, glyphcount: u32, glyphmetrics: *mut DWRITE_GLYPH_METRICS, issideways: Param7) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).GetGdiCompatibleGlyphMetrics)(::core::mem::transmute_copy(self), ::core::mem::transmute(emsize), ::core::mem::transmute(pixelsperdip), ::core::mem::transmute(transform), usegdinatural.into_param().abi(), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphmetrics), issideways.into_param().abi()).ok()
     }
 }
 impl ::core::convert::From<IDWriteFontFace> for ::windows::core::IUnknown {
@@ -9014,12 +9014,12 @@ impl IDWriteFontFace1 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetDesignGlyphMetrics<'a, const PARAM1: usize, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, glyphindices: &[u16; PARAM1], glyphmetrics: &mut [DWRITE_GLYPH_METRICS; PARAM1], issideways: Param3) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.GetDesignGlyphMetrics)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), PARAM1 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphmetrics)), issideways.into_param().abi()).ok()
+    pub unsafe fn GetDesignGlyphMetrics<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, glyphindices: *const u16, glyphcount: u32, glyphmetrics: *mut DWRITE_GLYPH_METRICS, issideways: Param3) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.GetDesignGlyphMetrics)(::core::mem::transmute_copy(self), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphmetrics), issideways.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
-    pub unsafe fn GetGlyphIndices<'a, const PARAM1: usize>(&self, codepoints: &[u32; PARAM1], glyphindices: &mut [u16; PARAM1]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.GetGlyphIndices)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(codepoints)), PARAM1 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphindices))).ok()
+    pub unsafe fn GetGlyphIndices(&self, codepoints: *const u32, codepointcount: u32, glyphindices: *mut u16) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.GetGlyphIndices)(::core::mem::transmute_copy(self), ::core::mem::transmute(codepoints), ::core::mem::transmute(codepointcount), ::core::mem::transmute(glyphindices)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -9047,8 +9047,8 @@ impl IDWriteFontFace1 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetGdiCompatibleGlyphMetrics<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, const PARAM5: usize, Param7: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, emsize: f32, pixelsperdip: f32, transform: *const DWRITE_MATRIX, usegdinatural: Param3, glyphindices: &[u16; PARAM5], glyphmetrics: &mut [DWRITE_GLYPH_METRICS; PARAM5], issideways: Param7) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.GetGdiCompatibleGlyphMetrics)(::core::mem::transmute_copy(self), ::core::mem::transmute(emsize), ::core::mem::transmute(pixelsperdip), ::core::mem::transmute(transform), usegdinatural.into_param().abi(), ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), PARAM5 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphmetrics)), issideways.into_param().abi()).ok()
+    pub unsafe fn GetGdiCompatibleGlyphMetrics<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param7: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, emsize: f32, pixelsperdip: f32, transform: *const DWRITE_MATRIX, usegdinatural: Param3, glyphindices: *const u16, glyphcount: u32, glyphmetrics: *mut DWRITE_GLYPH_METRICS, issideways: Param7) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.GetGdiCompatibleGlyphMetrics)(::core::mem::transmute_copy(self), ::core::mem::transmute(emsize), ::core::mem::transmute(pixelsperdip), ::core::mem::transmute(transform), usegdinatural.into_param().abi(), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphmetrics), issideways.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -9076,17 +9076,17 @@ impl IDWriteFontFace1 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetDesignGlyphAdvances<'a, const PARAM0: usize, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, glyphindices: &[u16; PARAM0], glyphadvances: &mut [i32; PARAM0], issideways: Param3) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).GetDesignGlyphAdvances)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphadvances)), issideways.into_param().abi()).ok()
+    pub unsafe fn GetDesignGlyphAdvances<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, glyphcount: u32, glyphindices: *const u16, glyphadvances: *mut i32, issideways: Param3) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).GetDesignGlyphAdvances)(::core::mem::transmute_copy(self), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphadvances), issideways.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetGdiCompatibleGlyphAdvances<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, const PARAM5: usize>(&self, emsize: f32, pixelsperdip: f32, transform: *const DWRITE_MATRIX, usegdinatural: Param3, issideways: Param4, glyphindices: &[u16; PARAM5], glyphadvances: &mut [i32; PARAM5]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).GetGdiCompatibleGlyphAdvances)(::core::mem::transmute_copy(self), ::core::mem::transmute(emsize), ::core::mem::transmute(pixelsperdip), ::core::mem::transmute(transform), usegdinatural.into_param().abi(), issideways.into_param().abi(), PARAM5 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphadvances))).ok()
+    pub unsafe fn GetGdiCompatibleGlyphAdvances<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, emsize: f32, pixelsperdip: f32, transform: *const DWRITE_MATRIX, usegdinatural: Param3, issideways: Param4, glyphcount: u32, glyphindices: *const u16, glyphadvances: *mut i32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).GetGdiCompatibleGlyphAdvances)(::core::mem::transmute_copy(self), ::core::mem::transmute(emsize), ::core::mem::transmute(pixelsperdip), ::core::mem::transmute(transform), usegdinatural.into_param().abi(), issideways.into_param().abi(), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphadvances)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
-    pub unsafe fn GetKerningPairAdjustments<'a, const PARAM0: usize>(&self, glyphindices: &[u16; PARAM0], glyphadvanceadjustments: &mut [i32; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).GetKerningPairAdjustments)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphadvanceadjustments))).ok()
+    pub unsafe fn GetKerningPairAdjustments(&self, glyphcount: u32, glyphindices: *const u16, glyphadvanceadjustments: *mut i32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).GetKerningPairAdjustments)(::core::mem::transmute_copy(self), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphadvanceadjustments)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -9100,8 +9100,8 @@ impl IDWriteFontFace1 {
         (::windows::core::Interface::vtable(self).GetRecommendedRenderingMode2)(::core::mem::transmute_copy(self), ::core::mem::transmute(fontemsize), ::core::mem::transmute(dpix), ::core::mem::transmute(dpiy), ::core::mem::transmute(transform), issideways.into_param().abi(), ::core::mem::transmute(outlinethreshold), ::core::mem::transmute(measuringmode), ::core::mem::transmute(&mut result__)).from_abi::<DWRITE_RENDERING_MODE>(result__)
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
-    pub unsafe fn GetVerticalGlyphVariants<'a, const PARAM0: usize>(&self, nominalglyphindices: &[u16; PARAM0], verticalglyphindices: &mut [u16; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).GetVerticalGlyphVariants)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(nominalglyphindices)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(verticalglyphindices))).ok()
+    pub unsafe fn GetVerticalGlyphVariants(&self, glyphcount: u32, nominalglyphindices: *const u16, verticalglyphindices: *mut u16) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).GetVerticalGlyphVariants)(::core::mem::transmute_copy(self), ::core::mem::transmute(glyphcount), ::core::mem::transmute(nominalglyphindices), ::core::mem::transmute(verticalglyphindices)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -9245,12 +9245,12 @@ impl IDWriteFontFace2 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetDesignGlyphMetrics<'a, const PARAM1: usize, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, glyphindices: &[u16; PARAM1], glyphmetrics: &mut [DWRITE_GLYPH_METRICS; PARAM1], issideways: Param3) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.GetDesignGlyphMetrics)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), PARAM1 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphmetrics)), issideways.into_param().abi()).ok()
+    pub unsafe fn GetDesignGlyphMetrics<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, glyphindices: *const u16, glyphcount: u32, glyphmetrics: *mut DWRITE_GLYPH_METRICS, issideways: Param3) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.GetDesignGlyphMetrics)(::core::mem::transmute_copy(self), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphmetrics), issideways.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
-    pub unsafe fn GetGlyphIndices<'a, const PARAM1: usize>(&self, codepoints: &[u32; PARAM1], glyphindices: &mut [u16; PARAM1]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.GetGlyphIndices)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(codepoints)), PARAM1 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphindices))).ok()
+    pub unsafe fn GetGlyphIndices(&self, codepoints: *const u32, codepointcount: u32, glyphindices: *mut u16) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.GetGlyphIndices)(::core::mem::transmute_copy(self), ::core::mem::transmute(codepoints), ::core::mem::transmute(codepointcount), ::core::mem::transmute(glyphindices)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -9278,8 +9278,8 @@ impl IDWriteFontFace2 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetGdiCompatibleGlyphMetrics<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, const PARAM5: usize, Param7: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, emsize: f32, pixelsperdip: f32, transform: *const DWRITE_MATRIX, usegdinatural: Param3, glyphindices: &[u16; PARAM5], glyphmetrics: &mut [DWRITE_GLYPH_METRICS; PARAM5], issideways: Param7) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.GetGdiCompatibleGlyphMetrics)(::core::mem::transmute_copy(self), ::core::mem::transmute(emsize), ::core::mem::transmute(pixelsperdip), ::core::mem::transmute(transform), usegdinatural.into_param().abi(), ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), PARAM5 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphmetrics)), issideways.into_param().abi()).ok()
+    pub unsafe fn GetGdiCompatibleGlyphMetrics<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param7: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, emsize: f32, pixelsperdip: f32, transform: *const DWRITE_MATRIX, usegdinatural: Param3, glyphindices: *const u16, glyphcount: u32, glyphmetrics: *mut DWRITE_GLYPH_METRICS, issideways: Param7) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.GetGdiCompatibleGlyphMetrics)(::core::mem::transmute_copy(self), ::core::mem::transmute(emsize), ::core::mem::transmute(pixelsperdip), ::core::mem::transmute(transform), usegdinatural.into_param().abi(), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphmetrics), issideways.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -9307,17 +9307,17 @@ impl IDWriteFontFace2 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetDesignGlyphAdvances<'a, const PARAM0: usize, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, glyphindices: &[u16; PARAM0], glyphadvances: &mut [i32; PARAM0], issideways: Param3) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.GetDesignGlyphAdvances)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphadvances)), issideways.into_param().abi()).ok()
+    pub unsafe fn GetDesignGlyphAdvances<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, glyphcount: u32, glyphindices: *const u16, glyphadvances: *mut i32, issideways: Param3) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.GetDesignGlyphAdvances)(::core::mem::transmute_copy(self), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphadvances), issideways.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetGdiCompatibleGlyphAdvances<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, const PARAM5: usize>(&self, emsize: f32, pixelsperdip: f32, transform: *const DWRITE_MATRIX, usegdinatural: Param3, issideways: Param4, glyphindices: &[u16; PARAM5], glyphadvances: &mut [i32; PARAM5]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.GetGdiCompatibleGlyphAdvances)(::core::mem::transmute_copy(self), ::core::mem::transmute(emsize), ::core::mem::transmute(pixelsperdip), ::core::mem::transmute(transform), usegdinatural.into_param().abi(), issideways.into_param().abi(), PARAM5 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphadvances))).ok()
+    pub unsafe fn GetGdiCompatibleGlyphAdvances<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, emsize: f32, pixelsperdip: f32, transform: *const DWRITE_MATRIX, usegdinatural: Param3, issideways: Param4, glyphcount: u32, glyphindices: *const u16, glyphadvances: *mut i32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.GetGdiCompatibleGlyphAdvances)(::core::mem::transmute_copy(self), ::core::mem::transmute(emsize), ::core::mem::transmute(pixelsperdip), ::core::mem::transmute(transform), usegdinatural.into_param().abi(), issideways.into_param().abi(), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphadvances)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
-    pub unsafe fn GetKerningPairAdjustments<'a, const PARAM0: usize>(&self, glyphindices: &[u16; PARAM0], glyphadvanceadjustments: &mut [i32; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.GetKerningPairAdjustments)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphadvanceadjustments))).ok()
+    pub unsafe fn GetKerningPairAdjustments(&self, glyphcount: u32, glyphindices: *const u16, glyphadvanceadjustments: *mut i32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.GetKerningPairAdjustments)(::core::mem::transmute_copy(self), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphadvanceadjustments)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -9331,8 +9331,8 @@ impl IDWriteFontFace2 {
         (::windows::core::Interface::vtable(self).base.GetRecommendedRenderingMode2)(::core::mem::transmute_copy(self), ::core::mem::transmute(fontemsize), ::core::mem::transmute(dpix), ::core::mem::transmute(dpiy), ::core::mem::transmute(transform), issideways.into_param().abi(), ::core::mem::transmute(outlinethreshold), ::core::mem::transmute(measuringmode), ::core::mem::transmute(&mut result__)).from_abi::<DWRITE_RENDERING_MODE>(result__)
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
-    pub unsafe fn GetVerticalGlyphVariants<'a, const PARAM0: usize>(&self, nominalglyphindices: &[u16; PARAM0], verticalglyphindices: &mut [u16; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.GetVerticalGlyphVariants)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(nominalglyphindices)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(verticalglyphindices))).ok()
+    pub unsafe fn GetVerticalGlyphVariants(&self, glyphcount: u32, nominalglyphindices: *const u16, verticalglyphindices: *mut u16) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.GetVerticalGlyphVariants)(::core::mem::transmute_copy(self), ::core::mem::transmute(glyphcount), ::core::mem::transmute(nominalglyphindices), ::core::mem::transmute(verticalglyphindices)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -9493,12 +9493,12 @@ impl IDWriteFontFace3 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetDesignGlyphMetrics<'a, const PARAM1: usize, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, glyphindices: &[u16; PARAM1], glyphmetrics: &mut [DWRITE_GLYPH_METRICS; PARAM1], issideways: Param3) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.GetDesignGlyphMetrics)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), PARAM1 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphmetrics)), issideways.into_param().abi()).ok()
+    pub unsafe fn GetDesignGlyphMetrics<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, glyphindices: *const u16, glyphcount: u32, glyphmetrics: *mut DWRITE_GLYPH_METRICS, issideways: Param3) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.GetDesignGlyphMetrics)(::core::mem::transmute_copy(self), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphmetrics), issideways.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
-    pub unsafe fn GetGlyphIndices<'a, const PARAM1: usize>(&self, codepoints: &[u32; PARAM1], glyphindices: &mut [u16; PARAM1]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.GetGlyphIndices)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(codepoints)), PARAM1 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphindices))).ok()
+    pub unsafe fn GetGlyphIndices(&self, codepoints: *const u32, codepointcount: u32, glyphindices: *mut u16) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.GetGlyphIndices)(::core::mem::transmute_copy(self), ::core::mem::transmute(codepoints), ::core::mem::transmute(codepointcount), ::core::mem::transmute(glyphindices)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -9526,8 +9526,8 @@ impl IDWriteFontFace3 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetGdiCompatibleGlyphMetrics<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, const PARAM5: usize, Param7: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, emsize: f32, pixelsperdip: f32, transform: *const DWRITE_MATRIX, usegdinatural: Param3, glyphindices: &[u16; PARAM5], glyphmetrics: &mut [DWRITE_GLYPH_METRICS; PARAM5], issideways: Param7) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.GetGdiCompatibleGlyphMetrics)(::core::mem::transmute_copy(self), ::core::mem::transmute(emsize), ::core::mem::transmute(pixelsperdip), ::core::mem::transmute(transform), usegdinatural.into_param().abi(), ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), PARAM5 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphmetrics)), issideways.into_param().abi()).ok()
+    pub unsafe fn GetGdiCompatibleGlyphMetrics<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param7: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, emsize: f32, pixelsperdip: f32, transform: *const DWRITE_MATRIX, usegdinatural: Param3, glyphindices: *const u16, glyphcount: u32, glyphmetrics: *mut DWRITE_GLYPH_METRICS, issideways: Param7) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.GetGdiCompatibleGlyphMetrics)(::core::mem::transmute_copy(self), ::core::mem::transmute(emsize), ::core::mem::transmute(pixelsperdip), ::core::mem::transmute(transform), usegdinatural.into_param().abi(), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphmetrics), issideways.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -9555,17 +9555,17 @@ impl IDWriteFontFace3 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetDesignGlyphAdvances<'a, const PARAM0: usize, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, glyphindices: &[u16; PARAM0], glyphadvances: &mut [i32; PARAM0], issideways: Param3) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.GetDesignGlyphAdvances)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphadvances)), issideways.into_param().abi()).ok()
+    pub unsafe fn GetDesignGlyphAdvances<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, glyphcount: u32, glyphindices: *const u16, glyphadvances: *mut i32, issideways: Param3) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.GetDesignGlyphAdvances)(::core::mem::transmute_copy(self), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphadvances), issideways.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetGdiCompatibleGlyphAdvances<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, const PARAM5: usize>(&self, emsize: f32, pixelsperdip: f32, transform: *const DWRITE_MATRIX, usegdinatural: Param3, issideways: Param4, glyphindices: &[u16; PARAM5], glyphadvances: &mut [i32; PARAM5]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.GetGdiCompatibleGlyphAdvances)(::core::mem::transmute_copy(self), ::core::mem::transmute(emsize), ::core::mem::transmute(pixelsperdip), ::core::mem::transmute(transform), usegdinatural.into_param().abi(), issideways.into_param().abi(), PARAM5 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphadvances))).ok()
+    pub unsafe fn GetGdiCompatibleGlyphAdvances<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, emsize: f32, pixelsperdip: f32, transform: *const DWRITE_MATRIX, usegdinatural: Param3, issideways: Param4, glyphcount: u32, glyphindices: *const u16, glyphadvances: *mut i32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.GetGdiCompatibleGlyphAdvances)(::core::mem::transmute_copy(self), ::core::mem::transmute(emsize), ::core::mem::transmute(pixelsperdip), ::core::mem::transmute(transform), usegdinatural.into_param().abi(), issideways.into_param().abi(), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphadvances)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
-    pub unsafe fn GetKerningPairAdjustments<'a, const PARAM0: usize>(&self, glyphindices: &[u16; PARAM0], glyphadvanceadjustments: &mut [i32; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.GetKerningPairAdjustments)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphadvanceadjustments))).ok()
+    pub unsafe fn GetKerningPairAdjustments(&self, glyphcount: u32, glyphindices: *const u16, glyphadvanceadjustments: *mut i32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.GetKerningPairAdjustments)(::core::mem::transmute_copy(self), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphadvanceadjustments)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -9579,8 +9579,8 @@ impl IDWriteFontFace3 {
         (::windows::core::Interface::vtable(self).base.base.GetRecommendedRenderingMode2)(::core::mem::transmute_copy(self), ::core::mem::transmute(fontemsize), ::core::mem::transmute(dpix), ::core::mem::transmute(dpiy), ::core::mem::transmute(transform), issideways.into_param().abi(), ::core::mem::transmute(outlinethreshold), ::core::mem::transmute(measuringmode), ::core::mem::transmute(&mut result__)).from_abi::<DWRITE_RENDERING_MODE>(result__)
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
-    pub unsafe fn GetVerticalGlyphVariants<'a, const PARAM0: usize>(&self, nominalglyphindices: &[u16; PARAM0], verticalglyphindices: &mut [u16; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.GetVerticalGlyphVariants)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(nominalglyphindices)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(verticalglyphindices))).ok()
+    pub unsafe fn GetVerticalGlyphVariants(&self, glyphcount: u32, nominalglyphindices: *const u16, verticalglyphindices: *mut u16) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.GetVerticalGlyphVariants)(::core::mem::transmute_copy(self), ::core::mem::transmute(glyphcount), ::core::mem::transmute(nominalglyphindices), ::core::mem::transmute(verticalglyphindices)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -9853,12 +9853,12 @@ impl IDWriteFontFace4 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetDesignGlyphMetrics<'a, const PARAM1: usize, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, glyphindices: &[u16; PARAM1], glyphmetrics: &mut [DWRITE_GLYPH_METRICS; PARAM1], issideways: Param3) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.GetDesignGlyphMetrics)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), PARAM1 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphmetrics)), issideways.into_param().abi()).ok()
+    pub unsafe fn GetDesignGlyphMetrics<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, glyphindices: *const u16, glyphcount: u32, glyphmetrics: *mut DWRITE_GLYPH_METRICS, issideways: Param3) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.GetDesignGlyphMetrics)(::core::mem::transmute_copy(self), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphmetrics), issideways.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
-    pub unsafe fn GetGlyphIndices<'a, const PARAM1: usize>(&self, codepoints: &[u32; PARAM1], glyphindices: &mut [u16; PARAM1]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.GetGlyphIndices)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(codepoints)), PARAM1 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphindices))).ok()
+    pub unsafe fn GetGlyphIndices(&self, codepoints: *const u32, codepointcount: u32, glyphindices: *mut u16) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.GetGlyphIndices)(::core::mem::transmute_copy(self), ::core::mem::transmute(codepoints), ::core::mem::transmute(codepointcount), ::core::mem::transmute(glyphindices)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -9886,8 +9886,8 @@ impl IDWriteFontFace4 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetGdiCompatibleGlyphMetrics<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, const PARAM5: usize, Param7: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, emsize: f32, pixelsperdip: f32, transform: *const DWRITE_MATRIX, usegdinatural: Param3, glyphindices: &[u16; PARAM5], glyphmetrics: &mut [DWRITE_GLYPH_METRICS; PARAM5], issideways: Param7) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.GetGdiCompatibleGlyphMetrics)(::core::mem::transmute_copy(self), ::core::mem::transmute(emsize), ::core::mem::transmute(pixelsperdip), ::core::mem::transmute(transform), usegdinatural.into_param().abi(), ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), PARAM5 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphmetrics)), issideways.into_param().abi()).ok()
+    pub unsafe fn GetGdiCompatibleGlyphMetrics<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param7: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, emsize: f32, pixelsperdip: f32, transform: *const DWRITE_MATRIX, usegdinatural: Param3, glyphindices: *const u16, glyphcount: u32, glyphmetrics: *mut DWRITE_GLYPH_METRICS, issideways: Param7) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.GetGdiCompatibleGlyphMetrics)(::core::mem::transmute_copy(self), ::core::mem::transmute(emsize), ::core::mem::transmute(pixelsperdip), ::core::mem::transmute(transform), usegdinatural.into_param().abi(), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphmetrics), issideways.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -9915,17 +9915,17 @@ impl IDWriteFontFace4 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetDesignGlyphAdvances<'a, const PARAM0: usize, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, glyphindices: &[u16; PARAM0], glyphadvances: &mut [i32; PARAM0], issideways: Param3) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.GetDesignGlyphAdvances)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphadvances)), issideways.into_param().abi()).ok()
+    pub unsafe fn GetDesignGlyphAdvances<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, glyphcount: u32, glyphindices: *const u16, glyphadvances: *mut i32, issideways: Param3) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.GetDesignGlyphAdvances)(::core::mem::transmute_copy(self), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphadvances), issideways.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetGdiCompatibleGlyphAdvances<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, const PARAM5: usize>(&self, emsize: f32, pixelsperdip: f32, transform: *const DWRITE_MATRIX, usegdinatural: Param3, issideways: Param4, glyphindices: &[u16; PARAM5], glyphadvances: &mut [i32; PARAM5]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.GetGdiCompatibleGlyphAdvances)(::core::mem::transmute_copy(self), ::core::mem::transmute(emsize), ::core::mem::transmute(pixelsperdip), ::core::mem::transmute(transform), usegdinatural.into_param().abi(), issideways.into_param().abi(), PARAM5 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphadvances))).ok()
+    pub unsafe fn GetGdiCompatibleGlyphAdvances<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, emsize: f32, pixelsperdip: f32, transform: *const DWRITE_MATRIX, usegdinatural: Param3, issideways: Param4, glyphcount: u32, glyphindices: *const u16, glyphadvances: *mut i32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.GetGdiCompatibleGlyphAdvances)(::core::mem::transmute_copy(self), ::core::mem::transmute(emsize), ::core::mem::transmute(pixelsperdip), ::core::mem::transmute(transform), usegdinatural.into_param().abi(), issideways.into_param().abi(), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphadvances)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
-    pub unsafe fn GetKerningPairAdjustments<'a, const PARAM0: usize>(&self, glyphindices: &[u16; PARAM0], glyphadvanceadjustments: &mut [i32; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.GetKerningPairAdjustments)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphadvanceadjustments))).ok()
+    pub unsafe fn GetKerningPairAdjustments(&self, glyphcount: u32, glyphindices: *const u16, glyphadvanceadjustments: *mut i32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.GetKerningPairAdjustments)(::core::mem::transmute_copy(self), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphadvanceadjustments)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -9939,8 +9939,8 @@ impl IDWriteFontFace4 {
         (::windows::core::Interface::vtable(self).base.base.base.GetRecommendedRenderingMode2)(::core::mem::transmute_copy(self), ::core::mem::transmute(fontemsize), ::core::mem::transmute(dpix), ::core::mem::transmute(dpiy), ::core::mem::transmute(transform), issideways.into_param().abi(), ::core::mem::transmute(outlinethreshold), ::core::mem::transmute(measuringmode), ::core::mem::transmute(&mut result__)).from_abi::<DWRITE_RENDERING_MODE>(result__)
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
-    pub unsafe fn GetVerticalGlyphVariants<'a, const PARAM0: usize>(&self, nominalglyphindices: &[u16; PARAM0], verticalglyphindices: &mut [u16; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.GetVerticalGlyphVariants)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(nominalglyphindices)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(verticalglyphindices))).ok()
+    pub unsafe fn GetVerticalGlyphVariants(&self, glyphcount: u32, nominalglyphindices: *const u16, verticalglyphindices: *mut u16) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.GetVerticalGlyphVariants)(::core::mem::transmute_copy(self), ::core::mem::transmute(glyphcount), ::core::mem::transmute(nominalglyphindices), ::core::mem::transmute(verticalglyphindices)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -10223,12 +10223,12 @@ impl IDWriteFontFace5 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetDesignGlyphMetrics<'a, const PARAM1: usize, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, glyphindices: &[u16; PARAM1], glyphmetrics: &mut [DWRITE_GLYPH_METRICS; PARAM1], issideways: Param3) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.base.GetDesignGlyphMetrics)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), PARAM1 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphmetrics)), issideways.into_param().abi()).ok()
+    pub unsafe fn GetDesignGlyphMetrics<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, glyphindices: *const u16, glyphcount: u32, glyphmetrics: *mut DWRITE_GLYPH_METRICS, issideways: Param3) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.base.GetDesignGlyphMetrics)(::core::mem::transmute_copy(self), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphmetrics), issideways.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
-    pub unsafe fn GetGlyphIndices<'a, const PARAM1: usize>(&self, codepoints: &[u32; PARAM1], glyphindices: &mut [u16; PARAM1]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.base.GetGlyphIndices)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(codepoints)), PARAM1 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphindices))).ok()
+    pub unsafe fn GetGlyphIndices(&self, codepoints: *const u32, codepointcount: u32, glyphindices: *mut u16) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.base.GetGlyphIndices)(::core::mem::transmute_copy(self), ::core::mem::transmute(codepoints), ::core::mem::transmute(codepointcount), ::core::mem::transmute(glyphindices)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -10256,8 +10256,8 @@ impl IDWriteFontFace5 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetGdiCompatibleGlyphMetrics<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, const PARAM5: usize, Param7: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, emsize: f32, pixelsperdip: f32, transform: *const DWRITE_MATRIX, usegdinatural: Param3, glyphindices: &[u16; PARAM5], glyphmetrics: &mut [DWRITE_GLYPH_METRICS; PARAM5], issideways: Param7) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.base.GetGdiCompatibleGlyphMetrics)(::core::mem::transmute_copy(self), ::core::mem::transmute(emsize), ::core::mem::transmute(pixelsperdip), ::core::mem::transmute(transform), usegdinatural.into_param().abi(), ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), PARAM5 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphmetrics)), issideways.into_param().abi()).ok()
+    pub unsafe fn GetGdiCompatibleGlyphMetrics<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param7: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, emsize: f32, pixelsperdip: f32, transform: *const DWRITE_MATRIX, usegdinatural: Param3, glyphindices: *const u16, glyphcount: u32, glyphmetrics: *mut DWRITE_GLYPH_METRICS, issideways: Param7) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.base.GetGdiCompatibleGlyphMetrics)(::core::mem::transmute_copy(self), ::core::mem::transmute(emsize), ::core::mem::transmute(pixelsperdip), ::core::mem::transmute(transform), usegdinatural.into_param().abi(), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphmetrics), issideways.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -10285,17 +10285,17 @@ impl IDWriteFontFace5 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetDesignGlyphAdvances<'a, const PARAM0: usize, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, glyphindices: &[u16; PARAM0], glyphadvances: &mut [i32; PARAM0], issideways: Param3) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.GetDesignGlyphAdvances)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphadvances)), issideways.into_param().abi()).ok()
+    pub unsafe fn GetDesignGlyphAdvances<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, glyphcount: u32, glyphindices: *const u16, glyphadvances: *mut i32, issideways: Param3) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.GetDesignGlyphAdvances)(::core::mem::transmute_copy(self), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphadvances), issideways.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetGdiCompatibleGlyphAdvances<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, const PARAM5: usize>(&self, emsize: f32, pixelsperdip: f32, transform: *const DWRITE_MATRIX, usegdinatural: Param3, issideways: Param4, glyphindices: &[u16; PARAM5], glyphadvances: &mut [i32; PARAM5]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.GetGdiCompatibleGlyphAdvances)(::core::mem::transmute_copy(self), ::core::mem::transmute(emsize), ::core::mem::transmute(pixelsperdip), ::core::mem::transmute(transform), usegdinatural.into_param().abi(), issideways.into_param().abi(), PARAM5 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphadvances))).ok()
+    pub unsafe fn GetGdiCompatibleGlyphAdvances<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, emsize: f32, pixelsperdip: f32, transform: *const DWRITE_MATRIX, usegdinatural: Param3, issideways: Param4, glyphcount: u32, glyphindices: *const u16, glyphadvances: *mut i32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.GetGdiCompatibleGlyphAdvances)(::core::mem::transmute_copy(self), ::core::mem::transmute(emsize), ::core::mem::transmute(pixelsperdip), ::core::mem::transmute(transform), usegdinatural.into_param().abi(), issideways.into_param().abi(), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphadvances)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
-    pub unsafe fn GetKerningPairAdjustments<'a, const PARAM0: usize>(&self, glyphindices: &[u16; PARAM0], glyphadvanceadjustments: &mut [i32; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.GetKerningPairAdjustments)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphadvanceadjustments))).ok()
+    pub unsafe fn GetKerningPairAdjustments(&self, glyphcount: u32, glyphindices: *const u16, glyphadvanceadjustments: *mut i32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.GetKerningPairAdjustments)(::core::mem::transmute_copy(self), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphadvanceadjustments)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -10309,8 +10309,8 @@ impl IDWriteFontFace5 {
         (::windows::core::Interface::vtable(self).base.base.base.base.GetRecommendedRenderingMode2)(::core::mem::transmute_copy(self), ::core::mem::transmute(fontemsize), ::core::mem::transmute(dpix), ::core::mem::transmute(dpiy), ::core::mem::transmute(transform), issideways.into_param().abi(), ::core::mem::transmute(outlinethreshold), ::core::mem::transmute(measuringmode), ::core::mem::transmute(&mut result__)).from_abi::<DWRITE_RENDERING_MODE>(result__)
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
-    pub unsafe fn GetVerticalGlyphVariants<'a, const PARAM0: usize>(&self, nominalglyphindices: &[u16; PARAM0], verticalglyphindices: &mut [u16; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.GetVerticalGlyphVariants)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(nominalglyphindices)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(verticalglyphindices))).ok()
+    pub unsafe fn GetVerticalGlyphVariants(&self, glyphcount: u32, nominalglyphindices: *const u16, verticalglyphindices: *mut u16) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.GetVerticalGlyphVariants)(::core::mem::transmute_copy(self), ::core::mem::transmute(glyphcount), ::core::mem::transmute(nominalglyphindices), ::core::mem::transmute(verticalglyphindices)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -10640,12 +10640,12 @@ impl IDWriteFontFace6 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetDesignGlyphMetrics<'a, const PARAM1: usize, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, glyphindices: &[u16; PARAM1], glyphmetrics: &mut [DWRITE_GLYPH_METRICS; PARAM1], issideways: Param3) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.base.base.GetDesignGlyphMetrics)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), PARAM1 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphmetrics)), issideways.into_param().abi()).ok()
+    pub unsafe fn GetDesignGlyphMetrics<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, glyphindices: *const u16, glyphcount: u32, glyphmetrics: *mut DWRITE_GLYPH_METRICS, issideways: Param3) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.base.base.GetDesignGlyphMetrics)(::core::mem::transmute_copy(self), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphmetrics), issideways.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
-    pub unsafe fn GetGlyphIndices<'a, const PARAM1: usize>(&self, codepoints: &[u32; PARAM1], glyphindices: &mut [u16; PARAM1]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.base.base.GetGlyphIndices)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(codepoints)), PARAM1 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphindices))).ok()
+    pub unsafe fn GetGlyphIndices(&self, codepoints: *const u32, codepointcount: u32, glyphindices: *mut u16) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.base.base.GetGlyphIndices)(::core::mem::transmute_copy(self), ::core::mem::transmute(codepoints), ::core::mem::transmute(codepointcount), ::core::mem::transmute(glyphindices)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -10673,8 +10673,8 @@ impl IDWriteFontFace6 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetGdiCompatibleGlyphMetrics<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, const PARAM5: usize, Param7: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, emsize: f32, pixelsperdip: f32, transform: *const DWRITE_MATRIX, usegdinatural: Param3, glyphindices: &[u16; PARAM5], glyphmetrics: &mut [DWRITE_GLYPH_METRICS; PARAM5], issideways: Param7) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.base.base.GetGdiCompatibleGlyphMetrics)(::core::mem::transmute_copy(self), ::core::mem::transmute(emsize), ::core::mem::transmute(pixelsperdip), ::core::mem::transmute(transform), usegdinatural.into_param().abi(), ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), PARAM5 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphmetrics)), issideways.into_param().abi()).ok()
+    pub unsafe fn GetGdiCompatibleGlyphMetrics<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param7: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, emsize: f32, pixelsperdip: f32, transform: *const DWRITE_MATRIX, usegdinatural: Param3, glyphindices: *const u16, glyphcount: u32, glyphmetrics: *mut DWRITE_GLYPH_METRICS, issideways: Param7) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.base.base.GetGdiCompatibleGlyphMetrics)(::core::mem::transmute_copy(self), ::core::mem::transmute(emsize), ::core::mem::transmute(pixelsperdip), ::core::mem::transmute(transform), usegdinatural.into_param().abi(), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphmetrics), issideways.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -10702,17 +10702,17 @@ impl IDWriteFontFace6 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetDesignGlyphAdvances<'a, const PARAM0: usize, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, glyphindices: &[u16; PARAM0], glyphadvances: &mut [i32; PARAM0], issideways: Param3) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.base.GetDesignGlyphAdvances)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphadvances)), issideways.into_param().abi()).ok()
+    pub unsafe fn GetDesignGlyphAdvances<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, glyphcount: u32, glyphindices: *const u16, glyphadvances: *mut i32, issideways: Param3) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.base.GetDesignGlyphAdvances)(::core::mem::transmute_copy(self), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphadvances), issideways.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetGdiCompatibleGlyphAdvances<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, const PARAM5: usize>(&self, emsize: f32, pixelsperdip: f32, transform: *const DWRITE_MATRIX, usegdinatural: Param3, issideways: Param4, glyphindices: &[u16; PARAM5], glyphadvances: &mut [i32; PARAM5]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.base.GetGdiCompatibleGlyphAdvances)(::core::mem::transmute_copy(self), ::core::mem::transmute(emsize), ::core::mem::transmute(pixelsperdip), ::core::mem::transmute(transform), usegdinatural.into_param().abi(), issideways.into_param().abi(), PARAM5 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphadvances))).ok()
+    pub unsafe fn GetGdiCompatibleGlyphAdvances<'a, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(&self, emsize: f32, pixelsperdip: f32, transform: *const DWRITE_MATRIX, usegdinatural: Param3, issideways: Param4, glyphcount: u32, glyphindices: *const u16, glyphadvances: *mut i32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.base.GetGdiCompatibleGlyphAdvances)(::core::mem::transmute_copy(self), ::core::mem::transmute(emsize), ::core::mem::transmute(pixelsperdip), ::core::mem::transmute(transform), usegdinatural.into_param().abi(), issideways.into_param().abi(), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphadvances)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
-    pub unsafe fn GetKerningPairAdjustments<'a, const PARAM0: usize>(&self, glyphindices: &[u16; PARAM0], glyphadvanceadjustments: &mut [i32; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.base.GetKerningPairAdjustments)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphadvanceadjustments))).ok()
+    pub unsafe fn GetKerningPairAdjustments(&self, glyphcount: u32, glyphindices: *const u16, glyphadvanceadjustments: *mut i32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.base.GetKerningPairAdjustments)(::core::mem::transmute_copy(self), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphindices), ::core::mem::transmute(glyphadvanceadjustments)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -10726,8 +10726,8 @@ impl IDWriteFontFace6 {
         (::windows::core::Interface::vtable(self).base.base.base.base.base.GetRecommendedRenderingMode2)(::core::mem::transmute_copy(self), ::core::mem::transmute(fontemsize), ::core::mem::transmute(dpix), ::core::mem::transmute(dpiy), ::core::mem::transmute(transform), issideways.into_param().abi(), ::core::mem::transmute(outlinethreshold), ::core::mem::transmute(measuringmode), ::core::mem::transmute(&mut result__)).from_abi::<DWRITE_RENDERING_MODE>(result__)
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
-    pub unsafe fn GetVerticalGlyphVariants<'a, const PARAM0: usize>(&self, nominalglyphindices: &[u16; PARAM0], verticalglyphindices: &mut [u16; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.base.GetVerticalGlyphVariants)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(nominalglyphindices)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(verticalglyphindices))).ok()
+    pub unsafe fn GetVerticalGlyphVariants(&self, glyphcount: u32, nominalglyphindices: *const u16, verticalglyphindices: *mut u16) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.base.GetVerticalGlyphVariants)(::core::mem::transmute_copy(self), ::core::mem::transmute(glyphcount), ::core::mem::transmute(nominalglyphindices), ::core::mem::transmute(verticalglyphindices)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
@@ -15519,9 +15519,10 @@ impl IDWriteTextAnalyzer {
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetGlyphs<'a, const PARAM1: usize, Param2: ::windows::core::IntoParam<'a, IDWriteFontFace>, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param6: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>, Param7: ::windows::core::IntoParam<'a, IDWriteNumberSubstitution>, const PARAM11: usize>(
+    pub unsafe fn GetGlyphs<'a, Param2: ::windows::core::IntoParam<'a, IDWriteFontFace>, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param6: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>, Param7: ::windows::core::IntoParam<'a, IDWriteNumberSubstitution>>(
         &self,
-        textstring: &[u16; PARAM1],
+        textstring: ::windows::core::PCWSTR,
+        textlength: u32,
         fontface: Param2,
         issideways: Param3,
         isrighttoleft: Param4,
@@ -15531,16 +15532,17 @@ impl IDWriteTextAnalyzer {
         features: *const *const DWRITE_TYPOGRAPHIC_FEATURES,
         featurerangelengths: *const u32,
         featureranges: u32,
-        clustermap: &mut [u16; PARAM1],
-        textprops: &mut [DWRITE_SHAPING_TEXT_PROPERTIES; PARAM1],
-        glyphindices: &mut [u16; PARAM11],
-        glyphprops: &mut [DWRITE_SHAPING_GLYPH_PROPERTIES; PARAM11],
+        maxglyphcount: u32,
+        clustermap: *mut u16,
+        textprops: *mut DWRITE_SHAPING_TEXT_PROPERTIES,
+        glyphindices: *mut u16,
+        glyphprops: *mut DWRITE_SHAPING_GLYPH_PROPERTIES,
         actualglyphcount: *mut u32,
     ) -> ::windows::core::Result<()> {
         (::windows::core::Interface::vtable(self).GetGlyphs)(
             ::core::mem::transmute_copy(self),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(textstring)),
-            PARAM1 as _,
+            ::core::mem::transmute(textstring),
+            ::core::mem::transmute(textlength),
             fontface.into_param().abi(),
             issideways.into_param().abi(),
             isrighttoleft.into_param().abi(),
@@ -15550,24 +15552,26 @@ impl IDWriteTextAnalyzer {
             ::core::mem::transmute(features),
             ::core::mem::transmute(featurerangelengths),
             ::core::mem::transmute(featureranges),
-            PARAM11 as _,
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(clustermap)),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(textprops)),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphindices)),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphprops)),
+            ::core::mem::transmute(maxglyphcount),
+            ::core::mem::transmute(clustermap),
+            ::core::mem::transmute(textprops),
+            ::core::mem::transmute(glyphindices),
+            ::core::mem::transmute(glyphprops),
             ::core::mem::transmute(actualglyphcount),
         )
         .ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetGlyphPlacements<'a, const PARAM3: usize, const PARAM6: usize, Param7: ::windows::core::IntoParam<'a, IDWriteFontFace>, Param9: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param10: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param12: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>>(
+    pub unsafe fn GetGlyphPlacements<'a, Param7: ::windows::core::IntoParam<'a, IDWriteFontFace>, Param9: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param10: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param12: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>>(
         &self,
-        textstring: &[u16; PARAM3],
-        clustermap: &[u16; PARAM3],
-        textprops: &mut [DWRITE_SHAPING_TEXT_PROPERTIES; PARAM3],
-        glyphindices: &[u16; PARAM6],
-        glyphprops: &[DWRITE_SHAPING_GLYPH_PROPERTIES; PARAM6],
+        textstring: ::windows::core::PCWSTR,
+        clustermap: *const u16,
+        textprops: *mut DWRITE_SHAPING_TEXT_PROPERTIES,
+        textlength: u32,
+        glyphindices: *const u16,
+        glyphprops: *const DWRITE_SHAPING_GLYPH_PROPERTIES,
+        glyphcount: u32,
         fontface: Param7,
         fontemsize: f32,
         issideways: Param9,
@@ -15577,18 +15581,18 @@ impl IDWriteTextAnalyzer {
         features: *const *const DWRITE_TYPOGRAPHIC_FEATURES,
         featurerangelengths: *const u32,
         featureranges: u32,
-        glyphadvances: &mut [f32; PARAM6],
-        glyphoffsets: &mut [DWRITE_GLYPH_OFFSET; PARAM6],
+        glyphadvances: *mut f32,
+        glyphoffsets: *mut DWRITE_GLYPH_OFFSET,
     ) -> ::windows::core::Result<()> {
         (::windows::core::Interface::vtable(self).GetGlyphPlacements)(
             ::core::mem::transmute_copy(self),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(textstring)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(clustermap)),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(textprops)),
-            PARAM3 as _,
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphprops)),
-            PARAM6 as _,
+            ::core::mem::transmute(textstring),
+            ::core::mem::transmute(clustermap),
+            ::core::mem::transmute(textprops),
+            ::core::mem::transmute(textlength),
+            ::core::mem::transmute(glyphindices),
+            ::core::mem::transmute(glyphprops),
+            ::core::mem::transmute(glyphcount),
             fontface.into_param().abi(),
             ::core::mem::transmute(fontemsize),
             issideways.into_param().abi(),
@@ -15598,20 +15602,22 @@ impl IDWriteTextAnalyzer {
             ::core::mem::transmute(features),
             ::core::mem::transmute(featurerangelengths),
             ::core::mem::transmute(featureranges),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphadvances)),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphoffsets)),
+            ::core::mem::transmute(glyphadvances),
+            ::core::mem::transmute(glyphoffsets),
         )
         .ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetGdiCompatibleGlyphPlacements<'a, const PARAM3: usize, const PARAM6: usize, Param7: ::windows::core::IntoParam<'a, IDWriteFontFace>, Param11: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param12: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param13: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param15: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>>(
+    pub unsafe fn GetGdiCompatibleGlyphPlacements<'a, Param7: ::windows::core::IntoParam<'a, IDWriteFontFace>, Param11: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param12: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param13: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param15: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>>(
         &self,
-        textstring: &[u16; PARAM3],
-        clustermap: &[u16; PARAM3],
-        textprops: &[DWRITE_SHAPING_TEXT_PROPERTIES; PARAM3],
-        glyphindices: &[u16; PARAM6],
-        glyphprops: &[DWRITE_SHAPING_GLYPH_PROPERTIES; PARAM6],
+        textstring: ::windows::core::PCWSTR,
+        clustermap: *const u16,
+        textprops: *const DWRITE_SHAPING_TEXT_PROPERTIES,
+        textlength: u32,
+        glyphindices: *const u16,
+        glyphprops: *const DWRITE_SHAPING_GLYPH_PROPERTIES,
+        glyphcount: u32,
         fontface: Param7,
         fontemsize: f32,
         pixelsperdip: f32,
@@ -15624,18 +15630,18 @@ impl IDWriteTextAnalyzer {
         features: *const *const DWRITE_TYPOGRAPHIC_FEATURES,
         featurerangelengths: *const u32,
         featureranges: u32,
-        glyphadvances: &mut [f32; PARAM6],
-        glyphoffsets: &mut [DWRITE_GLYPH_OFFSET; PARAM6],
+        glyphadvances: *mut f32,
+        glyphoffsets: *mut DWRITE_GLYPH_OFFSET,
     ) -> ::windows::core::Result<()> {
         (::windows::core::Interface::vtable(self).GetGdiCompatibleGlyphPlacements)(
             ::core::mem::transmute_copy(self),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(textstring)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(clustermap)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(textprops)),
-            PARAM3 as _,
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphprops)),
-            PARAM6 as _,
+            ::core::mem::transmute(textstring),
+            ::core::mem::transmute(clustermap),
+            ::core::mem::transmute(textprops),
+            ::core::mem::transmute(textlength),
+            ::core::mem::transmute(glyphindices),
+            ::core::mem::transmute(glyphprops),
+            ::core::mem::transmute(glyphcount),
             fontface.into_param().abi(),
             ::core::mem::transmute(fontemsize),
             ::core::mem::transmute(pixelsperdip),
@@ -15648,8 +15654,8 @@ impl IDWriteTextAnalyzer {
             ::core::mem::transmute(features),
             ::core::mem::transmute(featurerangelengths),
             ::core::mem::transmute(featureranges),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphadvances)),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphoffsets)),
+            ::core::mem::transmute(glyphadvances),
+            ::core::mem::transmute(glyphoffsets),
         )
         .ok()
     }
@@ -15760,9 +15766,10 @@ impl IDWriteTextAnalyzer1 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetGlyphs<'a, const PARAM1: usize, Param2: ::windows::core::IntoParam<'a, IDWriteFontFace>, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param6: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>, Param7: ::windows::core::IntoParam<'a, IDWriteNumberSubstitution>, const PARAM11: usize>(
+    pub unsafe fn GetGlyphs<'a, Param2: ::windows::core::IntoParam<'a, IDWriteFontFace>, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param6: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>, Param7: ::windows::core::IntoParam<'a, IDWriteNumberSubstitution>>(
         &self,
-        textstring: &[u16; PARAM1],
+        textstring: ::windows::core::PCWSTR,
+        textlength: u32,
         fontface: Param2,
         issideways: Param3,
         isrighttoleft: Param4,
@@ -15772,16 +15779,17 @@ impl IDWriteTextAnalyzer1 {
         features: *const *const DWRITE_TYPOGRAPHIC_FEATURES,
         featurerangelengths: *const u32,
         featureranges: u32,
-        clustermap: &mut [u16; PARAM1],
-        textprops: &mut [DWRITE_SHAPING_TEXT_PROPERTIES; PARAM1],
-        glyphindices: &mut [u16; PARAM11],
-        glyphprops: &mut [DWRITE_SHAPING_GLYPH_PROPERTIES; PARAM11],
+        maxglyphcount: u32,
+        clustermap: *mut u16,
+        textprops: *mut DWRITE_SHAPING_TEXT_PROPERTIES,
+        glyphindices: *mut u16,
+        glyphprops: *mut DWRITE_SHAPING_GLYPH_PROPERTIES,
         actualglyphcount: *mut u32,
     ) -> ::windows::core::Result<()> {
         (::windows::core::Interface::vtable(self).base.GetGlyphs)(
             ::core::mem::transmute_copy(self),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(textstring)),
-            PARAM1 as _,
+            ::core::mem::transmute(textstring),
+            ::core::mem::transmute(textlength),
             fontface.into_param().abi(),
             issideways.into_param().abi(),
             isrighttoleft.into_param().abi(),
@@ -15791,24 +15799,26 @@ impl IDWriteTextAnalyzer1 {
             ::core::mem::transmute(features),
             ::core::mem::transmute(featurerangelengths),
             ::core::mem::transmute(featureranges),
-            PARAM11 as _,
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(clustermap)),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(textprops)),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphindices)),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphprops)),
+            ::core::mem::transmute(maxglyphcount),
+            ::core::mem::transmute(clustermap),
+            ::core::mem::transmute(textprops),
+            ::core::mem::transmute(glyphindices),
+            ::core::mem::transmute(glyphprops),
             ::core::mem::transmute(actualglyphcount),
         )
         .ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetGlyphPlacements<'a, const PARAM3: usize, const PARAM6: usize, Param7: ::windows::core::IntoParam<'a, IDWriteFontFace>, Param9: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param10: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param12: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>>(
+    pub unsafe fn GetGlyphPlacements<'a, Param7: ::windows::core::IntoParam<'a, IDWriteFontFace>, Param9: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param10: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param12: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>>(
         &self,
-        textstring: &[u16; PARAM3],
-        clustermap: &[u16; PARAM3],
-        textprops: &mut [DWRITE_SHAPING_TEXT_PROPERTIES; PARAM3],
-        glyphindices: &[u16; PARAM6],
-        glyphprops: &[DWRITE_SHAPING_GLYPH_PROPERTIES; PARAM6],
+        textstring: ::windows::core::PCWSTR,
+        clustermap: *const u16,
+        textprops: *mut DWRITE_SHAPING_TEXT_PROPERTIES,
+        textlength: u32,
+        glyphindices: *const u16,
+        glyphprops: *const DWRITE_SHAPING_GLYPH_PROPERTIES,
+        glyphcount: u32,
         fontface: Param7,
         fontemsize: f32,
         issideways: Param9,
@@ -15818,18 +15828,18 @@ impl IDWriteTextAnalyzer1 {
         features: *const *const DWRITE_TYPOGRAPHIC_FEATURES,
         featurerangelengths: *const u32,
         featureranges: u32,
-        glyphadvances: &mut [f32; PARAM6],
-        glyphoffsets: &mut [DWRITE_GLYPH_OFFSET; PARAM6],
+        glyphadvances: *mut f32,
+        glyphoffsets: *mut DWRITE_GLYPH_OFFSET,
     ) -> ::windows::core::Result<()> {
         (::windows::core::Interface::vtable(self).base.GetGlyphPlacements)(
             ::core::mem::transmute_copy(self),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(textstring)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(clustermap)),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(textprops)),
-            PARAM3 as _,
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphprops)),
-            PARAM6 as _,
+            ::core::mem::transmute(textstring),
+            ::core::mem::transmute(clustermap),
+            ::core::mem::transmute(textprops),
+            ::core::mem::transmute(textlength),
+            ::core::mem::transmute(glyphindices),
+            ::core::mem::transmute(glyphprops),
+            ::core::mem::transmute(glyphcount),
             fontface.into_param().abi(),
             ::core::mem::transmute(fontemsize),
             issideways.into_param().abi(),
@@ -15839,20 +15849,22 @@ impl IDWriteTextAnalyzer1 {
             ::core::mem::transmute(features),
             ::core::mem::transmute(featurerangelengths),
             ::core::mem::transmute(featureranges),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphadvances)),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphoffsets)),
+            ::core::mem::transmute(glyphadvances),
+            ::core::mem::transmute(glyphoffsets),
         )
         .ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetGdiCompatibleGlyphPlacements<'a, const PARAM3: usize, const PARAM6: usize, Param7: ::windows::core::IntoParam<'a, IDWriteFontFace>, Param11: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param12: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param13: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param15: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>>(
+    pub unsafe fn GetGdiCompatibleGlyphPlacements<'a, Param7: ::windows::core::IntoParam<'a, IDWriteFontFace>, Param11: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param12: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param13: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param15: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>>(
         &self,
-        textstring: &[u16; PARAM3],
-        clustermap: &[u16; PARAM3],
-        textprops: &[DWRITE_SHAPING_TEXT_PROPERTIES; PARAM3],
-        glyphindices: &[u16; PARAM6],
-        glyphprops: &[DWRITE_SHAPING_GLYPH_PROPERTIES; PARAM6],
+        textstring: ::windows::core::PCWSTR,
+        clustermap: *const u16,
+        textprops: *const DWRITE_SHAPING_TEXT_PROPERTIES,
+        textlength: u32,
+        glyphindices: *const u16,
+        glyphprops: *const DWRITE_SHAPING_GLYPH_PROPERTIES,
+        glyphcount: u32,
         fontface: Param7,
         fontemsize: f32,
         pixelsperdip: f32,
@@ -15865,18 +15877,18 @@ impl IDWriteTextAnalyzer1 {
         features: *const *const DWRITE_TYPOGRAPHIC_FEATURES,
         featurerangelengths: *const u32,
         featureranges: u32,
-        glyphadvances: &mut [f32; PARAM6],
-        glyphoffsets: &mut [DWRITE_GLYPH_OFFSET; PARAM6],
+        glyphadvances: *mut f32,
+        glyphoffsets: *mut DWRITE_GLYPH_OFFSET,
     ) -> ::windows::core::Result<()> {
         (::windows::core::Interface::vtable(self).base.GetGdiCompatibleGlyphPlacements)(
             ::core::mem::transmute_copy(self),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(textstring)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(clustermap)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(textprops)),
-            PARAM3 as _,
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphprops)),
-            PARAM6 as _,
+            ::core::mem::transmute(textstring),
+            ::core::mem::transmute(clustermap),
+            ::core::mem::transmute(textprops),
+            ::core::mem::transmute(textlength),
+            ::core::mem::transmute(glyphindices),
+            ::core::mem::transmute(glyphprops),
+            ::core::mem::transmute(glyphcount),
             fontface.into_param().abi(),
             ::core::mem::transmute(fontemsize),
             ::core::mem::transmute(pixelsperdip),
@@ -15889,26 +15901,26 @@ impl IDWriteTextAnalyzer1 {
             ::core::mem::transmute(features),
             ::core::mem::transmute(featurerangelengths),
             ::core::mem::transmute(featureranges),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphadvances)),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphoffsets)),
+            ::core::mem::transmute(glyphadvances),
+            ::core::mem::transmute(glyphoffsets),
         )
         .ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
-    pub unsafe fn ApplyCharacterSpacing<'a, const PARAM4: usize>(&self, leadingspacing: f32, trailingspacing: f32, minimumadvancewidth: f32, clustermap: &[u16], glyphadvances: &[f32; PARAM4], glyphoffsets: &[DWRITE_GLYPH_OFFSET; PARAM4], glyphproperties: &[DWRITE_SHAPING_GLYPH_PROPERTIES; PARAM4], modifiedglyphadvances: &mut [f32; PARAM4], modifiedglyphoffsets: &mut [DWRITE_GLYPH_OFFSET; PARAM4]) -> ::windows::core::Result<()> {
+    pub unsafe fn ApplyCharacterSpacing(&self, leadingspacing: f32, trailingspacing: f32, minimumadvancewidth: f32, glyphcount: u32, clustermap: &[u16], glyphadvances: *const f32, glyphoffsets: *const DWRITE_GLYPH_OFFSET, glyphproperties: *const DWRITE_SHAPING_GLYPH_PROPERTIES, modifiedglyphadvances: *mut f32, modifiedglyphoffsets: *mut DWRITE_GLYPH_OFFSET) -> ::windows::core::Result<()> {
         (::windows::core::Interface::vtable(self).ApplyCharacterSpacing)(
             ::core::mem::transmute_copy(self),
             ::core::mem::transmute(leadingspacing),
             ::core::mem::transmute(trailingspacing),
             ::core::mem::transmute(minimumadvancewidth),
             clustermap.len() as _,
-            PARAM4 as _,
+            ::core::mem::transmute(glyphcount),
             ::core::mem::transmute(::windows::core::as_ptr_or_null(clustermap)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphadvances)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphoffsets)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphproperties)),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(modifiedglyphadvances)),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(modifiedglyphoffsets)),
+            ::core::mem::transmute(glyphadvances),
+            ::core::mem::transmute(glyphoffsets),
+            ::core::mem::transmute(glyphproperties),
+            ::core::mem::transmute(modifiedglyphadvances),
+            ::core::mem::transmute(modifiedglyphoffsets),
         )
         .ok()
     }
@@ -15938,34 +15950,34 @@ impl IDWriteTextAnalyzer1 {
         (::windows::core::Interface::vtable(self).GetTextComplexity)(::core::mem::transmute_copy(self), ::core::mem::transmute(textstring), ::core::mem::transmute(textlength), fontface.into_param().abi(), ::core::mem::transmute(istextsimple), ::core::mem::transmute(textlengthread), ::core::mem::transmute(glyphindices)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
-    pub unsafe fn GetJustificationOpportunities<'a, Param0: ::windows::core::IntoParam<'a, IDWriteFontFace>, Param2: ::windows::core::IntoParam<'a, DWRITE_SCRIPT_ANALYSIS>, const PARAM3: usize, const PARAM4: usize>(&self, fontface: Param0, fontemsize: f32, scriptanalysis: Param2, textstring: &[u16; PARAM3], clustermap: &[u16; PARAM3], glyphproperties: &[DWRITE_SHAPING_GLYPH_PROPERTIES; PARAM4], justificationopportunities: &mut [DWRITE_JUSTIFICATION_OPPORTUNITY; PARAM4]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).GetJustificationOpportunities)(::core::mem::transmute_copy(self), fontface.into_param().abi(), ::core::mem::transmute(fontemsize), scriptanalysis.into_param().abi(), PARAM3 as _, PARAM4 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(textstring)), ::core::mem::transmute(::windows::core::as_ptr_or_null(clustermap)), ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphproperties)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(justificationopportunities))).ok()
+    pub unsafe fn GetJustificationOpportunities<'a, Param0: ::windows::core::IntoParam<'a, IDWriteFontFace>, Param2: ::windows::core::IntoParam<'a, DWRITE_SCRIPT_ANALYSIS>>(&self, fontface: Param0, fontemsize: f32, scriptanalysis: Param2, textlength: u32, glyphcount: u32, textstring: ::windows::core::PCWSTR, clustermap: *const u16, glyphproperties: *const DWRITE_SHAPING_GLYPH_PROPERTIES, justificationopportunities: *mut DWRITE_JUSTIFICATION_OPPORTUNITY) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).GetJustificationOpportunities)(::core::mem::transmute_copy(self), fontface.into_param().abi(), ::core::mem::transmute(fontemsize), scriptanalysis.into_param().abi(), ::core::mem::transmute(textlength), ::core::mem::transmute(glyphcount), ::core::mem::transmute(textstring), ::core::mem::transmute(clustermap), ::core::mem::transmute(glyphproperties), ::core::mem::transmute(justificationopportunities)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
     pub unsafe fn JustifyGlyphAdvances(&self, linewidth: f32, glyphcount: u32, justificationopportunities: *const DWRITE_JUSTIFICATION_OPPORTUNITY, glyphadvances: *const f32, glyphoffsets: *const DWRITE_GLYPH_OFFSET, justifiedglyphadvances: *mut f32, justifiedglyphoffsets: *mut DWRITE_GLYPH_OFFSET) -> ::windows::core::Result<()> {
         (::windows::core::Interface::vtable(self).JustifyGlyphAdvances)(::core::mem::transmute_copy(self), ::core::mem::transmute(linewidth), ::core::mem::transmute(glyphcount), ::core::mem::transmute(justificationopportunities), ::core::mem::transmute(glyphadvances), ::core::mem::transmute(glyphoffsets), ::core::mem::transmute(justifiedglyphadvances), ::core::mem::transmute(justifiedglyphoffsets)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
-    pub unsafe fn GetJustifiedGlyphs<'a, Param0: ::windows::core::IntoParam<'a, IDWriteFontFace>, Param2: ::windows::core::IntoParam<'a, DWRITE_SCRIPT_ANALYSIS>, const PARAM4: usize, const PARAM5: usize>(&self, fontface: Param0, fontemsize: f32, scriptanalysis: Param2, textlength: u32, clustermap: *const u16, glyphindices: &[u16; PARAM4], glyphadvances: &[f32; PARAM4], justifiedglyphadvances: &[f32; PARAM4], justifiedglyphoffsets: &[DWRITE_GLYPH_OFFSET; PARAM4], glyphproperties: &[DWRITE_SHAPING_GLYPH_PROPERTIES; PARAM4], actualglyphcount: *mut u32, modifiedclustermap: *mut u16, modifiedglyphindices: &mut [u16; PARAM5], modifiedglyphadvances: &mut [f32; PARAM5], modifiedglyphoffsets: &mut [DWRITE_GLYPH_OFFSET; PARAM5]) -> ::windows::core::Result<()> {
+    pub unsafe fn GetJustifiedGlyphs<'a, Param0: ::windows::core::IntoParam<'a, IDWriteFontFace>, Param2: ::windows::core::IntoParam<'a, DWRITE_SCRIPT_ANALYSIS>>(&self, fontface: Param0, fontemsize: f32, scriptanalysis: Param2, textlength: u32, glyphcount: u32, maxglyphcount: u32, clustermap: *const u16, glyphindices: *const u16, glyphadvances: *const f32, justifiedglyphadvances: *const f32, justifiedglyphoffsets: *const DWRITE_GLYPH_OFFSET, glyphproperties: *const DWRITE_SHAPING_GLYPH_PROPERTIES, actualglyphcount: *mut u32, modifiedclustermap: *mut u16, modifiedglyphindices: *mut u16, modifiedglyphadvances: *mut f32, modifiedglyphoffsets: *mut DWRITE_GLYPH_OFFSET) -> ::windows::core::Result<()> {
         (::windows::core::Interface::vtable(self).GetJustifiedGlyphs)(
             ::core::mem::transmute_copy(self),
             fontface.into_param().abi(),
             ::core::mem::transmute(fontemsize),
             scriptanalysis.into_param().abi(),
             ::core::mem::transmute(textlength),
-            PARAM4 as _,
-            PARAM5 as _,
+            ::core::mem::transmute(glyphcount),
+            ::core::mem::transmute(maxglyphcount),
             ::core::mem::transmute(clustermap),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphadvances)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(justifiedglyphadvances)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(justifiedglyphoffsets)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphproperties)),
+            ::core::mem::transmute(glyphindices),
+            ::core::mem::transmute(glyphadvances),
+            ::core::mem::transmute(justifiedglyphadvances),
+            ::core::mem::transmute(justifiedglyphoffsets),
+            ::core::mem::transmute(glyphproperties),
             ::core::mem::transmute(actualglyphcount),
             ::core::mem::transmute(modifiedclustermap),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(modifiedglyphindices)),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(modifiedglyphadvances)),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(modifiedglyphoffsets)),
+            ::core::mem::transmute(modifiedglyphindices),
+            ::core::mem::transmute(modifiedglyphadvances),
+            ::core::mem::transmute(modifiedglyphoffsets),
         )
         .ok()
     }
@@ -16075,9 +16087,10 @@ impl IDWriteTextAnalyzer2 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetGlyphs<'a, const PARAM1: usize, Param2: ::windows::core::IntoParam<'a, IDWriteFontFace>, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param6: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>, Param7: ::windows::core::IntoParam<'a, IDWriteNumberSubstitution>, const PARAM11: usize>(
+    pub unsafe fn GetGlyphs<'a, Param2: ::windows::core::IntoParam<'a, IDWriteFontFace>, Param3: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param4: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param6: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>, Param7: ::windows::core::IntoParam<'a, IDWriteNumberSubstitution>>(
         &self,
-        textstring: &[u16; PARAM1],
+        textstring: ::windows::core::PCWSTR,
+        textlength: u32,
         fontface: Param2,
         issideways: Param3,
         isrighttoleft: Param4,
@@ -16087,16 +16100,17 @@ impl IDWriteTextAnalyzer2 {
         features: *const *const DWRITE_TYPOGRAPHIC_FEATURES,
         featurerangelengths: *const u32,
         featureranges: u32,
-        clustermap: &mut [u16; PARAM1],
-        textprops: &mut [DWRITE_SHAPING_TEXT_PROPERTIES; PARAM1],
-        glyphindices: &mut [u16; PARAM11],
-        glyphprops: &mut [DWRITE_SHAPING_GLYPH_PROPERTIES; PARAM11],
+        maxglyphcount: u32,
+        clustermap: *mut u16,
+        textprops: *mut DWRITE_SHAPING_TEXT_PROPERTIES,
+        glyphindices: *mut u16,
+        glyphprops: *mut DWRITE_SHAPING_GLYPH_PROPERTIES,
         actualglyphcount: *mut u32,
     ) -> ::windows::core::Result<()> {
         (::windows::core::Interface::vtable(self).base.base.GetGlyphs)(
             ::core::mem::transmute_copy(self),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(textstring)),
-            PARAM1 as _,
+            ::core::mem::transmute(textstring),
+            ::core::mem::transmute(textlength),
             fontface.into_param().abi(),
             issideways.into_param().abi(),
             isrighttoleft.into_param().abi(),
@@ -16106,24 +16120,26 @@ impl IDWriteTextAnalyzer2 {
             ::core::mem::transmute(features),
             ::core::mem::transmute(featurerangelengths),
             ::core::mem::transmute(featureranges),
-            PARAM11 as _,
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(clustermap)),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(textprops)),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphindices)),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphprops)),
+            ::core::mem::transmute(maxglyphcount),
+            ::core::mem::transmute(clustermap),
+            ::core::mem::transmute(textprops),
+            ::core::mem::transmute(glyphindices),
+            ::core::mem::transmute(glyphprops),
             ::core::mem::transmute(actualglyphcount),
         )
         .ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetGlyphPlacements<'a, const PARAM3: usize, const PARAM6: usize, Param7: ::windows::core::IntoParam<'a, IDWriteFontFace>, Param9: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param10: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param12: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>>(
+    pub unsafe fn GetGlyphPlacements<'a, Param7: ::windows::core::IntoParam<'a, IDWriteFontFace>, Param9: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param10: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param12: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>>(
         &self,
-        textstring: &[u16; PARAM3],
-        clustermap: &[u16; PARAM3],
-        textprops: &mut [DWRITE_SHAPING_TEXT_PROPERTIES; PARAM3],
-        glyphindices: &[u16; PARAM6],
-        glyphprops: &[DWRITE_SHAPING_GLYPH_PROPERTIES; PARAM6],
+        textstring: ::windows::core::PCWSTR,
+        clustermap: *const u16,
+        textprops: *mut DWRITE_SHAPING_TEXT_PROPERTIES,
+        textlength: u32,
+        glyphindices: *const u16,
+        glyphprops: *const DWRITE_SHAPING_GLYPH_PROPERTIES,
+        glyphcount: u32,
         fontface: Param7,
         fontemsize: f32,
         issideways: Param9,
@@ -16133,18 +16149,18 @@ impl IDWriteTextAnalyzer2 {
         features: *const *const DWRITE_TYPOGRAPHIC_FEATURES,
         featurerangelengths: *const u32,
         featureranges: u32,
-        glyphadvances: &mut [f32; PARAM6],
-        glyphoffsets: &mut [DWRITE_GLYPH_OFFSET; PARAM6],
+        glyphadvances: *mut f32,
+        glyphoffsets: *mut DWRITE_GLYPH_OFFSET,
     ) -> ::windows::core::Result<()> {
         (::windows::core::Interface::vtable(self).base.base.GetGlyphPlacements)(
             ::core::mem::transmute_copy(self),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(textstring)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(clustermap)),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(textprops)),
-            PARAM3 as _,
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphprops)),
-            PARAM6 as _,
+            ::core::mem::transmute(textstring),
+            ::core::mem::transmute(clustermap),
+            ::core::mem::transmute(textprops),
+            ::core::mem::transmute(textlength),
+            ::core::mem::transmute(glyphindices),
+            ::core::mem::transmute(glyphprops),
+            ::core::mem::transmute(glyphcount),
             fontface.into_param().abi(),
             ::core::mem::transmute(fontemsize),
             issideways.into_param().abi(),
@@ -16154,20 +16170,22 @@ impl IDWriteTextAnalyzer2 {
             ::core::mem::transmute(features),
             ::core::mem::transmute(featurerangelengths),
             ::core::mem::transmute(featureranges),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphadvances)),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphoffsets)),
+            ::core::mem::transmute(glyphadvances),
+            ::core::mem::transmute(glyphoffsets),
         )
         .ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn GetGdiCompatibleGlyphPlacements<'a, const PARAM3: usize, const PARAM6: usize, Param7: ::windows::core::IntoParam<'a, IDWriteFontFace>, Param11: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param12: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param13: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param15: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>>(
+    pub unsafe fn GetGdiCompatibleGlyphPlacements<'a, Param7: ::windows::core::IntoParam<'a, IDWriteFontFace>, Param11: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param12: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param13: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, Param15: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>>(
         &self,
-        textstring: &[u16; PARAM3],
-        clustermap: &[u16; PARAM3],
-        textprops: &[DWRITE_SHAPING_TEXT_PROPERTIES; PARAM3],
-        glyphindices: &[u16; PARAM6],
-        glyphprops: &[DWRITE_SHAPING_GLYPH_PROPERTIES; PARAM6],
+        textstring: ::windows::core::PCWSTR,
+        clustermap: *const u16,
+        textprops: *const DWRITE_SHAPING_TEXT_PROPERTIES,
+        textlength: u32,
+        glyphindices: *const u16,
+        glyphprops: *const DWRITE_SHAPING_GLYPH_PROPERTIES,
+        glyphcount: u32,
         fontface: Param7,
         fontemsize: f32,
         pixelsperdip: f32,
@@ -16180,18 +16198,18 @@ impl IDWriteTextAnalyzer2 {
         features: *const *const DWRITE_TYPOGRAPHIC_FEATURES,
         featurerangelengths: *const u32,
         featureranges: u32,
-        glyphadvances: &mut [f32; PARAM6],
-        glyphoffsets: &mut [DWRITE_GLYPH_OFFSET; PARAM6],
+        glyphadvances: *mut f32,
+        glyphoffsets: *mut DWRITE_GLYPH_OFFSET,
     ) -> ::windows::core::Result<()> {
         (::windows::core::Interface::vtable(self).base.base.GetGdiCompatibleGlyphPlacements)(
             ::core::mem::transmute_copy(self),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(textstring)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(clustermap)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(textprops)),
-            PARAM3 as _,
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphprops)),
-            PARAM6 as _,
+            ::core::mem::transmute(textstring),
+            ::core::mem::transmute(clustermap),
+            ::core::mem::transmute(textprops),
+            ::core::mem::transmute(textlength),
+            ::core::mem::transmute(glyphindices),
+            ::core::mem::transmute(glyphprops),
+            ::core::mem::transmute(glyphcount),
             fontface.into_param().abi(),
             ::core::mem::transmute(fontemsize),
             ::core::mem::transmute(pixelsperdip),
@@ -16204,26 +16222,26 @@ impl IDWriteTextAnalyzer2 {
             ::core::mem::transmute(features),
             ::core::mem::transmute(featurerangelengths),
             ::core::mem::transmute(featureranges),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphadvances)),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(glyphoffsets)),
+            ::core::mem::transmute(glyphadvances),
+            ::core::mem::transmute(glyphoffsets),
         )
         .ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
-    pub unsafe fn ApplyCharacterSpacing<'a, const PARAM4: usize>(&self, leadingspacing: f32, trailingspacing: f32, minimumadvancewidth: f32, clustermap: &[u16], glyphadvances: &[f32; PARAM4], glyphoffsets: &[DWRITE_GLYPH_OFFSET; PARAM4], glyphproperties: &[DWRITE_SHAPING_GLYPH_PROPERTIES; PARAM4], modifiedglyphadvances: &mut [f32; PARAM4], modifiedglyphoffsets: &mut [DWRITE_GLYPH_OFFSET; PARAM4]) -> ::windows::core::Result<()> {
+    pub unsafe fn ApplyCharacterSpacing(&self, leadingspacing: f32, trailingspacing: f32, minimumadvancewidth: f32, glyphcount: u32, clustermap: &[u16], glyphadvances: *const f32, glyphoffsets: *const DWRITE_GLYPH_OFFSET, glyphproperties: *const DWRITE_SHAPING_GLYPH_PROPERTIES, modifiedglyphadvances: *mut f32, modifiedglyphoffsets: *mut DWRITE_GLYPH_OFFSET) -> ::windows::core::Result<()> {
         (::windows::core::Interface::vtable(self).base.ApplyCharacterSpacing)(
             ::core::mem::transmute_copy(self),
             ::core::mem::transmute(leadingspacing),
             ::core::mem::transmute(trailingspacing),
             ::core::mem::transmute(minimumadvancewidth),
             clustermap.len() as _,
-            PARAM4 as _,
+            ::core::mem::transmute(glyphcount),
             ::core::mem::transmute(::windows::core::as_ptr_or_null(clustermap)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphadvances)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphoffsets)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphproperties)),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(modifiedglyphadvances)),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(modifiedglyphoffsets)),
+            ::core::mem::transmute(glyphadvances),
+            ::core::mem::transmute(glyphoffsets),
+            ::core::mem::transmute(glyphproperties),
+            ::core::mem::transmute(modifiedglyphadvances),
+            ::core::mem::transmute(modifiedglyphoffsets),
         )
         .ok()
     }
@@ -16253,34 +16271,34 @@ impl IDWriteTextAnalyzer2 {
         (::windows::core::Interface::vtable(self).base.GetTextComplexity)(::core::mem::transmute_copy(self), ::core::mem::transmute(textstring), ::core::mem::transmute(textlength), fontface.into_param().abi(), ::core::mem::transmute(istextsimple), ::core::mem::transmute(textlengthread), ::core::mem::transmute(glyphindices)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
-    pub unsafe fn GetJustificationOpportunities<'a, Param0: ::windows::core::IntoParam<'a, IDWriteFontFace>, Param2: ::windows::core::IntoParam<'a, DWRITE_SCRIPT_ANALYSIS>, const PARAM3: usize, const PARAM4: usize>(&self, fontface: Param0, fontemsize: f32, scriptanalysis: Param2, textstring: &[u16; PARAM3], clustermap: &[u16; PARAM3], glyphproperties: &[DWRITE_SHAPING_GLYPH_PROPERTIES; PARAM4], justificationopportunities: &mut [DWRITE_JUSTIFICATION_OPPORTUNITY; PARAM4]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.GetJustificationOpportunities)(::core::mem::transmute_copy(self), fontface.into_param().abi(), ::core::mem::transmute(fontemsize), scriptanalysis.into_param().abi(), PARAM3 as _, PARAM4 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(textstring)), ::core::mem::transmute(::windows::core::as_ptr_or_null(clustermap)), ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphproperties)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(justificationopportunities))).ok()
+    pub unsafe fn GetJustificationOpportunities<'a, Param0: ::windows::core::IntoParam<'a, IDWriteFontFace>, Param2: ::windows::core::IntoParam<'a, DWRITE_SCRIPT_ANALYSIS>>(&self, fontface: Param0, fontemsize: f32, scriptanalysis: Param2, textlength: u32, glyphcount: u32, textstring: ::windows::core::PCWSTR, clustermap: *const u16, glyphproperties: *const DWRITE_SHAPING_GLYPH_PROPERTIES, justificationopportunities: *mut DWRITE_JUSTIFICATION_OPPORTUNITY) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.GetJustificationOpportunities)(::core::mem::transmute_copy(self), fontface.into_param().abi(), ::core::mem::transmute(fontemsize), scriptanalysis.into_param().abi(), ::core::mem::transmute(textlength), ::core::mem::transmute(glyphcount), ::core::mem::transmute(textstring), ::core::mem::transmute(clustermap), ::core::mem::transmute(glyphproperties), ::core::mem::transmute(justificationopportunities)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
     pub unsafe fn JustifyGlyphAdvances(&self, linewidth: f32, glyphcount: u32, justificationopportunities: *const DWRITE_JUSTIFICATION_OPPORTUNITY, glyphadvances: *const f32, glyphoffsets: *const DWRITE_GLYPH_OFFSET, justifiedglyphadvances: *mut f32, justifiedglyphoffsets: *mut DWRITE_GLYPH_OFFSET) -> ::windows::core::Result<()> {
         (::windows::core::Interface::vtable(self).base.JustifyGlyphAdvances)(::core::mem::transmute_copy(self), ::core::mem::transmute(linewidth), ::core::mem::transmute(glyphcount), ::core::mem::transmute(justificationopportunities), ::core::mem::transmute(glyphadvances), ::core::mem::transmute(glyphoffsets), ::core::mem::transmute(justifiedglyphadvances), ::core::mem::transmute(justifiedglyphoffsets)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
-    pub unsafe fn GetJustifiedGlyphs<'a, Param0: ::windows::core::IntoParam<'a, IDWriteFontFace>, Param2: ::windows::core::IntoParam<'a, DWRITE_SCRIPT_ANALYSIS>, const PARAM4: usize, const PARAM5: usize>(&self, fontface: Param0, fontemsize: f32, scriptanalysis: Param2, textlength: u32, clustermap: *const u16, glyphindices: &[u16; PARAM4], glyphadvances: &[f32; PARAM4], justifiedglyphadvances: &[f32; PARAM4], justifiedglyphoffsets: &[DWRITE_GLYPH_OFFSET; PARAM4], glyphproperties: &[DWRITE_SHAPING_GLYPH_PROPERTIES; PARAM4], actualglyphcount: *mut u32, modifiedclustermap: *mut u16, modifiedglyphindices: &mut [u16; PARAM5], modifiedglyphadvances: &mut [f32; PARAM5], modifiedglyphoffsets: &mut [DWRITE_GLYPH_OFFSET; PARAM5]) -> ::windows::core::Result<()> {
+    pub unsafe fn GetJustifiedGlyphs<'a, Param0: ::windows::core::IntoParam<'a, IDWriteFontFace>, Param2: ::windows::core::IntoParam<'a, DWRITE_SCRIPT_ANALYSIS>>(&self, fontface: Param0, fontemsize: f32, scriptanalysis: Param2, textlength: u32, glyphcount: u32, maxglyphcount: u32, clustermap: *const u16, glyphindices: *const u16, glyphadvances: *const f32, justifiedglyphadvances: *const f32, justifiedglyphoffsets: *const DWRITE_GLYPH_OFFSET, glyphproperties: *const DWRITE_SHAPING_GLYPH_PROPERTIES, actualglyphcount: *mut u32, modifiedclustermap: *mut u16, modifiedglyphindices: *mut u16, modifiedglyphadvances: *mut f32, modifiedglyphoffsets: *mut DWRITE_GLYPH_OFFSET) -> ::windows::core::Result<()> {
         (::windows::core::Interface::vtable(self).base.GetJustifiedGlyphs)(
             ::core::mem::transmute_copy(self),
             fontface.into_param().abi(),
             ::core::mem::transmute(fontemsize),
             scriptanalysis.into_param().abi(),
             ::core::mem::transmute(textlength),
-            PARAM4 as _,
-            PARAM5 as _,
+            ::core::mem::transmute(glyphcount),
+            ::core::mem::transmute(maxglyphcount),
             ::core::mem::transmute(clustermap),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphadvances)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(justifiedglyphadvances)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(justifiedglyphoffsets)),
-            ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphproperties)),
+            ::core::mem::transmute(glyphindices),
+            ::core::mem::transmute(glyphadvances),
+            ::core::mem::transmute(justifiedglyphadvances),
+            ::core::mem::transmute(justifiedglyphoffsets),
+            ::core::mem::transmute(glyphproperties),
             ::core::mem::transmute(actualglyphcount),
             ::core::mem::transmute(modifiedclustermap),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(modifiedglyphindices)),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(modifiedglyphadvances)),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(modifiedglyphoffsets)),
+            ::core::mem::transmute(modifiedglyphindices),
+            ::core::mem::transmute(modifiedglyphadvances),
+            ::core::mem::transmute(modifiedglyphoffsets),
         )
         .ok()
     }
@@ -16295,8 +16313,8 @@ impl IDWriteTextAnalyzer2 {
         (::windows::core::Interface::vtable(self).GetTypographicFeatures)(::core::mem::transmute_copy(self), fontface.into_param().abi(), scriptanalysis.into_param().abi(), localename.into_param().abi(), tags.len() as _, ::core::mem::transmute(actualtagcount), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(tags))).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_DirectWrite\"`*"]
-    pub unsafe fn CheckTypographicFeature<'a, Param0: ::windows::core::IntoParam<'a, IDWriteFontFace>, Param1: ::windows::core::IntoParam<'a, DWRITE_SCRIPT_ANALYSIS>, Param2: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>, const PARAM4: usize>(&self, fontface: Param0, scriptanalysis: Param1, localename: Param2, featuretag: DWRITE_FONT_FEATURE_TAG, glyphindices: &[u16; PARAM4], featureapplies: &mut [u8; PARAM4]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).CheckTypographicFeature)(::core::mem::transmute_copy(self), fontface.into_param().abi(), scriptanalysis.into_param().abi(), localename.into_param().abi(), ::core::mem::transmute(featuretag), PARAM4 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(glyphindices)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(featureapplies))).ok()
+    pub unsafe fn CheckTypographicFeature<'a, Param0: ::windows::core::IntoParam<'a, IDWriteFontFace>, Param1: ::windows::core::IntoParam<'a, DWRITE_SCRIPT_ANALYSIS>, Param2: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>>(&self, fontface: Param0, scriptanalysis: Param1, localename: Param2, featuretag: DWRITE_FONT_FEATURE_TAG, glyphcount: u32, glyphindices: *const u16, featureapplies: *mut u8) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).CheckTypographicFeature)(::core::mem::transmute_copy(self), fontface.into_param().abi(), scriptanalysis.into_param().abi(), localename.into_param().abi(), ::core::mem::transmute(featuretag), ::core::mem::transmute(glyphcount), ::core::mem::transmute(glyphindices), ::core::mem::transmute(featureapplies)).ok()
     }
 }
 impl ::core::convert::From<IDWriteTextAnalyzer2> for ::windows::core::IUnknown {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Dwm/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Dwm/mod.rs
@@ -872,14 +872,14 @@ pub unsafe fn DwmRegisterThumbnail<'a, Param0: ::windows::core::IntoParam<'a, su
 #[doc = "*Required features: `\"Win32_Graphics_Dwm\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
-pub unsafe fn DwmRenderGesture<'a, const PARAM1: usize>(gt: GESTURE_TYPE, pdwpointerid: &[u32; PARAM1], ppoints: &[super::super::Foundation::POINT; PARAM1]) -> ::windows::core::Result<()> {
+pub unsafe fn DwmRenderGesture(gt: GESTURE_TYPE, ccontacts: u32, pdwpointerid: *const u32, ppoints: *const super::super::Foundation::POINT) -> ::windows::core::Result<()> {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn DwmRenderGesture(gt: GESTURE_TYPE, ccontacts: u32, pdwpointerid: *const u32, ppoints: *const super::super::Foundation::POINT) -> ::windows::core::HRESULT;
         }
-        DwmRenderGesture(::core::mem::transmute(gt), PARAM1 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(pdwpointerid)), ::core::mem::transmute(::windows::core::as_ptr_or_null(ppoints))).ok()
+        DwmRenderGesture(::core::mem::transmute(gt), ::core::mem::transmute(ccontacts), ::core::mem::transmute(pdwpointerid), ::core::mem::transmute(ppoints)).ok()
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Dxgi/mod.rs
@@ -4249,8 +4249,8 @@ impl IDXGIDevice {
         (::windows::core::Interface::vtable(self).CreateSurface)(::core::mem::transmute_copy(self), ::core::mem::transmute(pdesc), ppsurface.len() as _, ::core::mem::transmute(usage), ::core::mem::transmute(psharedresource), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(ppsurface))).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`*"]
-    pub unsafe fn QueryResourceResidency<'a, const PARAM2: usize>(&self, ppresources: &[::core::option::Option<::windows::core::IUnknown>; PARAM2], presidencystatus: &mut [DXGI_RESIDENCY; PARAM2]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).QueryResourceResidency)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(ppresources)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(presidencystatus)), PARAM2 as _).ok()
+    pub unsafe fn QueryResourceResidency(&self, ppresources: *const ::core::option::Option<::windows::core::IUnknown>, presidencystatus: *mut DXGI_RESIDENCY, numresources: u32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).QueryResourceResidency)(::core::mem::transmute_copy(self), ::core::mem::transmute(ppresources), ::core::mem::transmute(presidencystatus), ::core::mem::transmute(numresources)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`*"]
     pub unsafe fn SetGPUThreadPriority(&self, priority: i32) -> ::windows::core::Result<()> {
@@ -4367,8 +4367,8 @@ impl IDXGIDevice1 {
         (::windows::core::Interface::vtable(self).base.CreateSurface)(::core::mem::transmute_copy(self), ::core::mem::transmute(pdesc), ppsurface.len() as _, ::core::mem::transmute(usage), ::core::mem::transmute(psharedresource), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(ppsurface))).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`*"]
-    pub unsafe fn QueryResourceResidency<'a, const PARAM2: usize>(&self, ppresources: &[::core::option::Option<::windows::core::IUnknown>; PARAM2], presidencystatus: &mut [DXGI_RESIDENCY; PARAM2]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.QueryResourceResidency)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(ppresources)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(presidencystatus)), PARAM2 as _).ok()
+    pub unsafe fn QueryResourceResidency(&self, ppresources: *const ::core::option::Option<::windows::core::IUnknown>, presidencystatus: *mut DXGI_RESIDENCY, numresources: u32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.QueryResourceResidency)(::core::mem::transmute_copy(self), ::core::mem::transmute(ppresources), ::core::mem::transmute(presidencystatus), ::core::mem::transmute(numresources)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`*"]
     pub unsafe fn SetGPUThreadPriority(&self, priority: i32) -> ::windows::core::Result<()> {
@@ -4508,8 +4508,8 @@ impl IDXGIDevice2 {
         (::windows::core::Interface::vtable(self).base.base.CreateSurface)(::core::mem::transmute_copy(self), ::core::mem::transmute(pdesc), ppsurface.len() as _, ::core::mem::transmute(usage), ::core::mem::transmute(psharedresource), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(ppsurface))).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`*"]
-    pub unsafe fn QueryResourceResidency<'a, const PARAM2: usize>(&self, ppresources: &[::core::option::Option<::windows::core::IUnknown>; PARAM2], presidencystatus: &mut [DXGI_RESIDENCY; PARAM2]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.QueryResourceResidency)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(ppresources)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(presidencystatus)), PARAM2 as _).ok()
+    pub unsafe fn QueryResourceResidency(&self, ppresources: *const ::core::option::Option<::windows::core::IUnknown>, presidencystatus: *mut DXGI_RESIDENCY, numresources: u32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.QueryResourceResidency)(::core::mem::transmute_copy(self), ::core::mem::transmute(ppresources), ::core::mem::transmute(presidencystatus), ::core::mem::transmute(numresources)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`*"]
     pub unsafe fn SetGPUThreadPriority(&self, priority: i32) -> ::windows::core::Result<()> {
@@ -4691,8 +4691,8 @@ impl IDXGIDevice3 {
         (::windows::core::Interface::vtable(self).base.base.base.CreateSurface)(::core::mem::transmute_copy(self), ::core::mem::transmute(pdesc), ppsurface.len() as _, ::core::mem::transmute(usage), ::core::mem::transmute(psharedresource), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(ppsurface))).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`*"]
-    pub unsafe fn QueryResourceResidency<'a, const PARAM2: usize>(&self, ppresources: &[::core::option::Option<::windows::core::IUnknown>; PARAM2], presidencystatus: &mut [DXGI_RESIDENCY; PARAM2]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.QueryResourceResidency)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(ppresources)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(presidencystatus)), PARAM2 as _).ok()
+    pub unsafe fn QueryResourceResidency(&self, ppresources: *const ::core::option::Option<::windows::core::IUnknown>, presidencystatus: *mut DXGI_RESIDENCY, numresources: u32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.QueryResourceResidency)(::core::mem::transmute_copy(self), ::core::mem::transmute(ppresources), ::core::mem::transmute(presidencystatus), ::core::mem::transmute(numresources)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`*"]
     pub unsafe fn SetGPUThreadPriority(&self, priority: i32) -> ::windows::core::Result<()> {
@@ -4890,8 +4890,8 @@ impl IDXGIDevice4 {
         (::windows::core::Interface::vtable(self).base.base.base.base.CreateSurface)(::core::mem::transmute_copy(self), ::core::mem::transmute(pdesc), ppsurface.len() as _, ::core::mem::transmute(usage), ::core::mem::transmute(psharedresource), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(ppsurface))).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`*"]
-    pub unsafe fn QueryResourceResidency<'a, const PARAM2: usize>(&self, ppresources: &[::core::option::Option<::windows::core::IUnknown>; PARAM2], presidencystatus: &mut [DXGI_RESIDENCY; PARAM2]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.base.base.base.QueryResourceResidency)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(ppresources)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(presidencystatus)), PARAM2 as _).ok()
+    pub unsafe fn QueryResourceResidency(&self, ppresources: *const ::core::option::Option<::windows::core::IUnknown>, presidencystatus: *mut DXGI_RESIDENCY, numresources: u32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.base.base.base.QueryResourceResidency)(::core::mem::transmute_copy(self), ::core::mem::transmute(ppresources), ::core::mem::transmute(presidencystatus), ::core::mem::transmute(numresources)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`*"]
     pub unsafe fn SetGPUThreadPriority(&self, priority: i32) -> ::windows::core::Result<()> {
@@ -11449,8 +11449,8 @@ impl IDXGISwapChain3 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Graphics_Dxgi_Common\"`*"]
     #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-    pub unsafe fn ResizeBuffers1<'a, const PARAM0: usize>(&self, width: u32, height: u32, format: Common::DXGI_FORMAT, swapchainflags: u32, pcreationnodemask: &[u32; PARAM0], pppresentqueue: &[::core::option::Option<::windows::core::IUnknown>; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).ResizeBuffers1)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(width), ::core::mem::transmute(height), ::core::mem::transmute(format), ::core::mem::transmute(swapchainflags), ::core::mem::transmute(::windows::core::as_ptr_or_null(pcreationnodemask)), ::core::mem::transmute(::windows::core::as_ptr_or_null(pppresentqueue))).ok()
+    pub unsafe fn ResizeBuffers1(&self, buffercount: u32, width: u32, height: u32, format: Common::DXGI_FORMAT, swapchainflags: u32, pcreationnodemask: *const u32, pppresentqueue: *const ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).ResizeBuffers1)(::core::mem::transmute_copy(self), ::core::mem::transmute(buffercount), ::core::mem::transmute(width), ::core::mem::transmute(height), ::core::mem::transmute(format), ::core::mem::transmute(swapchainflags), ::core::mem::transmute(pcreationnodemask), ::core::mem::transmute(pppresentqueue)).ok()
     }
 }
 impl ::core::convert::From<IDXGISwapChain3> for ::windows::core::IUnknown {
@@ -11793,8 +11793,8 @@ impl IDXGISwapChain4 {
     }
     #[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`, `\"Win32_Graphics_Dxgi_Common\"`*"]
     #[cfg(feature = "Win32_Graphics_Dxgi_Common")]
-    pub unsafe fn ResizeBuffers1<'a, const PARAM0: usize>(&self, width: u32, height: u32, format: Common::DXGI_FORMAT, swapchainflags: u32, pcreationnodemask: &[u32; PARAM0], pppresentqueue: &[::core::option::Option<::windows::core::IUnknown>; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.ResizeBuffers1)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(width), ::core::mem::transmute(height), ::core::mem::transmute(format), ::core::mem::transmute(swapchainflags), ::core::mem::transmute(::windows::core::as_ptr_or_null(pcreationnodemask)), ::core::mem::transmute(::windows::core::as_ptr_or_null(pppresentqueue))).ok()
+    pub unsafe fn ResizeBuffers1(&self, buffercount: u32, width: u32, height: u32, format: Common::DXGI_FORMAT, swapchainflags: u32, pcreationnodemask: *const u32, pppresentqueue: *const ::core::option::Option<::windows::core::IUnknown>) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.ResizeBuffers1)(::core::mem::transmute_copy(self), ::core::mem::transmute(buffercount), ::core::mem::transmute(width), ::core::mem::transmute(height), ::core::mem::transmute(format), ::core::mem::transmute(swapchainflags), ::core::mem::transmute(pcreationnodemask), ::core::mem::transmute(pppresentqueue)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Dxgi\"`*"]
     pub unsafe fn SetHDRMetaData(&self, r#type: DXGI_HDR_METADATA_TYPE, pmetadata: &[u8]) -> ::windows::core::Result<()> {

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Gdi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Gdi/mod.rs
@@ -10707,28 +10707,28 @@ pub unsafe fn GetFontUnicodeRanges<'a, Param0: ::windows::core::IntoParam<'a, HD
 }
 #[doc = "*Required features: `\"Win32_Graphics_Gdi\"`*"]
 #[inline]
-pub unsafe fn GetGlyphIndicesA<'a, Param0: ::windows::core::IntoParam<'a, HDC>, const PARAM2: usize>(hdc: Param0, lpstr: &[u8; PARAM2], pgi: &mut [u16; PARAM2], fl: u32) -> u32 {
+pub unsafe fn GetGlyphIndicesA<'a, Param0: ::windows::core::IntoParam<'a, HDC>>(hdc: Param0, lpstr: ::windows::core::PCSTR, c: i32, pgi: *mut u16, fl: u32) -> u32 {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn GetGlyphIndicesA(hdc: HDC, lpstr: ::windows::core::PCSTR, c: i32, pgi: *mut u16, fl: u32) -> u32;
         }
-        ::core::mem::transmute(GetGlyphIndicesA(hdc.into_param().abi(), ::core::mem::transmute(::windows::core::as_ptr_or_null(lpstr)), PARAM2 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(pgi)), ::core::mem::transmute(fl)))
+        ::core::mem::transmute(GetGlyphIndicesA(hdc.into_param().abi(), ::core::mem::transmute(lpstr), ::core::mem::transmute(c), ::core::mem::transmute(pgi), ::core::mem::transmute(fl)))
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
 }
 #[doc = "*Required features: `\"Win32_Graphics_Gdi\"`*"]
 #[inline]
-pub unsafe fn GetGlyphIndicesW<'a, Param0: ::windows::core::IntoParam<'a, HDC>, const PARAM2: usize>(hdc: Param0, lpstr: &[u16; PARAM2], pgi: &mut [u16; PARAM2], fl: u32) -> u32 {
+pub unsafe fn GetGlyphIndicesW<'a, Param0: ::windows::core::IntoParam<'a, HDC>>(hdc: Param0, lpstr: ::windows::core::PCWSTR, c: i32, pgi: *mut u16, fl: u32) -> u32 {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn GetGlyphIndicesW(hdc: HDC, lpstr: ::windows::core::PCWSTR, c: i32, pgi: *mut u16, fl: u32) -> u32;
         }
-        ::core::mem::transmute(GetGlyphIndicesW(hdc.into_param().abi(), ::core::mem::transmute(::windows::core::as_ptr_or_null(lpstr)), PARAM2 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(pgi)), ::core::mem::transmute(fl)))
+        ::core::mem::transmute(GetGlyphIndicesW(hdc.into_param().abi(), ::core::mem::transmute(lpstr), ::core::mem::transmute(c), ::core::mem::transmute(pgi), ::core::mem::transmute(fl)))
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
@@ -14791,14 +14791,14 @@ pub unsafe fn PolyBezierTo<'a, Param0: ::windows::core::IntoParam<'a, HDC>>(hdc:
 #[doc = "*Required features: `\"Win32_Graphics_Gdi\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
-pub unsafe fn PolyDraw<'a, Param0: ::windows::core::IntoParam<'a, HDC>, const PARAM3: usize>(hdc: Param0, apt: &[super::super::Foundation::POINT; PARAM3], aj: &[u8; PARAM3]) -> super::super::Foundation::BOOL {
+pub unsafe fn PolyDraw<'a, Param0: ::windows::core::IntoParam<'a, HDC>>(hdc: Param0, apt: *const super::super::Foundation::POINT, aj: *const u8, cpt: i32) -> super::super::Foundation::BOOL {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn PolyDraw(hdc: HDC, apt: *const super::super::Foundation::POINT, aj: *const u8, cpt: i32) -> super::super::Foundation::BOOL;
         }
-        ::core::mem::transmute(PolyDraw(hdc.into_param().abi(), ::core::mem::transmute(::windows::core::as_ptr_or_null(apt)), ::core::mem::transmute(::windows::core::as_ptr_or_null(aj)), PARAM3 as _))
+        ::core::mem::transmute(PolyDraw(hdc.into_param().abi(), ::core::mem::transmute(apt), ::core::mem::transmute(aj), ::core::mem::transmute(cpt)))
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");

--- a/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Graphics/Imaging/mod.rs
@@ -3082,8 +3082,8 @@ pub struct IWICEnumMetadataItem(::windows::core::IUnknown);
 impl IWICEnumMetadataItem {
     #[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
-    pub unsafe fn Next<'a, const PARAM0: usize>(&self, rgeltschema: &mut [super::super::System::Com::StructuredStorage::PROPVARIANT; PARAM0], rgeltid: &mut [super::super::System::Com::StructuredStorage::PROPVARIANT; PARAM0], rgeltvalue: &mut [super::super::System::Com::StructuredStorage::PROPVARIANT; PARAM0], pceltfetched: *mut u32) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).Next)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(rgeltschema)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(rgeltid)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(rgeltvalue)), ::core::mem::transmute(pceltfetched)).ok()
+    pub unsafe fn Next(&self, celt: u32, rgeltschema: *mut super::super::System::Com::StructuredStorage::PROPVARIANT, rgeltid: *mut super::super::System::Com::StructuredStorage::PROPVARIANT, rgeltvalue: *mut super::super::System::Com::StructuredStorage::PROPVARIANT, pceltfetched: *mut u32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).Next)(::core::mem::transmute_copy(self), ::core::mem::transmute(celt), ::core::mem::transmute(rgeltschema), ::core::mem::transmute(rgeltid), ::core::mem::transmute(rgeltvalue), ::core::mem::transmute(pceltfetched)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Imaging\"`*"]
     pub unsafe fn Skip(&self, celt: u32) -> ::windows::core::Result<()> {
@@ -5623,8 +5623,8 @@ pub struct IWICPlanarBitmapSourceTransform(::windows::core::IUnknown);
 impl IWICPlanarBitmapSourceTransform {
     #[doc = "*Required features: `\"Win32_Graphics_Imaging\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn DoesSupportTransform<'a, const PARAM6: usize>(&self, puiwidth: *mut u32, puiheight: *mut u32, dsttransform: WICBitmapTransformOptions, dstplanaroptions: WICPlanarOptions, pguiddstformats: &[::windows::core::GUID; PARAM6], pplanedescriptions: &mut [WICBitmapPlaneDescription; PARAM6], pfissupported: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).DoesSupportTransform)(::core::mem::transmute_copy(self), ::core::mem::transmute(puiwidth), ::core::mem::transmute(puiheight), ::core::mem::transmute(dsttransform), ::core::mem::transmute(dstplanaroptions), ::core::mem::transmute(::windows::core::as_ptr_or_null(pguiddstformats)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(pplanedescriptions)), PARAM6 as _, ::core::mem::transmute(pfissupported)).ok()
+    pub unsafe fn DoesSupportTransform(&self, puiwidth: *mut u32, puiheight: *mut u32, dsttransform: WICBitmapTransformOptions, dstplanaroptions: WICPlanarOptions, pguiddstformats: *const ::windows::core::GUID, pplanedescriptions: *mut WICBitmapPlaneDescription, cplanes: u32, pfissupported: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).DoesSupportTransform)(::core::mem::transmute_copy(self), ::core::mem::transmute(puiwidth), ::core::mem::transmute(puiheight), ::core::mem::transmute(dsttransform), ::core::mem::transmute(dstplanaroptions), ::core::mem::transmute(pguiddstformats), ::core::mem::transmute(pplanedescriptions), ::core::mem::transmute(cplanes), ::core::mem::transmute(pfissupported)).ok()
     }
     #[doc = "*Required features: `\"Win32_Graphics_Imaging\"`*"]
     pub unsafe fn CopyPixels(&self, prcsource: *const WICRect, uiwidth: u32, uiheight: u32, dsttransform: WICBitmapTransformOptions, dstplanaroptions: WICPlanarOptions, pdstplanes: &[WICBitmapPlane]) -> ::windows::core::Result<()> {

--- a/crates/libs/windows/src/Windows/Win32/Media/DxMediaObjects/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/DxMediaObjects/mod.rs
@@ -403,8 +403,8 @@ pub struct IDMOVideoOutputOptimizations_Vtbl {
 pub struct IEnumDMO(::windows::core::IUnknown);
 impl IEnumDMO {
     #[doc = "*Required features: `\"Win32_Media_DxMediaObjects\"`*"]
-    pub unsafe fn Next<'a, const PARAM0: usize>(&self, pclsid: &mut [::windows::core::GUID; PARAM0], names: &mut [::windows::core::PWSTR; PARAM0], pcitemsfetched: *mut u32) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).Next)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(pclsid)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(names)), ::core::mem::transmute(pcitemsfetched)).ok()
+    pub unsafe fn Next(&self, citemstofetch: u32, pclsid: *mut ::windows::core::GUID, names: *mut ::windows::core::PWSTR, pcitemsfetched: *mut u32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).Next)(::core::mem::transmute_copy(self), ::core::mem::transmute(citemstofetch), ::core::mem::transmute(pclsid), ::core::mem::transmute(names), ::core::mem::transmute(pcitemsfetched)).ok()
     }
     #[doc = "*Required features: `\"Win32_Media_DxMediaObjects\"`*"]
     pub unsafe fn Skip(&self, citemstoskip: u32) -> ::windows::core::Result<()> {

--- a/crates/libs/windows/src/Windows/Win32/Media/MediaFoundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/MediaFoundation/mod.rs
@@ -52137,28 +52137,28 @@ pub unsafe fn MFConvertColorInfoToDXVA(pdwtodxva: *mut u32, pfromformat: *const 
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
 #[inline]
-pub unsafe fn MFConvertFromFP16Array<'a, const PARAM2: usize>(pdest: &mut [f32; PARAM2], psrc: &[u16; PARAM2]) -> ::windows::core::Result<()> {
+pub unsafe fn MFConvertFromFP16Array(pdest: *mut f32, psrc: *const u16, dwcount: u32) -> ::windows::core::Result<()> {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn MFConvertFromFP16Array(pdest: *mut f32, psrc: *const u16, dwcount: u32) -> ::windows::core::HRESULT;
         }
-        MFConvertFromFP16Array(::core::mem::transmute(::windows::core::as_mut_ptr_or_null(pdest)), ::core::mem::transmute(::windows::core::as_ptr_or_null(psrc)), PARAM2 as _).ok()
+        MFConvertFromFP16Array(::core::mem::transmute(pdest), ::core::mem::transmute(psrc), ::core::mem::transmute(dwcount)).ok()
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
 }
 #[doc = "*Required features: `\"Win32_Media_MediaFoundation\"`*"]
 #[inline]
-pub unsafe fn MFConvertToFP16Array<'a, const PARAM2: usize>(pdest: &mut [u16; PARAM2], psrc: &[f32; PARAM2]) -> ::windows::core::Result<()> {
+pub unsafe fn MFConvertToFP16Array(pdest: *mut u16, psrc: *const f32, dwcount: u32) -> ::windows::core::Result<()> {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn MFConvertToFP16Array(pdest: *mut u16, psrc: *const f32, dwcount: u32) -> ::windows::core::HRESULT;
         }
-        MFConvertToFP16Array(::core::mem::transmute(::windows::core::as_mut_ptr_or_null(pdest)), ::core::mem::transmute(::windows::core::as_ptr_or_null(psrc)), PARAM2 as _).ok()
+        MFConvertToFP16Array(::core::mem::transmute(pdest), ::core::mem::transmute(psrc), ::core::mem::transmute(dwcount)).ok()
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");

--- a/crates/libs/windows/src/Windows/Win32/Media/Multimedia/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Media/Multimedia/mod.rs
@@ -914,14 +914,14 @@ pub unsafe fn AVISaveA<'a, Param0: ::windows::core::IntoParam<'a, ::windows::cor
 #[doc = "*Required features: `\"Win32_Media_Multimedia\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
-pub unsafe fn AVISaveOptions<'a, Param0: ::windows::core::IntoParam<'a, super::super::Foundation::HWND>, const PARAM2: usize>(hwnd: Param0, uiflags: u32, ppavi: &[::core::option::Option<IAVIStream>; PARAM2], plpoptions: &mut [*mut AVICOMPRESSOPTIONS; PARAM2]) -> isize {
+pub unsafe fn AVISaveOptions<'a, Param0: ::windows::core::IntoParam<'a, super::super::Foundation::HWND>>(hwnd: Param0, uiflags: u32, nstreams: i32, ppavi: *const ::core::option::Option<IAVIStream>, plpoptions: *mut *mut AVICOMPRESSOPTIONS) -> isize {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn AVISaveOptions(hwnd: super::super::Foundation::HWND, uiflags: u32, nstreams: i32, ppavi: *const ::windows::core::RawPtr, plpoptions: *mut *mut AVICOMPRESSOPTIONS) -> isize;
         }
-        ::core::mem::transmute(AVISaveOptions(hwnd.into_param().abi(), ::core::mem::transmute(uiflags), PARAM2 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(ppavi)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(plpoptions))))
+        ::core::mem::transmute(AVISaveOptions(hwnd.into_param().abi(), ::core::mem::transmute(uiflags), ::core::mem::transmute(nstreams), ::core::mem::transmute(ppavi), ::core::mem::transmute(plpoptions)))
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
@@ -943,14 +943,14 @@ pub unsafe fn AVISaveOptionsFree(plpoptions: &[*const AVICOMPRESSOPTIONS]) -> ::
 #[doc = "*Required features: `\"Win32_Media_Multimedia\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
-pub unsafe fn AVISaveVA<'a, Param0: ::windows::core::IntoParam<'a, ::windows::core::PCSTR>, const PARAM3: usize>(szfile: Param0, pclsidhandler: *const ::windows::core::GUID, lpfncallback: AVISAVECALLBACK, ppavi: &[::core::option::Option<IAVIStream>; PARAM3], plpoptions: &[*const AVICOMPRESSOPTIONS; PARAM3]) -> ::windows::core::Result<()> {
+pub unsafe fn AVISaveVA<'a, Param0: ::windows::core::IntoParam<'a, ::windows::core::PCSTR>>(szfile: Param0, pclsidhandler: *const ::windows::core::GUID, lpfncallback: AVISAVECALLBACK, nstreams: i32, ppavi: *const ::core::option::Option<IAVIStream>, plpoptions: *const *const AVICOMPRESSOPTIONS) -> ::windows::core::Result<()> {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn AVISaveVA(szfile: ::windows::core::PCSTR, pclsidhandler: *const ::windows::core::GUID, lpfncallback: ::windows::core::RawPtr, nstreams: i32, ppavi: *const ::windows::core::RawPtr, plpoptions: *const *const AVICOMPRESSOPTIONS) -> ::windows::core::HRESULT;
         }
-        AVISaveVA(szfile.into_param().abi(), ::core::mem::transmute(pclsidhandler), ::core::mem::transmute(lpfncallback), PARAM3 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(ppavi)), ::core::mem::transmute(::windows::core::as_ptr_or_null(plpoptions))).ok()
+        AVISaveVA(szfile.into_param().abi(), ::core::mem::transmute(pclsidhandler), ::core::mem::transmute(lpfncallback), ::core::mem::transmute(nstreams), ::core::mem::transmute(ppavi), ::core::mem::transmute(plpoptions)).ok()
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
@@ -958,14 +958,14 @@ pub unsafe fn AVISaveVA<'a, Param0: ::windows::core::IntoParam<'a, ::windows::co
 #[doc = "*Required features: `\"Win32_Media_Multimedia\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
-pub unsafe fn AVISaveVW<'a, Param0: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>, const PARAM3: usize>(szfile: Param0, pclsidhandler: *const ::windows::core::GUID, lpfncallback: AVISAVECALLBACK, ppavi: &[::core::option::Option<IAVIStream>; PARAM3], plpoptions: &[*const AVICOMPRESSOPTIONS; PARAM3]) -> ::windows::core::Result<()> {
+pub unsafe fn AVISaveVW<'a, Param0: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>>(szfile: Param0, pclsidhandler: *const ::windows::core::GUID, lpfncallback: AVISAVECALLBACK, nstreams: i32, ppavi: *const ::core::option::Option<IAVIStream>, plpoptions: *const *const AVICOMPRESSOPTIONS) -> ::windows::core::Result<()> {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn AVISaveVW(szfile: ::windows::core::PCWSTR, pclsidhandler: *const ::windows::core::GUID, lpfncallback: ::windows::core::RawPtr, nstreams: i32, ppavi: *const ::windows::core::RawPtr, plpoptions: *const *const AVICOMPRESSOPTIONS) -> ::windows::core::HRESULT;
         }
-        AVISaveVW(szfile.into_param().abi(), ::core::mem::transmute(pclsidhandler), ::core::mem::transmute(lpfncallback), PARAM3 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(ppavi)), ::core::mem::transmute(::windows::core::as_ptr_or_null(plpoptions))).ok()
+        AVISaveVW(szfile.into_param().abi(), ::core::mem::transmute(pclsidhandler), ::core::mem::transmute(lpfncallback), ::core::mem::transmute(nstreams), ::core::mem::transmute(ppavi), ::core::mem::transmute(plpoptions)).ok()
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");

--- a/crates/libs/windows/src/Windows/Win32/NetworkManagement/Dns/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/NetworkManagement/Dns/mod.rs
@@ -4764,14 +4764,14 @@ pub unsafe fn DnsServiceBrowseCancel(pcancelhandle: *const DNS_SERVICE_CANCEL) -
 }
 #[doc = "*Required features: `\"Win32_NetworkManagement_Dns\"`*"]
 #[inline]
-pub unsafe fn DnsServiceConstructInstance<'a, Param0: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>, Param1: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>, const PARAM7: usize>(pservicename: Param0, phostname: Param1, pip4: *const u32, pip6: *const IP6_ADDRESS, wport: u16, wpriority: u16, wweight: u16, keys: &[::windows::core::PWSTR; PARAM7], values: &[::windows::core::PWSTR; PARAM7]) -> *mut DNS_SERVICE_INSTANCE {
+pub unsafe fn DnsServiceConstructInstance<'a, Param0: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>, Param1: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>>(pservicename: Param0, phostname: Param1, pip4: *const u32, pip6: *const IP6_ADDRESS, wport: u16, wpriority: u16, wweight: u16, dwpropertiescount: u32, keys: *const ::windows::core::PWSTR, values: *const ::windows::core::PWSTR) -> *mut DNS_SERVICE_INSTANCE {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn DnsServiceConstructInstance(pservicename: ::windows::core::PCWSTR, phostname: ::windows::core::PCWSTR, pip4: *const u32, pip6: *const IP6_ADDRESS, wport: u16, wpriority: u16, wweight: u16, dwpropertiescount: u32, keys: *const ::windows::core::PWSTR, values: *const ::windows::core::PWSTR) -> *mut DNS_SERVICE_INSTANCE;
         }
-        ::core::mem::transmute(DnsServiceConstructInstance(pservicename.into_param().abi(), phostname.into_param().abi(), ::core::mem::transmute(pip4), ::core::mem::transmute(pip6), ::core::mem::transmute(wport), ::core::mem::transmute(wpriority), ::core::mem::transmute(wweight), PARAM7 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(keys)), ::core::mem::transmute(::windows::core::as_ptr_or_null(values))))
+        ::core::mem::transmute(DnsServiceConstructInstance(pservicename.into_param().abi(), phostname.into_param().abi(), ::core::mem::transmute(pip4), ::core::mem::transmute(pip6), ::core::mem::transmute(wport), ::core::mem::transmute(wpriority), ::core::mem::transmute(wweight), ::core::mem::transmute(dwpropertiescount), ::core::mem::transmute(keys), ::core::mem::transmute(values)))
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");

--- a/crates/libs/windows/src/Windows/Win32/Networking/WinInet/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Networking/WinInet/mod.rs
@@ -10423,14 +10423,14 @@ pub unsafe fn UpdateUrlCacheContentPath<'a, Param0: ::windows::core::IntoParam<'
 #[doc = "*Required features: `\"Win32_Networking_WinInet\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
-pub unsafe fn UrlCacheCheckEntriesExist<'a, const PARAM1: usize>(rgpwszurls: &[::windows::core::PWSTR; PARAM1], rgfexist: &mut [super::super::Foundation::BOOL; PARAM1]) -> u32 {
+pub unsafe fn UrlCacheCheckEntriesExist(rgpwszurls: *const ::windows::core::PWSTR, centries: u32, rgfexist: *mut super::super::Foundation::BOOL) -> u32 {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn UrlCacheCheckEntriesExist(rgpwszurls: *const ::windows::core::PWSTR, centries: u32, rgfexist: *mut super::super::Foundation::BOOL) -> u32;
         }
-        ::core::mem::transmute(UrlCacheCheckEntriesExist(::core::mem::transmute(::windows::core::as_ptr_or_null(rgpwszurls)), PARAM1 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(rgfexist))))
+        ::core::mem::transmute(UrlCacheCheckEntriesExist(::core::mem::transmute(rgpwszurls), ::core::mem::transmute(centries), ::core::mem::transmute(rgfexist)))
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");

--- a/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authentication/Identity/mod.rs
@@ -22002,14 +22002,14 @@ pub unsafe fn TokenBindingGenerateIDForUri<'a, Param1: ::windows::core::IntoPara
 }
 #[doc = "*Required features: `\"Win32_Security_Authentication_Identity\"`*"]
 #[inline]
-pub unsafe fn TokenBindingGenerateMessage<'a, const PARAM2: usize>(tokenbindings: &[*const ::core::ffi::c_void; PARAM2], tokenbindingssize: &[u32; PARAM2], tokenbindingmessage: *mut *mut ::core::ffi::c_void, tokenbindingmessagesize: *mut u32) -> ::windows::core::Result<()> {
+pub unsafe fn TokenBindingGenerateMessage(tokenbindings: *const *const ::core::ffi::c_void, tokenbindingssize: *const u32, tokenbindingscount: u32, tokenbindingmessage: *mut *mut ::core::ffi::c_void, tokenbindingmessagesize: *mut u32) -> ::windows::core::Result<()> {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn TokenBindingGenerateMessage(tokenbindings: *const *const ::core::ffi::c_void, tokenbindingssize: *const u32, tokenbindingscount: u32, tokenbindingmessage: *mut *mut ::core::ffi::c_void, tokenbindingmessagesize: *mut u32) -> ::windows::core::HRESULT;
         }
-        TokenBindingGenerateMessage(::core::mem::transmute(::windows::core::as_ptr_or_null(tokenbindings)), ::core::mem::transmute(::windows::core::as_ptr_or_null(tokenbindingssize)), PARAM2 as _, ::core::mem::transmute(tokenbindingmessage), ::core::mem::transmute(tokenbindingmessagesize)).ok()
+        TokenBindingGenerateMessage(::core::mem::transmute(tokenbindings), ::core::mem::transmute(tokenbindingssize), ::core::mem::transmute(tokenbindingscount), ::core::mem::transmute(tokenbindingmessage), ::core::mem::transmute(tokenbindingmessagesize)).ok()
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");

--- a/crates/libs/windows/src/Windows/Win32/Security/Authorization/UI/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Authorization/UI/mod.rs
@@ -162,12 +162,13 @@ pub struct IEffectivePermission2(::windows::core::IUnknown);
 impl IEffectivePermission2 {
     #[doc = "*Required features: `\"Win32_Security_Authorization_UI\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn ComputeEffectivePermissionWithSecondarySecurity<'a, Param0: ::windows::core::IntoParam<'a, super::super::super::Foundation::PSID>, Param1: ::windows::core::IntoParam<'a, super::super::super::Foundation::PSID>, Param2: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>, const PARAM4: usize>(
+    pub unsafe fn ComputeEffectivePermissionWithSecondarySecurity<'a, Param0: ::windows::core::IntoParam<'a, super::super::super::Foundation::PSID>, Param1: ::windows::core::IntoParam<'a, super::super::super::Foundation::PSID>, Param2: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>>(
         &self,
         psid: Param0,
         pdevicesid: Param1,
         pszservername: Param2,
-        psecurityobjects: &mut [SECURITY_OBJECT; PARAM4],
+        psecurityobjects: *mut SECURITY_OBJECT,
+        dwsecurityobjectcount: u32,
         pusergroups: *const super::super::TOKEN_GROUPS,
         pauthzusergroupsoperations: *const super::AUTHZ_SID_OPERATION,
         pdevicegroups: *const super::super::TOKEN_GROUPS,
@@ -176,15 +177,15 @@ impl IEffectivePermission2 {
         pauthzuserclaimsoperations: *const super::AUTHZ_SECURITY_ATTRIBUTE_OPERATION,
         pauthzdeviceclaims: *const super::AUTHZ_SECURITY_ATTRIBUTES_INFORMATION,
         pauthzdeviceclaimsoperations: *const super::AUTHZ_SECURITY_ATTRIBUTE_OPERATION,
-        peffpermresultlists: &mut [EFFPERM_RESULT_LIST; PARAM4],
+        peffpermresultlists: *mut EFFPERM_RESULT_LIST,
     ) -> ::windows::core::Result<()> {
         (::windows::core::Interface::vtable(self).ComputeEffectivePermissionWithSecondarySecurity)(
             ::core::mem::transmute_copy(self),
             psid.into_param().abi(),
             pdevicesid.into_param().abi(),
             pszservername.into_param().abi(),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(psecurityobjects)),
-            PARAM4 as _,
+            ::core::mem::transmute(psecurityobjects),
+            ::core::mem::transmute(dwsecurityobjectcount),
             ::core::mem::transmute(pusergroups),
             ::core::mem::transmute(pauthzusergroupsoperations),
             ::core::mem::transmute(pdevicegroups),
@@ -193,7 +194,7 @@ impl IEffectivePermission2 {
             ::core::mem::transmute(pauthzuserclaimsoperations),
             ::core::mem::transmute(pauthzdeviceclaims),
             ::core::mem::transmute(pauthzdeviceclaimsoperations),
-            ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(peffpermresultlists)),
+            ::core::mem::transmute(peffpermresultlists),
         )
         .ok()
     }

--- a/crates/libs/windows/src/Windows/Win32/Security/Cryptography/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Security/Cryptography/mod.rs
@@ -21521,14 +21521,14 @@ pub unsafe fn CryptHashData(hhash: usize, pbdata: *const u8, dwdatalen: u32, dwf
 #[doc = "*Required features: `\"Win32_Security_Cryptography\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
-pub unsafe fn CryptHashMessage<'a, Param1: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>, const PARAM2: usize>(phashpara: *const CRYPT_HASH_MESSAGE_PARA, fdetachedhash: Param1, rgpbtobehashed: &[*const u8; PARAM2], rgcbtobehashed: &[u32; PARAM2], pbhashedblob: *mut u8, pcbhashedblob: *mut u32, pbcomputedhash: *mut u8, pcbcomputedhash: *mut u32) -> super::super::Foundation::BOOL {
+pub unsafe fn CryptHashMessage<'a, Param1: ::windows::core::IntoParam<'a, super::super::Foundation::BOOL>>(phashpara: *const CRYPT_HASH_MESSAGE_PARA, fdetachedhash: Param1, ctobehashed: u32, rgpbtobehashed: *const *const u8, rgcbtobehashed: *const u32, pbhashedblob: *mut u8, pcbhashedblob: *mut u32, pbcomputedhash: *mut u8, pcbcomputedhash: *mut u32) -> super::super::Foundation::BOOL {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn CryptHashMessage(phashpara: *const CRYPT_HASH_MESSAGE_PARA, fdetachedhash: super::super::Foundation::BOOL, ctobehashed: u32, rgpbtobehashed: *const *const u8, rgcbtobehashed: *const u32, pbhashedblob: *mut u8, pcbhashedblob: *mut u32, pbcomputedhash: *mut u8, pcbcomputedhash: *mut u32) -> super::super::Foundation::BOOL;
         }
-        ::core::mem::transmute(CryptHashMessage(::core::mem::transmute(phashpara), fdetachedhash.into_param().abi(), PARAM2 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(rgpbtobehashed)), ::core::mem::transmute(::windows::core::as_ptr_or_null(rgcbtobehashed)), ::core::mem::transmute(pbhashedblob), ::core::mem::transmute(pcbhashedblob), ::core::mem::transmute(pbcomputedhash), ::core::mem::transmute(pcbcomputedhash)))
+        ::core::mem::transmute(CryptHashMessage(::core::mem::transmute(phashpara), fdetachedhash.into_param().abi(), ::core::mem::transmute(ctobehashed), ::core::mem::transmute(rgpbtobehashed), ::core::mem::transmute(rgcbtobehashed), ::core::mem::transmute(pbhashedblob), ::core::mem::transmute(pcbhashedblob), ::core::mem::transmute(pbcomputedhash), ::core::mem::transmute(pcbcomputedhash)))
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
@@ -22565,14 +22565,14 @@ pub unsafe fn CryptVerifyCertificateSignatureEx<'a, Param0: ::windows::core::Int
 #[doc = "*Required features: `\"Win32_Security_Cryptography\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
-pub unsafe fn CryptVerifyDetachedMessageHash<'a, const PARAM3: usize>(phashpara: *const CRYPT_HASH_MESSAGE_PARA, pbdetachedhashblob: *const u8, cbdetachedhashblob: u32, rgpbtobehashed: &[*const u8; PARAM3], rgcbtobehashed: &[u32; PARAM3], pbcomputedhash: *mut u8, pcbcomputedhash: *mut u32) -> super::super::Foundation::BOOL {
+pub unsafe fn CryptVerifyDetachedMessageHash(phashpara: *const CRYPT_HASH_MESSAGE_PARA, pbdetachedhashblob: *const u8, cbdetachedhashblob: u32, ctobehashed: u32, rgpbtobehashed: *const *const u8, rgcbtobehashed: *const u32, pbcomputedhash: *mut u8, pcbcomputedhash: *mut u32) -> super::super::Foundation::BOOL {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn CryptVerifyDetachedMessageHash(phashpara: *const CRYPT_HASH_MESSAGE_PARA, pbdetachedhashblob: *const u8, cbdetachedhashblob: u32, ctobehashed: u32, rgpbtobehashed: *const *const u8, rgcbtobehashed: *const u32, pbcomputedhash: *mut u8, pcbcomputedhash: *mut u32) -> super::super::Foundation::BOOL;
         }
-        ::core::mem::transmute(CryptVerifyDetachedMessageHash(::core::mem::transmute(phashpara), ::core::mem::transmute(pbdetachedhashblob), ::core::mem::transmute(cbdetachedhashblob), PARAM3 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(rgpbtobehashed)), ::core::mem::transmute(::windows::core::as_ptr_or_null(rgcbtobehashed)), ::core::mem::transmute(pbcomputedhash), ::core::mem::transmute(pcbcomputedhash)))
+        ::core::mem::transmute(CryptVerifyDetachedMessageHash(::core::mem::transmute(phashpara), ::core::mem::transmute(pbdetachedhashblob), ::core::mem::transmute(cbdetachedhashblob), ::core::mem::transmute(ctobehashed), ::core::mem::transmute(rgpbtobehashed), ::core::mem::transmute(rgcbtobehashed), ::core::mem::transmute(pbcomputedhash), ::core::mem::transmute(pcbcomputedhash)))
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
@@ -22580,14 +22580,14 @@ pub unsafe fn CryptVerifyDetachedMessageHash<'a, const PARAM3: usize>(phashpara:
 #[doc = "*Required features: `\"Win32_Security_Cryptography\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
-pub unsafe fn CryptVerifyDetachedMessageSignature<'a, const PARAM4: usize>(pverifypara: *const CRYPT_VERIFY_MESSAGE_PARA, dwsignerindex: u32, pbdetachedsignblob: *const u8, cbdetachedsignblob: u32, rgpbtobesigned: &[*const u8; PARAM4], rgcbtobesigned: &[u32; PARAM4], ppsignercert: *mut *mut CERT_CONTEXT) -> super::super::Foundation::BOOL {
+pub unsafe fn CryptVerifyDetachedMessageSignature(pverifypara: *const CRYPT_VERIFY_MESSAGE_PARA, dwsignerindex: u32, pbdetachedsignblob: *const u8, cbdetachedsignblob: u32, ctobesigned: u32, rgpbtobesigned: *const *const u8, rgcbtobesigned: *const u32, ppsignercert: *mut *mut CERT_CONTEXT) -> super::super::Foundation::BOOL {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn CryptVerifyDetachedMessageSignature(pverifypara: *const CRYPT_VERIFY_MESSAGE_PARA, dwsignerindex: u32, pbdetachedsignblob: *const u8, cbdetachedsignblob: u32, ctobesigned: u32, rgpbtobesigned: *const *const u8, rgcbtobesigned: *const u32, ppsignercert: *mut *mut CERT_CONTEXT) -> super::super::Foundation::BOOL;
         }
-        ::core::mem::transmute(CryptVerifyDetachedMessageSignature(::core::mem::transmute(pverifypara), ::core::mem::transmute(dwsignerindex), ::core::mem::transmute(pbdetachedsignblob), ::core::mem::transmute(cbdetachedsignblob), PARAM4 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(rgpbtobesigned)), ::core::mem::transmute(::windows::core::as_ptr_or_null(rgcbtobesigned)), ::core::mem::transmute(ppsignercert)))
+        ::core::mem::transmute(CryptVerifyDetachedMessageSignature(::core::mem::transmute(pverifypara), ::core::mem::transmute(dwsignerindex), ::core::mem::transmute(pbdetachedsignblob), ::core::mem::transmute(cbdetachedsignblob), ::core::mem::transmute(ctobesigned), ::core::mem::transmute(rgpbtobesigned), ::core::mem::transmute(rgcbtobesigned), ::core::mem::transmute(ppsignercert)))
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");

--- a/crates/libs/windows/src/Windows/Win32/Storage/DataDeduplication/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/DataDeduplication/mod.rs
@@ -508,8 +508,8 @@ pub struct IDedupBackupSupport(::windows::core::IUnknown);
 impl IDedupBackupSupport {
     #[doc = "*Required features: `\"Win32_Storage_DataDeduplication\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn RestoreFiles<'a, const PARAM0: usize, Param2: ::windows::core::IntoParam<'a, IDedupReadFileCallback>>(&self, filefullpaths: &[super::super::Foundation::BSTR; PARAM0], store: Param2, flags: u32, fileresults: &mut [::windows::core::HRESULT; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).RestoreFiles)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(filefullpaths)), store.into_param().abi(), ::core::mem::transmute(flags), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(fileresults))).ok()
+    pub unsafe fn RestoreFiles<'a, Param2: ::windows::core::IntoParam<'a, IDedupReadFileCallback>>(&self, numberoffiles: u32, filefullpaths: *const super::super::Foundation::BSTR, store: Param2, flags: u32, fileresults: *mut ::windows::core::HRESULT) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).RestoreFiles)(::core::mem::transmute_copy(self), ::core::mem::transmute(numberoffiles), ::core::mem::transmute(filefullpaths), store.into_param().abi(), ::core::mem::transmute(flags), ::core::mem::transmute(fileresults)).ok()
     }
 }
 impl ::core::convert::From<IDedupBackupSupport> for ::windows::core::IUnknown {

--- a/crates/libs/windows/src/Windows/Win32/Storage/Imapi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Imapi/mod.rs
@@ -10518,8 +10518,8 @@ impl IStreamInterleave {
     }
     #[doc = "*Required features: `\"Win32_Storage_Imapi\"`, `\"Win32_System_Com\"`*"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn Initialize<'a, const PARAM2: usize>(&self, streams: &[::core::option::Option<super::super::System::Com::IStream>; PARAM2], interleavesizes: &[u32; PARAM2]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).Initialize)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(streams)), ::core::mem::transmute(::windows::core::as_ptr_or_null(interleavesizes)), PARAM2 as _).ok()
+    pub unsafe fn Initialize(&self, streams: *const ::core::option::Option<super::super::System::Com::IStream>, interleavesizes: *const u32, streamcount: u32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).Initialize)(::core::mem::transmute_copy(self), ::core::mem::transmute(streams), ::core::mem::transmute(interleavesizes), ::core::mem::transmute(streamcount)).ok()
     }
 }
 #[cfg(feature = "Win32_System_Com")]

--- a/crates/libs/windows/src/Windows/Win32/Storage/Jet/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Jet/mod.rs
@@ -9041,14 +9041,14 @@ pub unsafe fn JetOpenTableW<'a, Param0: ::windows::core::IntoParam<'a, super::St
 #[doc = "*Required features: `\"Win32_Storage_Jet\"`, `\"Win32_Storage_StructuredStorage\"`*"]
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 #[inline]
-pub unsafe fn JetOpenTempTable<'a, Param0: ::windows::core::IntoParam<'a, super::StructuredStorage::JET_SESID>, const PARAM2: usize>(sesid: Param0, prgcolumndef: &[JET_COLUMNDEF; PARAM2], grbit: u32, ptableid: *mut super::StructuredStorage::JET_TABLEID, prgcolumnid: &mut [u32; PARAM2]) -> i32 {
+pub unsafe fn JetOpenTempTable<'a, Param0: ::windows::core::IntoParam<'a, super::StructuredStorage::JET_SESID>>(sesid: Param0, prgcolumndef: *const JET_COLUMNDEF, ccolumn: u32, grbit: u32, ptableid: *mut super::StructuredStorage::JET_TABLEID, prgcolumnid: *mut u32) -> i32 {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn JetOpenTempTable(sesid: super::StructuredStorage::JET_SESID, prgcolumndef: *const JET_COLUMNDEF, ccolumn: u32, grbit: u32, ptableid: *mut super::StructuredStorage::JET_TABLEID, prgcolumnid: *mut u32) -> i32;
         }
-        ::core::mem::transmute(JetOpenTempTable(sesid.into_param().abi(), ::core::mem::transmute(::windows::core::as_ptr_or_null(prgcolumndef)), PARAM2 as _, ::core::mem::transmute(grbit), ::core::mem::transmute(ptableid), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(prgcolumnid))))
+        ::core::mem::transmute(JetOpenTempTable(sesid.into_param().abi(), ::core::mem::transmute(prgcolumndef), ::core::mem::transmute(ccolumn), ::core::mem::transmute(grbit), ::core::mem::transmute(ptableid), ::core::mem::transmute(prgcolumnid)))
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
@@ -9056,14 +9056,14 @@ pub unsafe fn JetOpenTempTable<'a, Param0: ::windows::core::IntoParam<'a, super:
 #[doc = "*Required features: `\"Win32_Storage_Jet\"`, `\"Win32_Storage_StructuredStorage\"`*"]
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 #[inline]
-pub unsafe fn JetOpenTempTable2<'a, Param0: ::windows::core::IntoParam<'a, super::StructuredStorage::JET_SESID>, const PARAM2: usize>(sesid: Param0, prgcolumndef: &[JET_COLUMNDEF; PARAM2], lcid: u32, grbit: u32, ptableid: *mut super::StructuredStorage::JET_TABLEID, prgcolumnid: &mut [u32; PARAM2]) -> i32 {
+pub unsafe fn JetOpenTempTable2<'a, Param0: ::windows::core::IntoParam<'a, super::StructuredStorage::JET_SESID>>(sesid: Param0, prgcolumndef: *const JET_COLUMNDEF, ccolumn: u32, lcid: u32, grbit: u32, ptableid: *mut super::StructuredStorage::JET_TABLEID, prgcolumnid: *mut u32) -> i32 {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn JetOpenTempTable2(sesid: super::StructuredStorage::JET_SESID, prgcolumndef: *const JET_COLUMNDEF, ccolumn: u32, lcid: u32, grbit: u32, ptableid: *mut super::StructuredStorage::JET_TABLEID, prgcolumnid: *mut u32) -> i32;
         }
-        ::core::mem::transmute(JetOpenTempTable2(sesid.into_param().abi(), ::core::mem::transmute(::windows::core::as_ptr_or_null(prgcolumndef)), PARAM2 as _, ::core::mem::transmute(lcid), ::core::mem::transmute(grbit), ::core::mem::transmute(ptableid), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(prgcolumnid))))
+        ::core::mem::transmute(JetOpenTempTable2(sesid.into_param().abi(), ::core::mem::transmute(prgcolumndef), ::core::mem::transmute(ccolumn), ::core::mem::transmute(lcid), ::core::mem::transmute(grbit), ::core::mem::transmute(ptableid), ::core::mem::transmute(prgcolumnid)))
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
@@ -9071,14 +9071,14 @@ pub unsafe fn JetOpenTempTable2<'a, Param0: ::windows::core::IntoParam<'a, super
 #[doc = "*Required features: `\"Win32_Storage_Jet\"`, `\"Win32_Storage_StructuredStorage\"`*"]
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 #[inline]
-pub unsafe fn JetOpenTempTable3<'a, Param0: ::windows::core::IntoParam<'a, super::StructuredStorage::JET_SESID>, const PARAM2: usize>(sesid: Param0, prgcolumndef: &[JET_COLUMNDEF; PARAM2], pidxunicode: *const JET_UNICODEINDEX, grbit: u32, ptableid: *mut super::StructuredStorage::JET_TABLEID, prgcolumnid: &mut [u32; PARAM2]) -> i32 {
+pub unsafe fn JetOpenTempTable3<'a, Param0: ::windows::core::IntoParam<'a, super::StructuredStorage::JET_SESID>>(sesid: Param0, prgcolumndef: *const JET_COLUMNDEF, ccolumn: u32, pidxunicode: *const JET_UNICODEINDEX, grbit: u32, ptableid: *mut super::StructuredStorage::JET_TABLEID, prgcolumnid: *mut u32) -> i32 {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn JetOpenTempTable3(sesid: super::StructuredStorage::JET_SESID, prgcolumndef: *const JET_COLUMNDEF, ccolumn: u32, pidxunicode: *const JET_UNICODEINDEX, grbit: u32, ptableid: *mut super::StructuredStorage::JET_TABLEID, prgcolumnid: *mut u32) -> i32;
         }
-        ::core::mem::transmute(JetOpenTempTable3(sesid.into_param().abi(), ::core::mem::transmute(::windows::core::as_ptr_or_null(prgcolumndef)), PARAM2 as _, ::core::mem::transmute(pidxunicode), ::core::mem::transmute(grbit), ::core::mem::transmute(ptableid), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(prgcolumnid))))
+        ::core::mem::transmute(JetOpenTempTable3(sesid.into_param().abi(), ::core::mem::transmute(prgcolumndef), ::core::mem::transmute(ccolumn), ::core::mem::transmute(pidxunicode), ::core::mem::transmute(grbit), ::core::mem::transmute(ptableid), ::core::mem::transmute(prgcolumnid)))
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
@@ -9146,14 +9146,14 @@ pub unsafe fn JetPrereadIndexRanges<'a, Param0: ::windows::core::IntoParam<'a, s
 #[doc = "*Required features: `\"Win32_Storage_Jet\"`, `\"Win32_Storage_StructuredStorage\"`*"]
 #[cfg(feature = "Win32_Storage_StructuredStorage")]
 #[inline]
-pub unsafe fn JetPrereadKeys<'a, Param0: ::windows::core::IntoParam<'a, super::StructuredStorage::JET_SESID>, Param1: ::windows::core::IntoParam<'a, super::StructuredStorage::JET_TABLEID>, const PARAM4: usize>(sesid: Param0, tableid: Param1, rgpvkeys: &[*const ::core::ffi::c_void; PARAM4], rgcbkeys: &[u32; PARAM4], pckeyspreread: *mut i32, grbit: u32) -> i32 {
+pub unsafe fn JetPrereadKeys<'a, Param0: ::windows::core::IntoParam<'a, super::StructuredStorage::JET_SESID>, Param1: ::windows::core::IntoParam<'a, super::StructuredStorage::JET_TABLEID>>(sesid: Param0, tableid: Param1, rgpvkeys: *const *const ::core::ffi::c_void, rgcbkeys: *const u32, ckeys: i32, pckeyspreread: *mut i32, grbit: u32) -> i32 {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn JetPrereadKeys(sesid: super::StructuredStorage::JET_SESID, tableid: super::StructuredStorage::JET_TABLEID, rgpvkeys: *const *const ::core::ffi::c_void, rgcbkeys: *const u32, ckeys: i32, pckeyspreread: *mut i32, grbit: u32) -> i32;
         }
-        ::core::mem::transmute(JetPrereadKeys(sesid.into_param().abi(), tableid.into_param().abi(), ::core::mem::transmute(::windows::core::as_ptr_or_null(rgpvkeys)), ::core::mem::transmute(::windows::core::as_ptr_or_null(rgcbkeys)), PARAM4 as _, ::core::mem::transmute(pckeyspreread), ::core::mem::transmute(grbit)))
+        ::core::mem::transmute(JetPrereadKeys(sesid.into_param().abi(), tableid.into_param().abi(), ::core::mem::transmute(rgpvkeys), ::core::mem::transmute(rgcbkeys), ::core::mem::transmute(ckeys), ::core::mem::transmute(pckeyspreread), ::core::mem::transmute(grbit)))
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");

--- a/crates/libs/windows/src/Windows/Win32/Storage/Vss/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Storage/Vss/mod.rs
@@ -2054,8 +2054,8 @@ pub struct IVssHardwareSnapshotProvider(::windows::core::IUnknown);
 impl IVssHardwareSnapshotProvider {
     #[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_VirtualDiskService\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_VirtualDiskService"))]
-    pub unsafe fn AreLunsSupported<'a, const PARAM0: usize>(&self, lcontext: i32, rgwszdevices: &[*const u16; PARAM0], pluninformation: &mut [super::VirtualDiskService::VDS_LUN_INFORMATION; PARAM0], pbissupported: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).AreLunsSupported)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(lcontext), ::core::mem::transmute(::windows::core::as_ptr_or_null(rgwszdevices)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(pluninformation)), ::core::mem::transmute(pbissupported)).ok()
+    pub unsafe fn AreLunsSupported(&self, lluncount: i32, lcontext: i32, rgwszdevices: *const *const u16, pluninformation: *mut super::VirtualDiskService::VDS_LUN_INFORMATION, pbissupported: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).AreLunsSupported)(::core::mem::transmute_copy(self), ::core::mem::transmute(lluncount), ::core::mem::transmute(lcontext), ::core::mem::transmute(rgwszdevices), ::core::mem::transmute(pluninformation), ::core::mem::transmute(pbissupported)).ok()
     }
     #[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_VirtualDiskService\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_VirtualDiskService"))]
@@ -2064,13 +2064,13 @@ impl IVssHardwareSnapshotProvider {
     }
     #[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_VirtualDiskService\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_VirtualDiskService"))]
-    pub unsafe fn BeginPrepareSnapshot<'a, Param0: ::windows::core::IntoParam<'a, ::windows::core::GUID>, Param1: ::windows::core::IntoParam<'a, ::windows::core::GUID>, const PARAM3: usize>(&self, snapshotsetid: Param0, snapshotid: Param1, lcontext: i32, rgdevicenames: &[*const u16; PARAM3], rgluninformation: &mut [super::VirtualDiskService::VDS_LUN_INFORMATION; PARAM3]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).BeginPrepareSnapshot)(::core::mem::transmute_copy(self), snapshotsetid.into_param().abi(), snapshotid.into_param().abi(), ::core::mem::transmute(lcontext), PARAM3 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(rgdevicenames)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(rgluninformation))).ok()
+    pub unsafe fn BeginPrepareSnapshot<'a, Param0: ::windows::core::IntoParam<'a, ::windows::core::GUID>, Param1: ::windows::core::IntoParam<'a, ::windows::core::GUID>>(&self, snapshotsetid: Param0, snapshotid: Param1, lcontext: i32, lluncount: i32, rgdevicenames: *const *const u16, rgluninformation: *mut super::VirtualDiskService::VDS_LUN_INFORMATION) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).BeginPrepareSnapshot)(::core::mem::transmute_copy(self), snapshotsetid.into_param().abi(), snapshotid.into_param().abi(), ::core::mem::transmute(lcontext), ::core::mem::transmute(lluncount), ::core::mem::transmute(rgdevicenames), ::core::mem::transmute(rgluninformation)).ok()
     }
     #[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_VirtualDiskService\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_VirtualDiskService"))]
-    pub unsafe fn GetTargetLuns<'a, const PARAM0: usize>(&self, rgdevicenames: &[*const u16; PARAM0], rgsourceluns: &[super::VirtualDiskService::VDS_LUN_INFORMATION; PARAM0], rgdestinationluns: &mut [super::VirtualDiskService::VDS_LUN_INFORMATION; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).GetTargetLuns)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(rgdevicenames)), ::core::mem::transmute(::windows::core::as_ptr_or_null(rgsourceluns)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(rgdestinationluns))).ok()
+    pub unsafe fn GetTargetLuns(&self, lluncount: i32, rgdevicenames: *const *const u16, rgsourceluns: *const super::VirtualDiskService::VDS_LUN_INFORMATION, rgdestinationluns: *mut super::VirtualDiskService::VDS_LUN_INFORMATION) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).GetTargetLuns)(::core::mem::transmute_copy(self), ::core::mem::transmute(lluncount), ::core::mem::transmute(rgdevicenames), ::core::mem::transmute(rgsourceluns), ::core::mem::transmute(rgdestinationluns)).ok()
     }
     #[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_VirtualDiskService\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_VirtualDiskService"))]
@@ -2158,8 +2158,8 @@ pub struct IVssHardwareSnapshotProviderEx(::windows::core::IUnknown);
 impl IVssHardwareSnapshotProviderEx {
     #[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_VirtualDiskService\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_VirtualDiskService"))]
-    pub unsafe fn AreLunsSupported<'a, const PARAM0: usize>(&self, lcontext: i32, rgwszdevices: &[*const u16; PARAM0], pluninformation: &mut [super::VirtualDiskService::VDS_LUN_INFORMATION; PARAM0], pbissupported: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.AreLunsSupported)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(lcontext), ::core::mem::transmute(::windows::core::as_ptr_or_null(rgwszdevices)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(pluninformation)), ::core::mem::transmute(pbissupported)).ok()
+    pub unsafe fn AreLunsSupported(&self, lluncount: i32, lcontext: i32, rgwszdevices: *const *const u16, pluninformation: *mut super::VirtualDiskService::VDS_LUN_INFORMATION, pbissupported: *mut super::super::Foundation::BOOL) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.AreLunsSupported)(::core::mem::transmute_copy(self), ::core::mem::transmute(lluncount), ::core::mem::transmute(lcontext), ::core::mem::transmute(rgwszdevices), ::core::mem::transmute(pluninformation), ::core::mem::transmute(pbissupported)).ok()
     }
     #[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_VirtualDiskService\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_VirtualDiskService"))]
@@ -2168,13 +2168,13 @@ impl IVssHardwareSnapshotProviderEx {
     }
     #[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_VirtualDiskService\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_VirtualDiskService"))]
-    pub unsafe fn BeginPrepareSnapshot<'a, Param0: ::windows::core::IntoParam<'a, ::windows::core::GUID>, Param1: ::windows::core::IntoParam<'a, ::windows::core::GUID>, const PARAM3: usize>(&self, snapshotsetid: Param0, snapshotid: Param1, lcontext: i32, rgdevicenames: &[*const u16; PARAM3], rgluninformation: &mut [super::VirtualDiskService::VDS_LUN_INFORMATION; PARAM3]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.BeginPrepareSnapshot)(::core::mem::transmute_copy(self), snapshotsetid.into_param().abi(), snapshotid.into_param().abi(), ::core::mem::transmute(lcontext), PARAM3 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(rgdevicenames)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(rgluninformation))).ok()
+    pub unsafe fn BeginPrepareSnapshot<'a, Param0: ::windows::core::IntoParam<'a, ::windows::core::GUID>, Param1: ::windows::core::IntoParam<'a, ::windows::core::GUID>>(&self, snapshotsetid: Param0, snapshotid: Param1, lcontext: i32, lluncount: i32, rgdevicenames: *const *const u16, rgluninformation: *mut super::VirtualDiskService::VDS_LUN_INFORMATION) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.BeginPrepareSnapshot)(::core::mem::transmute_copy(self), snapshotsetid.into_param().abi(), snapshotid.into_param().abi(), ::core::mem::transmute(lcontext), ::core::mem::transmute(lluncount), ::core::mem::transmute(rgdevicenames), ::core::mem::transmute(rgluninformation)).ok()
     }
     #[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_VirtualDiskService\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_VirtualDiskService"))]
-    pub unsafe fn GetTargetLuns<'a, const PARAM0: usize>(&self, rgdevicenames: &[*const u16; PARAM0], rgsourceluns: &[super::VirtualDiskService::VDS_LUN_INFORMATION; PARAM0], rgdestinationluns: &mut [super::VirtualDiskService::VDS_LUN_INFORMATION; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.GetTargetLuns)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(rgdevicenames)), ::core::mem::transmute(::windows::core::as_ptr_or_null(rgsourceluns)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(rgdestinationluns))).ok()
+    pub unsafe fn GetTargetLuns(&self, lluncount: i32, rgdevicenames: *const *const u16, rgsourceluns: *const super::VirtualDiskService::VDS_LUN_INFORMATION, rgdestinationluns: *mut super::VirtualDiskService::VDS_LUN_INFORMATION) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.GetTargetLuns)(::core::mem::transmute_copy(self), ::core::mem::transmute(lluncount), ::core::mem::transmute(rgdevicenames), ::core::mem::transmute(rgsourceluns), ::core::mem::transmute(rgdestinationluns)).ok()
     }
     #[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_VirtualDiskService\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_VirtualDiskService"))]
@@ -2193,19 +2193,19 @@ impl IVssHardwareSnapshotProviderEx {
     }
     #[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_VirtualDiskService\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_VirtualDiskService"))]
-    pub unsafe fn OnLunStateChange<'a, const PARAM2: usize>(&self, psnapshotluns: &[super::VirtualDiskService::VDS_LUN_INFORMATION; PARAM2], poriginalluns: &[super::VirtualDiskService::VDS_LUN_INFORMATION; PARAM2], dwflags: u32) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).OnLunStateChange)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(psnapshotluns)), ::core::mem::transmute(::windows::core::as_ptr_or_null(poriginalluns)), PARAM2 as _, ::core::mem::transmute(dwflags)).ok()
+    pub unsafe fn OnLunStateChange(&self, psnapshotluns: *const super::VirtualDiskService::VDS_LUN_INFORMATION, poriginalluns: *const super::VirtualDiskService::VDS_LUN_INFORMATION, dwcount: u32, dwflags: u32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).OnLunStateChange)(::core::mem::transmute_copy(self), ::core::mem::transmute(psnapshotluns), ::core::mem::transmute(poriginalluns), ::core::mem::transmute(dwcount), ::core::mem::transmute(dwflags)).ok()
     }
     #[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_VirtualDiskService\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_VirtualDiskService"))]
-    pub unsafe fn ResyncLuns<'a, const PARAM2: usize>(&self, psourceluns: &[super::VirtualDiskService::VDS_LUN_INFORMATION; PARAM2], ptargetluns: &[super::VirtualDiskService::VDS_LUN_INFORMATION; PARAM2]) -> ::windows::core::Result<IVssAsync> {
+    pub unsafe fn ResyncLuns(&self, psourceluns: *const super::VirtualDiskService::VDS_LUN_INFORMATION, ptargetluns: *const super::VirtualDiskService::VDS_LUN_INFORMATION, dwcount: u32) -> ::windows::core::Result<IVssAsync> {
         let mut result__: ::windows::core::RawPtr = ::core::mem::zeroed();
-        (::windows::core::Interface::vtable(self).ResyncLuns)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(psourceluns)), ::core::mem::transmute(::windows::core::as_ptr_or_null(ptargetluns)), PARAM2 as _, ::core::mem::transmute(&mut result__)).from_abi::<IVssAsync>(result__)
+        (::windows::core::Interface::vtable(self).ResyncLuns)(::core::mem::transmute_copy(self), ::core::mem::transmute(psourceluns), ::core::mem::transmute(ptargetluns), ::core::mem::transmute(dwcount), ::core::mem::transmute(&mut result__)).from_abi::<IVssAsync>(result__)
     }
     #[doc = "*Required features: `\"Win32_Storage_Vss\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_VirtualDiskService\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_VirtualDiskService"))]
-    pub unsafe fn OnReuseLuns<'a, const PARAM2: usize>(&self, psnapshotluns: &[super::VirtualDiskService::VDS_LUN_INFORMATION; PARAM2], poriginalluns: &[super::VirtualDiskService::VDS_LUN_INFORMATION; PARAM2]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).OnReuseLuns)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(psnapshotluns)), ::core::mem::transmute(::windows::core::as_ptr_or_null(poriginalluns)), PARAM2 as _).ok()
+    pub unsafe fn OnReuseLuns(&self, psnapshotluns: *const super::VirtualDiskService::VDS_LUN_INFORMATION, poriginalluns: *const super::VirtualDiskService::VDS_LUN_INFORMATION, dwcount: u32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).OnReuseLuns)(::core::mem::transmute_copy(self), ::core::mem::transmute(psnapshotluns), ::core::mem::transmute(poriginalluns), ::core::mem::transmute(dwcount)).ok()
     }
 }
 impl ::core::convert::From<IVssHardwareSnapshotProviderEx> for ::windows::core::IUnknown {

--- a/crates/libs/windows/src/Windows/Win32/System/Com/StructuredStorage/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/StructuredStorage/mod.rs
@@ -1630,13 +1630,13 @@ pub struct IPropertyBag2(::windows::core::IUnknown);
 impl IPropertyBag2 {
     #[doc = "*Required features: `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
-    pub unsafe fn Read<'a, const PARAM0: usize, Param2: ::windows::core::IntoParam<'a, super::IErrorLog>>(&self, ppropbag: &[PROPBAG2; PARAM0], perrlog: Param2, pvarvalue: &mut [super::VARIANT; PARAM0], phrerror: &mut [::windows::core::HRESULT; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).Read)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(ppropbag)), perrlog.into_param().abi(), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(pvarvalue)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(phrerror))).ok()
+    pub unsafe fn Read<'a, Param2: ::windows::core::IntoParam<'a, super::IErrorLog>>(&self, cproperties: u32, ppropbag: *const PROPBAG2, perrlog: Param2, pvarvalue: *mut super::VARIANT, phrerror: *mut ::windows::core::HRESULT) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).Read)(::core::mem::transmute_copy(self), ::core::mem::transmute(cproperties), ::core::mem::transmute(ppropbag), perrlog.into_param().abi(), ::core::mem::transmute(pvarvalue), ::core::mem::transmute(phrerror)).ok()
     }
     #[doc = "*Required features: `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
-    pub unsafe fn Write<'a, const PARAM0: usize>(&self, ppropbag: &[PROPBAG2; PARAM0], pvarvalue: &[super::VARIANT; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).Write)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(ppropbag)), ::core::mem::transmute(::windows::core::as_ptr_or_null(pvarvalue))).ok()
+    pub unsafe fn Write(&self, cproperties: u32, ppropbag: *const PROPBAG2, pvarvalue: *const super::VARIANT) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).Write)(::core::mem::transmute_copy(self), ::core::mem::transmute(cproperties), ::core::mem::transmute(ppropbag), ::core::mem::transmute(pvarvalue)).ok()
     }
     #[doc = "*Required features: `\"Win32_System_Com_StructuredStorage\"`*"]
     pub unsafe fn CountProperties(&self) -> ::windows::core::Result<u32> {
@@ -1787,25 +1787,25 @@ pub struct IPropertyStorage(::windows::core::IUnknown);
 impl IPropertyStorage {
     #[doc = "*Required features: `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn ReadMultiple<'a, const PARAM0: usize>(&self, rgpspec: &[PROPSPEC; PARAM0], rgpropvar: &mut [PROPVARIANT; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).ReadMultiple)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(rgpspec)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(rgpropvar))).ok()
+    pub unsafe fn ReadMultiple(&self, cpspec: u32, rgpspec: *const PROPSPEC, rgpropvar: *mut PROPVARIANT) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).ReadMultiple)(::core::mem::transmute_copy(self), ::core::mem::transmute(cpspec), ::core::mem::transmute(rgpspec), ::core::mem::transmute(rgpropvar)).ok()
     }
     #[doc = "*Required features: `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn WriteMultiple<'a, const PARAM0: usize>(&self, rgpspec: &[PROPSPEC; PARAM0], rgpropvar: &[PROPVARIANT; PARAM0], propidnamefirst: u32) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).WriteMultiple)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(rgpspec)), ::core::mem::transmute(::windows::core::as_ptr_or_null(rgpropvar)), ::core::mem::transmute(propidnamefirst)).ok()
+    pub unsafe fn WriteMultiple(&self, cpspec: u32, rgpspec: *const PROPSPEC, rgpropvar: *const PROPVARIANT, propidnamefirst: u32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).WriteMultiple)(::core::mem::transmute_copy(self), ::core::mem::transmute(cpspec), ::core::mem::transmute(rgpspec), ::core::mem::transmute(rgpropvar), ::core::mem::transmute(propidnamefirst)).ok()
     }
     #[doc = "*Required features: `\"Win32_System_Com_StructuredStorage\"`*"]
     pub unsafe fn DeleteMultiple(&self, rgpspec: &[PROPSPEC]) -> ::windows::core::Result<()> {
         (::windows::core::Interface::vtable(self).DeleteMultiple)(::core::mem::transmute_copy(self), rgpspec.len() as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(rgpspec))).ok()
     }
     #[doc = "*Required features: `\"Win32_System_Com_StructuredStorage\"`*"]
-    pub unsafe fn ReadPropertyNames<'a, const PARAM0: usize>(&self, rgpropid: &[u32; PARAM0], rglpwstrname: &mut [::windows::core::PWSTR; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).ReadPropertyNames)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(rgpropid)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(rglpwstrname))).ok()
+    pub unsafe fn ReadPropertyNames(&self, cpropid: u32, rgpropid: *const u32, rglpwstrname: *mut ::windows::core::PWSTR) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).ReadPropertyNames)(::core::mem::transmute_copy(self), ::core::mem::transmute(cpropid), ::core::mem::transmute(rgpropid), ::core::mem::transmute(rglpwstrname)).ok()
     }
     #[doc = "*Required features: `\"Win32_System_Com_StructuredStorage\"`*"]
-    pub unsafe fn WritePropertyNames<'a, const PARAM0: usize>(&self, rgpropid: &[u32; PARAM0], rglpwstrname: &[::windows::core::PWSTR; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).WritePropertyNames)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(rgpropid)), ::core::mem::transmute(::windows::core::as_ptr_or_null(rglpwstrname))).ok()
+    pub unsafe fn WritePropertyNames(&self, cpropid: u32, rgpropid: *const u32, rglpwstrname: *const ::windows::core::PWSTR) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).WritePropertyNames)(::core::mem::transmute_copy(self), ::core::mem::transmute(cpropid), ::core::mem::transmute(rgpropid), ::core::mem::transmute(rglpwstrname)).ok()
     }
     #[doc = "*Required features: `\"Win32_System_Com_StructuredStorage\"`*"]
     pub unsafe fn DeletePropertyNames(&self, rgpropid: &[u32]) -> ::windows::core::Result<()> {

--- a/crates/libs/windows/src/Windows/Win32/System/Com/Urlmon/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/Urlmon/mod.rs
@@ -6069,28 +6069,28 @@ pub unsafe fn RegisterFormatEnumerator<'a, Param0: ::windows::core::IntoParam<'a
 }
 #[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`*"]
 #[inline]
-pub unsafe fn RegisterMediaTypeClass<'a, Param0: ::windows::core::IntoParam<'a, super::IBindCtx>, const PARAM1: usize>(pbc: Param0, rgsztypes: &[::windows::core::PSTR; PARAM1], rgclsid: &[::windows::core::GUID; PARAM1], reserved: u32) -> ::windows::core::Result<()> {
+pub unsafe fn RegisterMediaTypeClass<'a, Param0: ::windows::core::IntoParam<'a, super::IBindCtx>>(pbc: Param0, ctypes: u32, rgsztypes: *const ::windows::core::PSTR, rgclsid: *const ::windows::core::GUID, reserved: u32) -> ::windows::core::Result<()> {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn RegisterMediaTypeClass(pbc: ::windows::core::RawPtr, ctypes: u32, rgsztypes: *const ::windows::core::PSTR, rgclsid: *const ::windows::core::GUID, reserved: u32) -> ::windows::core::HRESULT;
         }
-        RegisterMediaTypeClass(pbc.into_param().abi(), PARAM1 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(rgsztypes)), ::core::mem::transmute(::windows::core::as_ptr_or_null(rgclsid)), ::core::mem::transmute(reserved)).ok()
+        RegisterMediaTypeClass(pbc.into_param().abi(), ::core::mem::transmute(ctypes), ::core::mem::transmute(rgsztypes), ::core::mem::transmute(rgclsid), ::core::mem::transmute(reserved)).ok()
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
 }
 #[doc = "*Required features: `\"Win32_System_Com_Urlmon\"`*"]
 #[inline]
-pub unsafe fn RegisterMediaTypes<'a, const PARAM0: usize>(rgsztypes: &[::windows::core::PSTR; PARAM0], rgcftypes: &mut [u16; PARAM0]) -> ::windows::core::Result<()> {
+pub unsafe fn RegisterMediaTypes(ctypes: u32, rgsztypes: *const ::windows::core::PSTR, rgcftypes: *mut u16) -> ::windows::core::Result<()> {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn RegisterMediaTypes(ctypes: u32, rgsztypes: *const ::windows::core::PSTR, rgcftypes: *mut u16) -> ::windows::core::HRESULT;
         }
-        RegisterMediaTypes(PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(rgsztypes)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(rgcftypes))).ok()
+        RegisterMediaTypes(::core::mem::transmute(ctypes), ::core::mem::transmute(rgsztypes), ::core::mem::transmute(rgcftypes)).ok()
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");

--- a/crates/libs/windows/src/Windows/Win32/System/Com/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Com/mod.rs
@@ -6699,8 +6699,8 @@ impl IDispatch {
         (::windows::core::Interface::vtable(self).GetTypeInfo)(::core::mem::transmute_copy(self), ::core::mem::transmute(itinfo), ::core::mem::transmute(lcid), ::core::mem::transmute(&mut result__)).from_abi::<ITypeInfo>(result__)
     }
     #[doc = "*Required features: `\"Win32_System_Com\"`*"]
-    pub unsafe fn GetIDsOfNames<'a, const PARAM2: usize>(&self, riid: *const ::windows::core::GUID, rgsznames: &[::windows::core::PWSTR; PARAM2], lcid: u32, rgdispid: &mut [i32; PARAM2]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).GetIDsOfNames)(::core::mem::transmute_copy(self), ::core::mem::transmute(riid), ::core::mem::transmute(::windows::core::as_ptr_or_null(rgsznames)), PARAM2 as _, ::core::mem::transmute(lcid), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(rgdispid))).ok()
+    pub unsafe fn GetIDsOfNames(&self, riid: *const ::windows::core::GUID, rgsznames: *const ::windows::core::PWSTR, cnames: u32, lcid: u32, rgdispid: *mut i32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).GetIDsOfNames)(::core::mem::transmute_copy(self), ::core::mem::transmute(riid), ::core::mem::transmute(rgsznames), ::core::mem::transmute(cnames), ::core::mem::transmute(lcid), ::core::mem::transmute(rgdispid)).ok()
     }
     #[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
@@ -11631,8 +11631,8 @@ impl ITypeInfo {
         (::windows::core::Interface::vtable(self).GetImplTypeFlags)(::core::mem::transmute_copy(self), ::core::mem::transmute(index), ::core::mem::transmute(&mut result__)).from_abi::<i32>(result__)
     }
     #[doc = "*Required features: `\"Win32_System_Com\"`*"]
-    pub unsafe fn GetIDsOfNames<'a, const PARAM1: usize>(&self, rgsznames: &[::windows::core::PWSTR; PARAM1], pmemid: &mut [i32; PARAM1]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).GetIDsOfNames)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(rgsznames)), PARAM1 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(pmemid))).ok()
+    pub unsafe fn GetIDsOfNames(&self, rgsznames: *const ::windows::core::PWSTR, cnames: u32, pmemid: *mut i32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).GetIDsOfNames)(::core::mem::transmute_copy(self), ::core::mem::transmute(rgsznames), ::core::mem::transmute(cnames), ::core::mem::transmute(pmemid)).ok()
     }
     #[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]
@@ -11829,8 +11829,8 @@ impl ITypeInfo2 {
         (::windows::core::Interface::vtable(self).base.GetImplTypeFlags)(::core::mem::transmute_copy(self), ::core::mem::transmute(index), ::core::mem::transmute(&mut result__)).from_abi::<i32>(result__)
     }
     #[doc = "*Required features: `\"Win32_System_Com\"`*"]
-    pub unsafe fn GetIDsOfNames<'a, const PARAM1: usize>(&self, rgsznames: &[::windows::core::PWSTR; PARAM1], pmemid: &mut [i32; PARAM1]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).base.GetIDsOfNames)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(rgsznames)), PARAM1 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(pmemid))).ok()
+    pub unsafe fn GetIDsOfNames(&self, rgsznames: *const ::windows::core::PWSTR, cnames: u32, pmemid: *mut i32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).base.GetIDsOfNames)(::core::mem::transmute_copy(self), ::core::mem::transmute(rgsznames), ::core::mem::transmute(cnames), ::core::mem::transmute(pmemid)).ok()
     }
     #[doc = "*Required features: `\"Win32_System_Com\"`, `\"Win32_Foundation\"`, `\"Win32_System_Ole\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Ole"))]

--- a/crates/libs/windows/src/Windows/Win32/System/Hypervisor/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Hypervisor/mod.rs
@@ -8626,14 +8626,14 @@ pub unsafe fn WHvGetVirtualProcessorInterruptControllerState2<'a, Param0: ::wind
 }
 #[doc = "*Required features: `\"Win32_System_Hypervisor\"`*"]
 #[inline]
-pub unsafe fn WHvGetVirtualProcessorRegisters<'a, Param0: ::windows::core::IntoParam<'a, WHV_PARTITION_HANDLE>, const PARAM3: usize>(partition: Param0, vpindex: u32, registernames: &[WHV_REGISTER_NAME; PARAM3], registervalues: &mut [WHV_REGISTER_VALUE; PARAM3]) -> ::windows::core::Result<()> {
+pub unsafe fn WHvGetVirtualProcessorRegisters<'a, Param0: ::windows::core::IntoParam<'a, WHV_PARTITION_HANDLE>>(partition: Param0, vpindex: u32, registernames: *const WHV_REGISTER_NAME, registercount: u32, registervalues: *mut WHV_REGISTER_VALUE) -> ::windows::core::Result<()> {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn WHvGetVirtualProcessorRegisters(partition: WHV_PARTITION_HANDLE, vpindex: u32, registernames: *const WHV_REGISTER_NAME, registercount: u32, registervalues: *mut WHV_REGISTER_VALUE) -> ::windows::core::HRESULT;
         }
-        WHvGetVirtualProcessorRegisters(partition.into_param().abi(), ::core::mem::transmute(vpindex), ::core::mem::transmute(::windows::core::as_ptr_or_null(registernames)), PARAM3 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(registervalues))).ok()
+        WHvGetVirtualProcessorRegisters(partition.into_param().abi(), ::core::mem::transmute(vpindex), ::core::mem::transmute(registernames), ::core::mem::transmute(registercount), ::core::mem::transmute(registervalues)).ok()
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
@@ -8978,14 +8978,14 @@ pub unsafe fn WHvSetVirtualProcessorInterruptControllerState2<'a, Param0: ::wind
 }
 #[doc = "*Required features: `\"Win32_System_Hypervisor\"`*"]
 #[inline]
-pub unsafe fn WHvSetVirtualProcessorRegisters<'a, Param0: ::windows::core::IntoParam<'a, WHV_PARTITION_HANDLE>, const PARAM3: usize>(partition: Param0, vpindex: u32, registernames: &[WHV_REGISTER_NAME; PARAM3], registervalues: &[WHV_REGISTER_VALUE; PARAM3]) -> ::windows::core::Result<()> {
+pub unsafe fn WHvSetVirtualProcessorRegisters<'a, Param0: ::windows::core::IntoParam<'a, WHV_PARTITION_HANDLE>>(partition: Param0, vpindex: u32, registernames: *const WHV_REGISTER_NAME, registercount: u32, registervalues: *const WHV_REGISTER_VALUE) -> ::windows::core::Result<()> {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn WHvSetVirtualProcessorRegisters(partition: WHV_PARTITION_HANDLE, vpindex: u32, registernames: *const WHV_REGISTER_NAME, registercount: u32, registervalues: *const WHV_REGISTER_VALUE) -> ::windows::core::HRESULT;
         }
-        WHvSetVirtualProcessorRegisters(partition.into_param().abi(), ::core::mem::transmute(vpindex), ::core::mem::transmute(::windows::core::as_ptr_or_null(registernames)), PARAM3 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(registervalues))).ok()
+        WHvSetVirtualProcessorRegisters(partition.into_param().abi(), ::core::mem::transmute(vpindex), ::core::mem::transmute(registernames), ::core::mem::transmute(registercount), ::core::mem::transmute(registervalues)).ok()
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");

--- a/crates/libs/windows/src/Windows/Win32/System/Ole/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Ole/mod.rs
@@ -922,7 +922,7 @@ impl ::core::fmt::Debug for DVASPECT2 {
 #[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com"))]
 #[inline]
-pub unsafe fn DispCallFunc<'a, const PARAM4: usize>(pvinstance: *const ::core::ffi::c_void, ovft: usize, cc: super::Com::CALLCONV, vtreturn: u16, prgvt: &[u16; PARAM4], prgpvarg: &[*const super::Com::VARIANT; PARAM4]) -> ::windows::core::Result<super::Com::VARIANT> {
+pub unsafe fn DispCallFunc(pvinstance: *const ::core::ffi::c_void, ovft: usize, cc: super::Com::CALLCONV, vtreturn: u16, cactuals: u32, prgvt: *const u16, prgpvarg: *const *const super::Com::VARIANT) -> ::windows::core::Result<super::Com::VARIANT> {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
@@ -930,7 +930,7 @@ pub unsafe fn DispCallFunc<'a, const PARAM4: usize>(pvinstance: *const ::core::f
             fn DispCallFunc(pvinstance: *const ::core::ffi::c_void, ovft: usize, cc: super::Com::CALLCONV, vtreturn: u16, cactuals: u32, prgvt: *const u16, prgpvarg: *const *const super::Com::VARIANT, pvargresult: *mut super::Com::VARIANT) -> ::windows::core::HRESULT;
         }
         let mut result__: ::core::mem::ManuallyDrop<super::Com::VARIANT> = ::core::mem::zeroed();
-        DispCallFunc(::core::mem::transmute(pvinstance), ::core::mem::transmute(ovft), ::core::mem::transmute(cc), ::core::mem::transmute(vtreturn), PARAM4 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(prgvt)), ::core::mem::transmute(::windows::core::as_ptr_or_null(prgpvarg)), ::core::mem::transmute(&mut result__)).from_abi::<super::Com::VARIANT>(result__)
+        DispCallFunc(::core::mem::transmute(pvinstance), ::core::mem::transmute(ovft), ::core::mem::transmute(cc), ::core::mem::transmute(vtreturn), ::core::mem::transmute(cactuals), ::core::mem::transmute(prgvt), ::core::mem::transmute(prgpvarg), ::core::mem::transmute(&mut result__)).from_abi::<super::Com::VARIANT>(result__)
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
@@ -938,14 +938,14 @@ pub unsafe fn DispCallFunc<'a, const PARAM4: usize>(pvinstance: *const ::core::f
 #[doc = "*Required features: `\"Win32_System_Ole\"`, `\"Win32_System_Com\"`*"]
 #[cfg(feature = "Win32_System_Com")]
 #[inline]
-pub unsafe fn DispGetIDsOfNames<'a, Param0: ::windows::core::IntoParam<'a, super::Com::ITypeInfo>, const PARAM2: usize>(ptinfo: Param0, rgsznames: &[::windows::core::PWSTR; PARAM2], rgdispid: &mut [i32; PARAM2]) -> ::windows::core::Result<()> {
+pub unsafe fn DispGetIDsOfNames<'a, Param0: ::windows::core::IntoParam<'a, super::Com::ITypeInfo>>(ptinfo: Param0, rgsznames: *const ::windows::core::PWSTR, cnames: u32, rgdispid: *mut i32) -> ::windows::core::Result<()> {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn DispGetIDsOfNames(ptinfo: ::windows::core::RawPtr, rgsznames: *const ::windows::core::PWSTR, cnames: u32, rgdispid: *mut i32) -> ::windows::core::HRESULT;
         }
-        DispGetIDsOfNames(ptinfo.into_param().abi(), ::core::mem::transmute(::windows::core::as_ptr_or_null(rgsznames)), PARAM2 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(rgdispid))).ok()
+        DispGetIDsOfNames(ptinfo.into_param().abi(), ::core::mem::transmute(rgsznames), ::core::mem::transmute(cnames), ::core::mem::transmute(rgdispid)).ok()
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");

--- a/crates/libs/windows/src/Windows/Win32/System/Search/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Search/mod.rs
@@ -9753,8 +9753,8 @@ impl ICommandWithParameters {
         (::windows::core::Interface::vtable(self).GetParameterInfo)(::core::mem::transmute_copy(self), ::core::mem::transmute(pcparams), ::core::mem::transmute(prgparaminfo), ::core::mem::transmute(ppnamesbuffer)).ok()
     }
     #[doc = "*Required features: `\"Win32_System_Search\"`*"]
-    pub unsafe fn MapParameterNames<'a, const PARAM0: usize>(&self, rgparamnames: &[::windows::core::PWSTR; PARAM0], rgparamordinals: &mut [isize; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).MapParameterNames)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(rgparamnames)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(rgparamordinals))).ok()
+    pub unsafe fn MapParameterNames(&self, cparamnames: usize, rgparamnames: *const ::windows::core::PWSTR, rgparamordinals: *mut isize) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).MapParameterNames)(::core::mem::transmute_copy(self), ::core::mem::transmute(cparamnames), ::core::mem::transmute(rgparamnames), ::core::mem::transmute(rgparamordinals)).ok()
     }
     #[doc = "*Required features: `\"Win32_System_Search\"`*"]
     pub unsafe fn SetParameterInfo(&self, cparams: usize, rgparamordinals: *const usize, rgparambindinfo: *const DBPARAMBINDINFO) -> ::windows::core::Result<()> {
@@ -11505,8 +11505,8 @@ pub struct IDCInfo(::windows::core::IUnknown);
 impl IDCInfo {
     #[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-    pub unsafe fn GetInfo<'a, const PARAM0: usize>(&self, rgeinfotype: &[u32; PARAM0], prginfo: &mut [*mut DCINFO; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).GetInfo)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(rgeinfotype)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(prginfo))).ok()
+    pub unsafe fn GetInfo(&self, cinfo: u32, rgeinfotype: *const u32, prginfo: *mut *mut DCINFO) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).GetInfo)(::core::mem::transmute_copy(self), ::core::mem::transmute(cinfo), ::core::mem::transmute(rgeinfotype), ::core::mem::transmute(prginfo)).ok()
     }
     #[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -17519,8 +17519,8 @@ impl IScopedOperations {
         (::windows::core::Interface::vtable(self).Move)(::core::mem::transmute_copy(self), ::core::mem::transmute(crows), ::core::mem::transmute(rgpwszsourceurls), ::core::mem::transmute(rgpwszdesturls), ::core::mem::transmute(dwmoveflags), pauthenticate.into_param().abi(), ::core::mem::transmute(rgdwstatus), ::core::mem::transmute(rgpwsznewurls), ::core::mem::transmute(ppstringsbuffer)).ok()
     }
     #[doc = "*Required features: `\"Win32_System_Search\"`*"]
-    pub unsafe fn Delete<'a, const PARAM0: usize>(&self, rgpwszurls: &[::windows::core::PWSTR; PARAM0], dwdeleteflags: u32, rgdwstatus: &mut [u32; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).Delete)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(rgpwszurls)), ::core::mem::transmute(dwdeleteflags), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(rgdwstatus))).ok()
+    pub unsafe fn Delete(&self, crows: usize, rgpwszurls: *const ::windows::core::PWSTR, dwdeleteflags: u32, rgdwstatus: *mut u32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).Delete)(::core::mem::transmute_copy(self), ::core::mem::transmute(crows), ::core::mem::transmute(rgpwszurls), ::core::mem::transmute(dwdeleteflags), ::core::mem::transmute(rgdwstatus)).ok()
     }
     #[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_Storage_IndexServer\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_Storage_IndexServer", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
@@ -18355,8 +18355,8 @@ impl ISearchItemsChangedSink {
     }
     #[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_System_Com\"`*"]
     #[cfg(feature = "Win32_System_Com")]
-    pub unsafe fn OnItemsChanged<'a, const PARAM0: usize>(&self, rgdatachangeentries: &[SEARCH_ITEM_CHANGE; PARAM0], rgdwdocids: &mut [u32; PARAM0], rghrcompletioncodes: &mut [::windows::core::HRESULT; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).OnItemsChanged)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(rgdatachangeentries)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(rgdwdocids)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(rghrcompletioncodes))).ok()
+    pub unsafe fn OnItemsChanged(&self, dwnumberofchanges: u32, rgdatachangeentries: *const SEARCH_ITEM_CHANGE, rgdwdocids: *mut u32, rghrcompletioncodes: *mut ::windows::core::HRESULT) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).OnItemsChanged)(::core::mem::transmute_copy(self), ::core::mem::transmute(dwnumberofchanges), ::core::mem::transmute(rgdatachangeentries), ::core::mem::transmute(rgdwdocids), ::core::mem::transmute(rghrcompletioncodes)).ok()
     }
 }
 impl ::core::convert::From<ISearchItemsChangedSink> for ::windows::core::IUnknown {
@@ -18854,8 +18854,8 @@ impl ISearchPersistentItemsChangedSink {
         (::windows::core::Interface::vtable(self).StoppedMonitoringScope)(::core::mem::transmute_copy(self), pszurl.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_System_Search\"`*"]
-    pub unsafe fn OnItemsChanged<'a, const PARAM0: usize>(&self, datachangeentries: &[SEARCH_ITEM_PERSISTENT_CHANGE; PARAM0], hrcompletioncodes: &mut [::windows::core::HRESULT; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).OnItemsChanged)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(datachangeentries)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(hrcompletioncodes))).ok()
+    pub unsafe fn OnItemsChanged(&self, dwnumberofchanges: u32, datachangeentries: *const SEARCH_ITEM_PERSISTENT_CHANGE, hrcompletioncodes: *mut ::windows::core::HRESULT) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).OnItemsChanged)(::core::mem::transmute_copy(self), ::core::mem::transmute(dwnumberofchanges), ::core::mem::transmute(datachangeentries), ::core::mem::transmute(hrcompletioncodes)).ok()
     }
 }
 impl ::core::convert::From<ISearchPersistentItemsChangedSink> for ::windows::core::IUnknown {
@@ -19234,8 +19234,8 @@ impl ISearchQueryHelper {
     }
     #[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`, `\"Win32_UI_Shell_PropertiesSystem\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage", feature = "Win32_UI_Shell_PropertiesSystem"))]
-    pub unsafe fn WriteProperties<'a, const PARAM1: usize>(&self, itemid: i32, pcolumns: &[super::super::UI::Shell::PropertiesSystem::PROPERTYKEY; PARAM1], pvalues: &[SEARCH_COLUMN_PROPERTIES; PARAM1], pftgathermodifiedtime: *const super::super::Foundation::FILETIME) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).WriteProperties)(::core::mem::transmute_copy(self), ::core::mem::transmute(itemid), PARAM1 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(pcolumns)), ::core::mem::transmute(::windows::core::as_ptr_or_null(pvalues)), ::core::mem::transmute(pftgathermodifiedtime)).ok()
+    pub unsafe fn WriteProperties(&self, itemid: i32, dwnumberofcolumns: u32, pcolumns: *const super::super::UI::Shell::PropertiesSystem::PROPERTYKEY, pvalues: *const SEARCH_COLUMN_PROPERTIES, pftgathermodifiedtime: *const super::super::Foundation::FILETIME) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).WriteProperties)(::core::mem::transmute_copy(self), ::core::mem::transmute(itemid), ::core::mem::transmute(dwnumberofcolumns), ::core::mem::transmute(pcolumns), ::core::mem::transmute(pvalues), ::core::mem::transmute(pftgathermodifiedtime)).ok()
     }
     #[doc = "*Required features: `\"Win32_System_Search\"`*"]
     pub unsafe fn SetQueryMaxResults(&self, cmaxresults: i32) -> ::windows::core::Result<()> {
@@ -20142,13 +20142,13 @@ impl ISubscriptionItem {
     }
     #[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-    pub unsafe fn ReadProperties<'a, const PARAM0: usize>(&self, rgwszname: &[::windows::core::PWSTR; PARAM0], rgvalue: &mut [super::Com::VARIANT; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).ReadProperties)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(rgwszname)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(rgvalue))).ok()
+    pub unsafe fn ReadProperties(&self, ncount: u32, rgwszname: *const ::windows::core::PWSTR, rgvalue: *mut super::Com::VARIANT) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).ReadProperties)(::core::mem::transmute_copy(self), ::core::mem::transmute(ncount), ::core::mem::transmute(rgwszname), ::core::mem::transmute(rgvalue)).ok()
     }
     #[doc = "*Required features: `\"Win32_System_Search\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com\"`, `\"Win32_System_Ole\"`*"]
     #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com", feature = "Win32_System_Ole"))]
-    pub unsafe fn WriteProperties<'a, const PARAM0: usize>(&self, rgwszname: &[::windows::core::PWSTR; PARAM0], rgvalue: &[super::Com::VARIANT; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).WriteProperties)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(rgwszname)), ::core::mem::transmute(::windows::core::as_ptr_or_null(rgvalue))).ok()
+    pub unsafe fn WriteProperties(&self, ncount: u32, rgwszname: *const ::windows::core::PWSTR, rgvalue: *const super::Com::VARIANT) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).WriteProperties)(::core::mem::transmute_copy(self), ::core::mem::transmute(ncount), ::core::mem::transmute(rgwszname), ::core::mem::transmute(rgvalue)).ok()
     }
     #[doc = "*Required features: `\"Win32_System_Search\"`*"]
     pub unsafe fn EnumProperties(&self) -> ::windows::core::Result<IEnumItemProperties> {
@@ -20391,8 +20391,8 @@ impl ISubscriptionMgr2 {
         (::windows::core::Interface::vtable(self).GetItemFromCookie)(::core::mem::transmute_copy(self), ::core::mem::transmute(psubscriptioncookie), ::core::mem::transmute(&mut result__)).from_abi::<ISubscriptionItem>(result__)
     }
     #[doc = "*Required features: `\"Win32_System_Search\"`*"]
-    pub unsafe fn GetSubscriptionRunState<'a, const PARAM0: usize>(&self, pcookies: &[::windows::core::GUID; PARAM0], pdwrunstate: &mut [u32; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).GetSubscriptionRunState)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(pcookies)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(pdwrunstate))).ok()
+    pub unsafe fn GetSubscriptionRunState(&self, dwnumcookies: u32, pcookies: *const ::windows::core::GUID, pdwrunstate: *mut u32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).GetSubscriptionRunState)(::core::mem::transmute_copy(self), ::core::mem::transmute(dwnumcookies), ::core::mem::transmute(pcookies), ::core::mem::transmute(pdwrunstate)).ok()
     }
     #[doc = "*Required features: `\"Win32_System_Search\"`*"]
     pub unsafe fn EnumSubscriptions(&self, dwflags: u32) -> ::windows::core::Result<IEnumSubscription> {
@@ -22429,8 +22429,8 @@ impl IViewSort {
         (::windows::core::Interface::vtable(self).GetSortOrder)(::core::mem::transmute_copy(self), ::core::mem::transmute(pcvalues), ::core::mem::transmute(prgcolumns), ::core::mem::transmute(prgorders)).ok()
     }
     #[doc = "*Required features: `\"Win32_System_Search\"`*"]
-    pub unsafe fn SetSortOrder<'a, const PARAM0: usize>(&self, rgcolumns: &[usize; PARAM0], rgorders: &[u32; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).SetSortOrder)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(rgcolumns)), ::core::mem::transmute(::windows::core::as_ptr_or_null(rgorders))).ok()
+    pub unsafe fn SetSortOrder(&self, cvalues: usize, rgcolumns: *const usize, rgorders: *const u32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).SetSortOrder)(::core::mem::transmute_copy(self), ::core::mem::transmute(cvalues), ::core::mem::transmute(rgcolumns), ::core::mem::transmute(rgorders)).ok()
     }
 }
 impl ::core::convert::From<IViewSort> for ::windows::core::IUnknown {

--- a/crates/libs/windows/src/Windows/Win32/System/ServerBackup/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ServerBackup/mod.rs
@@ -65,9 +65,9 @@ pub struct IWsbApplicationAsync_Vtbl {
 pub struct IWsbApplicationBackupSupport(::windows::core::IUnknown);
 impl IWsbApplicationBackupSupport {
     #[doc = "*Required features: `\"Win32_System_ServerBackup\"`*"]
-    pub unsafe fn CheckConsistency<'a, Param0: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>, Param1: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>, Param2: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>, const PARAM3: usize>(&self, wszwritermetadata: Param0, wszcomponentname: Param1, wszcomponentlogicalpath: Param2, rgwszsourcevolumepath: &[::windows::core::PWSTR; PARAM3], rgwszsnapshotvolumepath: &[::windows::core::PWSTR; PARAM3]) -> ::windows::core::Result<IWsbApplicationAsync> {
+    pub unsafe fn CheckConsistency<'a, Param0: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>, Param1: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>, Param2: ::windows::core::IntoParam<'a, ::windows::core::PCWSTR>>(&self, wszwritermetadata: Param0, wszcomponentname: Param1, wszcomponentlogicalpath: Param2, cvolumes: u32, rgwszsourcevolumepath: *const ::windows::core::PWSTR, rgwszsnapshotvolumepath: *const ::windows::core::PWSTR) -> ::windows::core::Result<IWsbApplicationAsync> {
         let mut result__: ::windows::core::RawPtr = ::core::mem::zeroed();
-        (::windows::core::Interface::vtable(self).CheckConsistency)(::core::mem::transmute_copy(self), wszwritermetadata.into_param().abi(), wszcomponentname.into_param().abi(), wszcomponentlogicalpath.into_param().abi(), PARAM3 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(rgwszsourcevolumepath)), ::core::mem::transmute(::windows::core::as_ptr_or_null(rgwszsnapshotvolumepath)), ::core::mem::transmute(&mut result__)).from_abi::<IWsbApplicationAsync>(result__)
+        (::windows::core::Interface::vtable(self).CheckConsistency)(::core::mem::transmute_copy(self), wszwritermetadata.into_param().abi(), wszcomponentname.into_param().abi(), wszcomponentlogicalpath.into_param().abi(), ::core::mem::transmute(cvolumes), ::core::mem::transmute(rgwszsourcevolumepath), ::core::mem::transmute(rgwszsnapshotvolumepath), ::core::mem::transmute(&mut result__)).from_abi::<IWsbApplicationAsync>(result__)
     }
 }
 impl ::core::convert::From<IWsbApplicationBackupSupport> for ::windows::core::IUnknown {
@@ -131,8 +131,8 @@ impl IWsbApplicationRestoreSupport {
         (::windows::core::Interface::vtable(self).PostRestore)(::core::mem::transmute_copy(self), wszwritermetadata.into_param().abi(), wszcomponentname.into_param().abi(), wszcomponentlogicalpath.into_param().abi(), bnorollforward.into_param().abi()).ok()
     }
     #[doc = "*Required features: `\"Win32_System_ServerBackup\"`*"]
-    pub unsafe fn OrderComponents<'a, const PARAM0: usize>(&self, rgcomponentname: &[::windows::core::PWSTR; PARAM0], rgcomponentlogicalpaths: &[::windows::core::PWSTR; PARAM0], prgcomponentname: &mut [*mut ::windows::core::PWSTR; PARAM0], prgcomponentlogicalpath: &mut [*mut ::windows::core::PWSTR; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).OrderComponents)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(rgcomponentname)), ::core::mem::transmute(::windows::core::as_ptr_or_null(rgcomponentlogicalpaths)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(prgcomponentname)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(prgcomponentlogicalpath))).ok()
+    pub unsafe fn OrderComponents(&self, ccomponents: u32, rgcomponentname: *const ::windows::core::PWSTR, rgcomponentlogicalpaths: *const ::windows::core::PWSTR, prgcomponentname: *mut *mut ::windows::core::PWSTR, prgcomponentlogicalpath: *mut *mut ::windows::core::PWSTR) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).OrderComponents)(::core::mem::transmute_copy(self), ::core::mem::transmute(ccomponents), ::core::mem::transmute(rgcomponentname), ::core::mem::transmute(rgcomponentlogicalpaths), ::core::mem::transmute(prgcomponentname), ::core::mem::transmute(prgcomponentlogicalpath)).ok()
     }
     #[doc = "*Required features: `\"Win32_System_ServerBackup\"`*"]
     pub unsafe fn IsRollForwardSupported(&self) -> ::windows::core::Result<u8> {

--- a/crates/libs/windows/src/Windows/Win32/System/WinRT/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/WinRT/mod.rs
@@ -3962,7 +3962,7 @@ pub unsafe fn RoParameterizedTypeExtraGetTypeSignature<'a, Param0: ::windows::co
 }
 #[doc = "*Required features: `\"Win32_System_WinRT\"`*"]
 #[inline]
-pub unsafe fn RoRegisterActivationFactories<'a, const PARAM2: usize>(activatableclassids: &[::windows::core::HSTRING; PARAM2], activationfactorycallbacks: &[isize; PARAM2]) -> ::windows::core::Result<isize> {
+pub unsafe fn RoRegisterActivationFactories(activatableclassids: *const ::windows::core::HSTRING, activationfactorycallbacks: *const isize, count: u32) -> ::windows::core::Result<isize> {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
@@ -3970,7 +3970,7 @@ pub unsafe fn RoRegisterActivationFactories<'a, const PARAM2: usize>(activatable
             fn RoRegisterActivationFactories(activatableclassids: *const ::core::mem::ManuallyDrop<::windows::core::HSTRING>, activationfactorycallbacks: *const isize, count: u32, cookie: *mut isize) -> ::windows::core::HRESULT;
         }
         let mut result__: isize = ::core::mem::zeroed();
-        RoRegisterActivationFactories(::core::mem::transmute(::windows::core::as_ptr_or_null(activatableclassids)), ::core::mem::transmute(::windows::core::as_ptr_or_null(activationfactorycallbacks)), PARAM2 as _, ::core::mem::transmute(&mut result__)).from_abi::<isize>(result__)
+        RoRegisterActivationFactories(::core::mem::transmute(activatableclassids), ::core::mem::transmute(activationfactorycallbacks), ::core::mem::transmute(count), ::core::mem::transmute(&mut result__)).from_abi::<isize>(result__)
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");

--- a/crates/libs/windows/src/Windows/Win32/System/Wmi/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/Wmi/mod.rs
@@ -6207,8 +6207,8 @@ pub struct IWbemEventSink_Vtbl {
 pub struct IWbemHiPerfEnum(::windows::core::IUnknown);
 impl IWbemHiPerfEnum {
     #[doc = "*Required features: `\"Win32_System_Wmi\"`*"]
-    pub unsafe fn AddObjects<'a, const PARAM1: usize>(&self, lflags: i32, apids: &[i32; PARAM1], apobj: &[::core::option::Option<IWbemObjectAccess>; PARAM1]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).AddObjects)(::core::mem::transmute_copy(self), ::core::mem::transmute(lflags), PARAM1 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(apids)), ::core::mem::transmute(::windows::core::as_ptr_or_null(apobj))).ok()
+    pub unsafe fn AddObjects(&self, lflags: i32, unumobjects: u32, apids: *const i32, apobj: *const ::core::option::Option<IWbemObjectAccess>) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).AddObjects)(::core::mem::transmute_copy(self), ::core::mem::transmute(lflags), ::core::mem::transmute(unumobjects), ::core::mem::transmute(apids), ::core::mem::transmute(apobj)).ok()
     }
     #[doc = "*Required features: `\"Win32_System_Wmi\"`*"]
     pub unsafe fn RemoveObjects(&self, lflags: i32, apids: &[i32]) -> ::windows::core::Result<()> {

--- a/crates/libs/windows/src/Windows/Win32/UI/Animation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Animation/mod.rs
@@ -98,8 +98,8 @@ impl IUIAnimationInterpolator2 {
         (::windows::core::Interface::vtable(self).GetDimension)(::core::mem::transmute_copy(self), ::core::mem::transmute(&mut result__)).from_abi::<u32>(result__)
     }
     #[doc = "*Required features: `\"Win32_UI_Animation\"`*"]
-    pub unsafe fn SetInitialValueAndVelocity<'a, const PARAM2: usize>(&self, initialvalue: &[f64; PARAM2], initialvelocity: &[f64; PARAM2]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).SetInitialValueAndVelocity)(::core::mem::transmute_copy(self), ::core::mem::transmute(::windows::core::as_ptr_or_null(initialvalue)), ::core::mem::transmute(::windows::core::as_ptr_or_null(initialvelocity)), PARAM2 as _).ok()
+    pub unsafe fn SetInitialValueAndVelocity(&self, initialvalue: *const f64, initialvelocity: *const f64, cdimension: u32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).SetInitialValueAndVelocity)(::core::mem::transmute_copy(self), ::core::mem::transmute(initialvalue), ::core::mem::transmute(initialvelocity), ::core::mem::transmute(cdimension)).ok()
     }
     #[doc = "*Required features: `\"Win32_UI_Animation\"`*"]
     pub unsafe fn SetDuration(&self, duration: f64) -> ::windows::core::Result<()> {
@@ -1990,9 +1990,9 @@ impl IUIAnimationTransitionLibrary2 {
         (::windows::core::Interface::vtable(self).CreateCubicTransition)(::core::mem::transmute_copy(self), ::core::mem::transmute(duration), ::core::mem::transmute(finalvalue), ::core::mem::transmute(finalvelocity), ::core::mem::transmute(&mut result__)).from_abi::<IUIAnimationTransition2>(result__)
     }
     #[doc = "*Required features: `\"Win32_UI_Animation\"`*"]
-    pub unsafe fn CreateCubicVectorTransition<'a, const PARAM3: usize>(&self, duration: f64, finalvalue: &[f64; PARAM3], finalvelocity: &[f64; PARAM3]) -> ::windows::core::Result<IUIAnimationTransition2> {
+    pub unsafe fn CreateCubicVectorTransition(&self, duration: f64, finalvalue: *const f64, finalvelocity: *const f64, cdimension: u32) -> ::windows::core::Result<IUIAnimationTransition2> {
         let mut result__: ::windows::core::RawPtr = ::core::mem::zeroed();
-        (::windows::core::Interface::vtable(self).CreateCubicVectorTransition)(::core::mem::transmute_copy(self), ::core::mem::transmute(duration), ::core::mem::transmute(::windows::core::as_ptr_or_null(finalvalue)), ::core::mem::transmute(::windows::core::as_ptr_or_null(finalvelocity)), PARAM3 as _, ::core::mem::transmute(&mut result__)).from_abi::<IUIAnimationTransition2>(result__)
+        (::windows::core::Interface::vtable(self).CreateCubicVectorTransition)(::core::mem::transmute_copy(self), ::core::mem::transmute(duration), ::core::mem::transmute(finalvalue), ::core::mem::transmute(finalvelocity), ::core::mem::transmute(cdimension), ::core::mem::transmute(&mut result__)).from_abi::<IUIAnimationTransition2>(result__)
     }
     #[doc = "*Required features: `\"Win32_UI_Animation\"`*"]
     pub unsafe fn CreateSmoothStopTransition(&self, maximumduration: f64, finalvalue: f64) -> ::windows::core::Result<IUIAnimationTransition2> {
@@ -2470,8 +2470,8 @@ pub struct IUIAnimationVariableChangeHandler_Vtbl {
 pub struct IUIAnimationVariableChangeHandler2(::windows::core::IUnknown);
 impl IUIAnimationVariableChangeHandler2 {
     #[doc = "*Required features: `\"Win32_UI_Animation\"`*"]
-    pub unsafe fn OnValueChanged<'a, Param0: ::windows::core::IntoParam<'a, IUIAnimationStoryboard2>, Param1: ::windows::core::IntoParam<'a, IUIAnimationVariable2>, const PARAM4: usize>(&self, storyboard: Param0, variable: Param1, newvalue: &[f64; PARAM4], previousvalue: &[f64; PARAM4]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).OnValueChanged)(::core::mem::transmute_copy(self), storyboard.into_param().abi(), variable.into_param().abi(), ::core::mem::transmute(::windows::core::as_ptr_or_null(newvalue)), ::core::mem::transmute(::windows::core::as_ptr_or_null(previousvalue)), PARAM4 as _).ok()
+    pub unsafe fn OnValueChanged<'a, Param0: ::windows::core::IntoParam<'a, IUIAnimationStoryboard2>, Param1: ::windows::core::IntoParam<'a, IUIAnimationVariable2>>(&self, storyboard: Param0, variable: Param1, newvalue: *const f64, previousvalue: *const f64, cdimension: u32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).OnValueChanged)(::core::mem::transmute_copy(self), storyboard.into_param().abi(), variable.into_param().abi(), ::core::mem::transmute(newvalue), ::core::mem::transmute(previousvalue), ::core::mem::transmute(cdimension)).ok()
     }
 }
 impl ::core::convert::From<IUIAnimationVariableChangeHandler2> for ::windows::core::IUnknown {
@@ -2635,8 +2635,8 @@ pub struct IUIAnimationVariableIntegerChangeHandler_Vtbl {
 pub struct IUIAnimationVariableIntegerChangeHandler2(::windows::core::IUnknown);
 impl IUIAnimationVariableIntegerChangeHandler2 {
     #[doc = "*Required features: `\"Win32_UI_Animation\"`*"]
-    pub unsafe fn OnIntegerValueChanged<'a, Param0: ::windows::core::IntoParam<'a, IUIAnimationStoryboard2>, Param1: ::windows::core::IntoParam<'a, IUIAnimationVariable2>, const PARAM4: usize>(&self, storyboard: Param0, variable: Param1, newvalue: &[i32; PARAM4], previousvalue: &[i32; PARAM4]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).OnIntegerValueChanged)(::core::mem::transmute_copy(self), storyboard.into_param().abi(), variable.into_param().abi(), ::core::mem::transmute(::windows::core::as_ptr_or_null(newvalue)), ::core::mem::transmute(::windows::core::as_ptr_or_null(previousvalue)), PARAM4 as _).ok()
+    pub unsafe fn OnIntegerValueChanged<'a, Param0: ::windows::core::IntoParam<'a, IUIAnimationStoryboard2>, Param1: ::windows::core::IntoParam<'a, IUIAnimationVariable2>>(&self, storyboard: Param0, variable: Param1, newvalue: *const i32, previousvalue: *const i32, cdimension: u32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).OnIntegerValueChanged)(::core::mem::transmute_copy(self), storyboard.into_param().abi(), variable.into_param().abi(), ::core::mem::transmute(newvalue), ::core::mem::transmute(previousvalue), ::core::mem::transmute(cdimension)).ok()
     }
 }
 impl ::core::convert::From<IUIAnimationVariableIntegerChangeHandler2> for ::windows::core::IUnknown {

--- a/crates/libs/windows/src/Windows/Win32/UI/ColorSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/ColorSystem/mod.rs
@@ -183,14 +183,14 @@ pub const CATID_WcsPlugin: ::windows::core::GUID = ::windows::core::GUID::from_u
 #[doc = "*Required features: `\"Win32_UI_ColorSystem\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
-pub unsafe fn CMCheckColors<'a, const PARAM2: usize>(hcmtransform: isize, lpainputcolors: &[COLOR; PARAM2], ctinput: COLORTYPE, lparesult: &mut [u8; PARAM2]) -> super::super::Foundation::BOOL {
+pub unsafe fn CMCheckColors(hcmtransform: isize, lpainputcolors: *const COLOR, ncolors: u32, ctinput: COLORTYPE, lparesult: *mut u8) -> super::super::Foundation::BOOL {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn CMCheckColors(hcmtransform: isize, lpainputcolors: *const COLOR, ncolors: u32, ctinput: COLORTYPE, lparesult: *mut u8) -> super::super::Foundation::BOOL;
         }
-        ::core::mem::transmute(CMCheckColors(::core::mem::transmute(hcmtransform), ::core::mem::transmute(::windows::core::as_ptr_or_null(lpainputcolors)), PARAM2 as _, ::core::mem::transmute(ctinput), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(lparesult))))
+        ::core::mem::transmute(CMCheckColors(::core::mem::transmute(hcmtransform), ::core::mem::transmute(lpainputcolors), ::core::mem::transmute(ncolors), ::core::mem::transmute(ctinput), ::core::mem::transmute(lparesult)))
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
@@ -228,14 +228,14 @@ pub unsafe fn CMCheckRGBs<'a, Param8: ::windows::core::IntoParam<'a, super::supe
 #[doc = "*Required features: `\"Win32_UI_ColorSystem\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
-pub unsafe fn CMConvertColorNameToIndex<'a, const PARAM3: usize>(hprofile: isize, pacolorname: &[*const i8; PARAM3], paindex: &mut [u32; PARAM3]) -> super::super::Foundation::BOOL {
+pub unsafe fn CMConvertColorNameToIndex(hprofile: isize, pacolorname: *const *const i8, paindex: *mut u32, dwcount: u32) -> super::super::Foundation::BOOL {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn CMConvertColorNameToIndex(hprofile: isize, pacolorname: *const *const i8, paindex: *mut u32, dwcount: u32) -> super::super::Foundation::BOOL;
         }
-        ::core::mem::transmute(CMConvertColorNameToIndex(::core::mem::transmute(hprofile), ::core::mem::transmute(::windows::core::as_ptr_or_null(pacolorname)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(paindex)), PARAM3 as _))
+        ::core::mem::transmute(CMConvertColorNameToIndex(::core::mem::transmute(hprofile), ::core::mem::transmute(pacolorname), ::core::mem::transmute(paindex), ::core::mem::transmute(dwcount)))
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
@@ -243,14 +243,14 @@ pub unsafe fn CMConvertColorNameToIndex<'a, const PARAM3: usize>(hprofile: isize
 #[doc = "*Required features: `\"Win32_UI_ColorSystem\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
-pub unsafe fn CMConvertIndexToColorName<'a, const PARAM3: usize>(hprofile: isize, paindex: &[u32; PARAM3], pacolorname: &mut [*mut i8; PARAM3]) -> super::super::Foundation::BOOL {
+pub unsafe fn CMConvertIndexToColorName(hprofile: isize, paindex: *const u32, pacolorname: *mut *mut i8, dwcount: u32) -> super::super::Foundation::BOOL {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn CMConvertIndexToColorName(hprofile: isize, paindex: *const u32, pacolorname: *mut *mut i8, dwcount: u32) -> super::super::Foundation::BOOL;
         }
-        ::core::mem::transmute(CMConvertIndexToColorName(::core::mem::transmute(hprofile), ::core::mem::transmute(::windows::core::as_ptr_or_null(paindex)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(pacolorname)), PARAM3 as _))
+        ::core::mem::transmute(CMConvertIndexToColorName(::core::mem::transmute(hprofile), ::core::mem::transmute(paindex), ::core::mem::transmute(pacolorname), ::core::mem::transmute(dwcount)))
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
@@ -486,14 +486,14 @@ pub const CMS_USEHOOK: u32 = 128u32;
 #[doc = "*Required features: `\"Win32_UI_ColorSystem\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
-pub unsafe fn CMTranslateColors<'a, const PARAM2: usize>(hcmtransform: isize, lpainputcolors: &[COLOR; PARAM2], ctinput: COLORTYPE, lpaoutputcolors: &mut [COLOR; PARAM2], ctoutput: COLORTYPE) -> super::super::Foundation::BOOL {
+pub unsafe fn CMTranslateColors(hcmtransform: isize, lpainputcolors: *const COLOR, ncolors: u32, ctinput: COLORTYPE, lpaoutputcolors: *mut COLOR, ctoutput: COLORTYPE) -> super::super::Foundation::BOOL {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn CMTranslateColors(hcmtransform: isize, lpainputcolors: *const COLOR, ncolors: u32, ctinput: COLORTYPE, lpaoutputcolors: *mut COLOR, ctoutput: COLORTYPE) -> super::super::Foundation::BOOL;
         }
-        ::core::mem::transmute(CMTranslateColors(::core::mem::transmute(hcmtransform), ::core::mem::transmute(::windows::core::as_ptr_or_null(lpainputcolors)), PARAM2 as _, ::core::mem::transmute(ctinput), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(lpaoutputcolors)), ::core::mem::transmute(ctoutput)))
+        ::core::mem::transmute(CMTranslateColors(::core::mem::transmute(hcmtransform), ::core::mem::transmute(lpainputcolors), ::core::mem::transmute(ncolors), ::core::mem::transmute(ctinput), ::core::mem::transmute(lpaoutputcolors), ::core::mem::transmute(ctoutput)))
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
@@ -1014,14 +1014,14 @@ pub unsafe fn CheckBitmapBits<'a, Param8: ::windows::core::IntoParam<'a, super::
 #[doc = "*Required features: `\"Win32_UI_ColorSystem\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
-pub unsafe fn CheckColors<'a, const PARAM2: usize>(hcolortransform: isize, painputcolors: &[COLOR; PARAM2], ctinput: COLORTYPE, paresult: &mut [u8; PARAM2]) -> super::super::Foundation::BOOL {
+pub unsafe fn CheckColors(hcolortransform: isize, painputcolors: *const COLOR, ncolors: u32, ctinput: COLORTYPE, paresult: *mut u8) -> super::super::Foundation::BOOL {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn CheckColors(hcolortransform: isize, painputcolors: *const COLOR, ncolors: u32, ctinput: COLORTYPE, paresult: *mut u8) -> super::super::Foundation::BOOL;
         }
-        ::core::mem::transmute(CheckColors(::core::mem::transmute(hcolortransform), ::core::mem::transmute(::windows::core::as_ptr_or_null(painputcolors)), PARAM2 as _, ::core::mem::transmute(ctinput), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(paresult))))
+        ::core::mem::transmute(CheckColors(::core::mem::transmute(hcolortransform), ::core::mem::transmute(painputcolors), ::core::mem::transmute(ncolors), ::core::mem::transmute(ctinput), ::core::mem::transmute(paresult)))
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
@@ -1181,14 +1181,14 @@ pub unsafe fn ColorProfileSetDisplayDefaultAssociation<'a, Param1: ::windows::co
 #[doc = "*Required features: `\"Win32_UI_ColorSystem\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
-pub unsafe fn ConvertColorNameToIndex<'a, const PARAM3: usize>(hprofile: isize, pacolorname: &[*const i8; PARAM3], paindex: &mut [u32; PARAM3]) -> super::super::Foundation::BOOL {
+pub unsafe fn ConvertColorNameToIndex(hprofile: isize, pacolorname: *const *const i8, paindex: *mut u32, dwcount: u32) -> super::super::Foundation::BOOL {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn ConvertColorNameToIndex(hprofile: isize, pacolorname: *const *const i8, paindex: *mut u32, dwcount: u32) -> super::super::Foundation::BOOL;
         }
-        ::core::mem::transmute(ConvertColorNameToIndex(::core::mem::transmute(hprofile), ::core::mem::transmute(::windows::core::as_ptr_or_null(pacolorname)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(paindex)), PARAM3 as _))
+        ::core::mem::transmute(ConvertColorNameToIndex(::core::mem::transmute(hprofile), ::core::mem::transmute(pacolorname), ::core::mem::transmute(paindex), ::core::mem::transmute(dwcount)))
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
@@ -1196,14 +1196,14 @@ pub unsafe fn ConvertColorNameToIndex<'a, const PARAM3: usize>(hprofile: isize, 
 #[doc = "*Required features: `\"Win32_UI_ColorSystem\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
-pub unsafe fn ConvertIndexToColorName<'a, const PARAM3: usize>(hprofile: isize, paindex: &[u32; PARAM3], pacolorname: &mut [*mut i8; PARAM3]) -> super::super::Foundation::BOOL {
+pub unsafe fn ConvertIndexToColorName(hprofile: isize, paindex: *const u32, pacolorname: *mut *mut i8, dwcount: u32) -> super::super::Foundation::BOOL {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn ConvertIndexToColorName(hprofile: isize, paindex: *const u32, pacolorname: *mut *mut i8, dwcount: u32) -> super::super::Foundation::BOOL;
         }
-        ::core::mem::transmute(ConvertIndexToColorName(::core::mem::transmute(hprofile), ::core::mem::transmute(::windows::core::as_ptr_or_null(paindex)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(pacolorname)), PARAM3 as _))
+        ::core::mem::transmute(ConvertIndexToColorName(::core::mem::transmute(hprofile), ::core::mem::transmute(paindex), ::core::mem::transmute(pacolorname), ::core::mem::transmute(dwcount)))
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");
@@ -2346,9 +2346,9 @@ impl IDeviceModelPlugIn {
     }
     #[doc = "*Required features: `\"Win32_UI_ColorSystem\"`, `\"Win32_Foundation\"`*"]
     #[cfg(feature = "Win32_Foundation")]
-    pub unsafe fn ColorimetricToDeviceColorsWithBlack<'a, const PARAM0: usize>(&self, cchannels: u32, pxyzcolors: &[XYZColorF; PARAM0], pblackinformation: &[BlackInformation; PARAM0]) -> ::windows::core::Result<f32> {
+    pub unsafe fn ColorimetricToDeviceColorsWithBlack(&self, ccolors: u32, cchannels: u32, pxyzcolors: *const XYZColorF, pblackinformation: *const BlackInformation) -> ::windows::core::Result<f32> {
         let mut result__: f32 = ::core::mem::zeroed();
-        (::windows::core::Interface::vtable(self).ColorimetricToDeviceColorsWithBlack)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(cchannels), ::core::mem::transmute(::windows::core::as_ptr_or_null(pxyzcolors)), ::core::mem::transmute(::windows::core::as_ptr_or_null(pblackinformation)), ::core::mem::transmute(&mut result__)).from_abi::<f32>(result__)
+        (::windows::core::Interface::vtable(self).ColorimetricToDeviceColorsWithBlack)(::core::mem::transmute_copy(self), ::core::mem::transmute(ccolors), ::core::mem::transmute(cchannels), ::core::mem::transmute(pxyzcolors), ::core::mem::transmute(pblackinformation), ::core::mem::transmute(&mut result__)).from_abi::<f32>(result__)
     }
     #[doc = "*Required features: `\"Win32_UI_ColorSystem\"`*"]
     pub unsafe fn SetTransformDeviceModelInfo<'a, Param1: ::windows::core::IntoParam<'a, IDeviceModelPlugIn>>(&self, imodelposition: u32, pidevicemodelother: Param1) -> ::windows::core::Result<()> {
@@ -2449,8 +2449,8 @@ impl IGamutMapModelPlugIn {
         (::windows::core::Interface::vtable(self).Initialize)(::core::mem::transmute_copy(self), bstrxml.into_param().abi(), psrcplugin.into_param().abi(), pdestplugin.into_param().abi(), ::core::mem::transmute(psrcgbd), ::core::mem::transmute(pdestgbd)).ok()
     }
     #[doc = "*Required features: `\"Win32_UI_ColorSystem\"`*"]
-    pub unsafe fn SourceToDestinationAppearanceColors<'a, const PARAM0: usize>(&self, pinputcolors: &[JChColorF; PARAM0], poutputcolors: &mut [JChColorF; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).SourceToDestinationAppearanceColors)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(pinputcolors)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(poutputcolors))).ok()
+    pub unsafe fn SourceToDestinationAppearanceColors(&self, ccolors: u32, pinputcolors: *const JChColorF, poutputcolors: *mut JChColorF) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).SourceToDestinationAppearanceColors)(::core::mem::transmute_copy(self), ::core::mem::transmute(ccolors), ::core::mem::transmute(pinputcolors), ::core::mem::transmute(poutputcolors)).ok()
     }
 }
 impl ::core::convert::From<IGamutMapModelPlugIn> for ::windows::core::IUnknown {
@@ -3352,14 +3352,14 @@ pub unsafe fn TranslateBitmapBits<'a, Param10: ::windows::core::IntoParam<'a, su
 #[doc = "*Required features: `\"Win32_UI_ColorSystem\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
-pub unsafe fn TranslateColors<'a, const PARAM2: usize>(hcolortransform: isize, painputcolors: &[COLOR; PARAM2], ctinput: COLORTYPE, paoutputcolors: &mut [COLOR; PARAM2], ctoutput: COLORTYPE) -> super::super::Foundation::BOOL {
+pub unsafe fn TranslateColors(hcolortransform: isize, painputcolors: *const COLOR, ncolors: u32, ctinput: COLORTYPE, paoutputcolors: *mut COLOR, ctoutput: COLORTYPE) -> super::super::Foundation::BOOL {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn TranslateColors(hcolortransform: isize, painputcolors: *const COLOR, ncolors: u32, ctinput: COLORTYPE, paoutputcolors: *mut COLOR, ctoutput: COLORTYPE) -> super::super::Foundation::BOOL;
         }
-        ::core::mem::transmute(TranslateColors(::core::mem::transmute(hcolortransform), ::core::mem::transmute(::windows::core::as_ptr_or_null(painputcolors)), PARAM2 as _, ::core::mem::transmute(ctinput), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(paoutputcolors)), ::core::mem::transmute(ctoutput)))
+        ::core::mem::transmute(TranslateColors(::core::mem::transmute(hcolortransform), ::core::mem::transmute(painputcolors), ::core::mem::transmute(ncolors), ::core::mem::transmute(ctinput), ::core::mem::transmute(paoutputcolors), ::core::mem::transmute(ctoutput)))
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");

--- a/crates/libs/windows/src/Windows/Win32/UI/Shell/PropertiesSystem/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/Shell/PropertiesSystem/mod.rs
@@ -6679,14 +6679,14 @@ pub unsafe fn SHPropStgReadMultiple<'a, Param0: ::windows::core::IntoParam<'a, s
 #[doc = "*Required features: `\"Win32_UI_Shell_PropertiesSystem\"`, `\"Win32_Foundation\"`, `\"Win32_System_Com_StructuredStorage\"`*"]
 #[cfg(all(feature = "Win32_Foundation", feature = "Win32_System_Com_StructuredStorage"))]
 #[inline]
-pub unsafe fn SHPropStgWriteMultiple<'a, Param0: ::windows::core::IntoParam<'a, super::super::super::System::Com::StructuredStorage::IPropertyStorage>, const PARAM2: usize>(pps: Param0, pucodepage: *mut u32, rgpspec: &[super::super::super::System::Com::StructuredStorage::PROPSPEC; PARAM2], rgvar: &mut [super::super::super::System::Com::StructuredStorage::PROPVARIANT; PARAM2], propidnamefirst: u32) -> ::windows::core::Result<()> {
+pub unsafe fn SHPropStgWriteMultiple<'a, Param0: ::windows::core::IntoParam<'a, super::super::super::System::Com::StructuredStorage::IPropertyStorage>>(pps: Param0, pucodepage: *mut u32, cpspec: u32, rgpspec: *const super::super::super::System::Com::StructuredStorage::PROPSPEC, rgvar: *mut super::super::super::System::Com::StructuredStorage::PROPVARIANT, propidnamefirst: u32) -> ::windows::core::Result<()> {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn SHPropStgWriteMultiple(pps: ::windows::core::RawPtr, pucodepage: *mut u32, cpspec: u32, rgpspec: *const super::super::super::System::Com::StructuredStorage::PROPSPEC, rgvar: *mut super::super::super::System::Com::StructuredStorage::PROPVARIANT, propidnamefirst: u32) -> ::windows::core::HRESULT;
         }
-        SHPropStgWriteMultiple(pps.into_param().abi(), ::core::mem::transmute(pucodepage), PARAM2 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(rgpspec)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(rgvar)), ::core::mem::transmute(propidnamefirst)).ok()
+        SHPropStgWriteMultiple(pps.into_param().abi(), ::core::mem::transmute(pucodepage), ::core::mem::transmute(cpspec), ::core::mem::transmute(rgpspec), ::core::mem::transmute(rgvar), ::core::mem::transmute(propidnamefirst)).ok()
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");

--- a/crates/libs/windows/src/Windows/Win32/UI/TextServices/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/TextServices/mod.rs
@@ -9877,8 +9877,8 @@ impl ITfLangBarItemMgr {
         (::windows::core::Interface::vtable(self).GetItemFloatingRect)(::core::mem::transmute_copy(self), ::core::mem::transmute(dwthreadid), ::core::mem::transmute(rguid), ::core::mem::transmute(&mut result__)).from_abi::<super::super::Foundation::RECT>(result__)
     }
     #[doc = "*Required features: `\"Win32_UI_TextServices\"`*"]
-    pub unsafe fn GetItemsStatus<'a, const PARAM0: usize>(&self, prgguid: &[::windows::core::GUID; PARAM0], pdwstatus: &mut [u32; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).GetItemsStatus)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(prgguid)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(pdwstatus))).ok()
+    pub unsafe fn GetItemsStatus(&self, ulcount: u32, prgguid: *const ::windows::core::GUID, pdwstatus: *mut u32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).GetItemsStatus)(::core::mem::transmute_copy(self), ::core::mem::transmute(ulcount), ::core::mem::transmute(prgguid), ::core::mem::transmute(pdwstatus)).ok()
     }
     #[doc = "*Required features: `\"Win32_UI_TextServices\"`*"]
     pub unsafe fn GetItemNum(&self) -> ::windows::core::Result<u32> {
@@ -9886,12 +9886,12 @@ impl ITfLangBarItemMgr {
         (::windows::core::Interface::vtable(self).GetItemNum)(::core::mem::transmute_copy(self), ::core::mem::transmute(&mut result__)).from_abi::<u32>(result__)
     }
     #[doc = "*Required features: `\"Win32_UI_TextServices\"`*"]
-    pub unsafe fn GetItems<'a, const PARAM0: usize>(&self, ppitem: &mut [::core::option::Option<ITfLangBarItem>; PARAM0], pinfo: &mut [TF_LANGBARITEMINFO; PARAM0], pdwstatus: &mut [u32; PARAM0], pcfetched: *mut u32) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).GetItems)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(ppitem)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(pinfo)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(pdwstatus)), ::core::mem::transmute(pcfetched)).ok()
+    pub unsafe fn GetItems(&self, ulcount: u32, ppitem: *mut ::core::option::Option<ITfLangBarItem>, pinfo: *mut TF_LANGBARITEMINFO, pdwstatus: *mut u32, pcfetched: *mut u32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).GetItems)(::core::mem::transmute_copy(self), ::core::mem::transmute(ulcount), ::core::mem::transmute(ppitem), ::core::mem::transmute(pinfo), ::core::mem::transmute(pdwstatus), ::core::mem::transmute(pcfetched)).ok()
     }
     #[doc = "*Required features: `\"Win32_UI_TextServices\"`*"]
-    pub unsafe fn AdviseItemsSink<'a, const PARAM0: usize>(&self, ppunk: &[::core::option::Option<ITfLangBarItemSink>; PARAM0], pguiditem: &[::windows::core::GUID; PARAM0], pdwcookie: &mut [u32; PARAM0]) -> ::windows::core::Result<()> {
-        (::windows::core::Interface::vtable(self).AdviseItemsSink)(::core::mem::transmute_copy(self), PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(ppunk)), ::core::mem::transmute(::windows::core::as_ptr_or_null(pguiditem)), ::core::mem::transmute(::windows::core::as_mut_ptr_or_null(pdwcookie))).ok()
+    pub unsafe fn AdviseItemsSink(&self, ulcount: u32, ppunk: *const ::core::option::Option<ITfLangBarItemSink>, pguiditem: *const ::windows::core::GUID, pdwcookie: *mut u32) -> ::windows::core::Result<()> {
+        (::windows::core::Interface::vtable(self).AdviseItemsSink)(::core::mem::transmute_copy(self), ::core::mem::transmute(ulcount), ::core::mem::transmute(ppunk), ::core::mem::transmute(pguiditem), ::core::mem::transmute(pdwcookie)).ok()
     }
     #[doc = "*Required features: `\"Win32_UI_TextServices\"`*"]
     pub unsafe fn UnadviseItemsSink(&self, pdwcookie: &[u32]) -> ::windows::core::Result<()> {

--- a/crates/libs/windows/src/Windows/Win32/UI/WindowsAndMessaging/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/UI/WindowsAndMessaging/mod.rs
@@ -13634,14 +13634,14 @@ pub unsafe fn SetPropW<'a, Param0: ::windows::core::IntoParam<'a, super::super::
 #[doc = "*Required features: `\"Win32_UI_WindowsAndMessaging\"`, `\"Win32_Foundation\"`*"]
 #[cfg(feature = "Win32_Foundation")]
 #[inline]
-pub unsafe fn SetSysColors<'a, const PARAM0: usize>(lpaelements: &[i32; PARAM0], lpargbvalues: &[u32; PARAM0]) -> super::super::Foundation::BOOL {
+pub unsafe fn SetSysColors(celements: i32, lpaelements: *const i32, lpargbvalues: *const u32) -> super::super::Foundation::BOOL {
     #[cfg(windows)]
     {
         #[link(name = "windows")]
         extern "system" {
             fn SetSysColors(celements: i32, lpaelements: *const i32, lpargbvalues: *const u32) -> super::super::Foundation::BOOL;
         }
-        ::core::mem::transmute(SetSysColors(PARAM0 as _, ::core::mem::transmute(::windows::core::as_ptr_or_null(lpaelements)), ::core::mem::transmute(::windows::core::as_ptr_or_null(lpargbvalues))))
+        ::core::mem::transmute(SetSysColors(::core::mem::transmute(celements), ::core::mem::transmute(lpaelements), ::core::mem::transmute(lpargbvalues)))
     }
     #[cfg(not(windows))]
     unimplemented!("Unsupported target OS");


### PR DESCRIPTION
This further restricts win32 array params to only those without a shared length param so that all such params can be served with Rust slices and do not require Rust arrays. 

Fixes #1638 