### PR TITLE
Added conversions between HSTRING and OsStr/OsString

### DIFF
--- a/crates/libs/windows/src/core/hstring.rs
+++ b/crates/libs/windows/src/core/hstring.rs
@@ -265,6 +265,78 @@ impl PartialEq<&HSTRING> for alloc::string::String {
     }
 }
 
+impl PartialEq<std::ffi::OsString> for HSTRING {
+    fn eq(&self, other: &std::ffi::OsString) -> bool {
+        *self == **other
+    }
+}
+
+impl PartialEq<std::ffi::OsString> for &HSTRING {
+    fn eq(&self, other: &std::ffi::OsString) -> bool {
+        **self == **other
+    }
+}
+
+impl PartialEq<&std::ffi::OsString> for HSTRING {
+    fn eq(&self, other: &&std::ffi::OsString) -> bool {
+        *self == ***other
+    }
+}
+
+impl PartialEq<std::ffi::OsStr> for HSTRING {
+    fn eq(&self, other: &std::ffi::OsStr) -> bool {
+        self.as_wide().iter().copied().eq(std::os::windows::ffi::OsStrExt::encode_wide(other))
+    }
+}
+
+impl PartialEq<std::ffi::OsStr> for &HSTRING {
+    fn eq(&self, other: &std::ffi::OsStr) -> bool {
+        **self == *other
+    }
+}
+
+impl PartialEq<&std::ffi::OsStr> for HSTRING {
+    fn eq(&self, other: &&std::ffi::OsStr) -> bool {
+        *self == **other
+    }
+}
+
+impl PartialEq<HSTRING> for std::ffi::OsStr {
+    fn eq(&self, other: &HSTRING) -> bool {
+        *other == *self
+    }
+}
+
+impl PartialEq<HSTRING> for &std::ffi::OsStr {
+    fn eq(&self, other: &HSTRING) -> bool {
+        *other == **self
+    }
+}
+
+impl PartialEq<&HSTRING> for std::ffi::OsStr {
+    fn eq(&self, other: &&HSTRING) -> bool {
+        **other == *self
+    }
+}
+
+impl PartialEq<HSTRING> for std::ffi::OsString {
+    fn eq(&self, other: &HSTRING) -> bool {
+        *other == **self
+    }
+}
+
+impl PartialEq<HSTRING> for &std::ffi::OsString {
+    fn eq(&self, other: &HSTRING) -> bool {
+        *other == ***self
+    }
+}
+
+impl PartialEq<&HSTRING> for std::ffi::OsString {
+    fn eq(&self, other: &&HSTRING) -> bool {
+        **other == **self
+    }
+}
+
 impl<'a> core::convert::TryFrom<&'a HSTRING> for alloc::string::String {
     type Error = alloc::string::FromUtf16Error;
 
@@ -283,7 +355,7 @@ impl core::convert::TryFrom<HSTRING> for alloc::string::String {
 
 impl<'a> core::convert::From<&'a HSTRING> for std::ffi::OsString {
     fn from(hstring: &HSTRING) -> Self {
-        std::os::windows::ffi::OsStringExt::from_wide(hstring.as_wide())
+        hstring.to_os_string()
     }
 }
 

--- a/crates/libs/windows/src/core/hstring.rs
+++ b/crates/libs/windows/src/core/hstring.rs
@@ -48,6 +48,11 @@ impl HSTRING {
         alloc::string::String::from_utf16_lossy(self.as_wide())
     }
 
+    /// Get the contents of this `HSTRING` as a OsString.
+    pub fn to_os_string(&self) -> std::ffi::OsString {
+        std::os::windows::ffi::OsStringExt::from_wide(self.as_wide())
+    }
+
     /// Clear the contents of the string and free the memory if `self` holds the
     /// last reference to the string data.
     pub fn clear(&mut self) {
@@ -164,6 +169,24 @@ impl core::convert::From<&alloc::string::String> for HSTRING {
     }
 }
 
+impl core::convert::From<&std::ffi::OsStr> for HSTRING {
+    fn from(value: &std::ffi::OsStr) -> Self {
+        unsafe { Self::from_wide_iter(std::os::windows::ffi::OsStrExt::encode_wide(value), value.len() as u32) }
+    }
+}
+
+impl core::convert::From<std::ffi::OsString> for HSTRING {
+    fn from(value: std::ffi::OsString) -> Self {
+        value.as_os_str().into()
+    }
+}
+
+impl core::convert::From<&std::ffi::OsString> for HSTRING {
+    fn from(value: &std::ffi::OsString) -> Self {
+        value.as_os_str().into()
+    }
+}
+
 impl PartialEq for HSTRING {
     fn eq(&self, other: &Self) -> bool {
         *self.as_wide() == *other.as_wide()
@@ -258,6 +281,18 @@ impl core::convert::TryFrom<HSTRING> for alloc::string::String {
     }
 }
 
+impl<'a> core::convert::From<&'a HSTRING> for std::ffi::OsString {
+    fn from(hstring: &HSTRING) -> Self {
+        std::os::windows::ffi::OsStringExt::from_wide(hstring.as_wide())
+    }
+}
+
+impl core::convert::From<HSTRING> for std::ffi::OsString {
+    fn from(hstring: HSTRING) -> Self {
+        Self::from(&hstring)
+    }
+}
+
 #[cfg(feature = "alloc")]
 impl<'a> IntoParam<'a, HSTRING> for &str {
     fn into_param(self) -> Param<'a, HSTRING> {
@@ -267,6 +302,18 @@ impl<'a> IntoParam<'a, HSTRING> for &str {
 
 #[cfg(feature = "alloc")]
 impl<'a> IntoParam<'a, HSTRING> for alloc::string::String {
+    fn into_param(self) -> Param<'a, HSTRING> {
+        Param::Owned(self.into())
+    }
+}
+
+impl<'a> IntoParam<'a, HSTRING> for &std::ffi::OsStr {
+    fn into_param(self) -> Param<'a, HSTRING> {
+        Param::Owned(self.into())
+    }
+}
+
+impl<'a> IntoParam<'a, HSTRING> for std::ffi::OsString {
     fn into_param(self) -> Param<'a, HSTRING> {
         Param::Owned(self.into())
     }

--- a/crates/libs/windows/src/core/hstring.rs
+++ b/crates/libs/windows/src/core/hstring.rs
@@ -379,12 +379,14 @@ impl<'a> IntoParam<'a, HSTRING> for alloc::string::String {
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> IntoParam<'a, HSTRING> for &std::ffi::OsStr {
     fn into_param(self) -> Param<'a, HSTRING> {
         Param::Owned(self.into())
     }
 }
 
+#[cfg(feature = "alloc")]
 impl<'a> IntoParam<'a, HSTRING> for std::ffi::OsString {
     fn into_param(self) -> Param<'a, HSTRING> {
         Param::Owned(self.into())

--- a/crates/tests/core/tests/hstrings.rs
+++ b/crates/tests/core/tests/hstrings.rs
@@ -54,6 +54,16 @@ fn from_empty_string() {
 }
 
 #[test]
+fn from_os_string_string() {
+    let wide_data = &[0xD834, 0xDD1E, 0x006d, 0x0075, 0xD800, 0x0069, 0x0063];
+    use std::os::windows::prelude::OsStringExt;
+    let o = std::ffi::OsString::from_wide(wide_data);
+    let h = StringType::from(o);
+    let d = StringType::from_wide(wide_data);
+    assert_eq!(h, d);
+}
+
+#[test]
 fn hstring_to_string() {
     let h = StringType::from("test");
     let s = String::try_from(h).unwrap();
@@ -79,10 +89,49 @@ fn hstring_to_string_lossy() {
 }
 
 #[test]
+fn hstring_to_os_string() {
+    // 𝄞mu<invalid>ic
+    let wide_data = &[0xD834, 0xDD1E, 0x006d, 0x0075, 0xD800, 0x0069, 0x0063];
+    let h = StringType::from_wide(wide_data);
+    let s = h.to_os_string();
+    use std::os::windows::prelude::OsStringExt;
+    assert_eq!(s, std::ffi::OsString::from_wide(wide_data));
+}
+
+#[test]
 fn hstring_equality_combinations() {
     let h = StringType::from("test");
     let s = String::from("test");
     let ss: &str = "test";
+
+    assert_eq!(h, s);
+    assert_eq!(&h, s);
+    assert_eq!(h, &s);
+    assert_eq!(&h, &s);
+
+    assert_eq!(s, h);
+    assert_eq!(s, &h);
+    assert_eq!(&s, h);
+    assert_eq!(&s, &h);
+
+    assert_eq!(h, *ss);
+    assert_eq!(&h, *ss);
+    assert_eq!(h, ss);
+    assert_eq!(&h, ss);
+
+    assert_eq!(*ss, h);
+    assert_eq!(*ss, &h);
+    assert_eq!(ss, h);
+    assert_eq!(ss, &h);
+}
+
+#[test]
+fn hstring_osstring_equality_combinations() {
+    let wide_data = &[0xD834, 0xDD1E, 0x006d, 0x0075, 0xD800, 0x0069, 0x0063];
+    let h = StringType::from_wide(wide_data);
+    use std::os::windows::prelude::OsStringExt;
+    let s = std::ffi::OsString::from_wide(wide_data);
+    let ss = s.as_os_str();
 
     assert_eq!(h, s);
     assert_eq!(&h, s);


### PR DESCRIPTION
I think these conversions are all quite straightforward and self-explanatory.

I'm not sure what exactly is supposed to be hidden behind the `alloc` feature, and whether I have applied this correctly. 