### PR TITLE
Make Matrix3x2::identity() and Matrix3x2::translation(f32, f32) const

### DIFF
--- a/crates/libs/bindgen/src/extensions/matrix3x2.rs
+++ b/crates/libs/bindgen/src/extensions/matrix3x2.rs
@@ -3,7 +3,7 @@ use super::*;
 pub fn gen() -> TokenStream {
     quote! {
         impl Matrix3x2 {
-            pub fn identity() -> Self {
+            pub const fn identity() -> Self {
                 Self {
                     M11: 1.0,
                     M12: 0.0,
@@ -13,7 +13,7 @@ pub fn gen() -> TokenStream {
                     M32: 0.0,
                 }
             }
-            pub fn translation(x: f32, y: f32) -> Self {
+            pub const fn translation(x: f32, y: f32) -> Self {
                 Self {
                     M11: 1.0,
                     M12: 0.0,

--- a/crates/libs/windows/src/Windows/Foundation/Numerics/mod.rs
+++ b/crates/libs/windows/src/Windows/Foundation/Numerics/mod.rs
@@ -42,10 +42,10 @@ impl ::core::default::Default for Matrix3x2 {
     }
 }
 impl Matrix3x2 {
-    pub fn identity() -> Self {
+    pub const fn identity() -> Self {
         Self { M11: 1.0, M12: 0.0, M21: 0.0, M22: 1.0, M31: 0.0, M32: 0.0 }
     }
-    pub fn translation(x: f32, y: f32) -> Self {
+    pub const fn translation(x: f32, y: f32) -> Self {
         Self { M11: 1.0, M12: 0.0, M21: 0.0, M22: 1.0, M31: x, M32: y }
     }
     pub fn rotation(angle: f32, x: f32, y: f32) -> Self {


### PR DESCRIPTION
Although this can't be applied to the rotation function, identity and translation functions can be made `const fn`s, which enables the use of those in const contexts.