### PR TITLE
Use `BSTR` allocator as `PCSTR` and `PCWSTR` parameter allocator

### DIFF
--- a/crates/libs/bindgen/src/replacements/bstr.rs
+++ b/crates/libs/bindgen/src/replacements/bstr.rs
@@ -36,6 +36,14 @@ pub fn gen() -> TokenStream {
 
                 unsafe { ::core::slice::from_raw_parts(self.0, self.len()) }
             }
+
+            pub unsafe fn from_raw(raw: *const u16) -> Self {
+                Self(raw)
+            }
+
+            pub fn into_raw(self) -> *const u16 {
+                unsafe { std::mem::transmute(self) }
+            }
         }
         impl ::core::clone::Clone for BSTR {
             fn clone(&self) -> Self {

--- a/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Foundation/mod.rs
@@ -247,6 +247,12 @@ impl BSTR {
         }
         unsafe { ::core::slice::from_raw_parts(self.0, self.len()) }
     }
+    pub unsafe fn from_raw(raw: *const u16) -> Self {
+        Self(raw)
+    }
+    pub fn into_raw(self) -> *const u16 {
+        unsafe { std::mem::transmute(self) }
+    }
 }
 impl ::core::clone::Clone for BSTR {
     fn clone(&self) -> Self {

--- a/crates/libs/windows/src/core/bindings.rs
+++ b/crates/libs/windows/src/core/bindings.rs
@@ -1221,6 +1221,12 @@ impl BSTR {
         }
         unsafe { ::core::slice::from_raw_parts(self.0, self.len()) }
     }
+    pub unsafe fn from_raw(raw: *const u16) -> Self {
+        Self(raw)
+    }
+    pub fn into_raw(self) -> *const u16 {
+        unsafe { std::mem::transmute(self) }
+    }
 }
 impl ::core::clone::Clone for BSTR {
     fn clone(&self) -> Self {
@@ -1403,6 +1409,19 @@ unsafe impl ::windows::core::Abi for HINSTANCE {
     type Abi = Self;
 }
 pub const S_OK: ::windows::core::HRESULT = ::windows::core::HRESULT(0i32);
+#[inline]
+pub unsafe fn SysAllocStringByteLen<'a, Param0: ::windows::core::IntoParam<'a, ::windows::core::PCSTR>>(psz: Param0, len: u32) -> BSTR {
+    #[cfg(windows)]
+    {
+        #[link(name = "windows")]
+        extern "system" {
+            fn SysAllocStringByteLen(psz: ::windows::core::PCSTR, len: u32) -> BSTR;
+        }
+        ::core::mem::transmute(SysAllocStringByteLen(psz.into_param().abi(), ::core::mem::transmute(len)))
+    }
+    #[cfg(not(windows))]
+    unimplemented!("Unsupported target OS");
+}
 #[inline]
 pub unsafe fn SysAllocStringLen(strin: &[u16]) -> BSTR {
     #[cfg(windows)]

--- a/crates/libs/windows/src/core/pcstr.rs
+++ b/crates/libs/windows/src/core/pcstr.rs
@@ -46,6 +46,7 @@ unsafe impl Abi for PCSTR {
 #[cfg(feature = "alloc")]
 impl<'a> IntoParam<'a, PCSTR> for &str {
     fn into_param(self) -> Param<'a, PCSTR> {
+        // TODO: workaround for https://github.com/microsoft/win32metadata/issues/868
         unsafe { Param::Boxed(PCSTR(SysAllocStringByteLen(PCSTR(self.as_ptr()), self.len() as _).into_raw() as _)) }
     }
 }

--- a/crates/libs/windows/src/core/pcstr.rs
+++ b/crates/libs/windows/src/core/pcstr.rs
@@ -1,5 +1,4 @@
 use super::*;
-use bindings::*;
 
 /// A pointer to a constant null-terminated string of 8-bit Windows (ANSI) characters.
 #[repr(transparent)]
@@ -38,7 +37,7 @@ unsafe impl Abi for PCSTR {
     unsafe fn drop_param(param: &mut Param<'_, Self>) {
         if let Param::Boxed(value) = param {
             if !value.is_null() {
-                BSTR::from_raw(value.0 as _);
+                bindings::BSTR::from_raw(value.0 as _);
             }
         }
     }
@@ -47,7 +46,7 @@ unsafe impl Abi for PCSTR {
 impl<'a> IntoParam<'a, PCSTR> for &str {
     fn into_param(self) -> Param<'a, PCSTR> {
         // TODO: workaround for https://github.com/microsoft/win32metadata/issues/868
-        unsafe { Param::Boxed(PCSTR(SysAllocStringByteLen(PCSTR(self.as_ptr()), self.len() as _).into_raw() as _)) }
+        unsafe { Param::Boxed(PCSTR(bindings::SysAllocStringByteLen(PCSTR(self.as_ptr()), self.len() as _).into_raw() as _)) }
     }
 }
 #[cfg(feature = "alloc")]

--- a/crates/libs/windows/src/core/pcwstr.rs
+++ b/crates/libs/windows/src/core/pcwstr.rs
@@ -55,12 +55,14 @@ impl<'a> IntoParam<'a, PCWSTR> for alloc::string::String {
         IntoParam::into_param(self.as_str())
     }
 }
+#[cfg(feature = "alloc")]
 impl<'a> IntoParam<'a, PCWSTR> for &::std::ffi::OsStr {
     fn into_param(self) -> Param<'a, PCWSTR> {
         use ::std::os::windows::ffi::OsStrExt;
         unsafe { Param::Boxed(PCWSTR(SysAllocStringLen(&self.encode_wide().collect::<alloc::vec::Vec<u16>>()).into_raw())) }
     }
 }
+#[cfg(feature = "alloc")]
 impl<'a> IntoParam<'a, PCWSTR> for ::std::ffi::OsString {
     fn into_param(self) -> Param<'a, PCWSTR> {
         IntoParam::into_param(self.as_os_str())

--- a/crates/libs/windows/src/core/pcwstr.rs
+++ b/crates/libs/windows/src/core/pcwstr.rs
@@ -1,4 +1,5 @@
 use super::*;
+use bindings::*;
 
 /// A pointer to a constant null-terminated string of 16-bit Unicode characters.
 #[repr(transparent)]
@@ -37,7 +38,7 @@ unsafe impl Abi for PCWSTR {
     unsafe fn drop_param(param: &mut Param<'_, Self>) {
         if let Param::Boxed(value) = param {
             if !value.is_null() {
-                alloc::boxed::Box::from_raw(value.0 as *mut u16);
+                BSTR::from_raw(value.0);
             }
         }
     }
@@ -45,7 +46,7 @@ unsafe impl Abi for PCWSTR {
 #[cfg(feature = "alloc")]
 impl<'a> IntoParam<'a, PCWSTR> for &str {
     fn into_param(self) -> Param<'a, PCWSTR> {
-        Param::Boxed(PCWSTR(alloc::boxed::Box::<[u16]>::into_raw(self.encode_utf16().chain(::core::iter::once(0)).collect::<alloc::vec::Vec<u16>>().into_boxed_slice()) as _))
+        unsafe { Param::Boxed(PCWSTR(SysAllocStringLen(&self.encode_utf16().collect::<alloc::vec::Vec<u16>>()).into_raw())) }
     }
 }
 #[cfg(feature = "alloc")]
@@ -57,7 +58,7 @@ impl<'a> IntoParam<'a, PCWSTR> for alloc::string::String {
 impl<'a> IntoParam<'a, PCWSTR> for &::std::ffi::OsStr {
     fn into_param(self) -> Param<'a, PCWSTR> {
         use ::std::os::windows::ffi::OsStrExt;
-        Param::Boxed(PCWSTR(alloc::boxed::Box::<[u16]>::into_raw(self.encode_wide().chain(::core::iter::once(0)).collect::<alloc::vec::Vec<u16>>().into_boxed_slice()) as _))
+        unsafe { Param::Boxed(PCWSTR(SysAllocStringLen(&self.encode_wide().collect::<alloc::vec::Vec<u16>>()).into_raw())) }
     }
 }
 impl<'a> IntoParam<'a, PCWSTR> for ::std::ffi::OsString {

--- a/crates/libs/windows/src/core/pcwstr.rs
+++ b/crates/libs/windows/src/core/pcwstr.rs
@@ -1,5 +1,4 @@
 use super::*;
-use bindings::*;
 
 /// A pointer to a constant null-terminated string of 16-bit Unicode characters.
 #[repr(transparent)]
@@ -38,7 +37,7 @@ unsafe impl Abi for PCWSTR {
     unsafe fn drop_param(param: &mut Param<'_, Self>) {
         if let Param::Boxed(value) = param {
             if !value.is_null() {
-                BSTR::from_raw(value.0);
+                bindings::BSTR::from_raw(value.0);
             }
         }
     }
@@ -46,7 +45,7 @@ unsafe impl Abi for PCWSTR {
 #[cfg(feature = "alloc")]
 impl<'a> IntoParam<'a, PCWSTR> for &str {
     fn into_param(self) -> Param<'a, PCWSTR> {
-        unsafe { Param::Boxed(PCWSTR(SysAllocStringLen(&self.encode_utf16().collect::<alloc::vec::Vec<u16>>()).into_raw())) }
+        unsafe { Param::Boxed(PCWSTR(bindings::SysAllocStringLen(&self.encode_utf16().collect::<alloc::vec::Vec<u16>>()).into_raw())) }
     }
 }
 #[cfg(feature = "alloc")]
@@ -59,7 +58,7 @@ impl<'a> IntoParam<'a, PCWSTR> for alloc::string::String {
 impl<'a> IntoParam<'a, PCWSTR> for &::std::ffi::OsStr {
     fn into_param(self) -> Param<'a, PCWSTR> {
         use ::std::os::windows::ffi::OsStrExt;
-        unsafe { Param::Boxed(PCWSTR(SysAllocStringLen(&self.encode_wide().collect::<alloc::vec::Vec<u16>>()).into_raw())) }
+        unsafe { Param::Boxed(PCWSTR(bindings::SysAllocStringLen(&self.encode_wide().collect::<alloc::vec::Vec<u16>>()).into_raw())) }
     }
 }
 #[cfg(feature = "alloc")]

--- a/crates/tests/win32_arrays/tests/fixed.rs
+++ b/crates/tests/win32_arrays/tests/fixed.rs
@@ -1,4 +1,4 @@
-use windows::{Win32::Storage::FileSystem::*, Win32::UI::Input::KeyboardAndMouse::*, Win32::Foundation::*};
+use windows::{Win32::Foundation::*, Win32::Storage::FileSystem::*, Win32::UI::Input::KeyboardAndMouse::*};
 
 #[test]
 fn keyboard_state() {

--- a/crates/tests/win32_arrays/tests/fixed.rs
+++ b/crates/tests/win32_arrays/tests/fixed.rs
@@ -1,4 +1,4 @@
-use windows::{Win32::Storage::FileSystem::*, Win32::UI::Input::KeyboardAndMouse::*};
+use windows::{Win32::Storage::FileSystem::*, Win32::UI::Input::KeyboardAndMouse::*, Win32::Foundation::*};
 
 #[test]
 fn keyboard_state() {
@@ -12,11 +12,21 @@ fn keyboard_state() {
 }
 
 #[test]
-fn temp_file() {
+fn temp_file_ansi() {
     unsafe {
         let mut buffer: [u8; 260] = std::mem::zeroed();
         let a = GetTempFileNameA(".", "test", 0x7b, &mut buffer);
         assert_eq!(a, 0x7b);
         assert_eq!(&buffer[..12], b".\\tes7B.tmp\0");
+    }
+}
+
+#[test]
+fn temp_file_wide() {
+    unsafe {
+        let mut buffer: [u16; 260] = std::mem::zeroed();
+        let a = GetTempFileNameW(".", "test", 0x7b, &mut buffer);
+        assert_eq!(a, 0x7b);
+        assert_eq!(SysAllocStringLen(&buffer[..12]), ".\\tes7B.tmp\0");
     }
 }

--- a/crates/tools/bindings/src/main.rs
+++ b/crates/tools/bindings/src/main.rs
@@ -23,6 +23,7 @@ fn main() -> std::io::Result<()> {
         "Windows.Win32.Foundation.HANDLE",
         "Windows.Win32.Foundation.HINSTANCE",
         "Windows.Win32.Foundation.S_OK",
+        "Windows.Win32.Foundation.SysAllocStringByteLen",
         "Windows.Win32.Foundation.SysAllocStringLen",
         "Windows.Win32.Foundation.SysFreeString",
         "Windows.Win32.Foundation.SysStringLen",


### PR DESCRIPTION
`BSTR`s are length-prefixed buffers so the pointer is sufficient to free the allocation. This makes it ideal for `PCSTR` and `PCWSTR` since they can only hold on to the pointer.

Fixes #1652 
Fixes #1601

This includes a workaround for https://github.com/microsoft/win32metadata/issues/868