### PR TITLE
Heap functions are private

### DIFF
--- a/crates/libs/windows/src/core/mod.rs
+++ b/crates/libs/windows/src/core/mod.rs
@@ -42,8 +42,7 @@ pub use error::*;
 #[doc(hidden)]
 pub use factory_cache::*;
 pub use guid::*;
-#[doc(hidden)]
-pub use heap::*;
+pub(crate) use heap::*;
 pub use hresult::*;
 pub use hstring::*;
 pub use inspectable::*;


### PR DESCRIPTION
Just enforcing the fact that the heap functions are private to the `windows` crate. They are used for string handling internally. 