### PR TITLE
Add missing features to enum bitwise operators

### DIFF
--- a/crates/libs/bindgen/src/enums.rs
+++ b/crates/libs/bindgen/src/enums.rs
@@ -133,6 +133,7 @@ pub fn gen(def: &TypeDef, gen: &Gen) -> TokenStream {
 
         if def.has_flags() {
             tokens.combine(&quote! {
+                #features
                 impl ::core::ops::BitOr for #ident {
                     type Output = Self;
 
@@ -140,6 +141,7 @@ pub fn gen(def: &TypeDef, gen: &Gen) -> TokenStream {
                         Self(self.0 | other.0)
                     }
                 }
+                #features
                 impl ::core::ops::BitAnd for #ident {
                     type Output = Self;
 
@@ -147,16 +149,19 @@ pub fn gen(def: &TypeDef, gen: &Gen) -> TokenStream {
                         Self(self.0 & other.0)
                     }
                 }
+                #features
                 impl ::core::ops::BitOrAssign for #ident {
                     fn bitor_assign(&mut self, other: Self) {
                         self.0.bitor_assign(other.0)
                     }
                 }
+                #features
                 impl ::core::ops::BitAndAssign for #ident {
                     fn bitand_assign(&mut self, other: Self) {
                         self.0.bitand_assign(other.0)
                     }
                 }
+                #features
                 impl ::core::ops::Not for #ident {
                     type Output = Self;
 

--- a/crates/libs/windows/src/Windows/Security/Authentication/Identity/Provider/mod.rs
+++ b/crates/libs/windows/src/Windows/Security/Authentication/Identity/Provider/mod.rs
@@ -1088,28 +1088,33 @@ impl ::core::fmt::Debug for SecondaryAuthenticationFactorDeviceCapabilities {
         f.debug_tuple("SecondaryAuthenticationFactorDeviceCapabilities").field(&self.0).finish()
     }
 }
+#[cfg(feature = "deprecated")]
 impl ::core::ops::BitOr for SecondaryAuthenticationFactorDeviceCapabilities {
     type Output = Self;
     fn bitor(self, other: Self) -> Self {
         Self(self.0 | other.0)
     }
 }
+#[cfg(feature = "deprecated")]
 impl ::core::ops::BitAnd for SecondaryAuthenticationFactorDeviceCapabilities {
     type Output = Self;
     fn bitand(self, other: Self) -> Self {
         Self(self.0 & other.0)
     }
 }
+#[cfg(feature = "deprecated")]
 impl ::core::ops::BitOrAssign for SecondaryAuthenticationFactorDeviceCapabilities {
     fn bitor_assign(&mut self, other: Self) {
         self.0.bitor_assign(other.0)
     }
 }
+#[cfg(feature = "deprecated")]
 impl ::core::ops::BitAndAssign for SecondaryAuthenticationFactorDeviceCapabilities {
     fn bitand_assign(&mut self, other: Self) {
         self.0.bitand_assign(other.0)
     }
 }
+#[cfg(feature = "deprecated")]
 impl ::core::ops::Not for SecondaryAuthenticationFactorDeviceCapabilities {
     type Output = Self;
     fn not(self) -> Self {


### PR DESCRIPTION
Noticed these were missing during some exhaustive testing. 