### PR TITLE
Undo Rust 2021 adoption

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        rust: [1.56.0, stable, nightly]
+        rust: [1.46.0, stable, nightly]
     steps:
     - name: Checkout
       uses: actions/checkout@v2

--- a/crates/libs/bindgen/Cargo.toml
+++ b/crates/libs/bindgen/Cargo.toml
@@ -2,7 +2,7 @@
 name = "windows-bindgen"
 version = "0.35.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Code gen support for the windows crate"
 repository = "https://github.com/microsoft/windows-rs"

--- a/crates/libs/implement/Cargo.toml
+++ b/crates/libs/implement/Cargo.toml
@@ -2,7 +2,7 @@
 name = "windows-implement"
 version = "0.35.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "The implement macro for the windows crate"
 repository = "https://github.com/microsoft/windows-rs"

--- a/crates/libs/interface/Cargo.toml
+++ b/crates/libs/interface/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "windows-interface"
 version = "0.35.0"
-edition = "2021"
+edition = "2018"
 authors = ["Microsoft"]
 license = "MIT OR Apache-2.0"
 description = "The interface macro for the windows crate"

--- a/crates/libs/metadata/Cargo.toml
+++ b/crates/libs/metadata/Cargo.toml
@@ -2,7 +2,7 @@
 name = "windows-metadata"
 version = "0.35.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Code gen support for the windows crate"
 repository = "https://github.com/microsoft/windows-rs"

--- a/crates/libs/sys/Cargo.toml
+++ b/crates/libs/sys/Cargo.toml
@@ -3,12 +3,12 @@
 name = "windows-sys"
 version = "0.35.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Rust for Windows"
 repository = "https://github.com/microsoft/windows-rs"
 readme = "../../../.github/readme.md"
-rust-version = "1.56"
+rust-version = "1.46"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/crates/libs/tokens/Cargo.toml
+++ b/crates/libs/tokens/Cargo.toml
@@ -2,7 +2,7 @@
 name = "windows-tokens"
 version = "0.35.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Code gen support for the windows crate"
 repository = "https://github.com/microsoft/windows-rs"

--- a/crates/libs/windows/Cargo.toml
+++ b/crates/libs/windows/Cargo.toml
@@ -3,7 +3,7 @@
 name = "windows"
 version = "0.35.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Rust for Windows"
 repository = "https://github.com/microsoft/windows-rs"

--- a/crates/samples/com_uri/Cargo.toml
+++ b/crates/samples/com_uri/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sample_com_uri"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/samples/consent/Cargo.toml
+++ b/crates/samples/consent/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sample_consent"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/samples/core_app/Cargo.toml
+++ b/crates/samples/core_app/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sample_core_app"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/samples/create_window/Cargo.toml
+++ b/crates/samples/create_window/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sample_create_window"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/samples/create_window_sys/Cargo.toml
+++ b/crates/samples/create_window_sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sample_create_window_sys"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows-sys]
 path = "../../libs/sys"

--- a/crates/samples/data_protection/Cargo.toml
+++ b/crates/samples/data_protection/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sample_data_protection"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/samples/direct2d/Cargo.toml
+++ b/crates/samples/direct2d/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sample_direct2d"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/samples/direct3d12/Cargo.toml
+++ b/crates/samples/direct3d12/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sample_direct3d12"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 array-init = "2.0.0"

--- a/crates/samples/enum_windows/Cargo.toml
+++ b/crates/samples/enum_windows/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sample_enum_windows"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/samples/enum_windows_sys/Cargo.toml
+++ b/crates/samples/enum_windows_sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sample_enum_windows_sys"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows-sys]
 path = "../../libs/sys"

--- a/crates/samples/kernel_event/Cargo.toml
+++ b/crates/samples/kernel_event/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sample_kernel_event"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/samples/memory_buffer/Cargo.toml
+++ b/crates/samples/memory_buffer/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sample_memory_buffer"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/samples/message_box/Cargo.toml
+++ b/crates/samples/message_box/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sample_message_box"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/samples/ocr/Cargo.toml
+++ b/crates/samples/ocr/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sample_ocr"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 futures = "0.3.5"

--- a/crates/samples/overlapped/Cargo.toml
+++ b/crates/samples/overlapped/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sample_overlapped"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/samples/rss/Cargo.toml
+++ b/crates/samples/rss/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sample_rss"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/samples/simple/Cargo.toml
+++ b/crates/samples/simple/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sample_simple"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/samples/spellchecker/Cargo.toml
+++ b/crates/samples/spellchecker/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sample_spellchecker"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/samples/uiautomation/Cargo.toml
+++ b/crates/samples/uiautomation/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sample_uiautomation"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/samples/xaml_app/Cargo.toml
+++ b/crates/samples/xaml_app/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sample_xaml_app"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/samples/xml/Cargo.toml
+++ b/crates/samples/xml/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sample_xml"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/targets/aarch64_msvc/Cargo.toml
+++ b/crates/targets/aarch64_msvc/Cargo.toml
@@ -2,7 +2,7 @@
 name = "windows_aarch64_msvc"
 version = "0.35.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Code gen support for the windows crate"
 repository = "https://github.com/microsoft/windows-rs"

--- a/crates/targets/i686_gnu/Cargo.toml
+++ b/crates/targets/i686_gnu/Cargo.toml
@@ -2,7 +2,7 @@
 name = "windows_i686_gnu"
 version = "0.35.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Code gen support for the windows crate"
 repository = "https://github.com/microsoft/windows-rs"

--- a/crates/targets/i686_msvc/Cargo.toml
+++ b/crates/targets/i686_msvc/Cargo.toml
@@ -2,7 +2,7 @@
 name = "windows_i686_msvc"
 version = "0.35.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Code gen support for the windows crate"
 repository = "https://github.com/microsoft/windows-rs"

--- a/crates/targets/x86_64_gnu/Cargo.toml
+++ b/crates/targets/x86_64_gnu/Cargo.toml
@@ -2,7 +2,7 @@
 name = "windows_x86_64_gnu"
 version = "0.35.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Code gen support for the windows crate"
 repository = "https://github.com/microsoft/windows-rs"

--- a/crates/targets/x86_64_msvc/Cargo.toml
+++ b/crates/targets/x86_64_msvc/Cargo.toml
@@ -2,7 +2,7 @@
 name = "windows_x86_64_msvc"
 version = "0.35.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Code gen support for the windows crate"
 repository = "https://github.com/microsoft/windows-rs"

--- a/crates/tests/agile/Cargo.toml
+++ b/crates/tests/agile/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_agile"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/agile_reference/Cargo.toml
+++ b/crates/tests/agile_reference/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_agile_reference"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/alternate_success_code/Cargo.toml
+++ b/crates/tests/alternate_success_code/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_alternate_success_code"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/arch/Cargo.toml
+++ b/crates/tests/arch/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_arch"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/arch_feature/Cargo.toml
+++ b/crates/tests/arch_feature/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_arch_feature"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/bstr/Cargo.toml
+++ b/crates/tests/bstr/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_bstr"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/const_fields/Cargo.toml
+++ b/crates/tests/const_fields/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_const_fields"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/core/Cargo.toml
+++ b/crates/tests/core/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_core"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies]
 windows = { path = "../../libs/windows" }

--- a/crates/tests/debug/Cargo.toml
+++ b/crates/tests/debug/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_debug"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/deprecated/Cargo.toml
+++ b/crates/tests/deprecated/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_deprecated"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/dispatch/Cargo.toml
+++ b/crates/tests/dispatch/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_dispatch"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/does_not_return/Cargo.toml
+++ b/crates/tests/does_not_return/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_does_not_return"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/enums/Cargo.toml
+++ b/crates/tests/enums/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_enums"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/error/Cargo.toml
+++ b/crates/tests/error/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_error"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/event/Cargo.toml
+++ b/crates/tests/event/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_event"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/handles/Cargo.toml
+++ b/crates/tests/handles/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_handles"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/helpers/Cargo.toml
+++ b/crates/tests/helpers/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_helpers"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 publish = false
 
 [dependencies.windows]

--- a/crates/tests/interop/Cargo.toml
+++ b/crates/tests/interop/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_interop"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/lib/Cargo.toml
+++ b/crates/tests/lib/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_lib"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/matrix3x2/Cargo.toml
+++ b/crates/tests/matrix3x2/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_matrix3x2"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/mshtml/Cargo.toml
+++ b/crates/tests/mshtml/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_mshtml"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/nightly_class_factory/Cargo.toml
+++ b/crates/tests/nightly_class_factory/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_nightly_class_factory"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/nightly_component/Cargo.toml
+++ b/crates/tests/nightly_component/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test_nightly_component"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 
 [lib]
 crate-type = ["cdylib"]

--- a/crates/tests/nightly_component_client/Cargo.toml
+++ b/crates/tests/nightly_component_client/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_nightly_component_client"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/nightly_data_object/Cargo.toml
+++ b/crates/tests/nightly_data_object/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_nightly_data_object"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/nightly_drop_target/Cargo.toml
+++ b/crates/tests/nightly_drop_target/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_nightly_drop_target"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/nightly_identity/Cargo.toml
+++ b/crates/tests/nightly_identity/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_nightly_identity"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/nightly_implement/Cargo.toml
+++ b/crates/tests/nightly_implement/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_nightly_implement"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/nightly_interface/Cargo.toml
+++ b/crates/tests/nightly_interface/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_nightly_interface"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/nightly_map/Cargo.toml
+++ b/crates/tests/nightly_map/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_nightly_map"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/nightly_no_use/Cargo.toml
+++ b/crates/tests/nightly_no_use/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_nightly_no_use"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/nightly_null_result/Cargo.toml
+++ b/crates/tests/nightly_null_result/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_nightly_null_result"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/nightly_properties/Cargo.toml
+++ b/crates/tests/nightly_properties/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_nightly_properties"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/nightly_vector/Cargo.toml
+++ b/crates/tests/nightly_vector/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_nightly_vector"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/nightly_winrt/Cargo.toml
+++ b/crates/tests/nightly_winrt/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_nightly_winrt"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/not_dll/Cargo.toml
+++ b/crates/tests/not_dll/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_not_dll"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/ntstatus/Cargo.toml
+++ b/crates/tests/ntstatus/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_ntstatus"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/return_struct/Cargo.toml
+++ b/crates/tests/return_struct/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_return_struct"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/string_param/Cargo.toml
+++ b/crates/tests/string_param/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_string_param"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/structs/Cargo.toml
+++ b/crates/tests/structs/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_structs"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/sys/Cargo.toml
+++ b/crates/tests/sys/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_sys"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows-sys]
 path = "../../libs/sys"

--- a/crates/tests/unions/Cargo.toml
+++ b/crates/tests/unions/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_unions"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/weak/Cargo.toml
+++ b/crates/tests/weak/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_weak"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/weak_ref/Cargo.toml
+++ b/crates/tests/weak_ref/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_weak_ref"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/win32/Cargo.toml
+++ b/crates/tests/win32/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_win32"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/win32_arrays/Cargo.toml
+++ b/crates/tests/win32_arrays/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_win32_arrays"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows]
 path = "../../libs/windows"

--- a/crates/tests/writer/Cargo.toml
+++ b/crates/tests/writer/Cargo.toml
@@ -2,7 +2,7 @@
 name = "test_writer"
 version = "0.0.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 
 [dependencies.windows-metadata]
 path = "../../libs/metadata"

--- a/crates/tools/bindings/Cargo.toml
+++ b/crates/tools/bindings/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tool_bindings"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 publish = false
 
 [dependencies]

--- a/crates/tools/gnu/Cargo.toml
+++ b/crates/tools/gnu/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tool_gnu"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 publish = false
 
 [dependencies]

--- a/crates/tools/ilrs/Cargo.toml
+++ b/crates/tools/ilrs/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tool_ilrs"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 publish = false
 
 [dependencies]

--- a/crates/tools/msvc/Cargo.toml
+++ b/crates/tools/msvc/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tool_msvc"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 publish = false
 
 [dependencies]

--- a/crates/tools/sys/Cargo.toml
+++ b/crates/tools/sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tool_sys"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 publish = false
 
 [dependencies]

--- a/crates/tools/sys/src/main.rs
+++ b/crates/tools/sys/src/main.rs
@@ -27,12 +27,12 @@ fn main() {
 name = "windows-sys"
 version = "0.35.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Rust for Windows"
 repository = "https://github.com/microsoft/windows-rs"
 readme = "../../../.github/readme.md"
-rust-version = "1.56"
+rust-version = "1.46"
 
 [package.metadata.docs.rs]
 default-target = "x86_64-pc-windows-msvc"

--- a/crates/tools/windows/Cargo.toml
+++ b/crates/tools/windows/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tool_windows"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 publish = false
 
 [dependencies]

--- a/crates/tools/windows/src/main.rs
+++ b/crates/tools/windows/src/main.rs
@@ -27,7 +27,7 @@ fn main() {
 name = "windows"
 version = "0.35.0"
 authors = ["Microsoft"]
-edition = "2021"
+edition = "2018"
 license = "MIT OR Apache-2.0"
 description = "Rust for Windows"
 repository = "https://github.com/microsoft/windows-rs"

--- a/crates/tools/yml/Cargo.toml
+++ b/crates/tools/yml/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tool_yml"
 version = "0.0.0"
-edition = "2021"
+edition = "2018"
 publish = false
 
 [dependencies]

--- a/crates/tools/yml/src/main.rs
+++ b/crates/tools/yml/src/main.rs
@@ -198,7 +198,7 @@ jobs:
     runs-on: windows-2019
     strategy:
       matrix:
-        rust: [1.56.0, stable, nightly]
+        rust: [1.46.0, stable, nightly]
     steps:
     - name: Checkout
       uses: actions/checkout@v2


### PR DESCRIPTION
[Adopting Rust 2021](https://github.com/microsoft/windows-rs/pull/1636) had some unintended consequences. Turns outs it's [not quite as seamless](https://github.com/microsoft/windows-rs/issues/1699#issuecomment-1101667920) as [is claimed](https://doc.rust-lang.org/stable/edition-guide/editions/index.html). 

This update just reverts to 2018 so that we can continue to support `windows-sys` on 1.46 rather than forcing it artificially to 1.56 just to satisfy Cargo. 