### PR TITLE
Handle type mismatch with invalid handle values

### DIFF
--- a/crates/libs/bindgen/src/handles.rs
+++ b/crates/libs/bindgen/src/handles.rs
@@ -35,8 +35,13 @@ pub fn gen_win_handle(def: &TypeDef, gen: &Gen) -> TokenStream {
 
         if !invalid.is_empty() {
             let invalid = invalid.iter().map(|value| {
-                let value = Literal::i64_unsuffixed(*value);
-                quote! { self.0 == #value }
+                let literal = Literal::i64_unsuffixed(*value);
+
+                if *value < 0 && underlying_type.is_unsigned() {
+                    quote! { self.0 == #literal as _ }
+                } else {
+                    quote! { self.0 == #literal }
+                }
             });
             quote! {
                 impl #ident {

--- a/crates/libs/metadata/src/reader/type.rs
+++ b/crates/libs/metadata/src/reader/type.rs
@@ -212,6 +212,10 @@ impl Type {
         matches!(self, Self::ConstPtr(_) | Self::MutPtr(_))
     }
 
+    pub fn is_unsigned(&self) -> bool {
+        matches!(self, Self::U8 | Self::U16 | Self::U32 | Self::U64 | Self::USize)
+    }
+
     pub fn is_void(&self) -> bool {
         match self {
             // TODO: do we care about void behind pointers?

--- a/crates/libs/windows/src/Windows/Win32/Devices/Bluetooth/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/Devices/Bluetooth/mod.rs
@@ -3321,7 +3321,7 @@ pub const GenericTelephonyServiceClassID_UUID16: u32 = 4612u32;
 pub struct HANDLE_SDP_TYPE(pub u64);
 impl HANDLE_SDP_TYPE {
     pub fn is_invalid(&self) -> bool {
-        self.0 == -1 || self.0 == 0
+        self.0 == -1 as _ || self.0 == 0
     }
 }
 impl ::core::default::Default for HANDLE_SDP_TYPE {

--- a/crates/libs/windows/src/Windows/Win32/System/ApplicationInstallationAndServicing/mod.rs
+++ b/crates/libs/windows/src/Windows/Win32/System/ApplicationInstallationAndServicing/mod.rs
@@ -7947,7 +7947,7 @@ impl ::core::default::Default for MSIFILEHASHINFO {
 pub struct MSIHANDLE(pub u32);
 impl MSIHANDLE {
     pub fn is_invalid(&self) -> bool {
-        self.0 == -1 || self.0 == 0
+        self.0 == -1 as _ || self.0 == 0
     }
 }
 impl ::core::default::Default for MSIHANDLE {

--- a/crates/tests/handles/Cargo.toml
+++ b/crates/tests/handles/Cargo.toml
@@ -10,6 +10,8 @@ features = [
     "Win32_Foundation",
     "Win32_Graphics_Gdi",
     "Win32_System_Registry",
+    "Win32_Devices_Bluetooth",
+    "Win32_System_ApplicationInstallationAndServicing",
 ]
 
 [dependencies.windows-sys]

--- a/crates/tests/handles/tests/win.rs
+++ b/crates/tests/handles/tests/win.rs
@@ -1,4 +1,4 @@
-use windows::{Win32::Foundation::*, Win32::Graphics::Gdi::*, Win32::System::Registry::*, Win32::Devices::Bluetooth::*, Win32::System::ApplicationInstallationAndServicing::*};
+use windows::{Win32::Devices::Bluetooth::*, Win32::Foundation::*, Win32::Graphics::Gdi::*, Win32::System::ApplicationInstallationAndServicing::*, Win32::System::Registry::*};
 
 #[test]
 fn handle() {

--- a/crates/tests/handles/tests/win.rs
+++ b/crates/tests/handles/tests/win.rs
@@ -1,4 +1,4 @@
-use windows::{Win32::Foundation::*, Win32::Graphics::Gdi::*, Win32::System::Registry::*};
+use windows::{Win32::Foundation::*, Win32::Graphics::Gdi::*, Win32::System::Registry::*, Win32::Devices::Bluetooth::*, Win32::System::ApplicationInstallationAndServicing::*};
 
 #[test]
 fn handle() {
@@ -54,4 +54,15 @@ fn const_pattern() {
         HKEY_CLASSES_ROOT => assert!(true),
         _ => assert!(false),
     }
+}
+
+#[test]
+fn unsigned_negative_invalid() {
+    assert!(MSIHANDLE(u32::MAX).is_invalid());
+    assert!(MSIHANDLE(0).is_invalid());
+    assert!(!MSIHANDLE(1).is_invalid());
+
+    assert!(HANDLE_SDP_TYPE(u64::MAX).is_invalid());
+    assert!(HANDLE_SDP_TYPE(0).is_invalid());
+    assert!(!HANDLE_SDP_TYPE(1).is_invalid());
 }


### PR DESCRIPTION
A handle's invalid values are expressed in signed integers, but some handles may have unsigned underlying types. This handles this edge case. 

Excuse the puns. 😉 