### PR TITLE
Correct `compose` offset in `implement` macro

### DIFF
--- a/crates/libs/implement/src/lib.rs
+++ b/crates/libs/implement/src/lib.rs
@@ -143,7 +143,8 @@ pub fn implement(attributes: proc_macro::TokenStream, original_type: proc_macro:
         impl <#constraints> ::windows::core::Compose for #original_ident::<#(#generics,)*> {
             unsafe fn compose<'a>(implementation: Self) -> (::windows::core::IInspectable, &'a mut ::core::option::Option<::windows::core::IInspectable>) {
                 let inspectable: ::windows::core::IInspectable = implementation.into();
-                let this = (&inspectable as *const _ as *mut ::windows::core::RawPtr).sub(1) as *mut #impl_ident::<#(#generics,)*>;
+                let this: ::windows::core::RawPtr = ::core::mem::transmute_copy(&inspectable);
+                let this = (this as *mut ::windows::core::RawPtr).sub(1) as *mut #impl_ident::<#(#generics,)*>;
                 (inspectable, &mut (*this).base)
             }
         }

--- a/crates/samples/xaml_app/src/main.rs
+++ b/crates/samples/xaml_app/src/main.rs
@@ -14,12 +14,18 @@ use windows::{
 };
 
 #[implement(IApplicationOverrides)]
-struct MyApp();
+struct MyApp {
+    text: &'static str,
+    placeholder: &'static str,
+}
 
 impl IApplicationOverrides_Impl for MyApp {
     fn OnLaunched(&self, _: &Option<LaunchActivatedEventArgs>) -> Result<()> {
         let window = Window::Current()?;
-        window.SetContent(TextBox::new()?)?;
+        let text_box = TextBox::new()?;
+        text_box.SetText(self.text)?;
+        text_box.SetPlaceholderText(self.placeholder)?;
+        window.SetContent(text_box)?;
         window.Activate()
     }
 }
@@ -35,7 +41,7 @@ fn main() -> Result<()> {
     }
 
     Application::Start(ApplicationInitializationCallback::new(|_| {
-        Application::compose(MyApp())?;
+        Application::compose(MyApp { text: "Hello world", placeholder: "What are you going to build today?" })?;
         Ok(())
     }))
 }


### PR DESCRIPTION
This affects only Xaml - I have updated the Xaml sample to trigger the offset calculation. 

Once authoring support is further along (#1094), we should add a composition test to the `test_component` to validate this as well. 